### PR TITLE
Avoid dependencies on built-in libraries

### DIFF
--- a/ClickHouse.Driver/ClickHouse.Driver.csproj
+++ b/ClickHouse.Driver/ClickHouse.Driver.csproj
@@ -47,9 +47,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition="$(TargetFramework.StartsWith('net4')) Or $(TargetFramework) == 'netstandard2.1' Or $(TargetFramework) == 'net6.0'">
     <PackageReference Include="System.Text.Json" Version="10.0.1" />
   </ItemGroup>
 


### PR DESCRIPTION
That can avoid potential dependency conflicts.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the explicit `System.Net.Http` package reference to rely on the framework-provided implementation, reducing potential dependency conflicts.
> 
> - Remove `PackageReference` to `System.Net.Http` from `ClickHouse.Driver.csproj`
> - Minor csproj cleanup: normalize `ItemGroup` condition formatting
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 28433890ef767f6f3cd34f551eb7cbc75663cfd2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->