### PR TITLE
Relieve GC and memory pressure for typical workloads in ClickHouseDataReader

### DIFF
--- a/ClickHouse.Driver.Benchmark/ClickHouse.Driver.Benchmark.csproj
+++ b/ClickHouse.Driver.Benchmark/ClickHouse.Driver.Benchmark.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/ClickHouse.Driver.Benchmark/RecyclableMemoryStreamBenchmark.cs
+++ b/ClickHouse.Driver.Benchmark/RecyclableMemoryStreamBenchmark.cs
@@ -1,0 +1,194 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using BenchmarkDotNet.Attributes;
+using ClickHouse.Driver.ADO.Readers;
+using ClickHouse.Driver.Benchmark.References;
+using ClickHouse.Driver.Formats;
+
+namespace ClickHouse.Driver.Benchmark;
+
+[MemoryDiagnoser]
+[SimpleJob(warmupCount: 3, iterationCount: 10)]
+public class RecyclableMemoryStreamBenchmark
+{
+    private byte[] smallResponseData;   // 10 KB
+    private byte[] mediumResponseData;  // 500 KB  
+    private byte[] largeResponseData;   // 5 MB
+    private TypeSettings typeSettings;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        typeSettings = new TypeSettings();
+        
+        // Create mock responses of different sizes
+        smallResponseData = CreateMockBinaryResponse(100, 10);      // 100 rows, 10 columns ~ 10KB
+        mediumResponseData = CreateMockBinaryResponse(5000, 10);    // 5000 rows, 10 columns ~ 500KB
+        largeResponseData = CreateMockBinaryResponse(50000, 10);    // 50000 rows, 10 columns ~ 5MB
+    }
+
+    [Benchmark(Baseline = true)]
+    [Arguments(100)]    // Small response
+    [Arguments(5000)]   // Medium response
+    [Arguments(50000)]  // Large response
+    public long ReadAllData_BufferedStream(int rowCount)
+    {
+        var data = rowCount switch
+        {
+            100 => smallResponseData,
+            5000 => mediumResponseData,
+            50000 => largeResponseData,
+            _ => throw new ArgumentException()
+        };
+
+        using var reader = BufferedStreamClickHouseDataReader.FromHttpResponse(
+            CreateMockHttpResponse(data), typeSettings);
+        
+        long sum = 0;
+        var rowsRead = 0;
+        while (reader.Read() && rowsRead < rowCount)
+        {
+            for (var i = 0; i < reader.FieldCount; i++)
+            {
+                if (reader.GetFieldType(i) == typeof(int))
+                    sum += reader.GetInt32(i);
+            }
+            rowsRead++;
+        }
+        
+        return sum;
+    }
+
+    [Benchmark]
+    [Arguments(100)]    // Small response
+    [Arguments(5000)]   // Medium response
+    [Arguments(50000)]  // Large response
+    public long ReadAllData_RecyclableMemoryStream(int rowCount)
+    {
+        var data = rowCount switch
+        {
+            100 => smallResponseData,
+            5000 => mediumResponseData,
+            50000 => largeResponseData,
+            _ => throw new ArgumentException()
+        };
+
+        using var reader = ClickHouseDataReader.FromHttpResponse(
+            CreateMockHttpResponse(data), typeSettings);
+        
+        long sum = 0;
+        var rowsRead = 0;
+        while (reader.Read() && rowsRead < rowCount)
+        {
+            for (var i = 0; i < reader.FieldCount; i++)
+            {
+                if (reader.GetFieldType(i) == typeof(int))
+                    sum += reader.GetInt32(i);
+            }
+            rowsRead++;
+        }
+        
+        return sum;
+    }
+
+    [Benchmark(Baseline = true)]
+    public void MultipleSmallQueries_BufferedStream()
+    {
+        // Simulate multiple small queries - BufferedStream allocates new buffer each time
+        for (var i = 0; i < 100; i++)
+        {
+            using var reader = BufferedStreamClickHouseDataReader.FromHttpResponse(
+                CreateMockHttpResponse(smallResponseData), typeSettings);
+            
+            while (reader.Read())
+            {
+                _ = reader.GetValue(0);
+            }
+        }
+    }
+
+    [Benchmark]
+    public void MultipleSmallQueries_RecyclableStream()
+    {
+        // Simulate multiple small queries that would benefit from buffer pooling
+        for (var i = 0; i < 100; i++)
+        {
+            using var reader = ClickHouseDataReader.FromHttpResponse(
+                CreateMockHttpResponse(smallResponseData), typeSettings);
+            
+            while (reader.Read())
+            {
+                _ = reader.GetValue(0);
+            }
+        }
+    }
+
+    private static HttpResponseMessage CreateMockHttpResponse(byte[] data)
+    {
+        var content = new ByteArrayContent(data);
+        content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/octet-stream");
+        
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = content
+        };
+    }
+
+    private static byte[] CreateMockBinaryResponse(int rows, int columns)
+    {
+        using var stream = new MemoryStream();
+        using var writer = new ExtendedBinaryWriter(stream);
+        
+        writer.Write7BitEncodedInt(columns);
+        
+        for (var i = 0; i < columns; i++)
+        {
+            writer.Write($"column{i}");
+        }
+        
+        for (var i = 0; i < columns; i++)
+        {
+            switch (i % 4)
+            {
+                case 0:
+                    writer.Write("Int32");
+                    break;
+                case 1:
+                    writer.Write("String");
+                    break;
+                case 2:
+                    writer.Write("Float64");
+                    break;
+                case 3:
+                    writer.Write("UInt64");
+                    break;
+            }
+        }
+        
+        for (var row = 0; row < rows; row++)
+        {
+            for (var col = 0; col < columns; col++)
+            {
+                switch (col % 4)
+                {
+                    case 0: // Int32
+                        writer.Write(row);
+                        break;
+                    case 1: // String
+                        writer.Write($"row{row}_col{col}"); 
+                        break;
+                    case 2: // Float64
+                        writer.Write(row / 100.0); 
+                        break;
+                    case 3: // UInt64
+                        writer.Write((ulong)row * 1000); 
+                        break;
+                }
+            }
+        }
+        
+        return stream.ToArray();
+    }
+}

--- a/ClickHouse.Driver.Benchmark/RecyclableMemoryStreamBenchmark.cs
+++ b/ClickHouse.Driver.Benchmark/RecyclableMemoryStreamBenchmark.cs
@@ -11,6 +11,7 @@ namespace ClickHouse.Driver.Benchmark;
 
 [MemoryDiagnoser]
 [SimpleJob(warmupCount: 3, iterationCount: 10)]
+[MarkdownExporter]
 public class RecyclableMemoryStreamBenchmark
 {
     private byte[] smallResponseData;   // 10 KB

--- a/ClickHouse.Driver.Benchmark/References/BufferedStreamClickHouseDataReader.cs
+++ b/ClickHouse.Driver.Benchmark/References/BufferedStreamClickHouseDataReader.cs
@@ -1,85 +1,55 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Data;
 using System.Data.Common;
 using System.Globalization;
 using System.IO;
-using System.Net;
 using System.Net.Http;
-using System.Numerics;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using ClickHouse.Driver.Formats;
 using ClickHouse.Driver.Numerics;
 using ClickHouse.Driver.Types;
-using ClickHouse.Driver.Utility;
-using Microsoft.IO;
 
-namespace ClickHouse.Driver.ADO.Readers;
+namespace ClickHouse.Driver.Benchmark.References;
 
-// TODO: implement IDbColumnSchemaGenerator
-public class ClickHouseDataReader : DbDataReader, IEnumerator<IDataReader>, IEnumerable<IDataReader>, IDataRecord
+/// <summary>
+/// Original ClickHouseDataReader implementation using BufferedStream for benchmarking comparison
+/// </summary>
+internal class BufferedStreamClickHouseDataReader : DbDataReader, IEnumerator<IDataReader>, IEnumerable<IDataReader>, IDataRecord
 {
-#if NET6_0_OR_GREATER
-    private static readonly RecyclableMemoryStreamManager StreamManager = new(new RecyclableMemoryStreamManager.Options
-    {
-        BlockSize = 128 * 1024,                         // 128KiB blocks
-        LargeBufferMultiple = 1024 * 1024,              // 1MiB
-        MaximumBufferSize = 128 * 1024 * 1024,          // 128MiB
-        GenerateCallStacks = false,
-        AggressiveBufferReturn = true,
-        MaximumLargePoolFreeBytes = 256 * 1024 * 1024,  // 256MiB
-        MaximumSmallPoolFreeBytes = 128 * 1024 * 1024,  // 128MiB
-    });
-#else
-    private static readonly RecyclableMemoryStreamManager StreamManager = new RecyclableMemoryStreamManager();
-#endif
+    private const int BufferSize = 512 * 1024;
 
-    private readonly HttpResponseMessage httpResponse; // Used to dispose at the end of reader
+    private readonly HttpResponseMessage httpResponse;
     private readonly ExtendedBinaryReader reader;
-    private readonly RecyclableMemoryStream recyclableStream;
 
-    private ClickHouseDataReader(HttpResponseMessage httpResponse, ExtendedBinaryReader reader, RecyclableMemoryStream recyclableStream, string[] names, ClickHouseType[] types)
+    private BufferedStreamClickHouseDataReader(HttpResponseMessage httpResponse, ExtendedBinaryReader reader, string[] names, ClickHouseType[] types)
     {
         this.httpResponse = httpResponse ?? throw new ArgumentNullException(nameof(httpResponse));
         this.reader = reader ?? throw new ArgumentNullException(nameof(reader));
-        this.recyclableStream = recyclableStream;
         RawTypes = types;
         FieldNames = names;
         CurrentRow = new object[FieldNames.Length];
     }
 
-    internal static ClickHouseDataReader FromHttpResponse(HttpResponseMessage httpResponse, TypeSettings settings)
+    internal static BufferedStreamClickHouseDataReader FromHttpResponse(HttpResponseMessage httpResponse, TypeSettings settings)
     {
         if (httpResponse is null) throw new ArgumentNullException(nameof(httpResponse));
         ExtendedBinaryReader reader = null;
-        RecyclableMemoryStream recyclableStream = null;
         try
         {
-            recyclableStream = StreamManager.GetStream("ClickHouseDataReader");
-            httpResponse.Content.CopyToAsync(recyclableStream).GetAwaiter().GetResult();
-            recyclableStream.Position = 0;
-            
-            reader = new ExtendedBinaryReader(recyclableStream); // will dispose of stream
+            var stream = new BufferedStream(httpResponse.Content.ReadAsStreamAsync().GetAwaiter().GetResult(), BufferSize);
+            reader = new ExtendedBinaryReader(stream);
             var (names, types) = ReadHeaders(reader, settings);
-            return new ClickHouseDataReader(httpResponse, reader, recyclableStream, names, types);
+            return new BufferedStreamClickHouseDataReader(httpResponse, reader, names, types);
         }
         catch (Exception)
         {
             httpResponse?.Dispose();
             reader?.Dispose();
-            recyclableStream?.Dispose();
             throw;
         }
-    }
-
-    internal ClickHouseType GetEffectiveClickHouseType(int ordinal)
-    {
-        var type = RawTypes[ordinal];
-        return type is NullableType nt ? nt.UnderlyingType : type;
     }
 
     internal ClickHouseType GetClickHouseType(int ordinal) => RawTypes[ordinal];
@@ -117,9 +87,6 @@ public class ClickHouseDataReader : DbDataReader, IEnumerator<IDataReader>, IEnu
     public override string GetDataTypeName(int ordinal) => GetClickHouseType(ordinal).ToString();
 
     public override DateTime GetDateTime(int ordinal) => (DateTime)GetValue(ordinal);
-
-    public virtual DateTimeOffset GetDateTimeOffset(int ordinal) => GetEffectiveClickHouseType(ordinal) is AbstractDateTimeType adt ?
-        adt.CoerceToDateTimeOffset(GetDateTime(ordinal)) : throw new InvalidCastException();
 
     public override decimal GetDecimal(int ordinal)
     {
@@ -185,37 +152,14 @@ public class ClickHouseDataReader : DbDataReader, IEnumerator<IDataReader>, IEnu
 
     public override T GetFieldValue<T>(int ordinal) => (T)GetValue(ordinal);
 
-    public override DataTable GetSchemaTable() => SchemaDescriber.DescribeSchema(this);
+    public override DataTable GetSchemaTable() => throw new NotImplementedException();
 
     public override Task<bool> NextResultAsync(CancellationToken cancellationToken) => Task.FromResult(false);
-
-    // Custom extension
-    public ushort GetUInt16(int ordinal) => (ushort)GetValue(ordinal);
-
-    // Custom extension
-    public uint GetUInt32(int ordinal) => (uint)GetValue(ordinal);
-
-    // Custom extension
-    public ulong GetUInt64(int ordinal) => (ulong)GetValue(ordinal);
-
-    // Custom extension
-    public IPAddress GetIPAddress(int ordinal) => (IPAddress)GetValue(ordinal);
-
-#if !NET462
-    // Custom extension
-    public ITuple GetTuple(int ordinal) => (ITuple)GetValue(ordinal);
-#endif
-
-    // Custom extension
-    public sbyte GetSByte(int ordinal) => (sbyte)GetValue(ordinal);
-
-    // Custom extension
-    public BigInteger GetBigInteger(int ordinal) => (BigInteger)GetValue(ordinal);
 
     public override bool Read()
     {
         if (reader.PeekChar() == -1)
-            return false; // End of stream reached
+            return false;
 
         var count = RawTypes.Length;
         var data = CurrentRow;
@@ -227,17 +171,14 @@ public class ClickHouseDataReader : DbDataReader, IEnumerator<IDataReader>, IEnu
         return true;
     }
 
-#pragma warning disable CA2215 // Dispose methods should call base class dispose
     protected override void Dispose(bool disposing)
     {
         if (disposing)
         {
             httpResponse?.Dispose();
             reader?.Dispose();
-            recyclableStream?.Dispose();
         }
     }
-#pragma warning restore CA2215 // Dispose methods should call base class dispose
 
     private static (string[], ClickHouseType[]) ReadHeaders(ExtendedBinaryReader reader, TypeSettings settings)
     {

--- a/ClickHouse.Driver.IntegrationTests/ClickHouse.Driver.IntegrationTests.csproj
+++ b/ClickHouse.Driver.IntegrationTests/ClickHouse.Driver.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/ClickHouse.Driver/ADO/Readers/ClickHouseDataReader.cs
+++ b/ClickHouse.Driver/ADO/Readers/ClickHouseDataReader.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Data;
 using System.Data.Common;
 using System.Globalization;
-using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Numerics;
@@ -26,7 +24,7 @@ public class ClickHouseDataReader : DbDataReader, IEnumerator<IDataReader>, IEnu
 #if NET6_0_OR_GREATER
     private static readonly RecyclableMemoryStreamManager StreamManager = new(new RecyclableMemoryStreamManager.Options
     {
-        BlockSize = 128 * 1024,                         // 128KiB blocks
+        BlockSize = 128 * 1024,                         // 128KiB
         LargeBufferMultiple = 1024 * 1024,              // 1MiB
         MaximumBufferSize = 128 * 1024 * 1024,          // 128MiB
         GenerateCallStacks = false,
@@ -59,7 +57,7 @@ public class ClickHouseDataReader : DbDataReader, IEnumerator<IDataReader>, IEnu
         RecyclableMemoryStream recyclableStream = null;
         try
         {
-            recyclableStream = StreamManager.GetStream("ClickHouseDataReader");
+            recyclableStream = StreamManager.GetStream(nameof(ClickHouseDataReader));
             httpResponse.Content.CopyToAsync(recyclableStream).GetAwaiter().GetResult();
             recyclableStream.Position = 0;
             

--- a/ClickHouse.Driver/ADO/Readers/ClickHouseDataReader.cs
+++ b/ClickHouse.Driver/ADO/Readers/ClickHouseDataReader.cs
@@ -63,7 +63,7 @@ public class ClickHouseDataReader : DbDataReader, IEnumerator<IDataReader>, IEnu
             httpResponse.Content.CopyToAsync(recyclableStream).GetAwaiter().GetResult();
             recyclableStream.Position = 0;
             
-            reader = new ExtendedBinaryReader(recyclableStream); // will dispose of stream
+            reader = new ExtendedBinaryReader(recyclableStream); // recyclableStream is disposed separately
             var (names, types) = ReadHeaders(reader, settings);
             return new ClickHouseDataReader(httpResponse, reader, recyclableStream, names, types);
         }

--- a/ClickHouse.Driver/Types/TypeConverter.cs
+++ b/ClickHouse.Driver/Types/TypeConverter.cs
@@ -9,6 +9,7 @@ using ClickHouse.Driver.Types.Grammar;
 using NodaTime;
 
 [assembly: InternalsVisibleTo("ClickHouse.Driver.Tests")] // assembly-level tag to expose below classes to tests
+[assembly: InternalsVisibleTo("ClickHouse.Driver.Benchmark")] // allow benchmarks to access internal types
 
 namespace ClickHouse.Driver.Types;
 

--- a/run-benchmarks.ps1
+++ b/run-benchmarks.ps1
@@ -1,0 +1,52 @@
+#!/usr/bin/env pwsh
+
+# Run ArrayPool benchmark for ClickHouseDataReader
+
+param(
+    [switch]$SkipBuild,
+    [switch]$Detailed,
+    [string]$Filter = "*RecyclableMemoryStreamBenchmark*",
+    [int]$WarmupCount = 3,
+    [int]$IterationCount = 5
+)
+
+if (-not $SkipBuild) {
+    Write-Host "Building ClickHouse.Driver.Benchmark in Release mode..." -ForegroundColor Green
+    dotnet build ClickHouse.Driver.Benchmark/ClickHouse.Driver.Benchmark.csproj --configuration Release
+
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "Build failed!" -ForegroundColor Red
+        exit 1
+    }
+} else {
+    Write-Host "Skipping build (using existing binaries)..." -ForegroundColor Yellow
+}
+
+Write-Host "`nRunning benchmark with filter: $Filter" -ForegroundColor Green
+Write-Host "WarmupCount: $WarmupCount, IterationCount: $IterationCount" -ForegroundColor Cyan
+
+if ($Detailed) {
+    # Run with detailed memory diagnostics
+    Write-Host "Running with detailed diagnostics..." -ForegroundColor Yellow
+    dotnet run --project ClickHouse.Driver.Benchmark/ClickHouse.Driver.Benchmark.csproj `
+        --configuration Release `
+        --no-build `
+        -- --filter "$Filter" `
+        --warmupCount $WarmupCount `
+        --iterationCount $IterationCount `
+        --memory `
+        --disasm `
+        --profiler ETW
+} else {
+    # Standard run with memory diagnostics
+    dotnet run --project ClickHouse.Driver.Benchmark/ClickHouse.Driver.Benchmark.csproj `
+        --configuration Release `
+        --no-build `
+        -- --filter "$Filter" `
+        --warmupCount $WarmupCount `
+        --iterationCount $IterationCount `
+        --memory
+}
+
+Write-Host "`nBenchmark complete! Results are in BenchmarkDotNet.Artifacts folder" -ForegroundColor Green
+Write-Host "You can find detailed results in: BenchmarkDotNet.Artifacts\results\" -ForegroundColor Cyan

--- a/run-tests.ps1
+++ b/run-tests.ps1
@@ -1,0 +1,232 @@
+# ClickHouse .NET Driver Test Runner Script
+# This script configures the environment and runs tests against a Docker ClickHouse instance
+
+param(
+    [string]$Filter = "",
+    [string]$Framework = "",
+    [switch]$IntegrationTests = $false,
+    [switch]$Verbose = $false,
+    [switch]$SkipDockerSetup = $false
+)
+
+Write-Host "ClickHouse .NET Driver Test Runner" -ForegroundColor Cyan
+Write-Host "===================================" -ForegroundColor Cyan
+
+# Function to check if a command exists
+function Test-CommandExists {
+    param($Command)
+    try {
+        if (Get-Command $Command -ErrorAction Stop) {
+            return $true
+        }
+    } catch {
+        return $false
+    }
+}
+
+# Function to wait for ClickHouse to be ready
+function Wait-ForClickHouse {
+    param(
+        [string]$ContainerName = "clickhouse-test",
+        [int]$MaxAttempts = 30
+    )
+    
+    Write-Host "Waiting for ClickHouse to be ready..." -ForegroundColor Yellow
+    
+    for ($i = 1; $i -le $MaxAttempts; $i++) {
+        try {
+            # Try to execute a simple query
+            $result = docker exec $ContainerName clickhouse-client --query "SELECT 1" 2>&1
+            if ($result -eq "1") {
+                Write-Host "ClickHouse is ready!" -ForegroundColor Green
+                return $true
+            }
+        } catch {
+            # Ignore errors during startup
+        }
+        
+        Write-Host "Attempt $i/$MaxAttempts - ClickHouse not ready yet..." -ForegroundColor Gray
+        Start-Sleep -Seconds 1
+    }
+    
+    return $false
+}
+
+if (-not $SkipDockerSetup) {
+    # Check if Docker is installed
+    Write-Host "`nChecking Docker installation..." -ForegroundColor Yellow
+    if (-not (Test-CommandExists "docker")) {
+        Write-Host "Docker is not installed!" -ForegroundColor Red
+        Write-Host "`nDocker Desktop can be downloaded from: https://www.docker.com/products/docker-desktop" -ForegroundColor Yellow
+        Write-Host "After installing Docker, please restart this script." -ForegroundColor Yellow
+        exit 1
+    }
+
+    # Check if Docker is running
+    Write-Host "Checking if Docker is running..." -ForegroundColor Yellow
+    try {
+        docker version | Out-Null
+        Write-Host "Docker is installed and running." -ForegroundColor Green
+    } catch {
+        Write-Host "Docker is installed but not running!" -ForegroundColor Red
+        Write-Host "Please start Docker Desktop and try again." -ForegroundColor Yellow
+        exit 1
+    }
+
+    # Define expected container configuration
+    $expectedContainerName = "clickhouse-test"
+    $expectedUsername = "default"
+    $expectedPassword = "test123"
+    $expectedHttpPort = 8123
+    $expectedNativePort = 9000
+
+    # Check for any running ClickHouse container
+    Write-Host "`nChecking for ClickHouse containers..." -ForegroundColor Yellow
+    $runningContainers = docker ps --format "table {{.Names}}\t{{.Ports}}" | Select-Object -Skip 1 | Where-Object { $_ -match "clickhouse" }
+    
+    $needNewContainer = $true
+    
+    if ($runningContainers) {
+        Write-Host "Found running ClickHouse container(s):" -ForegroundColor Yellow
+        $runningContainers | ForEach-Object { Write-Host "  $_" -ForegroundColor Gray }
+        
+        # Check if our expected container is running with correct ports
+        $expectedContainer = docker ps --filter "name=$expectedContainerName" --format "json" | ConvertFrom-Json
+        if ($expectedContainer) {
+            $ports = docker port $expectedContainerName 2>$null
+            if ($ports -match "${expectedHttpPort}/tcp" -and $ports -match "${expectedNativePort}/tcp") {
+                Write-Host "Container '$expectedContainerName' is running with correct ports." -ForegroundColor Green
+                $needNewContainer = $false
+            } else {
+                Write-Host "Container '$expectedContainerName' exists but has incorrect port mappings." -ForegroundColor Yellow
+            }
+        }
+    }
+
+    if ($needNewContainer) {
+        Write-Host "`nSetting up ClickHouse container..." -ForegroundColor Yellow
+        
+        # Stop and remove existing test container if it exists
+        $existingContainer = docker ps -a --filter "name=$expectedContainerName" --format "json" | ConvertFrom-Json
+        if ($existingContainer) {
+            Write-Host "Removing existing container '$expectedContainerName'..." -ForegroundColor Yellow
+            docker stop $expectedContainerName 2>$null | Out-Null
+            docker rm $expectedContainerName 2>$null | Out-Null
+        }
+        
+        # Pull latest ClickHouse image
+        Write-Host "Pulling latest ClickHouse image..." -ForegroundColor Yellow
+        docker pull clickhouse/clickhouse-server:latest
+        
+        # Start new container with proper configuration
+        Write-Host "Starting new ClickHouse container..." -ForegroundColor Yellow
+        $containerId = docker run -d `
+            --name $expectedContainerName `
+            -p ${expectedHttpPort}:8123 `
+            -p ${expectedNativePort}:9000 `
+            -e CLICKHOUSE_DB=default `
+            -e CLICKHOUSE_USER=$expectedUsername `
+            -e CLICKHOUSE_PASSWORD=$expectedPassword `
+            clickhouse/clickhouse-server:latest
+        
+        if ($LASTEXITCODE -eq 0) {
+            Write-Host "Container started successfully (ID: $($containerId.Substring(0, 12)))" -ForegroundColor Green
+            
+            # Wait for ClickHouse to be ready
+            if (-not (Wait-ForClickHouse -ContainerName $expectedContainerName)) {
+                Write-Host "ClickHouse failed to start properly!" -ForegroundColor Red
+                Write-Host "`nContainer logs:" -ForegroundColor Yellow
+                docker logs $expectedContainerName --tail 50
+                exit 1
+            }
+        } else {
+            Write-Host "Failed to start ClickHouse container!" -ForegroundColor Red
+            exit 1
+        }
+    }
+    
+    # Verify connection
+    Write-Host "`nVerifying ClickHouse connection..." -ForegroundColor Yellow
+    try {
+        $testUrl = "http://localhost:${expectedHttpPort}/ping"
+        $response = Invoke-WebRequest -Uri $testUrl -Method Get -Headers @{
+            "X-ClickHouse-User" = $expectedUsername
+            "X-ClickHouse-Key" = $expectedPassword
+        } -UseBasicParsing -ErrorAction Stop
+        
+        if ($response.StatusCode -eq 200) {
+            Write-Host "Successfully connected to ClickHouse!" -ForegroundColor Green
+        }
+    } catch {
+        Write-Host "Warning: Could not verify HTTP connection. Tests may fail." -ForegroundColor Yellow
+        Write-Host "Error: $_" -ForegroundColor Gray
+    }
+}
+
+# Set environment variable for tests
+$env:CLICKHOUSE_CONNECTION = "Host=localhost;Port=8123;Username=default;Password=test123;Database=default"
+Write-Host "`nConnection string set: $env:CLICKHOUSE_CONNECTION" -ForegroundColor Green
+
+# Build the test command
+$testProject = if ($IntegrationTests) { 
+    "ClickHouse.Driver.IntegrationTests" 
+} else { 
+    "ClickHouse.Driver.Tests" 
+}
+
+$testCommand = "dotnet test $testProject/"
+
+# Add framework if specified
+if ($Framework) {
+    $testCommand += " --framework $Framework"
+}
+
+# Add filter if specified
+if ($Filter) {
+    $testCommand += " --filter `"$Filter`""
+}
+
+# Add verbosity
+if ($Verbose) {
+    $testCommand += " -v normal"
+} else {
+    $testCommand += " -v minimal"
+}
+
+# Display test configuration
+Write-Host "`nTest Configuration:" -ForegroundColor Cyan
+Write-Host "  Project: $testProject" -ForegroundColor White
+if ($Framework) { Write-Host "  Framework: $Framework" -ForegroundColor White }
+if ($Filter) { Write-Host "  Filter: $Filter" -ForegroundColor White }
+Write-Host "  Verbosity: $(if ($Verbose) { 'normal' } else { 'minimal' })" -ForegroundColor White
+
+Write-Host "`nRunning command: $testCommand" -ForegroundColor Yellow
+Write-Host "`nStarting tests..." -ForegroundColor Green
+Write-Host "=================" -ForegroundColor Green
+
+# Run the tests
+try {
+    Invoke-Expression $testCommand
+    $exitCode = $LASTEXITCODE
+} catch {
+    Write-Host "`nError running tests: $_" -ForegroundColor Red
+    exit 1
+}
+
+# Check test results
+if ($exitCode -eq 0) {
+    Write-Host "`nTests completed successfully!" -ForegroundColor Green
+} else {
+    Write-Host "`nTests failed with exit code: $exitCode" -ForegroundColor Red
+}
+
+# Offer to view container logs if tests failed
+if ($exitCode -ne 0) {
+    $viewLogs = Read-Host "`nWould you like to view ClickHouse container logs? (y/n)"
+    if ($viewLogs -eq 'y') {
+        Write-Host "`nLast 50 lines of ClickHouse logs:" -ForegroundColor Yellow
+        docker logs clickhouse-test --tail 50
+    }
+}
+
+exit $exitCode


### PR DESCRIPTION
Using the buffered stream approach in `ClickHouseDataReader` allocates 512KB for each usage, regardless of payload size.

This change switches to using pooled `RecyclableMemoryStream` instances, removing GC pressure for more frequent queries, with good characteristics for small to medium result sets, and comparable performance <50000 rows.

Benchmark results are below. 

@SpencerTorres 


```

BenchmarkDotNet v0.15.1, Windows 11 (10.0.26100.4770/24H2/2024Update/HudsonValley)
11th Gen Intel Core i7-11800H 2.30GHz, 1 CPU, 16 logical and 8 physical cores
.NET SDK 9.0.302
  [Host]     : .NET 9.0.7 (9.0.725.31616), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
  Job-VQDIOV : .NET 9.0.7 (9.0.725.31616), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI

IterationCount=5  WarmupCount=3  

```
| Method                                | rowCount | Mean         | Error        | StdDev     | Ratio | RatioSD | Gen0      | Gen1      | Gen2      | Allocated   | Alloc Ratio |
|-------------------------------------- |--------- |-------------:|-------------:|-----------:|------:|--------:|----------:|----------:|----------:|------------:|------------:|
| **MultipleSmallQueries_BufferedStream**   | **?**        |  **8,363.45 μs** |   **626.341 μs** |  **96.927 μs** |  **1.00** |    **0.01** | **8265.6250** | **7984.3750** | **7984.3750** | **54723.52 KB** |        **1.00** |
| MultipleSmallQueries_RecyclableStream | ?        |  4,498.88 μs |   205.551 μs |  31.809 μs |  0.54 |    0.01 |  281.2500 |         - |         - |  3518.76 KB |        0.06 |
|                                       |          |              |              |            |       |         |           |           |           |             |             |
| **ReadAllData_BufferedStream**            | **100**      |     **92.50 μs** |    **12.453 μs** |   **3.234 μs** |  **1.00** |    **0.04** |   **88.2568** |   **85.3271** |   **85.3271** |   **547.24 KB** |        **1.00** |
| ReadAllData_RecyclableMemoryStream    | 100      |     50.53 μs |     5.207 μs |   1.352 μs |  0.55 |    0.02 |    2.8687 |         - |         - |    35.19 KB |        0.06 |
|                                       |          |              |              |            |       |         |           |           |           |             |             |
| **ReadAllData_BufferedStream**            | **5000**     |  **2,601.00 μs** |   **174.953 μs** |  **27.074 μs** |  **1.00** |    **0.01** |  **218.7500** |   **97.6563** |   **97.6563** |  **2040.19 KB** |        **1.00** |
| ReadAllData_RecyclableMemoryStream    | 5000     |  2,703.11 μs |   782.847 μs | 203.303 μs |  1.04 |    0.07 |  121.0938 |         - |         - |  1528.31 KB |        0.75 |
|                                       |          |              |              |            |       |         |           |           |           |             |             |
| **ReadAllData_BufferedStream**            | **50000**    | **24,327.43 μs** |   **831.624 μs** | **128.695 μs** |  **1.00** |    **0.01** | **1250.0000** |   **31.2500** |   **31.2500** | **15751.07 KB** |        **1.00** |
| ReadAllData_RecyclableMemoryStream    | 50000    | 24,226.19 μs | 3,581.985 μs | 930.230 μs |  1.00 |    0.04 | 1218.7500 |         - |         - |  15240.4 KB |        0.97 |
