### PR TITLE
Add ReadOnlyMemory<byte> support for String and FixedString

### DIFF
--- a/ClickHouse.Driver/Types/FixedStringType.cs
+++ b/ClickHouse.Driver/Types/FixedStringType.cs
@@ -50,7 +50,8 @@ internal class FixedStringType : ParameterizedType
 
         if (span.Length > Length)
         {
-            span = span.Slice(0, Length);
+            throw new ArgumentException(
+                $"FixedString({Length}) cannot accept data longer than {Length} bytes, but got {span.Length} bytes");
         }
 
         writer.Write(span);

--- a/ClickHouse.Driver/Types/StringType.cs
+++ b/ClickHouse.Driver/Types/StringType.cs
@@ -16,7 +16,7 @@ internal class StringType : ClickHouseType
         switch (value)
         {
             case  string str:
-                writer.Write(str.Length);
+                writer.Write(str);
                 break;
             case  byte[] bytes:
                 writer.Write7BitEncodedInt(bytes.Length);
@@ -24,7 +24,7 @@ internal class StringType : ClickHouseType
                 break;
             case ReadOnlyMemory<byte> memory:
                 var span = memory.Span;
-                writer.Write(span.Length);
+                writer.Write7BitEncodedInt(span.Length);
                 writer.Write(span);
                 break;
             default:


### PR DESCRIPTION
Adds support for inserting raw binary data into `String` and `FixedString(N)` columns using `ReadOnlyMemory<byte>`, enabling **zero-copy** and **zero-allocation** writes when the data is already in memory as bytes.

This is especially useful for:
- Storing binary blobs (images, protobuf messages, hashes, encrypted data) without UTF-8 encoding overhead
- High-performance scenarios with pre-encoded or raw byte buffers
- Avoiding unnecessary allocations when working with `byte[]`, `Memory<byte>`, or spans

Fixes [#131]