### PR TITLE
Add 25.12 to test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,7 @@ jobs:
       matrix:
         version:
           - "latest"
+          - "25.12"
           - "25.11"
           - "25.10"
           - "25.8"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Expands CI coverage for ClickHouse versions.
> 
> - Adds `"25.12"` to the `regress-clickhouse` matrix in `.github/workflows/tests.yml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a18aa5951a4d9513f5132b7d8c1cbcbfa58bcc9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->