### PR TITLE
add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @alex-clickhouse @mzitnik


### PR DESCRIPTION
## Summary
Tag @alex-clickhouse  and @mzitnik  on a new PR open. see https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#about-code-owners

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds repository CODEOWNERS to auto-request reviews from designated owners.
> 
> - New `.github/CODEOWNERS` assigns `@alex-clickhouse` and `@mzitnik` as owners for all paths (`*`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dbec5496fcb94868e91dfe7696e426eb0e8b6973. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->