### PR TITLE
fix qbit tests on cloud

### DIFF
--- a/ClickHouse.Driver.Tests/Utilities/TestUtilities.cs
+++ b/ClickHouse.Driver.Tests/Utilities/TestUtilities.cs
@@ -144,7 +144,7 @@ public static class TestUtilities
             // it could cause problems by hiding other issues
             builder["set_allow_suspicious_variant_types"] = 1; 
         }
-        if (SupportedFeatures.HasFlag(Feature.QBit))
+        if (SupportedFeatures.HasFlag(Feature.QBit) && TestEnvironment != TestEnv.Cloud)
         {
             // Cloud doesn't want us changing this option
             builder["set_allow_experimental_qbit_type"] = 1;
@@ -522,8 +522,9 @@ public static class TestUtilities
             yield return new DataTypeSample("Time64(6)", typeof(TimeSpan), "'-5:25:05.123456'::Time64(6)", (new TimeSpan(5, 25, 5).Add(TimeSpan.FromMilliseconds(123.456)).Negate()));
         }
 
-        if (SupportedFeatures.HasFlag(Feature.QBit))
+        if (SupportedFeatures.HasFlag(Feature.QBit) && TestEnvironment != TestEnv.Cloud)
         {
+            // Needs to be enabled via setting, and cloud throws if we do: DB::Exception: Setting allow_experimental_qbit_type should not be changed. (SETTING_CONSTRAINT_VIOLATION)
             yield return new DataTypeSample("QBit(Float32, 4)", typeof(float[]), "[1.0, 2.0, 3.0, 4.0]::QBit(Float32, 4)", new float[] { 1f, 2f, 3f, 4f });
             yield return new DataTypeSample("QBit(Float64, 5)", typeof(double[]), "[1.0, 2.0, 3.0, 4.0, 5.0]::QBit(Float64, 5)", new double[] { 1.0, 2.0, 3.0, 4.0, 5.0 });
             yield return new DataTypeSample("QBit(BFloat16, 6)", typeof(float[]), "[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]::QBit(BFloat16, 6)", new float[] { 1f, 2f, 3f, 4f, 5f, 6f });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Avoids failures on ClickHouse Cloud where changing `allow_experimental_qbit_type` is disallowed.
> 
> - In `TestUtilities.GetDataTypeSamples`, require `SupportedFeatures.HasFlag(Feature.QBit) && TestEnvironment != TestEnv.Cloud` before yielding `QBit(...)` samples
> - Adds an explanatory comment about the cloud `SETTING_CONSTRAINT_VIOLATION`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b282df277f287ce747d095e7421751e7f2aee24. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->