### PR TITLE
feat(examples): add ASP.NET health checks example

### DIFF
--- a/examples/AspNet_001_HealthChecks.cs
+++ b/examples/AspNet_001_HealthChecks.cs
@@ -1,0 +1,120 @@
+#if NET7_0_OR_GREATER
+using ClickHouse.Driver.ADO;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+
+namespace ClickHouse.Driver.Examples;
+
+/// <summary>
+/// Demonstrates how to implement ASP.NET health checks for ClickHouse.
+/// Shows the health check implementation and how to register it in an ASP.NET application.
+/// </summary>
+public static class AspNetHealthChecks
+{
+    public static async Task Run()
+    {
+        Console.WriteLine("ClickHouse ASP.NET Health Checks Example\n");
+
+        var services = new ServiceCollection();
+        services.AddLogging(builder => builder.AddConsole().SetMinimumLevel(LogLevel.Warning));
+
+        var connectionString = "Host=localhost;Port=8123;Protocol=http;Username=default;Password=;Database=default";
+
+        // Register ClickHouse data source
+        services.AddClickHouseDataSource(connectionString);
+
+        // Register health checks using the extension method
+        services.AddHealthChecks()
+            .AddClickHouse(name: "clickhouse", tags: ["database", "clickhouse"]);
+
+        var serviceProvider = services.BuildServiceProvider();
+
+        // Resolve and run the health check
+        var healthCheckService = serviceProvider.GetRequiredService<HealthCheckService>();
+        var report = await healthCheckService.CheckHealthAsync();
+
+        Console.WriteLine($"   Overall status: {report.Status}");
+        foreach (var entry in report.Entries)
+        {
+            Console.WriteLine($"   - {entry.Key}: {entry.Value.Status}");
+            if (!string.IsNullOrEmpty(entry.Value.Description))
+            {
+                Console.WriteLine($"     Description: {entry.Value.Description}");
+            }
+        }
+
+        Console.WriteLine("\nAll health check examples completed!");
+    }
+}
+
+/// <summary>
+/// A health check for ClickHouse databases.
+/// </summary>
+public class ClickHouseHealthCheck : IHealthCheck
+{
+    private readonly ClickHouseConnection _connection;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ClickHouseHealthCheck"/> class.
+    /// </summary>
+    /// <param name="connection">The ClickHouse connection to use for health checks.</param>
+    public ClickHouseHealthCheck(ClickHouseConnection connection)
+    {
+        ArgumentNullException.ThrowIfNull(connection);
+        _connection = connection;
+    }
+
+    /// <inheritdoc />
+    public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await _connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+            using var command = _connection.CreateCommand();
+            command.CommandText = "SELECT 1";
+            await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+
+            return HealthCheckResult.Healthy();
+        }
+        catch (Exception ex)
+        {
+            return new HealthCheckResult(
+                context.Registration.FailureStatus,
+                description: ex.Message,
+                exception: ex);
+        }
+    }
+}
+
+/// <summary>
+/// Extension methods for adding ClickHouse health checks to the health check builder.
+/// </summary>
+public static class ClickHouseHealthCheckBuilderExtensions
+{
+    /// <summary>
+    /// Adds a health check for ClickHouse using a ClickHouseConnection from DI.
+    /// </summary>
+    /// <param name="builder">The health check builder.</param>
+    /// <param name="name">The name of the health check. Defaults to "clickhouse".</param>
+    /// <param name="failureStatus">The status to report when the health check fails. Defaults to Unhealthy.</param>
+    /// <param name="tags">Optional tags for the health check.</param>
+    /// <param name="timeout">Optional timeout for the health check.</param>
+    /// <returns>The health check builder for chaining.</returns>
+    public static IHealthChecksBuilder AddClickHouse(
+        this IHealthChecksBuilder builder,
+        string name = "clickhouse",
+        HealthStatus? failureStatus = null,
+        IEnumerable<string>? tags = null,
+        TimeSpan? timeout = null)
+    {
+        return builder.Add(new HealthCheckRegistration(
+            name,
+            sp => new ClickHouseHealthCheck(sp.GetRequiredService<ClickHouseConnection>()),
+            failureStatus,
+            tags,
+            timeout));
+    }
+}
+#endif

--- a/examples/ClickHouse.Driver.Examples.csproj
+++ b/examples/ClickHouse.Driver.Examples.csproj
@@ -14,6 +14,7 @@
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.1" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.1" />
+      <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.1" />
       <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.1" />
     </ItemGroup>
 

--- a/examples/Program.cs
+++ b/examples/Program.cs
@@ -77,6 +77,10 @@ class Program
         Console.WriteLine($"\n\nRunning: {nameof(DependencyInjection)}");
         await DependencyInjection.Run();
         WaitForUser(isInteractive);
+
+        Console.WriteLine($"\n\nRunning: {nameof(AspNetHealthChecks)}");
+        await AspNetHealthChecks.Run();
+        WaitForUser(isInteractive);
 #endif
 
         Console.WriteLine($"\n\nRunning: {nameof(HttpClientConfiguration)}");

--- a/examples/README.md
+++ b/examples/README.md
@@ -17,6 +17,10 @@ If something is missing, or you found a mistake in one of these examples, please
 - [Core_003_DependencyInjection.cs](Core_003_DependencyInjection.cs) - Using ClickHouse with dependency injection and config binding
 - [Core_004_HttpClientConfiguration.cs](Core_004_HttpClientConfiguration.cs) - Providing custom HttpClient or IHttpClientFactory for SSL/TLS, proxy, timeouts, and more control over connection settings
 
+### ASP.NET Integration
+
+- [AspNet_001_HealthChecks.cs](AspNet_001_HealthChecks.cs) - Implementing ASP.NET health checks for ClickHouse
+
 ### Authentication
 
 - [Auth_001_JwtAuthentication.cs](Auth_001_JwtAuthentication.cs) - Using JWT/Bearer token authentication with ClickHouse.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds an ASP.NET health checks example and wires it into the examples app.
> 
> - New `AspNet_001_HealthChecks.cs`: implements `ClickHouseHealthCheck` (runs `SELECT 1`), DI-based registration, and `AddClickHouse` `IHealthChecksBuilder` extension; demo `Run()` uses `AddClickHouseDataSource` and `HealthCheckService`
> - `Program.cs`: invokes `AspNetHealthChecks.Run()` under `NET7_0_OR_GREATER`
> - `ClickHouse.Driver.Examples.csproj`: adds `Microsoft.Extensions.Diagnostics.HealthChecks` package
> - `README.md`: new "ASP.NET Integration" section linking the health checks example
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1cd76952fdd520c90254bf8c08891bcd1374fbb7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->