### PR TITLE
Connection | support skipping server cert validation

### DIFF
--- a/ClickHouse.Driver/ADO/ClickHouseConnection.cs
+++ b/ClickHouse.Driver/ADO/ClickHouseConnection.cs
@@ -53,8 +53,9 @@ public class ClickHouseConnection : DbConnection, IClickHouseConnection, IClonea
     {
     }
 
-    public ClickHouseConnection(string connectionString)
+    public ClickHouseConnection(string connectionString, bool skipServerCertificateValidation = false)
     {
+        SkipServerCertificateValidation = skipServerCertificateValidation;
         ConnectionString = connectionString;
     }
 
@@ -152,10 +153,11 @@ public class ClickHouseConnection : DbConnection, IClickHouseConnection, IClonea
 
     public bool UseCompression { get; private set; }
 
+    public bool SkipServerCertificateValidation { get; private set; }
+
     public bool UseFormDataParameters { get; private set; }
 
-    public void SetFormDataParameters(
-        bool sendParametersAsFormData)
+    public void SetFormDataParameters(bool sendParametersAsFormData)
     {
         this.UseFormDataParameters = sendParametersAsFormData;
     }
@@ -194,7 +196,7 @@ public class ClickHouseConnection : DbConnection, IClickHouseConnection, IClonea
         // If sessions are enabled, always use single connection
         else if (!string.IsNullOrEmpty(session))
         {
-            var factory = new SingleConnectionHttpClientFactory() { Timeout = timeout };
+            var factory = new SingleConnectionHttpClientFactory(SkipServerCertificateValidation) { Timeout = timeout };
             disposables.Add(factory);
             httpClientFactory = factory;
         }
@@ -202,7 +204,7 @@ public class ClickHouseConnection : DbConnection, IClickHouseConnection, IClonea
         // Default case - use default connection pool
         else
         {
-            httpClientFactory = new DefaultPoolHttpClientFactory() { Timeout = timeout };
+            httpClientFactory = new DefaultPoolHttpClientFactory(SkipServerCertificateValidation) { Timeout = timeout };
         }
     }
 

--- a/ClickHouse.Driver/Http/DefaultHttpClientHandler.cs
+++ b/ClickHouse.Driver/Http/DefaultHttpClientHandler.cs
@@ -1,0 +1,17 @@
+using System.Net;
+using System.Net.Http;
+
+namespace ClickHouse.Driver.Http;
+
+internal class DefaultHttpClientHandler : HttpClientHandler
+{
+    public DefaultHttpClientHandler(bool skipServerCertificateValidation)
+    {
+        AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;
+
+        if (skipServerCertificateValidation)
+        {
+            ServerCertificateCustomValidationCallback = (_, _, _, _) => true;
+        }
+    }
+}

--- a/ClickHouse.Driver/Http/DefaultPoolHttpClientFactory.cs
+++ b/ClickHouse.Driver/Http/DefaultPoolHttpClientFactory.cs
@@ -1,14 +1,20 @@
 ﻿using System;
-using System.Net;
 using System.Net.Http;
 
 namespace ClickHouse.Driver.Http;
 
-internal class DefaultPoolHttpClientFactory : IHttpClientFactory
+internal class DefaultPoolHttpClientFactory : IHttpClientFactory, IDisposable
 {
-    private static readonly HttpClientHandler DefaultHttpClientHandler = new() { AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate };
+    private readonly DefaultHttpClientHandler handler;
 
     public TimeSpan Timeout { get; init; }
 
-    public HttpClient CreateClient(string name) => new(DefaultHttpClientHandler, false) { Timeout = Timeout };
+    public DefaultPoolHttpClientFactory(bool skipServerCertificateValidation)
+    {
+        handler = new(skipServerCertificateValidation);
+    }
+
+    public HttpClient CreateClient(string name) => new(handler, false) { Timeout = Timeout };
+
+    public void Dispose() => handler.Dispose();
 }

--- a/ClickHouse.Driver/Http/SingleConnectionHttpClientFactory.cs
+++ b/ClickHouse.Driver/Http/SingleConnectionHttpClientFactory.cs
@@ -1,28 +1,20 @@
 ﻿using System;
-using System.Net;
 using System.Net.Http;
 
 namespace ClickHouse.Driver.Http;
 
 internal class SingleConnectionHttpClientFactory : IHttpClientFactory, IDisposable
 {
-    private readonly HttpClientHandler handler;
+    private readonly DefaultHttpClientHandler handler;
 
     public TimeSpan Timeout { get; init; }
 
-    public SingleConnectionHttpClientFactory()
+    public SingleConnectionHttpClientFactory(bool skipServerCertificateValidation)
     {
-        handler = new HttpClientHandler()
-        {
-            AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
-            MaxConnectionsPerServer = 1,
-        };
+        handler = new(skipServerCertificateValidation) { MaxConnectionsPerServer = 1 };
     }
 
-    public HttpClient CreateClient(string name) => new(handler, false)
-    {
-        Timeout = Timeout,
-    };
+    public HttpClient CreateClient(string name) => new(handler, false) { Timeout = Timeout };
 
     public void Dispose() => handler.Dispose();
 }


### PR DESCRIPTION
## Description

This PR introduces support for an `SkipServerCertificateValidation` flag in the ClickHouse driver, enabling users to connect to ClickHouse over TLS/SSL without enforcing certificate or hostname validation.

## Motivation

While strong TLS validation is essential in production environments, there are legitimate use cases where disabling strict TLS checks is necessary, such as:

- Development and testing environments using:
  - Self-signed certificates
  - Certificates with mismatched hostnames (e.g., `localhost`)
- CI/CD pipelines and ephemeral environments where setting up full TLS trust chains is impractical

Many other drivers (e.g., MongoDB, PostgreSQL, MySQL) support similar flags (`allowInsecureTls`, `sslmode=allow`, etc.), offering a flexible developer experience while leaving secure defaults intact.

## Security Considerations

- The flag is disabled by default, preserving current secure behavior.
