### PR TITLE
Fix datetime parameter formating bug

### DIFF
--- a/ClickHouse.Driver.Tests/Types/TimezoneHandlingTests.cs
+++ b/ClickHouse.Driver.Tests/Types/TimezoneHandlingTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using ClickHouse.Driver.ADO;
 using ClickHouse.Driver.ADO.Readers;
 using ClickHouse.Driver.Copy;
+using ClickHouse.Driver.Types;
 using ClickHouse.Driver.Utility;
 using NodaTime;
 using NUnit.Framework;
@@ -216,13 +217,7 @@ public class WriteDateTimeHttpParamTests : AbstractConnectionTestFixture
         var result = (DateTime)await connection.ExecuteScalarAsync("SELECT dt_amsterdam FROM test.datetime_http_test");
 
         // Unspecified should roundtrip perfectly when target timezone matches
-        Assert.That(result.Year, Is.EqualTo(original.Year));
-        Assert.That(result.Month, Is.EqualTo(original.Month));
-        Assert.That(result.Day, Is.EqualTo(original.Day));
-        Assert.That(result.Hour, Is.EqualTo(original.Hour));
-        Assert.That(result.Minute, Is.EqualTo(original.Minute));
-        Assert.That(result.Second, Is.EqualTo(original.Second));
-        Assert.That(result.Kind, Is.EqualTo(DateTimeKind.Unspecified));
+        Assert.That(result, Is.EqualTo(original));
     }
 
     [Test]
@@ -292,7 +287,7 @@ public class WriteDateTimeHttpParamTests : AbstractConnectionTestFixture
     }
 
     [Test]
-    public async Task HttpParam_UtcKind_ToAmsterdamColumn_PreservesInstant()
+    public async Task HttpParam_UtcKind_ToAmsterdamColumnWithoutTzHint_PreservesInstant()
     {
         // UTC DateTime(12:00 UTC) written to Amsterdam column should store as 13:00 Amsterdam
         // because 12:00 UTC = 13:00 Amsterdam (Amsterdam is UTC+1 in January)
@@ -301,6 +296,24 @@ public class WriteDateTimeHttpParamTests : AbstractConnectionTestFixture
         var command = connection.CreateCommand();
         command.AddParameter("dt", utcDt);
         command.CommandText = "INSERT INTO test.datetime_http_test (dt_amsterdam) VALUES ({dt:DateTime})";
+        await command.ExecuteNonQueryAsync();
+
+        var result = (DateTime)await connection.ExecuteScalarAsync("SELECT dt_amsterdam FROM test.datetime_http_test");
+
+        // 12:00 UTC = 13:00 Amsterdam
+        Assert.That(result.Hour, Is.EqualTo(13), "UTC DateTime should be converted to target timezone");
+    }
+    
+    [Test]
+    public async Task HttpParam_UtcKind_ToAmsterdamColumnWithTzHint_PreservesInstant()
+    {
+        // UTC DateTime(12:00 UTC) written to Amsterdam column should store as 13:00 Amsterdam
+        // because 12:00 UTC = 13:00 Amsterdam (Amsterdam is UTC+1 in January)
+        var utcDt = new DateTime(2024, 1, 15, 12, 0, 0, DateTimeKind.Utc);
+
+        var command = connection.CreateCommand();
+        command.AddParameter("dt", "DateTime('Europe/Amsterdam')", utcDt);
+        command.CommandText = "INSERT INTO test.datetime_http_test (dt_amsterdam) VALUES ({dt:DateTime('Europe/Amsterdam')})";
         await command.ExecuteNonQueryAsync();
 
         var result = (DateTime)await connection.ExecuteScalarAsync("SELECT dt_amsterdam FROM test.datetime_http_test");
@@ -328,7 +341,102 @@ public class WriteDateTimeHttpParamTests : AbstractConnectionTestFixture
     }
 
     [Test]
-    public async Task HttpParam_DateTimeOffset_PreservesCorrectInstant()
+    public async Task HttpParam_LocalKind_ToAmsterdamColumnWithNoTzHint_PreservesInstant()
+    {
+        // Local DateTime(12:00 Local) written to Amsterdam column should preserve the instant
+        // For example: if local is UTC+0, 12:00 Local = 12:00 UTC = 13:00 Amsterdam (UTC+1 in January)
+        var localDt = new DateTime(2024, 1, 15, 12, 0, 0, DateTimeKind.Local);
+        var expectedUtc = new DateTimeOffset(localDt).UtcDateTime;
+
+        var command = connection.CreateCommand();
+        command.AddParameter("dt", localDt);
+        command.CommandText = "INSERT INTO test.datetime_http_test (dt_amsterdam) VALUES ({dt:DateTime})";
+        await command.ExecuteNonQueryAsync();
+
+        var reader = (ClickHouseDataReader)await connection.ExecuteReaderAsync("SELECT dt_amsterdam FROM test.datetime_http_test");
+        Assert.That(reader.Read(), Is.True);
+        var resultDto = reader.GetDateTimeOffset(0);
+
+        // The instant should be preserved - compare UTC times
+        Assert.That(resultDto.UtcDateTime, Is.EqualTo(expectedUtc).Within(TimeSpan.FromSeconds(1)));
+    }
+    
+    [Test]
+    public async Task HttpParam_LocalKind_ToAmsterdamColumn_PreservesInstant()
+    {
+        // Local DateTime(12:00 Local) written to Amsterdam column should preserve the instant
+        // For example: if local is UTC+0, 12:00 Local = 12:00 UTC = 13:00 Amsterdam (UTC+1 in January)
+        var localDt = new DateTime(2024, 1, 15, 12, 0, 0, DateTimeKind.Local);
+        var expectedUtc = new DateTimeOffset(localDt).UtcDateTime;
+
+        var command = connection.CreateCommand();
+        command.AddParameter("dt", "DateTime('Europe/Amsterdam')", localDt);
+        command.CommandText = "INSERT INTO test.datetime_http_test (dt_amsterdam) VALUES ({dt:DateTime('Europe/Amsterdam')})";
+        await command.ExecuteNonQueryAsync();
+
+        var reader = (ClickHouseDataReader)await connection.ExecuteReaderAsync("SELECT dt_amsterdam FROM test.datetime_http_test");
+        Assert.That(reader.Read(), Is.True);
+        var resultDto = reader.GetDateTimeOffset(0);
+
+        // The instant should be preserved - compare UTC times
+        Assert.That(resultDto.UtcDateTime, Is.EqualTo(expectedUtc).Within(TimeSpan.FromSeconds(1)));
+    }
+
+    [Test]
+    public async Task HttpParam_UnspecifiedKind_ToNoTimezoneColumn_PreservesWallClock()
+    {
+        // Unspecified DateTime to column without timezone - should preserve wall-clock time
+        var dt = new DateTime(2024, 1, 15, 12, 30, 45, DateTimeKind.Unspecified);
+
+        var command = connection.CreateCommand();
+        command.AddParameter("dt", dt);
+        command.CommandText = "INSERT INTO test.datetime_http_test (dt_no_tz) VALUES ({dt:DateTime})";
+        await command.ExecuteNonQueryAsync();
+
+        var result = (DateTime)await connection.ExecuteScalarAsync("SELECT dt_no_tz FROM test.datetime_http_test");
+
+        Assert.That(result, Is.EqualTo(dt));
+    }
+
+    [Test]
+    public async Task HttpParam_UtcKind_ToNoTimezoneColumn_WritesUtcValue()
+    {
+        // UTC DateTime to column without timezone - the UTC value should be written
+        var utcDt = new DateTime(2024, 1, 15, 12, 0, 0, DateTimeKind.Utc);
+
+        var command = connection.CreateCommand();
+        command.AddParameter("dt", utcDt);
+        command.CommandText = "INSERT INTO test.datetime_http_test (dt_no_tz) VALUES ({dt:DateTime})";
+        await command.ExecuteNonQueryAsync();
+
+        var result = (DateTime)await connection.ExecuteScalarAsync("SELECT dt_no_tz FROM test.datetime_http_test");
+
+        // The UTC time (12:00) should be stored as-is
+        Assert.That(result.Hour, Is.EqualTo(12));
+        Assert.That(result.Kind, Is.EqualTo(DateTimeKind.Unspecified));
+    }
+
+    [Test]
+    public async Task HttpParam_LocalKind_ToNoTimezoneColumn_WritesUtcValue()
+    {
+        // Local DateTime to column without timezone - should be converted to UTC first
+        var localDt = new DateTime(2024, 1, 15, 12, 0, 0, DateTimeKind.Local);
+        var expectedUtc = new DateTimeOffset(localDt).UtcDateTime;
+
+        var command = connection.CreateCommand();
+        command.AddParameter("dt", localDt);
+        command.CommandText = "INSERT INTO test.datetime_http_test (dt_no_tz) VALUES ({dt:DateTime})";
+        await command.ExecuteNonQueryAsync();
+
+        var result = (DateTime)await connection.ExecuteScalarAsync("SELECT dt_no_tz FROM test.datetime_http_test");
+
+        // The UTC-converted time should be stored
+        Assert.That(result.Hour, Is.EqualTo(expectedUtc.Hour));
+        Assert.That(result.Kind, Is.EqualTo(DateTimeKind.Unspecified));
+    }
+
+    [Test]
+    public async Task HttpParam_DateTimeOffset_ToUtcColumn_PreservesInstant()
     {
         // DateTimeOffset should correctly preserve the instant
         var dto = new DateTimeOffset(2024, 1, 15, 15, 0, 0, TimeSpan.FromHours(3)); // 15:00 +03:00 = 12:00 UTC
@@ -342,6 +450,77 @@ public class WriteDateTimeHttpParamTests : AbstractConnectionTestFixture
 
         // DateTimeOffset correctly converts to UTC
         Assert.That(result, Is.EqualTo(new DateTime(2024, 1, 15, 12, 0, 0, DateTimeKind.Utc)));
+    }
+
+    [Test]
+    public async Task HttpParam_DateTimeOffset_ToAmsterdamColumn_PreservesInstant()
+    {
+        // DateTimeOffset 15:00 +03:00 = 12:00 UTC = 13:00 Amsterdam (UTC+1 in January)
+        // When ClickHouse type is specified on the parameter, the formatter converts to that timezone
+        var dto = new DateTimeOffset(2024, 1, 15, 15, 0, 0, TimeSpan.FromHours(3));
+
+        var command = connection.CreateCommand();
+        command.AddParameter("dt", "DateTime('Europe/Amsterdam')", dto);
+        command.CommandText = "INSERT INTO test.datetime_http_test (dt_amsterdam) VALUES ({dt:DateTime('Europe/Amsterdam')})";
+        await command.ExecuteNonQueryAsync();
+
+        var result = (DateTime)await connection.ExecuteScalarAsync("SELECT dt_amsterdam FROM test.datetime_http_test");
+
+        // 12:00 UTC = 13:00 Amsterdam
+        Assert.That(result.Hour, Is.EqualTo(13), "DateTimeOffset instant should be preserved and converted to Amsterdam time");
+    }
+
+    /// <summary>
+    /// Regression test: DateTimeConversions.DateTimeEpochStart (1970-01-01 00:00:00 UTC) was
+    /// formatted as Unix timestamp "0" which ClickHouse rejected.
+    /// </summary>
+    [Test]
+    public async Task HttpParam_DateTimeUnixEpoch_ShouldWork()
+    {
+        var dt = DateTimeConversions.DateTimeEpochStart; // 1970-01-01 00:00:00 UTC
+
+        var command = connection.CreateCommand();
+        command.AddParameter("dt", dt);
+        command.CommandText = "INSERT INTO test.datetime_http_test (dt_utc) VALUES ({dt:DateTime})";
+        await command.ExecuteNonQueryAsync();
+
+        var result = (DateTime)await connection.ExecuteScalarAsync("SELECT dt_utc FROM test.datetime_http_test");
+        Assert.That(result, Is.EqualTo(DateTimeConversions.DateTimeEpochStart));
+    }
+
+    /// <summary>
+    /// Test that DateTimeOffset at Unix epoch also works.
+    /// </summary>
+    [Test]
+    public async Task HttpParam_DateTimeOffsetUnixEpoch_ShouldWork()
+    {
+        var dto = new DateTimeOffset(DateTimeConversions.DateTimeEpochStart, TimeSpan.Zero); // 1970-01-01 00:00:00 +00:00
+
+        var command = connection.CreateCommand();
+        command.AddParameter("dt", dto);
+        command.CommandText = "INSERT INTO test.datetime_http_test (dt_utc) VALUES ({dt:DateTime})";
+        await command.ExecuteNonQueryAsync();
+
+        var result = (DateTime)await connection.ExecuteScalarAsync("SELECT dt_utc FROM test.datetime_http_test");
+        Assert.That(result, Is.EqualTo(DateTimeConversions.DateTimeEpochStart));
+    }
+    
+    /// <summary>
+    /// Test 1 sec after epoch.
+    /// </summary>
+    [Test]
+    public async Task HttpParam_DateTimeMinRange_ShouldWork()
+    {
+        // DateTime minimum for ClickHouse DateTime type is 1970-01-01 00:00:00
+        var dt = new DateTime(1970, 1, 1, 0, 0, 1, DateTimeKind.Utc); // 1 second after epoch
+
+        var command = connection.CreateCommand();
+        command.AddParameter("dt", dt);
+        command.CommandText = "INSERT INTO test.datetime_http_test (dt_utc) VALUES ({dt:DateTime})";
+        await command.ExecuteNonQueryAsync();
+
+        var result = (DateTime)await connection.ExecuteScalarAsync("SELECT dt_utc FROM test.datetime_http_test");
+        Assert.That(result, Is.EqualTo(dt));
     }
 }
 
@@ -496,6 +675,89 @@ public class WriteDateTimeBulkCopyTests : AbstractConnectionTestFixture
     }
 
     [Test]
+    public async Task BulkCopy_LocalKind_ToAmsterdamColumn_PreservesInstant()
+    {
+        // Local DateTime written to Amsterdam column should preserve the instant
+        var localDt = new DateTime(2024, 1, 15, 12, 0, 0, DateTimeKind.Local);
+        var expectedUtc = new DateTimeOffset(localDt).UtcDateTime;
+
+        using var bulkCopy = new ClickHouseBulkCopy(connection)
+        {
+            DestinationTableName = "test.datetime_bulk_test",
+            ColumnNames = ["dt_amsterdam"]
+        };
+        await bulkCopy.InitAsync();
+        await bulkCopy.WriteToServerAsync([[localDt]]);
+
+        var reader = (ClickHouseDataReader)await connection.ExecuteReaderAsync("SELECT dt_amsterdam FROM test.datetime_bulk_test");
+        Assert.That(reader.Read(), Is.True);
+        var resultDto = reader.GetDateTimeOffset(0);
+
+        // The instant should be preserved - compare UTC times
+        Assert.That(resultDto.UtcDateTime, Is.EqualTo(expectedUtc).Within(TimeSpan.FromSeconds(1)));
+    }
+
+    [Test]
+    public async Task BulkCopy_UnspecifiedKind_ToNoTimezoneColumn_PreservesWallClock()
+    {
+        // Unspecified DateTime to column without timezone - should preserve wall-clock time
+        var dt = new DateTime(2024, 1, 15, 12, 30, 45, DateTimeKind.Unspecified);
+
+        using var bulkCopy = new ClickHouseBulkCopy(connection)
+        {
+            DestinationTableName = "test.datetime_bulk_test",
+            ColumnNames = ["dt_no_tz"]
+        };
+        await bulkCopy.InitAsync();
+        await bulkCopy.WriteToServerAsync([[dt]]);
+
+        var result = (DateTime)await connection.ExecuteScalarAsync("SELECT dt_no_tz FROM test.datetime_bulk_test");
+
+        Assert.That(result, Is.EqualTo(dt));
+    }
+
+    [Test]
+    public async Task BulkCopy_UtcKind_ToNoTimezoneColumn_PreservesInstant()
+    {
+        // UTC DateTime to column without timezone
+        var utcDt = new DateTime(2024, 1, 15, 12, 0, 0, DateTimeKind.Utc);
+
+        using var bulkCopy = new ClickHouseBulkCopy(connection)
+        {
+            DestinationTableName = "test.datetime_bulk_test",
+            ColumnNames = ["dt_no_tz"]
+        };
+        await bulkCopy.InitAsync();
+        await bulkCopy.WriteToServerAsync([[utcDt]]);
+
+        var result = (DateTime)await connection.ExecuteScalarAsync("SELECT dt_no_tz FROM test.datetime_bulk_test");
+
+        // The UTC time should be stored
+        Assert.That(result, Is.EqualTo(utcDt));
+    }
+
+    [Test]
+    public async Task BulkCopy_LocalKind_ToNoTimezoneColumn_PreservesInstant()
+    {
+        // Local DateTime to column without timezone
+        var localDt = new DateTime(2024, 1, 15, 12, 0, 0, DateTimeKind.Local);
+        var expectedUtc = new DateTimeOffset(localDt).UtcDateTime;
+
+        using var bulkCopy = new ClickHouseBulkCopy(connection)
+        {
+            DestinationTableName = "test.datetime_bulk_test",
+            ColumnNames = ["dt_no_tz"]
+        };
+        await bulkCopy.InitAsync();
+        await bulkCopy.WriteToServerAsync([[localDt]]);
+
+        var result = (DateTime)await connection.ExecuteScalarAsync("SELECT dt_no_tz FROM test.datetime_bulk_test");
+
+        // The UTC-converted time should be stored, but returned as Unspecified kind
+        Assert.That(result, Is.EqualTo(DateTime.SpecifyKind(expectedUtc, DateTimeKind.Unspecified)));
+    }
+
+    [Test]
     public async Task BulkCopy_DateTimeOffset_PreservesCorrectInstant()
     {
         // DateTimeOffset should correctly preserve the instant
@@ -513,5 +775,283 @@ public class WriteDateTimeBulkCopyTests : AbstractConnectionTestFixture
 
         // DateTimeOffset correctly converts to UTC
         Assert.That(result, Is.EqualTo(new DateTime(2024, 1, 15, 12, 0, 0, DateTimeKind.Utc)));
+    }
+
+    /// <summary>
+    /// Test that DateTimeConversions.DateTimeEpochStart works with bulk copy (binary serialization).
+    /// </summary>
+    [Test]
+    public async Task BulkCopy_DateTimeUnixEpoch_ShouldWork()
+    {
+        var dt = DateTimeConversions.DateTimeEpochStart; // 1970-01-01 00:00:00 UTC
+
+        using var bulkCopy = new ClickHouseBulkCopy(connection)
+        {
+            DestinationTableName = "test.datetime_bulk_test",
+            ColumnNames = ["dt_utc"]
+        };
+        await bulkCopy.InitAsync();
+        await bulkCopy.WriteToServerAsync([[dt]]);
+
+        var result = (DateTime)await connection.ExecuteScalarAsync("SELECT dt_utc FROM test.datetime_bulk_test");
+        Assert.That(result, Is.EqualTo(DateTimeConversions.DateTimeEpochStart));
+    }
+
+    /// <summary>
+    /// Test that new DateTimeOffset(DateTimeConversions.DateTimeEpochStart, TimeSpan.Zero) works with bulk copy (binary serialization).
+    /// </summary>
+    [Test]
+    public async Task BulkCopy_DateTimeOffsetUnixEpoch_ShouldWork()
+    {
+        var dto = new DateTimeOffset(DateTimeConversions.DateTimeEpochStart, TimeSpan.Zero); // 1970-01-01 00:00:00 +00:00
+
+        using var bulkCopy = new ClickHouseBulkCopy(connection)
+        {
+            DestinationTableName = "test.datetime_bulk_test",
+            ColumnNames = ["dt_utc"]
+        };
+        await bulkCopy.InitAsync();
+        await bulkCopy.WriteToServerAsync([[dto]]);
+
+        var result = (DateTime)await connection.ExecuteScalarAsync("SELECT dt_utc FROM test.datetime_bulk_test");
+        Assert.That(result, Is.EqualTo(DateTimeConversions.DateTimeEpochStart));
+    }
+}
+
+/// <summary>
+/// Tests for writing DateTime64 values via HTTP parameters.
+/// DateTime64 has sub-second precision and may have different edge cases than DateTime.
+/// </summary>
+[TestFixture]
+public class WriteDateTime64HttpParamTests : AbstractConnectionTestFixture
+{
+    [SetUp]
+    public async Task SetUp()
+    {
+        await connection.ExecuteStatementAsync("DROP TABLE IF EXISTS test.datetime64_http_test");
+        await connection.ExecuteStatementAsync(@"
+            CREATE TABLE test.datetime64_http_test (
+                dt64_utc DateTime64(3, 'UTC'),
+                dt64_amsterdam DateTime64(3, 'Europe/Amsterdam'),
+                dt64_no_tz DateTime64(3)
+            ) ENGINE = Memory");
+    }
+
+    [TearDown]
+    public async Task TearDown()
+    {
+        await connection.ExecuteStatementAsync("DROP TABLE IF EXISTS test.datetime64_http_test");
+    }
+
+    [Test]
+    public async Task HttpParam_DateTime64_UnixEpoch_ShouldWork()
+    {
+        var dt = DateTimeConversions.DateTimeEpochStart;
+
+        var command = connection.CreateCommand();
+        command.AddParameter("dt", "DateTime64(3)", dt);
+        command.CommandText = "INSERT INTO test.datetime64_http_test (dt64_utc) VALUES ({dt:DateTime64(3)})";
+        await command.ExecuteNonQueryAsync();
+
+        var result = (DateTime)await connection.ExecuteScalarAsync("SELECT dt64_utc FROM test.datetime64_http_test");
+        Assert.That(result, Is.EqualTo(DateTimeConversions.DateTimeEpochStart));
+    }
+
+    [Test]
+    public async Task HttpParam_DateTime64_UtcKind_ToUtcColumn_PreservesInstant()
+    {
+        var utcDt = new DateTime(2024, 1, 15, 12, 30, 45, 123, DateTimeKind.Utc);
+
+        var command = connection.CreateCommand();
+        command.AddParameter("dt", "DateTime64(3)", utcDt);
+        command.CommandText = "INSERT INTO test.datetime64_http_test (dt64_utc) VALUES ({dt:DateTime64(3)})";
+        await command.ExecuteNonQueryAsync();
+
+        var result = (DateTime)await connection.ExecuteScalarAsync("SELECT dt64_utc FROM test.datetime64_http_test");
+
+        Assert.That(result, Is.EqualTo(utcDt));
+    }
+
+    [Test]
+    public async Task HttpParam_DateTime64_UnspecifiedKind_ToUtcColumn_PreservesWallClock()
+    {
+        var dt = new DateTime(2024, 1, 15, 12, 30, 45, 123, DateTimeKind.Unspecified);
+
+        var command = connection.CreateCommand();
+        command.AddParameter("dt", "DateTime64(3)", dt);
+        command.CommandText = "INSERT INTO test.datetime64_http_test (dt64_utc) VALUES ({dt:DateTime64(3)})";
+        await command.ExecuteNonQueryAsync();
+
+        var result = (DateTime)await connection.ExecuteScalarAsync("SELECT dt64_utc FROM test.datetime64_http_test");
+
+        Assert.That(result, Is.EqualTo(DateTime.SpecifyKind(dt, DateTimeKind.Utc)));
+    }
+
+    [Test]
+    public async Task HttpParam_DateTime64_UtcKind_ToAmsterdamColumn_PreservesInstant()
+    {
+        // 12:00 UTC = 13:00 Amsterdam (UTC+1 in January)
+        var utcDt = new DateTime(2024, 1, 15, 12, 0, 0, DateTimeKind.Utc);
+
+        var command = connection.CreateCommand();
+        command.AddParameter("dt", "DateTime64(3)", utcDt);
+        command.CommandText = "INSERT INTO test.datetime64_http_test (dt64_amsterdam) VALUES ({dt:DateTime64(3)})";
+        await command.ExecuteNonQueryAsync();
+
+        var result = (DateTime)await connection.ExecuteScalarAsync("SELECT dt64_amsterdam FROM test.datetime64_http_test");
+
+        Assert.That(result.Hour, Is.EqualTo(13), "UTC DateTime should be converted to Amsterdam timezone");
+        Assert.That(result.Kind, Is.EqualTo(DateTimeKind.Unspecified));
+    }
+
+    [Test]
+    public async Task HttpParam_DateTime64_LocalKind_ToUtcColumn_PreservesInstant()
+    {
+        var localDt = new DateTime(2024, 1, 15, 12, 0, 0, DateTimeKind.Local);
+        var expectedUtc = new DateTimeOffset(localDt).UtcDateTime;
+
+        var command = connection.CreateCommand();
+        command.AddParameter("dt", "DateTime64(3)", localDt);
+        command.CommandText = "INSERT INTO test.datetime64_http_test (dt64_utc) VALUES ({dt:DateTime64(3)})";
+        await command.ExecuteNonQueryAsync();
+
+        var result = (DateTime)await connection.ExecuteScalarAsync("SELECT dt64_utc FROM test.datetime64_http_test");
+
+        Assert.That(result, Is.EqualTo(DateTime.SpecifyKind(expectedUtc, DateTimeKind.Utc)).Within(TimeSpan.FromMilliseconds(1)));
+    }
+
+    [Test]
+    public async Task HttpParam_DateTime64_DateTimeOffset_PreservesInstant()
+    {
+        var dto = new DateTimeOffset(2024, 1, 15, 15, 0, 0, 123, TimeSpan.FromHours(3)); // 15:00 +03:00 = 12:00 UTC
+
+        var command = connection.CreateCommand();
+        command.AddParameter("dt", "DateTime64(3)", dto);
+        command.CommandText = "INSERT INTO test.datetime64_http_test (dt64_utc) VALUES ({dt:DateTime64(3)})";
+        await command.ExecuteNonQueryAsync();
+
+        var result = (DateTime)await connection.ExecuteScalarAsync("SELECT dt64_utc FROM test.datetime64_http_test");
+
+        Assert.That(result.Hour, Is.EqualTo(12));
+        Assert.That(result.Millisecond, Is.EqualTo(123));
+    }
+}
+
+/// <summary>
+/// Tests for writing DateTime64 values via binary bulk copy.
+/// </summary>
+[TestFixture]
+public class WriteDateTime64BulkCopyTests : AbstractConnectionTestFixture
+{
+    [SetUp]
+    public async Task SetUp()
+    {
+        await connection.ExecuteStatementAsync("DROP TABLE IF EXISTS test.datetime64_bulk_test");
+        await connection.ExecuteStatementAsync(@"
+            CREATE TABLE test.datetime64_bulk_test (
+                dt64_utc DateTime64(3, 'UTC'),
+                dt64_amsterdam DateTime64(3, 'Europe/Amsterdam'),
+                dt64_no_tz DateTime64(3)
+            ) ENGINE = Memory");
+    }
+
+    [TearDown]
+    public async Task TearDown()
+    {
+        await connection.ExecuteStatementAsync("DROP TABLE IF EXISTS test.datetime64_bulk_test");
+    }
+
+    [Test]
+    public async Task BulkCopy_DateTime64_UnixEpoch_ShouldWork()
+    {
+        var dt = DateTimeConversions.DateTimeEpochStart;
+
+        using var bulkCopy = new ClickHouseBulkCopy(connection)
+        {
+            DestinationTableName = "test.datetime64_bulk_test",
+            ColumnNames = ["dt64_utc"]
+        };
+        await bulkCopy.InitAsync();
+        await bulkCopy.WriteToServerAsync([[dt]]);
+
+        var result = (DateTime)await connection.ExecuteScalarAsync("SELECT dt64_utc FROM test.datetime64_bulk_test");
+        Assert.That(result, Is.EqualTo(DateTimeConversions.DateTimeEpochStart));
+    }
+
+    [Test]
+    public async Task BulkCopy_DateTime64_UtcKind_ToUtcColumn_PreservesInstant()
+    {
+        var utcDt = new DateTime(2024, 1, 15, 12, 30, 45, 123, DateTimeKind.Utc);
+
+        using var bulkCopy = new ClickHouseBulkCopy(connection)
+        {
+            DestinationTableName = "test.datetime64_bulk_test",
+            ColumnNames = ["dt64_utc"]
+        };
+        await bulkCopy.InitAsync();
+        await bulkCopy.WriteToServerAsync([[utcDt]]);
+
+        var result = (DateTime)await connection.ExecuteScalarAsync("SELECT dt64_utc FROM test.datetime64_bulk_test");
+
+        Assert.That(result, Is.EqualTo(utcDt));
+    }
+
+    [Test]
+    public async Task BulkCopy_DateTime64_UnspecifiedKind_ToUtcColumn_PreservesWallClock()
+    {
+        var dt = new DateTime(2024, 1, 15, 12, 30, 45, 123, DateTimeKind.Unspecified);
+
+        using var bulkCopy = new ClickHouseBulkCopy(connection)
+        {
+            DestinationTableName = "test.datetime64_bulk_test",
+            ColumnNames = ["dt64_utc"]
+        };
+        await bulkCopy.InitAsync();
+        await bulkCopy.WriteToServerAsync([[dt]]);
+
+        var result = (DateTime)await connection.ExecuteScalarAsync("SELECT dt64_utc FROM test.datetime64_bulk_test");
+
+        Assert.That(result.Hour, Is.EqualTo(12));
+        Assert.That(result.Minute, Is.EqualTo(30));
+        Assert.That(result.Second, Is.EqualTo(45));
+        Assert.That(result.Millisecond, Is.EqualTo(123));
+    }
+
+    [Test]
+    public async Task BulkCopy_DateTime64_UtcKind_ToAmsterdamColumn_PreservesInstant()
+    {
+        // 12:00 UTC = 13:00 Amsterdam (UTC+1 in January)
+        var utcDt = new DateTime(2024, 1, 15, 12, 0, 0, DateTimeKind.Utc);
+
+        using var bulkCopy = new ClickHouseBulkCopy(connection)
+        {
+            DestinationTableName = "test.datetime64_bulk_test",
+            ColumnNames = ["dt64_amsterdam"]
+        };
+        await bulkCopy.InitAsync();
+        await bulkCopy.WriteToServerAsync([[utcDt]]);
+
+        var result = (DateTime)await connection.ExecuteScalarAsync("SELECT dt64_amsterdam FROM test.datetime64_bulk_test");
+
+        Assert.That(result.Hour, Is.EqualTo(13), "UTC DateTime should be converted to Amsterdam timezone");
+    }
+
+    [Test]
+    public async Task BulkCopy_DateTime64_LocalKind_ToUtcColumn_PreservesInstant()
+    {
+        var localDt = new DateTime(2024, 1, 15, 12, 0, 0, DateTimeKind.Local);
+        var expectedUtc = new DateTimeOffset(localDt).UtcDateTime;
+
+        using var bulkCopy = new ClickHouseBulkCopy(connection)
+        {
+            DestinationTableName = "test.datetime64_bulk_test",
+            ColumnNames = ["dt64_utc"]
+        };
+        await bulkCopy.InitAsync();
+        await bulkCopy.WriteToServerAsync([[localDt]]);
+
+        var result = (DateTime)await connection.ExecuteScalarAsync("SELECT dt64_utc FROM test.datetime64_bulk_test");
+
+        Assert.That(result, Is.EqualTo(DateTime.SpecifyKind(expectedUtc, DateTimeKind.Utc)).Within(TimeSpan.FromMilliseconds(1)));
     }
 }


### PR DESCRIPTION
Previously, when we wanted to preserve an instant we would simply send the number of ticks in UTC. That would get interpreted as UTC no matter what the column type, thus making everything consistent. There's a problem with this, however:

This is fine:

`curl "http://localhost:8123/?param_dt=1705320000" -d "INSERT INTO test.datetime_test VALUES ({dt:DateTime})"`

But this throws:

`curl "http://localhost:8123/?param_dt=0" -d "INSERT INTO test.datetime_test VALUES ({dt:DateTime})"`

`Code: 41. DB::Exception: Cannot parse DateTime: value 0 cannot be parsed as DateTime for query parameter 'dt':  at row 0: While executing ValuesBlockInputFormat. (CANNOT_PARSE_DATETIME) (version 25.12.1.649 (official build))`

This means that values near the epoch won't work, hence the bug reported here: https://github.com/ClickHouse/clickhouse-cs/issues/183

This PR changes the http parameter formatting approach to use strings instead, with the appropriate timezone adjustments based on the parameter type to maintain consistent behavior. Also adds a bunch more tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fixes DateTime HTTP parameter formatting**
> 
> - Switches `HttpParameterFormatter` to emit ISO strings for `DateTime`/`DateTime64`, converting UTC/Local values into the parameter’s target timezone (or UTC) while sending Unspecified as-is
> - Adds helpers `FormatDateTimeInTargetTimezone` and `FormatDateTime64InTargetTimezone` for timezone-aware ISO formatting
> 
> **Extensive test coverage added**
> 
> - New tests for HTTP params and bulk copy covering `Unspecified`, `Utc`, `Local`, and `DateTimeOffset` across UTC, `Europe/Amsterdam`, and no-timezone columns
> - Validates instant preservation vs wall-clock semantics, with/without timezone hints in parameter types
> - Regression tests for Unix epoch (`0`) and min range, plus `DateTime64` sub-second precision handling
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9f1a481aad324ace0e9c55f947a7d5ce03877a1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->