### PR TITLE
Add list type conversion to clickhouse array

### DIFF
--- a/ClickHouse.Driver.Tests/Types/TypeMappingTests.cs
+++ b/ClickHouse.Driver.Tests/Types/TypeMappingTests.cs
@@ -79,6 +79,7 @@ public class TypeMappingTests
     [TestCase(typeof(uint?), ExpectedResult = "Nullable(UInt32)")]
     [TestCase(typeof(uint?[]), ExpectedResult = "Array(Nullable(UInt32))")]
     [TestCase(typeof(string[][]), ExpectedResult = "Array(Array(String))")]
+    [TestCase(typeof(List<string>), ExpectedResult = "Array(String)")]
 #if NET6_0_OR_GREATER
     [TestCase(typeof(DateOnly), ExpectedResult = "Date")]
 #endif

--- a/ClickHouse.Driver/Types/TypeConverter.cs
+++ b/ClickHouse.Driver/Types/TypeConverter.cs
@@ -267,6 +267,11 @@ internal static class TypeConverter
             return new ArrayType() { UnderlyingType = ToClickHouseType(type.GetElementType()) };
         }
 
+        if (type.IsGenericType && type.GetGenericTypeDefinition().FullName.StartsWith("System.Collections.Generic.List", StringComparison.InvariantCulture))
+        {
+            return new ArrayType() { UnderlyingType = ToClickHouseType(type.GetGenericArguments()[0]) };
+        }
+
         var underlyingType = Nullable.GetUnderlyingType(type);
         if (underlyingType != null)
         {


### PR DESCRIPTION
Array types are already supported in this driver. This PR adds the ability to convert Lists as well.