### PR TITLE
Add Initial Support for Interval Types (Starting With IntervalNanosecond)

### DIFF
--- a/ClickHouse.Driver.Tests/ADO/DataReaderTests.cs
+++ b/ClickHouse.Driver.Tests/ADO/DataReaderTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Data;
+﻿using System;
+using System.Data;
 using System.Linq;
 using System.Threading.Tasks;
 using ClickHouse.Driver.ADO.Readers;
@@ -198,6 +199,15 @@ public class DataReaderTests : AbstractConnectionTestFixture
         using var reader = await connection.ExecuteReaderAsync("SELECT * FROM system.numbers LIMIT 100");
         var rows = reader.Cast<IDataRecord>().Select(row => row[0]).ToList();
         Assert.That(rows, Is.EqualTo(Enumerable.Range(0, 100)).AsCollection);
+        ClassicAssert.IsFalse(reader.Read());
+    }
+
+    [Test]
+    public async Task ShouldReadTimeSpanWhenIntervalNanosecond()
+    {
+        using var reader = (ClickHouseDataReader)await connection.ExecuteReaderAsync("SELECT toIntervalNanosecond(100) as value");
+        ClassicAssert.IsTrue(reader.Read());
+        Assert.That(reader.GetTimeSpan(0), Is.EqualTo(TimeSpan.FromTicks(1)));
         ClassicAssert.IsFalse(reader.Read());
     }
 }

--- a/ClickHouse.Driver.Tests/ORM/DapperTests.cs
+++ b/ClickHouse.Driver.Tests/ORM/DapperTests.cs
@@ -46,6 +46,8 @@ public class DapperTests : AbstractConnectionTestFixture
             return false;
         if (clickHouseType.Contains("Nested"))
             return false;
+        if (clickHouseType.StartsWith("Interval")) // TimeSpan does not implement IConvertible
+            return false;
         switch (clickHouseType)
         {
             case "UUID":
@@ -253,13 +255,13 @@ public class DapperTests : AbstractConnectionTestFixture
         // Verify the insert worked and defaults were applied
         var result = await connection.QueryAsync("SELECT * FROM test.dapper_except");
         var row = result.Single() as IDictionary<string, object>;
-        
+
         Assert.That(row, Is.Not.Null);
         Assert.That(row.Count, Is.EqualTo(5)); // All 5 columns should be present
         Assert.That(row["id"], Is.EqualTo(100));
         Assert.That(row["name"], Is.EqualTo("dapper-test"));
         Assert.That(row["value"], Is.EqualTo(123.45));
-        
+
         // Verify default timestamps were set
         var created = (DateTime)row["created"];
         var updated = (DateTime)row["updated"];

--- a/ClickHouse.Driver.Tests/SQL/SqlSimpleSelectTests.cs
+++ b/ClickHouse.Driver.Tests/SQL/SqlSimpleSelectTests.cs
@@ -116,6 +116,7 @@ public class SqlSimpleSelectTests : IDisposable
             .Where(dt => dt.Contains("Int") || dt.Contains("Float"))
             .Where(dt => !dt.Contains("128") || TestUtilities.SupportedFeatures.HasFlag(Feature.WideTypes))
             .Where(dt => !dt.Contains("256") || TestUtilities.SupportedFeatures.HasFlag(Feature.WideTypes))
+            .Where(dt => !dt.StartsWith("Interval"))
             .Select(dt => $"to{dt}(55)")
             .ToArray();
 
@@ -244,7 +245,7 @@ public class SqlSimpleSelectTests : IDisposable
     [TestCaseSource(typeof(SqlSimpleSelectTests), nameof(SimpleSelectTypes))]
     public async Task ShouldExecuteRandomDataSelectQuery(string type)
     {
-        if (type.StartsWith("Nested") || type == "Nothing" || type.StartsWith("Variant") || type.StartsWith("Json"))
+        if (type.StartsWith("Nested") || type == "Nothing" || type.StartsWith("Variant") || type.StartsWith("Json") || type.StartsWith("Interval"))
             Assert.Ignore($"Type {type} not supported by generateRandom");
 
         using var reader = await connection.ExecuteReaderAsync($"SELECT * FROM generateRandom('value {type.Replace("'", "\\'")}', 10, 10, 10) LIMIT 100");

--- a/ClickHouse.Driver.Tests/Types/TypeMappingTests.cs
+++ b/ClickHouse.Driver.Tests/Types/TypeMappingTests.cs
@@ -47,6 +47,8 @@ public class TypeMappingTests
     [TestCase("DateTime64(3)", ExpectedResult = typeof(DateTime))]
     [TestCase("DateTime64(3, 'Etc/UTC')", ExpectedResult = typeof(DateTime))]
 
+    [TestCase("IntervalNanosecond", ExpectedResult = typeof(TimeSpan))]
+
     [TestCase("Map(String, Int32)", ExpectedResult = typeof(Dictionary<string, int>))]
     [TestCase("Map(Tuple(Int32, Int32), Int32)", ExpectedResult = typeof(Dictionary<Tuple<int,int>, int>))]
     
@@ -76,6 +78,9 @@ public class TypeMappingTests
     [TestCase(typeof(string), ExpectedResult = "String")]
 
     [TestCase(typeof(DateTime), ExpectedResult = "DateTime")]
+
+    // TODO: What if we map all intervals to TimeSpan?
+    [TestCase(typeof(TimeSpan), ExpectedResult = "IntervalNanosecond")]
 
     [TestCase(typeof(IPAddress), ExpectedResult = "IPv4")]
     [TestCase(typeof(Guid), ExpectedResult = "UUID")]

--- a/ClickHouse.Driver.Tests/Utilities/TestUtilities.cs
+++ b/ClickHouse.Driver.Tests/Utilities/TestUtilities.cs
@@ -195,6 +195,8 @@ public static class TestUtilities
         yield return new DataTypeSample("DateTime64(7, 'UTC')", typeof(DateTime), "toDateTime64('2043-03-01 18:34:04.4444444', 9, 'UTC')", new DateTime(644444444444444444, DateTimeKind.Utc));
         yield return new DataTypeSample("DateTime64(7, 'Pacific/Fiji')", typeof(DateTime), "toDateTime64('2043-03-01 18:34:04.4444444', 9, 'Pacific/Fiji')", new DateTime(644444444444444444, DateTimeKind.Unspecified));
 
+        yield return new DataTypeSample("IntervalNanosecond", typeof(TimeSpan), "toIntervalNanosecond(123456700)", TimeSpan.FromTicks(1234567));
+
         yield return new DataTypeSample("Decimal32(3)", typeof(ClickHouseDecimal), "toDecimal32(123.45, 3)", new ClickHouseDecimal(123.450m));
         yield return new DataTypeSample("Decimal32(3)", typeof(ClickHouseDecimal), "toDecimal32(-123.45, 3)", new ClickHouseDecimal(-123.450m));
 

--- a/ClickHouse.Driver/ADO/Readers/ClickHouseDataReader.cs
+++ b/ClickHouse.Driver/ADO/Readers/ClickHouseDataReader.cs
@@ -191,6 +191,9 @@ public class ClickHouseDataReader : DbDataReader, IEnumerator<IDataReader>, IEnu
     // Custom extension
     public BigInteger GetBigInteger(int ordinal) => (BigInteger)GetValue(ordinal);
 
+    // Custom extension
+    public virtual TimeSpan GetTimeSpan(int ordinal) => (TimeSpan)GetValue(ordinal);
+
     public override bool Read()
     {
         if (reader.PeekChar() == -1)

--- a/ClickHouse.Driver/Formats/HttpParameterFormatter.cs
+++ b/ClickHouse.Driver/Formats/HttpParameterFormatter.cs
@@ -48,6 +48,9 @@ internal static class HttpParameterFormatter
             case DateType dt:
                 return Convert.ToDateTime(value, CultureInfo.InvariantCulture).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
 
+            case IntervalNanosecondType dt:
+                return (((TimeSpan)value).Ticks * IntervalNanosecondType.NanosecondsPerTick).ToString(CultureInfo.InvariantCulture);
+
             case StringType st:
             case FixedStringType tt:
             case Enum8Type e8t:

--- a/ClickHouse.Driver/Types/IntervalNanosecondType.cs
+++ b/ClickHouse.Driver/Types/IntervalNanosecondType.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using ClickHouse.Driver.Formats;
+
+namespace ClickHouse.Driver.Types;
+
+internal class IntervalNanosecondType : IntervalType
+{
+#if NET7_0_OR_GREATER
+    public const long NanosecondsPerTick = TimeSpan.NanosecondsPerTick;
+#else
+    public const long NanosecondsPerTick = 100;
+#endif
+
+    public override Type FrameworkType => typeof(TimeSpan);
+
+    // Anything less than 100 nanoseconds will be truncated to 0 as TimeSpan's smallest unit is 1 tick (100 nanoseconds)
+    public override object Read(ExtendedBinaryReader reader) => TimeSpan.FromTicks(reader.ReadInt64() / NanosecondsPerTick);
+
+    public override string ToString() => "IntervalNanosecond";
+
+    public override void Write(ExtendedBinaryWriter writer, object value) => writer.Write(((TimeSpan)value).Ticks * NanosecondsPerTick);
+}

--- a/ClickHouse.Driver/Types/IntervalType.cs
+++ b/ClickHouse.Driver/Types/IntervalType.cs
@@ -1,0 +1,6 @@
+﻿namespace ClickHouse.Driver.Types;
+
+internal abstract class IntervalType : ClickHouseType
+{
+    public virtual bool Signed => true;
+}

--- a/ClickHouse.Driver/Types/TypeConverter.cs
+++ b/ClickHouse.Driver/Types/TypeConverter.cs
@@ -143,6 +143,9 @@ internal static class TypeConverter
         RegisterParameterizedType<DateTime32Type>();
         RegisterParameterizedType<DateTime64Type>();
 
+        // Interval types
+        RegisterPlainType<IntervalNanosecondType>();
+
         // Special 'nothing' type
         RegisterPlainType<NothingType>();
 


### PR DESCRIPTION
## Summary

This PR introduces initial support for ClickHouse Interval types, beginning with IntervalNanosecond.
Before implementing the full family of interval types, I’d like to get early feedback to ensure that the approach, structure, and overall direction align with the project’s standards.

### What’s Included

- Parsing and serialization support for IntervalNanosecond.
- Initial unit tests covering the new type.

Let me know about the approach, code quality, test coverage, and anything else that should be included before extending support to all interval types — and after the full implementation I will follow the version-update instructions accordingly

## Checklist

- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG