### PR TITLE
ClickHouseConnection |  passing query-id to postStream

### DIFF
--- a/ClickHouse.Driver/ADO/ClickHouseCommand.cs
+++ b/ClickHouse.Driver/ADO/ClickHouseCommand.cs
@@ -181,7 +181,7 @@ public class ClickHouseCommand : DbCommand, IClickHouseCommand, IDisposable
             .SendAsync(postMessage, HttpCompletionOption.ResponseHeadersRead, token)
             .ConfigureAwait(false);
 
-        QueryId = ExtractQueryId(response);
+        QueryId = ClickHouseConnection.ExtractQueryId(response);
         QueryStats = ExtractQueryStats(response);
         activity.SetQueryStats(QueryStats);
         return await ClickHouseConnection.HandleError(response, sqlQuery, activity).ConfigureAwait(false);
@@ -268,14 +268,5 @@ public class ClickHouseCommand : DbCommand, IClickHouseCommand, IDisposable
         {
         }
         return null;
-    }
-
-    private static string ExtractQueryId(HttpResponseMessage response)
-    {
-        const string queryIdHeader = "X-ClickHouse-Query-Id";
-        if (response.Headers.Contains(queryIdHeader))
-            return response.Headers.GetValues(queryIdHeader).FirstOrDefault();
-        else
-            return null;
     }
 }

--- a/ClickHouse.Driver/ADO/ClickHouseConnection.cs
+++ b/ClickHouse.Driver/ADO/ClickHouseConnection.cs
@@ -262,6 +262,7 @@ public class ClickHouseConnection : DbConnection, IClickHouseConnection, IClonea
             activity.SetSuccess();
             return response;
         }
+
         var error = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
         var ex = ClickHouseServerException.FromServerResponse(error, query);
         activity.SetException(ex);
@@ -434,6 +435,15 @@ public class ClickHouseConnection : DbConnection, IClickHouseConnection, IClonea
             headers.AcceptEncoding.Add(new StringWithQualityHeaderValue("gzip"));
             headers.AcceptEncoding.Add(new StringWithQualityHeaderValue("deflate"));
         }
+    }
+
+    internal static string ExtractQueryId(HttpResponseMessage response)
+    {
+        const string queryIdHeader = "X-ClickHouse-Query-Id";
+        if (response.Headers.Contains(queryIdHeader))
+            return response.Headers.GetValues(queryIdHeader).FirstOrDefault();
+        else
+            return null;
     }
 
     internal ClickHouseConnectionStringBuilder ConnectionStringBuilder => ClickHouseConnectionStringBuilder.FromSettings(Settings);


### PR DESCRIPTION
## Summary
Allow passing query-id to the connection's postStream function, same as possible with all command-based operations..

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG