### PR TITLE
Fix sync-over-async in data reader

### DIFF
--- a/ClickHouse.Driver/ADO/ClickHouseCommand.cs
+++ b/ClickHouse.Driver/ADO/ClickHouseCommand.cs
@@ -152,7 +152,7 @@ public class ClickHouseCommand : DbCommand, IClickHouseCommand, IDisposable
                 break;
         }
         var result = await PostSqlQueryAsync(sqlBuilder.ToString(), lcts.Token).ConfigureAwait(false);
-        return ClickHouseDataReader.FromHttpResponse(result, connection.TypeSettings);
+        return await ClickHouseDataReader.FromHttpResponseAsync(result, connection.TypeSettings).ConfigureAwait(false);
     }
 
     private async Task<HttpResponseMessage> PostSqlQueryAsync(string sqlQuery, CancellationToken token)

--- a/ClickHouse.Driver/ADO/Readers/ClickHouseDataReader.cs
+++ b/ClickHouse.Driver/ADO/Readers/ClickHouseDataReader.cs
@@ -36,13 +36,13 @@ public class ClickHouseDataReader : DbDataReader, IEnumerator<IDataReader>, IEnu
         CurrentRow = new object[FieldNames.Length];
     }
 
-    internal static ClickHouseDataReader FromHttpResponse(HttpResponseMessage httpResponse, TypeSettings settings)
+    internal static async Task<ClickHouseDataReader> FromHttpResponseAsync(HttpResponseMessage httpResponse, TypeSettings settings)
     {
         if (httpResponse is null) throw new ArgumentNullException(nameof(httpResponse));
         ExtendedBinaryReader reader = null;
         try
         {
-            var stream = new BufferedStream(httpResponse.Content.ReadAsStreamAsync().GetAwaiter().GetResult(), BufferSize);
+            var stream = new BufferedStream(await httpResponse.Content.ReadAsStreamAsync().ConfigureAwait(false), BufferSize);
             reader = new ExtendedBinaryReader(stream); // will dispose of stream
             var (names, types) = ReadHeaders(reader, settings);
             return new ClickHouseDataReader(httpResponse, reader, names, types);


### PR DESCRIPTION
That could lead to critical thread starvation. Though, in that particular case, I'm not sure what I/O operation `ReadAsStreamAsync` do. Since `HttpCompletionOption.ResponseHeadersRead` is used I would expect this method to just synchronously return a stream. But let's not make any assumption and use the method correctly.