### PR TITLE
Remove support for net462, net48, netstandard21

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 ### Project Context
 - **ClickHouse.Driver** is the official ADO.NET client for ClickHouse database
 - **Critical priorities**: Stability, correctness, performance, and comprehensive testing
-- **Tech stack**: C#/.NET targeting `net462`, `net48`, `netstandard2.1`, `net6.0`, `net8.0`, `net9.0`, `net10.0`
+- **Tech stack**: C#/.NET targeting `net6.0`, `net8.0`, `net9.0`, `net10.0`
 - **Tests run on**: `net6.0`, `net8.0`, `net9.0`, `net10.0`; Integration tests: `net10.0`; Benchmarks: `net10.0`
 
 ### Solution Structure
@@ -37,7 +37,7 @@ ClickHouse.Driver.sln
 
 ### Correctness & Safety First
 - **Protocol fidelity**: Correct serialization/deserialization of ClickHouse types across all supported versions
-- **Multi-framework compatibility**: Changes must work on .NET Framework 4.6.2 through .NET 10.0
+- **Multi-framework compatibility**: Changes must work on .NET 6.0 through .NET 10.0
 - **Type mapping**: ClickHouse has 60+ specialized types - ensure correct mapping, no data loss
 - **Thread safety**: Database client must handle concurrent operations safely
 - **Async patterns**: Maintain proper async/await, `CancellationToken` support, no sync-over-async

--- a/ClickHouse.Driver.Tests/ADO/DataReaderTests.cs
+++ b/ClickHouse.Driver.Tests/ADO/DataReaderTests.cs
@@ -154,7 +154,6 @@ public class DataReaderTests : AbstractConnectionTestFixture
         ClassicAssert.IsFalse(reader.Read());
     }
 
-#if NET48 || NET5_0_OR_GREATER
     [Test]
     public async Task ShouldReadTuple()
     {
@@ -163,7 +162,6 @@ public class DataReaderTests : AbstractConnectionTestFixture
         ClassicAssert.NotNull(reader.GetTuple(0));
         ClassicAssert.IsFalse(reader.Read());
     }
-#endif
 
     [Test]
     public async Task ShouldReadGuid()

--- a/ClickHouse.Driver.Tests/BulkCopy/BulkCopyTests.cs
+++ b/ClickHouse.Driver.Tests/BulkCopy/BulkCopyTests.cs
@@ -356,7 +356,6 @@ public class BulkCopyTests : AbstractConnectionTestFixture
         using var reader = await connection.ExecuteReaderAsync($"SELECT * from {targetTable}");
     }
 
-#if NET48 || NET5_0_OR_GREATER
     [Test]
     public async Task ShouldInsertNestedTable()
     {
@@ -381,7 +380,6 @@ public class BulkCopyTests : AbstractConnectionTestFixture
             Assert.That(await connection.ExecuteScalarAsync($"SELECT count() FROM {targetTable}"), Is.EqualTo(1));
         });
     }
-#endif
 
     [Test]
     public async Task ShouldInsertDoubleNestedTable()

--- a/ClickHouse.Driver.Tests/ClickHouse.Driver.Tests.csproj
+++ b/ClickHouse.Driver.Tests/ClickHouse.Driver.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net48;net6.0;net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>

--- a/ClickHouse.Driver.Tests/Misc/UriBuilderTests.cs
+++ b/ClickHouse.Driver.Tests/Misc/UriBuilderTests.cs
@@ -7,7 +7,6 @@ namespace ClickHouse.Driver.Tests.Misc;
 
 public class UriBuilderTests
 {
-#if !NET462 && !NET48
     [Test]
     public void ShouldSetUriParametersCorrectly()
     {
@@ -291,5 +290,4 @@ public class UriBuilderTests
         // Now GetEffectiveQueryId should return the custom ID, not the cached GUID
         Assert.That(uriBuilder.GetEffectiveQueryId(), Is.EqualTo("my-custom-id"));
     }
-#endif
 }

--- a/ClickHouse.Driver.Tests/ORM/DapperTests.cs
+++ b/ClickHouse.Driver.Tests/ORM/DapperTests.cs
@@ -32,9 +32,7 @@ public class DapperTests : AbstractConnectionTestFixture
     {
         SqlMapper.AddTypeHandler(new ClickHouseDecimalHandler());
         SqlMapper.AddTypeHandler(new DateTimeOffsetHandler());
-#if NET48 || NET5_0_OR_GREATER
         SqlMapper.AddTypeHandler(new ITupleHandler());
-#endif
         SqlMapper.AddTypeMap(typeof(DateTime), DbType.DateTime2);
         SqlMapper.AddTypeMap(typeof(DateTimeOffset), DbType.DateTime2);
         SqlMapper.AddTypeHandler(new ClickHouseIpHandler());
@@ -85,7 +83,6 @@ public class DapperTests : AbstractConnectionTestFixture
         return true;
     }
 
-#if NET48 || NET5_0_OR_GREATER
     private class ITupleHandler : SqlMapper.TypeHandler<ITuple>
     {
         public override void SetValue(IDbDataParameter parameter, ITuple value) => parameter.Value = value;
@@ -101,7 +98,6 @@ public class DapperTests : AbstractConnectionTestFixture
         ClassicAssert.IsInstanceOf<ITuple>(result);
         Assert.That(result.AsEnumerable(), Is.EqualTo(new[] { 1, 2, 3 }).AsCollection);
     }
-#endif
 
     private class DateTimeOffsetHandler : SqlMapper.TypeHandler<DateTimeOffset>
     {

--- a/ClickHouse.Driver.Tests/Types/TupleTypeTests.cs
+++ b/ClickHouse.Driver.Tests/Types/TupleTypeTests.cs
@@ -11,7 +11,6 @@ namespace ClickHouse.Driver.Tests.Types;
 
 public class TupleTypeTests : AbstractConnectionTestFixture
 {
-#if NET48 || NET5_0_OR_GREATER
     [Test]
     public async Task ShouldSelectTuple([Range(1, 24, 4)] int count)
     {
@@ -27,7 +26,6 @@ public class TupleTypeTests : AbstractConnectionTestFixture
     }
 
     private static IEnumerable<object> AsEnumerable(ITuple tuple) => Enumerable.Range(0, tuple.Length).Select(i => tuple[i]);
-#endif
 
     [Test]
     [TestCase("Tuple(String, Int32)")]

--- a/ClickHouse.Driver/ADO/ClickHouseConnection.cs
+++ b/ClickHouse.Driver/ADO/ClickHouseConnection.cs
@@ -542,7 +542,7 @@ public class ClickHouseConnection : DbConnection, IClickHouseConnection, IClonea
     /// <exception cref="ClickHouseJsonSerializationException">
     /// Thrown if any property type cannot be mapped to a ClickHouse type.
     /// </exception>
-    public void RegisterJsonSerializationType<T>() 
+    public void RegisterJsonSerializationType<T>()
     where T : class
         => jsonTypeRegistry.RegisterType<T>();
 

--- a/ClickHouse.Driver/ADO/Readers/ClickHouseDataReader.cs
+++ b/ClickHouse.Driver/ADO/Readers/ClickHouseDataReader.cs
@@ -200,10 +200,8 @@ public class ClickHouseDataReader : DbDataReader, IEnumerator<IDataReader>, IEnu
     // Custom extension
     public IPAddress GetIPAddress(int ordinal) => (IPAddress)GetValue(ordinal);
 
-#if !NET462
     // Custom extension
     public ITuple GetTuple(int ordinal) => (ITuple)GetValue(ordinal);
-#endif
 
     // Custom extension
     public sbyte GetSByte(int ordinal) => (sbyte)GetValue(ordinal);

--- a/ClickHouse.Driver/ClickHouse.Driver.csproj
+++ b/ClickHouse.Driver/ClickHouse.Driver.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net48;netstandard2.1;net6.0;net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -47,13 +47,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.Json" Version="10.0.1" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">
-    <Reference Include="System.Web" />
-    <PackageReference Include="Microsoft.Bcl.HashCode" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ClickHouse.Driver/Formats/HttpParameterFormatter.cs
+++ b/ClickHouse.Driver/Formats/HttpParameterFormatter.cs
@@ -124,10 +124,8 @@ internal static class HttpParameterFormatter
                 var values = enumerable.Cast<object>().Select(x => Format(nestedType, x, false));
                 return $"[{string.Join(",", values)}]";
 
-#if !NET462
             case TupleType tupleType when value is ITuple tuple:
                 return $"({string.Join(",", tupleType.UnderlyingTypes.Select((x, i) => Format(x, tuple[i], true)))})";
-#endif
 
             case TupleType tupleType when value is IList list:
                 return $"({string.Join(",", tupleType.UnderlyingTypes.Select((x, i) => Format(x, list[i], true)))})";

--- a/ClickHouse.Driver/Types/BFloat16Type.cs
+++ b/ClickHouse.Driver/Types/BFloat16Type.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Globalization;
-using System.Runtime.InteropServices;
 using ClickHouse.Driver.Formats;
 
 namespace ClickHouse.Driver.Types;
@@ -19,39 +18,6 @@ internal class BFloat16Type : FloatType
 {
     public override Type FrameworkType => typeof(float);
 
-#if NET462 || NET48 || NETSTANDARD2_1
-    [StructLayout(LayoutKind.Explicit)]
-    private struct FloatUInt32Union
-    {
-        [FieldOffset(0)]
-        public float FloatValue;
-
-        [FieldOffset(0)]
-        public uint UIntValue;
-    }
-
-    public override object Read(ExtendedBinaryReader reader)
-    {
-        // BFloat16 is 16 bits: 1 sign + 8 exponent + 7 mantissa
-        // Read as ushort and expand to float32 by left-shifting 16 bits
-        ushort bfloat16Bits = reader.ReadUInt16();
-
-        var converter = new FloatUInt32Union { UIntValue = (uint)bfloat16Bits << 16 };
-        return converter.FloatValue;
-    }
-
-    public override void Write(ExtendedBinaryWriter writer, object value)
-    {
-        // Convert float to BFloat16 by truncating to top 16 bits
-        float floatValue = Convert.ToSingle(value, CultureInfo.InvariantCulture);
-
-        var converter = new FloatUInt32Union { FloatValue = floatValue };
-        ushort bfloat16Bits = (ushort)(converter.UIntValue >> 16);
-
-        writer.Write(bfloat16Bits);
-    }
-
-#else
     public override object Read(ExtendedBinaryReader reader)
     {
         // BFloat16 is 16 bits: 1 sign + 8 exponent + 7 mantissa
@@ -70,6 +36,5 @@ internal class BFloat16Type : FloatType
         writer.Write(bfloat16Bits);
     }
 
-#endif
     public override string ToString() => "BFloat16";
 }

--- a/ClickHouse.Driver/Types/TupleType.cs
+++ b/ClickHouse.Driver/Types/TupleType.cs
@@ -28,10 +28,8 @@ internal class TupleType : ParameterizedType
     {
         var count = underlyingTypes.Length;
 
-#if !NET462
         if (count > 7)
             return typeof(LargeTuple);
-#endif
 
         var typeArgs = new Type[count];
         for (var i = 0; i < count; i++)
@@ -42,7 +40,6 @@ internal class TupleType : ParameterizedType
         return genericType.MakeGenericType(typeArgs);
     }
 
-#if !NET462
     public ITuple MakeTuple(params object[] values)
     {
         var count = values.Length;
@@ -62,7 +59,6 @@ internal class TupleType : ParameterizedType
 
         return (ITuple)Activator.CreateInstance(frameworkType, valuesCopy);
     }
-#endif
 
     public override Type FrameworkType => frameworkType;
 
@@ -87,16 +83,12 @@ internal class TupleType : ParameterizedType
             var value = UnderlyingTypes[i].Read(reader);
             contents[i] = ClearDBNull(value);
         }
-#if !NET462
+
         return MakeTuple(contents);
-#else
-        return contents;
-#endif
     }
 
     public override void Write(ExtendedBinaryWriter writer, object value)
     {
-#if !NET462
         if (value is ITuple tuple)
         {
             if (tuple.Length != UnderlyingTypes.Length)
@@ -107,7 +99,7 @@ internal class TupleType : ParameterizedType
             }
             return;
         }
-#endif
+
         if (value is IList list)
         {
             if (list.Count != UnderlyingTypes.Length)

--- a/ClickHouse.Driver/Utility/DataReaderExtensions.cs
+++ b/ClickHouse.Driver/Utility/DataReaderExtensions.cs
@@ -42,7 +42,6 @@ internal static class DataReaderExtensions
         }
     }
 
-#if !NET462
     internal static IEnumerable<object> AsEnumerable(this ITuple tuple)
     {
         for (int i = 0; i < tuple.Length; i++)
@@ -50,5 +49,4 @@ internal static class DataReaderExtensions
             yield return tuple[i];
         }
     }
-#endif
 }

--- a/ClickHouse.Driver/Utility/LargeTuple.cs
+++ b/ClickHouse.Driver/Utility/LargeTuple.cs
@@ -1,4 +1,3 @@
-﻿#if !NET462
 using System.Runtime.CompilerServices;
 
 namespace ClickHouse.Driver.Utility;
@@ -16,4 +15,3 @@ internal class LargeTuple : ITuple
 
     public int Length => items.Length;
 }
-#endif

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,6 +2,8 @@ v?
 ---
 
 **Breaking Changes:**
+* **Dropped support for .NET Framework and .NET Standard.** The library now targets only `net6.0`, `net8.0`, `net9.0`, and `net10.0`. Removed support for `net462`, `net48`, and `netstandard2.1`. If you are using .NET Framework, you will need to stay on the previous version or migrate to .NET 6.0+.
+
 * **Removed feature discovery query from `OpenAsync`.** The connection's `OpenAsync()` method no longer executes `SELECT version()` to discover server capabilities. This makes connection opening instantaneous (no network round-trip) but removes the `SupportedFeatures` property from `ClickHouseConnection`. The `ServerVersion` property now throws `InvalidOperationException`.
 
   **Migration guidance:** If you need to check the server version:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> High because this is a breaking platform-support change that removes .NET Framework/.NET Standard builds and adjusts tuple/bit-conversion codepaths, which can impact downstream consumers and serialization behavior.
> 
> **Overview**
> **Drops legacy TFMs** by removing `net462`, `net48`, and `netstandard2.1` from both the library and test projects, and deleting framework-specific references/package dependencies.
> 
> **Cleans up code that existed only for older TFMs**: tuple support (`ITuple`, `LargeTuple`, `GetTuple`, and HTTP parameter formatting) is now unconditional, and `BFloat16Type` removes the older union-based implementation in favor of `BitConverter` APIs.
> 
> **Updates tests/docs/release notes** to reflect the new supported frameworks and to run tuple-related tests unconditionally on the remaining targets.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a345de8acc68c5f457993a96f570f7d6740d467. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->