### PR TITLE
Change user agent key for the .net version

### DIFF
--- a/ClickHouse.Driver/Utility/UserAgentProvider.cs
+++ b/ClickHouse.Driver/Utility/UserAgentProvider.cs
@@ -47,13 +47,13 @@ internal static class UserAgentProvider
                 var runtime = Environment.Version.ToString();
 
                 // Pre-build ProductInfoHeaderValue objects
-                SystemProductInfo = new ProductInfoHeaderValue($"(platform:{osPlatform}; os:{osDescription}; runtime:{runtime}; arch:{architecture})");
+                SystemProductInfo = new ProductInfoHeaderValue($"(platform:{osPlatform}; os:{osDescription}; lv:{runtime}; arch:{architecture})");
             }
             catch
             {
                 // If anything fails during initialization, create fallback values
                 DriverProductInfo ??= new ProductInfoHeaderValue("ClickHouse.Driver", "unknown");
-                SystemProductInfo = new ProductInfoHeaderValue("(platform:unknown; os:unknown; runtime:unknown; arch:unknown)");
+                SystemProductInfo = new ProductInfoHeaderValue("(platform:unknown; os:unknown; lv:unknown; arch:unknown)");
             }
         }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates the system portion of the user agent string.
> 
> - In `UserAgentProvider`, `SystemProductInfo` now uses `lv:{Environment.Version}` instead of `runtime:{Environment.Version}`
> - Fallback `SystemProductInfo` updated accordingly (`lv:unknown`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 858873acccb811c23dc4acc57d6f092737ce0c36. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->