### PR TITLE
Sanitize env values in user agent string

### DIFF
--- a/ClickHouse.Driver/Utility/UserAgentProvider.cs
+++ b/ClickHouse.Driver/Utility/UserAgentProvider.cs
@@ -59,6 +59,11 @@ internal static class UserAgentProvider
 
         private static bool ContainsNonAscii(string value)
         {
+            if (value is null)
+            {
+                return false;
+            }
+
             return value.Any(c => (int)c > 0x7f);
         }
 
@@ -67,6 +72,11 @@ internal static class UserAgentProvider
         /// </summary>
         private static string SanitizeString(string value)
         {
+            if (value is null)
+            {
+                return string.Empty;
+            }
+
             return value.Replace(';', '|');
         }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves robustness of user agent header construction.
> 
> - Sanitizes `osPlatform`, `osDescription`, and `architecture` by replacing semicolons with `|` to prevent header parsing issues
> - Adds null-safe checks in `ContainsNonAscii` and `SanitizeString`
> - Applies sanitization before composing `SystemProductInfo`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ae8d6210a2200557d125d9d611b215526a7a592. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->