### PR TITLE
Rework FixedString to return byte[] instead of string

### DIFF
--- a/ClickHouse.Driver.Tests/BulkCopy/BulkCopyTests.cs
+++ b/ClickHouse.Driver.Tests/BulkCopy/BulkCopyTests.cs
@@ -23,12 +23,14 @@ public class BulkCopyTests : AbstractConnectionTestFixture
     {
         foreach (var sample in TestUtilities.GetDataTypeSamples())
         {
-            if (new[] { "Enum8", "Nothing", "Tuple(Int32, Tuple(UInt8, String, Nullable(Int32)))" }.Contains(sample.ClickHouseType))
+            if (new[] { "Enum8", "Nothing" }.Contains(sample.ClickHouseType))
                 continue;
             yield return new TestCaseData(sample.ClickHouseType, sample.ExampleValue);
         }
         yield return new TestCaseData("String", "1\t2\n3");
         yield return new TestCaseData("DateTime('Asia/Ashkhabad')", new DateTime(2020, 2, 20, 20, 20, 20, DateTimeKind.Unspecified));
+        yield return new TestCaseData("FixedString(4)", "asdf");
+        yield return new TestCaseData("FixedString(4)", new byte[] { 121, 122, 123, 124 }); // Test both formats for FixedString
     }
 
     [Test]

--- a/ClickHouse.Driver.Tests/ORM/DapperTests.cs
+++ b/ClickHouse.Driver.Tests/ORM/DapperTests.cs
@@ -48,6 +48,8 @@ public class DapperTests : AbstractConnectionTestFixture
             return false;
         if (clickHouseType.Contains("Nested"))
             return false;
+        if (clickHouseType.Contains("FixedString"))
+            return false;
         switch (clickHouseType)
         {
             case "UUID":

--- a/ClickHouse.Driver.Tests/SQL/SqlParameterizedSelectTests.cs
+++ b/ClickHouse.Driver.Tests/SQL/SqlParameterizedSelectTests.cs
@@ -33,7 +33,7 @@ public class SqlParameterizedSelectTests : IDisposable
     [TestCaseSource(typeof(SqlParameterizedSelectTests), nameof(TypedQueryParameters))]
     public async Task ShouldExecuteParameterizedCompareWithTypeDetection(string exampleExpression, string clickHouseType, object value)
     {
-        if (clickHouseType.StartsWith("DateTime64") || clickHouseType == "Date" || clickHouseType == "Date32" || clickHouseType == "Time")
+        if (clickHouseType.StartsWith("DateTime64") || clickHouseType == "Date" || clickHouseType == "Date32" || clickHouseType == "Time" || clickHouseType.Contains("FixedString"))
             Assert.Pass("Automatic type detection does not work for " + clickHouseType);
         if (clickHouseType.StartsWith("Enum"))
             clickHouseType = "String";
@@ -58,6 +58,8 @@ public class SqlParameterizedSelectTests : IDisposable
 
     [Test]
     [TestCaseSource(typeof(SqlParameterizedSelectTests), nameof(TypedQueryParameters))]
+    [TestCase(null, "FixedString(4)", "asdf", TestName = "Parametrized select with string for FixedString")]
+    [TestCase(null, "FixedString(4)", new byte[] { 91, 92, 93, 94}, TestName = "Parametrized select with byte array for FixedString")]
     public async Task ShouldExecuteParameterizedSelectWithExplicitType(string _, string clickHouseType, object value)
     {
         if (clickHouseType.StartsWith("Enum"))

--- a/ClickHouse.Driver.Tests/SQL/SqlParameterizedSelectWithFormDataTests.cs
+++ b/ClickHouse.Driver.Tests/SQL/SqlParameterizedSelectWithFormDataTests.cs
@@ -33,7 +33,7 @@ public class SqlParameterizedSelectWithFormDataTests
     [TestCaseSource(typeof(SqlParameterizedSelectTests), nameof(TypedQueryParameters))]
     public async Task ShouldExecuteParameterizedCompareWithTypeDetection(string exampleExpression, string clickHouseType, object value)
     {
-        if (clickHouseType.StartsWith("DateTime64") || clickHouseType == "Date" || clickHouseType == "Date32" || clickHouseType == "Time")
+        if (clickHouseType.StartsWith("DateTime64") || clickHouseType == "Date" || clickHouseType == "Date32" || clickHouseType == "Time" || clickHouseType.Contains("FixedString"))
             Assert.Pass("Automatic type detection does not work for " + clickHouseType);
         if (clickHouseType.StartsWith("Enum"))
             clickHouseType = "String";

--- a/ClickHouse.Driver.Tests/Types/FixedStringTypeTests.cs
+++ b/ClickHouse.Driver.Tests/Types/FixedStringTypeTests.cs
@@ -1,0 +1,88 @@
+using System;
+using System.IO;
+using ClickHouse.Driver.Formats;
+using ClickHouse.Driver.Types;
+using NUnit.Framework;
+
+namespace ClickHouse.Driver.Tests.Types;
+
+public class FixedStringTypeTests
+{
+    [Test]
+    public void Write_WithMatchingByteArrayLength_Succeeds()
+    {
+        var type = new FixedStringType { Length = 4 };
+        using var stream = new MemoryStream();
+        using var writer = new ExtendedBinaryWriter(stream);
+
+        var bytes = new byte[] { 1, 2, 3, 4 };
+        Assert.DoesNotThrow(() => type.Write(writer, bytes));
+
+        Assert.That(stream.ToArray(), Is.EqualTo(bytes));
+    }
+
+    [Test]
+    public void Write_WithShorterByteArray_ThrowsArgumentException()
+    {
+        var type = new FixedStringType { Length = 4 };
+        using var stream = new MemoryStream();
+        using var writer = new ExtendedBinaryWriter(stream);
+
+        var bytes = new byte[] { 1, 2 };
+        var ex = Assert.Throws<ArgumentException>(() => type.Write(writer, bytes));
+
+        Assert.That(ex.Message, Does.Contain("length 2"));
+        Assert.That(ex.Message, Does.Contain("FixedString(4)"));
+    }
+
+    [Test]
+    public void Write_WithLongerByteArray_ThrowsArgumentException()
+    {
+        var type = new FixedStringType { Length = 4 };
+        using var stream = new MemoryStream();
+        using var writer = new ExtendedBinaryWriter(stream);
+
+        var bytes = new byte[] { 1, 2, 3, 4, 5, 6 };
+        var ex = Assert.Throws<ArgumentException>(() => type.Write(writer, bytes));
+
+        Assert.That(ex.Message, Does.Contain("length 6"));
+        Assert.That(ex.Message, Does.Contain("FixedString(4)"));
+    }
+
+    [Test]
+    public void Write_WithNull_ThrowsArgumentException()
+    {
+        var type = new FixedStringType { Length = 4 };
+        using var stream = new MemoryStream();
+        using var writer = new ExtendedBinaryWriter(stream);
+
+        var ex = Assert.Throws<ArgumentException>(() => type.Write(writer, null));
+
+        Assert.That(ex.Message, Does.Contain("null"));
+    }
+
+    [Test]
+    public void Write_WithUnsupportedType_ThrowsArgumentException()
+    {
+        var type = new FixedStringType { Length = 4 };
+        using var stream = new MemoryStream();
+        using var writer = new ExtendedBinaryWriter(stream);
+
+        var ex = Assert.Throws<ArgumentException>(() => type.Write(writer, 12345));
+
+        Assert.That(ex.Message, Does.Contain("Int32"));
+    }
+
+    [Test]
+    public void Write_WithString_PadsWithNullBytes()
+    {
+        var type = new FixedStringType { Length = 6 };
+        using var stream = new MemoryStream();
+        using var writer = new ExtendedBinaryWriter(stream);
+
+        type.Write(writer, "test");
+
+        var result = stream.ToArray();
+        Assert.That(result, Is.EqualTo(new byte[] { (byte)'t', (byte)'e', (byte)'s', (byte)'t', 0, 0 }));
+    }
+}

--- a/ClickHouse.Driver.Tests/Types/JsonTypeTests.cs
+++ b/ClickHouse.Driver.Tests/Types/JsonTypeTests.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Numerics;
+using System.Text;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using ClickHouse.Driver.ADO;
@@ -202,7 +203,7 @@ public class JsonTypeTests : AbstractConnectionTestFixture
             "code FixedString(10)",
             "{\"code\": \"ABC1234567\"}",
             "code",
-            "ABC1234567"
+            Encoding.UTF8.GetBytes("ABC1234567")
         ).SetName("FixedString(10)");
     }
     

--- a/ClickHouse.Driver.Tests/Types/TypeMappingTests.cs
+++ b/ClickHouse.Driver.Tests/Types/TypeMappingTests.cs
@@ -32,7 +32,7 @@ public class TypeMappingTests
     [TestCase("Decimal128(3)", ExpectedResult = typeof(ClickHouseDecimal))]
 
     [TestCase("String", ExpectedResult = typeof(string))]
-    [TestCase("FixedString(5)", ExpectedResult = typeof(string))]
+    [TestCase("FixedString(5)", ExpectedResult = typeof(byte[]))]
 
     [TestCase("UUID", ExpectedResult = typeof(Guid))]
 

--- a/ClickHouse.Driver.Tests/Utilities/TestUtilities.cs
+++ b/ClickHouse.Driver.Tests/Utilities/TestUtilities.cs
@@ -4,6 +4,7 @@ using System.Data.Common;
 using System.Linq;
 using System.Net;
 using System.Numerics;
+using System.Text;
 using System.Threading.Tasks;
 using ClickHouse.Driver.ADO;
 using ClickHouse.Driver.Numerics;
@@ -272,8 +273,8 @@ public static class TestUtilities
         yield return new DataTypeSample("String", typeof(string), "'お茶'", "お茶");
 
         // yield return new DataTypeSample("String", typeof(string), "'1\t2\n3'", "1\t2\n3");
-        yield return new DataTypeSample("FixedString(3)", typeof(string), "toFixedString('ASD',3)", "ASD");
-        yield return new DataTypeSample("FixedString(5)", typeof(string), "toFixedString('ASD',5)", "ASD\0\0");
+        yield return new DataTypeSample("FixedString(3)", typeof(byte[]), "toFixedString('ASD',3)", Encoding.UTF8.GetBytes("ASD"));
+        yield return new DataTypeSample("FixedString(5)", typeof(byte[]), "toFixedString('ASD',5)", Encoding.UTF8.GetBytes("ASD\0\0"));
 
         yield return new DataTypeSample("UUID", typeof(Guid), "toUUID('00000000-0000-0000-0000-000000000000')", new Guid("00000000-0000-0000-0000-000000000000"));
         yield return new DataTypeSample("UUID", typeof(Guid), "toUUID('61f0c404-5cb3-11e7-907b-a6006ad3dba0')", new Guid("61f0c404-5cb3-11e7-907b-a6006ad3dba0"));
@@ -488,7 +489,7 @@ public static class TestUtilities
             // 0x15: String
             new DataTypeSample("String", typeof(string), "'test'", "test"),
             // 0x16: FixedString
-            new DataTypeSample("FixedString(4)", typeof(string), "toFixedString('test', 4)", "test"),
+            new DataTypeSample("FixedString(4)", typeof(byte[]), "toFixedString('test', 4)", Encoding.UTF8.GetBytes("test")),
             // 0x17: Enum8
             new DataTypeSample("Enum8('a' = 1, 'b' = 2)", typeof(string), "CAST('a', 'Enum8(\\'a\\' = 1, \\'b\\' = 2)')", "a"),
             // 0x18: Enum16

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,6 +2,7 @@ v0.9.0
 ---
 
 **Breaking Changes:**
+ * FixedString is now returned as byte[] rather than String. FixedStrings are not necessarily valid UTF-8 strings, and the string transformation caused loss of information in some cases. Use Encoding.UTF8.GetString() on the resulting byte[] array to emulate the old behavior. String can still be used as a parameter or when inserting using BulkCopy into a FixedString column. When part of a json object, FixedString is still returned as a string.
  * Removed obsolete MySQL compatibility mapping TIME -> Int64.
  * Json serialization of bool arrays now uses the Boolean type instead of UInt8 (it is now consistent with how bool values outside arrays were handled).
  * GEOMETRY is no longer an alias for String.


### PR DESCRIPTION
FixedString does not necessarily contain valid UTF8 strings, and information would be lost when decoding a byte[] into a string when it was not actually a UTF8 string. The FixedString type is now read into a byte[] instead of String.