### PR TITLE
Update RELEASENOTES.md

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -55,11 +55,11 @@ v?
   This differs from bulk copy operations where the column timezone is known and used automatically.
 
 * **Removed `UseServerTimezone` setting.** This setting has been removed from the connection string, `ClickHouseClientSettings`, and `ClickHouseConnectionStringBuilder`. It no longer has any effect since columns without timezones now return `Unspecified` DateTime values without any timezone changes applied to what is returned from the server.
-
 * **Moved `ServerTimezone` property from `ClickHouseConnection` to `ClickHouseCommand`.** The server timezone is now available on `ClickHouseCommand.ServerTimezone` after any query execution (the timezone is now extracted from the `X-ClickHouse-Timezone` response header instead of requiring a separate query).
-
+* **Helper and extension methods made internal:** DateTimeConversions, DataReaderExtensions, DictionaryExtensions, EnumerableExtensions, MathUtils, StringExtensions.
 
 **New Features/Improvements:**
+ * Added support for QBit data type. QBit is a transposed vector column, designed to allow the user to choose a desired quantization level at runtime, speeding up approximate similarity searches. See the GitHub repo for usage examples.
  * Added support for setting roles at the connection and command levels.
  * Added support for custom headers at the connection level.
  * Added support for JWT/Bearer token authentication at both connection and command levels.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates release notes with two items:
> 
> - **Breaking change:** helper/extension utilities (`DateTimeConversions`, `DataReaderExtensions`, `DictionaryExtensions`, `EnumerableExtensions`, `MathUtils`, `StringExtensions`) are now `internal`.
> - **Feature:** added support for `QBit` data type (transposed vector column for approximate similarity searches).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c2211231cfe89535ad0f0e8be291590c13d25bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->