### PR TITLE
Add support for POCO inserts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ v1.1.0
 ---
 
 **New Features:**
+* **POCO binary inserts**: new `InsertBinaryAsync<T>` overload on `ClickHouseClient` accepts `IEnumerable<T>` directly, mapping public properties to columns automatically. Register types upfront with `RegisterBinaryInsertType<T>()`. Customize column names and ClickHouse types with `[ClickHouseColumn(Name = "...", Type = "...")]`, or exclude properties with `[ClickHouseNotMapped]`. When all properties specify explicit types via the attribute, the schema probe is skipped entirely.
 * `InsertOptions.ColumnTypes`: provide a dictionary of column name → ClickHouse type string to skip the schema probe query (`SELECT ... WHERE 1=0`) entirely. Ideal when the table schema is known at compile time.
 * `InsertOptions.UseSchemaCache`: when `true`, the full table schema is cached per (database, table) for the lifetime of the `ClickHouseClient` instance. Subsequent inserts to the same table reuse the cached schema regardless of which columns are selected, eliminating redundant round-trips.
 

--- a/ClickHouse.Driver.Benchmark/PocoInsertBenchmark.cs
+++ b/ClickHouse.Driver.Benchmark/PocoInsertBenchmark.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using ClickHouse.Driver.ADO;
+
+namespace ClickHouse.Driver.Benchmark;
+
+/// <summary>
+/// Compares POCO insert performance against the object[] path.
+/// Both benchmarks insert the same data into an ENGINE Null table
+/// so the measurement is purely client-side serialization + network overhead.
+/// </summary>
+[Config(typeof(ComparisonConfig))]
+[MemoryDiagnoser(true)]
+public class PocoInsertBenchmark
+{
+    private ClickHouseClient client;
+    private const string TableName = "test.benchmark_poco_insert";
+
+    public class SensorReading
+    {
+        public long Id { get; set; }
+        public string Name { get; set; }
+        public double Value { get; set; }
+    }
+
+    [Params(100_000, 500_000)]
+    public int Count { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("CLICKHOUSE_CONNECTION")
+            ?? "Host=localhost";
+        client = new ClickHouseClient(connectionString);
+
+        client.ExecuteNonQueryAsync("CREATE DATABASE IF NOT EXISTS test").Wait();
+        client.ExecuteNonQueryAsync(
+            $"CREATE TABLE IF NOT EXISTS {TableName} (Id Int64, Name String, Value Float64) ENGINE Null").Wait();
+
+        client.RegisterBinaryInsertType<SensorReading>();
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        client?.Dispose();
+    }
+
+    [Benchmark(Baseline = true)]
+    public async Task<long> ObjectArray()
+    {
+        var columns = new[] { "Id", "Name", "Value" };
+        var rows = GenerateObjectArrayRows(Count);
+        return await client.InsertBinaryAsync(TableName, columns, rows);
+    }
+
+    [Benchmark]
+    public async Task<long> Poco()
+    {
+        var rows = GeneratePocoRows(Count);
+        return await client.InsertBinaryAsync(TableName, rows);
+    }
+
+    private static IEnumerable<object[]> GenerateObjectArrayRows(int count)
+    {
+        for (int i = 0; i < count; i++)
+            yield return new object[] { (long)i, $"sensor_{i % 10}", (double)i * 0.1 };
+    }
+
+    private static IEnumerable<SensorReading> GeneratePocoRows(int count)
+    {
+        for (int i = 0; i < count; i++)
+            yield return new SensorReading { Id = i, Name = $"sensor_{i % 10}", Value = i * 0.1 };
+    }
+}

--- a/ClickHouse.Driver.Benchmark/PocoInsertBenchmark.cs
+++ b/ClickHouse.Driver.Benchmark/PocoInsertBenchmark.cs
@@ -30,15 +30,15 @@ public class PocoInsertBenchmark
     public int Count { get; set; }
 
     [GlobalSetup]
-    public void Setup()
+    public async Task Setup()
     {
         var connectionString = Environment.GetEnvironmentVariable("CLICKHOUSE_CONNECTION")
             ?? "Host=localhost";
         client = new ClickHouseClient(connectionString);
 
-        client.ExecuteNonQueryAsync("CREATE DATABASE IF NOT EXISTS test").Wait();
-        client.ExecuteNonQueryAsync(
-            $"CREATE TABLE IF NOT EXISTS {TableName} (Id Int64, Name String, Value Float64) ENGINE Null").Wait();
+        await client.ExecuteNonQueryAsync("CREATE DATABASE IF NOT EXISTS test");
+        await client.ExecuteNonQueryAsync(
+            $"CREATE TABLE IF NOT EXISTS {TableName} (Id Int64, Name String, Value Float64) ENGINE Null");
 
         client.RegisterBinaryInsertType<SensorReading>();
     }

--- a/ClickHouse.Driver.Benchmark/PocoInsertColumn.cs
+++ b/ClickHouse.Driver.Benchmark/PocoInsertColumn.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+
+namespace ClickHouse.Driver.Benchmark;
+
+[Config(typeof(ComparisonConfig))]
+[MemoryDiagnoser(true)]
+public class PocoInsertColumn
+{
+    private ClickHouseClient client;
+
+    public class Row
+    {
+        public long Col1 { get; set; }
+    }
+
+    [Params(500000)]
+    public int Count { get; set; }
+
+    private IEnumerable<Row> Rows
+    {
+        get
+        {
+            int counter = 0;
+            while (counter < int.MaxValue)
+                yield return new Row { Col1 = counter++ };
+        }
+    }
+
+    [GlobalSetup]
+    public async Task Setup()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("CLICKHOUSE_CONNECTION")
+            ?? "Host=localhost";
+        client = new ClickHouseClient(connectionString);
+
+        await client.ExecuteNonQueryAsync("CREATE DATABASE IF NOT EXISTS test");
+        await client.ExecuteNonQueryAsync(
+            "CREATE TABLE IF NOT EXISTS test.benchmark_poco_insert_int64 (Col1 Int64) ENGINE Null");
+
+        client.RegisterBinaryInsertType<Row>();
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        client?.Dispose();
+    }
+
+    [Benchmark]
+    public async Task<long> PocoInsertInt64() =>
+        await client.InsertBinaryAsync("test.benchmark_poco_insert_int64", Rows.Take(Count));
+}

--- a/ClickHouse.Driver.Tests/Copy/BinaryInsertTypeRegistryTests.cs
+++ b/ClickHouse.Driver.Tests/Copy/BinaryInsertTypeRegistryTests.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using ClickHouse.Driver.ADO;
+using NUnit.Framework;
+
+namespace ClickHouse.Driver.Tests.Copy;
+
+[TestFixture]
+public class BinaryInsertTypeRegistryTests
+{
+    private ClickHouseClient client;
+
+    private class SimplePoco
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public double Score { get; set; }
+    }
+
+    private class PocoWithTypeAttribute
+    {
+        [ClickHouseColumn(Type = "UInt64")]
+        public long Id { get; set; }
+
+        [ClickHouseColumn(Type = "Nullable(String)")]
+        public string Name { get; set; }
+    }
+
+    private class PocoWithDuplicateColumnNames
+    {
+        [ClickHouseColumn(Name = "shared_col")]
+        public int First { get; set; }
+
+        [ClickHouseColumn(Name = "shared_col")]
+        public string Second { get; set; }
+    }
+
+    private class EmptyPoco
+    {
+    }
+
+    private class AllNotMappedPoco
+    {
+        [ClickHouseNotMapped]
+        public int Id { get; set; }
+
+        [ClickHouseNotMapped]
+        public string Name { get; set; }
+    }
+
+    [SetUp]
+    public void SetUp()
+    {
+        client = new ClickHouseClient(new ClickHouseClientSettings());
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        client?.Dispose();
+    }
+
+    [Test]
+    public void RegisterBinaryInsertType_WithDuplicateColumnNames_ShouldThrow()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            client.RegisterBinaryInsertType<PocoWithDuplicateColumnNames>());
+
+        Assert.That(ex.Message, Does.Contain("shared_col"));
+    }
+
+
+    [Test]
+    public void RegisterBinaryInsertType_WithNoPublicProperties_ShouldThrow()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            client.RegisterBinaryInsertType<EmptyPoco>());
+
+        Assert.That(ex.Message, Does.Contain("no public readable properties"));
+    }
+
+    [Test]
+    public void RegisterBinaryInsertType_WithAllPropertiesNotMapped_ShouldThrow()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            client.RegisterBinaryInsertType<AllNotMappedPoco>());
+
+        Assert.That(ex.Message, Does.Contain("no public readable properties"));
+    }
+}

--- a/ClickHouse.Driver.Tests/Copy/BinaryInsertTypeRegistryTests.cs
+++ b/ClickHouse.Driver.Tests/Copy/BinaryInsertTypeRegistryTests.cs
@@ -27,6 +27,30 @@ public class BinaryInsertTypeRegistryTests
         public string Name { get; set; }
     }
 
+    private class PocoWithEmptyColumnName
+    {
+        [ClickHouseColumn(Name = "")]
+        public int Id { get; set; }
+    }
+
+    private class PocoWithWhitespaceColumnName
+    {
+        [ClickHouseColumn(Name = "   ")]
+        public int Id { get; set; }
+    }
+
+    private class PocoWithEmptyTypeName
+    {
+        [ClickHouseColumn(Type = "")]
+        public int Id { get; set; }
+    }
+
+    private class PocoWithWhitespaceTypeName
+    {
+        [ClickHouseColumn(Type = "   ")]
+        public int Id { get; set; }
+    }
+
     private class PocoWithDuplicateColumnNames
     {
         [ClickHouseColumn(Name = "shared_col")]
@@ -59,6 +83,44 @@ public class BinaryInsertTypeRegistryTests
     public void TearDown()
     {
         client?.Dispose();
+    }
+
+    [Test]
+    public void RegisterBinaryInsertType_WithEmptyColumnName_ShouldThrow()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            client.RegisterBinaryInsertType<PocoWithEmptyColumnName>());
+
+        Assert.That(ex.Message, Does.Contain("empty or whitespace"));
+    }
+
+    [Test]
+    public void RegisterBinaryInsertType_WithWhitespaceColumnName_ShouldThrow()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            client.RegisterBinaryInsertType<PocoWithWhitespaceColumnName>());
+
+        Assert.That(ex.Message, Does.Contain("empty or whitespace"));
+    }
+
+    [Test]
+    public void RegisterBinaryInsertType_WithEmptyTypeName_ShouldThrow()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            client.RegisterBinaryInsertType<PocoWithEmptyTypeName>());
+
+        Assert.That(ex.Message, Does.Contain("empty or whitespace"));
+        Assert.That(ex.Message, Does.Contain("ClickHouse type"));
+    }
+
+    [Test]
+    public void RegisterBinaryInsertType_WithWhitespaceTypeName_ShouldThrow()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            client.RegisterBinaryInsertType<PocoWithWhitespaceTypeName>());
+
+        Assert.That(ex.Message, Does.Contain("empty or whitespace"));
+        Assert.That(ex.Message, Does.Contain("ClickHouse type"));
     }
 
     [Test]

--- a/ClickHouse.Driver.Tests/Copy/InsertBinaryPocoTests.cs
+++ b/ClickHouse.Driver.Tests/Copy/InsertBinaryPocoTests.cs
@@ -53,7 +53,7 @@ public class InsertBinaryPocoTests : AbstractConnectionTestFixture
         [ClickHouseColumn(Type = "UInt64")]
         public ulong Id { get; set; }
 
-        // No explicit type — requires schema probe
+        // No explicit type, requires schema probe
         public string Value { get; set; }
     }
 
@@ -71,6 +71,27 @@ public class InsertBinaryPocoTests : AbstractConnectionTestFixture
         public string this[int index] => null;
     }
 
+    // Internal getter, should be excluded (property visible via public setter, but getter isn't public)
+    private class PocoWithInternalGetter
+    {
+        public ulong Id { get; set; }
+        public string Value { internal get; set; }
+    }
+
+    // Protected getter
+    private class PocoWithProtectedGetter
+    {
+        public ulong Id { get; set; }
+        public string Value { protected get; set; }
+    }
+
+    // Private getter
+    private class PocoWithPrivateGetter
+    {
+        public ulong Id { get; set; }
+        public string Value { private get; set; }
+    }
+
     private class PocoWithNullable
     {
         public ulong Id { get; set; }
@@ -85,7 +106,7 @@ public class InsertBinaryPocoTests : AbstractConnectionTestFixture
         public ulong Id { get; set; }
     }
 
-    // Declares Value as UInt64 but the property is actually a string — type mismatch at serialization time
+    // Declares Value as UInt64 but the property is actually a string, type mismatch at serialization time
     private class PocoWithWrongExplicitType
     {
         [ClickHouseColumn(Type = "UInt64")]
@@ -95,7 +116,7 @@ public class InsertBinaryPocoTests : AbstractConnectionTestFixture
         public string Value { get; set; }
     }
 
-    // Deliberately never registered — used only by the unregistered type test
+    // Deliberately never registered
     private class UnregisteredPoco
     {
         public ulong Id { get; set; }
@@ -154,6 +175,119 @@ public class InsertBinaryPocoTests : AbstractConnectionTestFixture
 
             Assert.That(ex.Row, Is.Not.Null);
             Assert.That(ex.InnerException, Is.Not.Null);
+        }
+        finally
+        {
+            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
+        }
+    }
+
+    [Test]
+    public async Task InsertBinaryAsync_WithInternalGetter_ShouldExcludeProperty()
+    {
+        var tableName = CreateTestTableName();
+        try
+        {
+            // Table has a Value column with DEFAULT — if the internal-getter property
+            // were included, it would either serialize wrong or fail.
+            await client.ExecuteNonQueryAsync($@"
+                CREATE TABLE IF NOT EXISTS test.{tableName}
+                (Id UInt64, Value String DEFAULT 'default_val')
+                ENGINE = MergeTree() ORDER BY Id");
+
+            client.RegisterBinaryInsertType<PocoWithInternalGetter>();
+
+            var rows = new[]
+            {
+                new PocoWithInternalGetter { Id = 1, Value = "hidden" },
+            };
+
+            var inserted = await client.InsertBinaryAsync(
+                tableName, rows, new InsertOptions { Database = "test", Format = RowBinaryFormat.RowBinaryWithDefaults });
+
+            Assert.That(inserted, Is.EqualTo(1));
+
+            using var reader = await client.ExecuteReaderAsync(
+                $"SELECT Id, Value FROM test.{tableName}",
+                options: new QueryOptions { Database = "test" });
+
+            Assert.That(reader.Read(), Is.True);
+            Assert.That(reader.GetValue(0), Is.EqualTo(1UL));
+            Assert.That(reader.GetValue(1), Is.EqualTo("default_val"));
+        }
+        finally
+        {
+            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
+        }
+    }
+
+    [Test]
+    public async Task InsertBinaryAsync_WithProtectedGetter_ShouldExcludeProperty()
+    {
+        var tableName = CreateTestTableName();
+        try
+        {
+            await client.ExecuteNonQueryAsync($@"
+                CREATE TABLE IF NOT EXISTS test.{tableName}
+                (Id UInt64, Value String DEFAULT 'default_val')
+                ENGINE = MergeTree() ORDER BY Id");
+
+            client.RegisterBinaryInsertType<PocoWithProtectedGetter>();
+
+            var rows = new[]
+            {
+                new PocoWithProtectedGetter { Id = 1, Value = "hidden" },
+            };
+
+            var inserted = await client.InsertBinaryAsync(
+                tableName, rows, new InsertOptions { Database = "test", Format = RowBinaryFormat.RowBinaryWithDefaults });
+
+            Assert.That(inserted, Is.EqualTo(1));
+
+            using var reader = await client.ExecuteReaderAsync(
+                $"SELECT Id, Value FROM test.{tableName}",
+                options: new QueryOptions { Database = "test" });
+
+            Assert.That(reader.Read(), Is.True);
+            Assert.That(reader.GetValue(0), Is.EqualTo(1UL));
+            Assert.That(reader.GetValue(1), Is.EqualTo("default_val"));
+        }
+        finally
+        {
+            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
+        }
+    }
+
+    [Test]
+    public async Task InsertBinaryAsync_WithPrivateGetter_ShouldExcludeProperty()
+    {
+        var tableName = CreateTestTableName();
+        try
+        {
+            await client.ExecuteNonQueryAsync($@"
+                CREATE TABLE IF NOT EXISTS test.{tableName}
+                (Id UInt64, Value String DEFAULT 'default_val')
+                ENGINE = MergeTree() ORDER BY Id");
+
+            client.RegisterBinaryInsertType<PocoWithPrivateGetter>();
+
+            var rows = new[]
+            {
+                new PocoWithPrivateGetter { Id = 1, Value = "hidden" },
+            };
+
+            var inserted = await client.InsertBinaryAsync(
+                tableName, rows, new InsertOptions { Database = "test", Format = RowBinaryFormat.RowBinaryWithDefaults });
+
+            Assert.That(inserted, Is.EqualTo(1));
+
+            using var reader = await client.ExecuteReaderAsync(
+                $"SELECT Id, Value FROM test.{tableName}",
+                options: new QueryOptions { Database = "test" });
+
+            Assert.That(reader.Read(), Is.True);
+            Assert.That(reader.GetValue(0), Is.EqualTo(1UL));
+            Assert.That(reader.GetValue(1), Is.EqualTo("default_val"));
         }
         finally
         {

--- a/ClickHouse.Driver.Tests/Copy/InsertBinaryPocoTests.cs
+++ b/ClickHouse.Driver.Tests/Copy/InsertBinaryPocoTests.cs
@@ -719,6 +719,64 @@ public class InsertBinaryPocoTests : AbstractConnectionTestFixture
     }
 
     [Test]
+    public async Task InsertBinaryAsync_AfterAlterTableAddsColumn_ShouldInsertSuccessfully()
+    {
+        var tableName = CreateTestTableName();
+        try
+        {
+            await client.ExecuteNonQueryAsync($@"
+                CREATE TABLE IF NOT EXISTS test.{tableName}
+                (Id UInt64, Value String)
+                ENGINE = MergeTree() ORDER BY Id");
+
+            client.RegisterBinaryInsertType<SimplePoco>();
+
+            var firstBatch = new[]
+            {
+                new SimplePoco { Id = 1, Value = "before_alter" },
+            };
+
+            var inserted = await client.InsertBinaryAsync(
+                tableName, firstBatch, new InsertOptions { Database = "test" });
+
+            Assert.That(inserted, Is.EqualTo(1));
+
+            // Add a new column with a default value
+            await client.ExecuteNonQueryAsync(
+                $"ALTER TABLE test.{tableName} ADD COLUMN Extra String DEFAULT 'default_extra'");
+
+            // Insert again with the same POCO (which doesn't have the new column)
+            var secondBatch = new[]
+            {
+                new SimplePoco { Id = 2, Value = "after_alter" },
+            };
+
+            inserted = await client.InsertBinaryAsync(
+                tableName, secondBatch, new InsertOptions { Database = "test" });
+
+            Assert.That(inserted, Is.EqualTo(1));
+
+            // Verify both rows exist and the new column got its default value
+            using var reader = await client.ExecuteReaderAsync(
+                $"SELECT Id, Value, Extra FROM test.{tableName} ORDER BY Id",
+                options: new QueryOptions { Database = "test" });
+
+            Assert.That(reader.Read(), Is.True);
+            Assert.That(reader.GetValue(0), Is.EqualTo(1UL));
+            Assert.That(reader.GetValue(1), Is.EqualTo("before_alter"));
+
+            Assert.That(reader.Read(), Is.True);
+            Assert.That(reader.GetValue(0), Is.EqualTo(2UL));
+            Assert.That(reader.GetValue(1), Is.EqualTo("after_alter"));
+            Assert.That(reader.GetValue(2), Is.EqualTo("default_extra"));
+        }
+        finally
+        {
+            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
+        }
+    }
+
+    [Test]
     public async Task InsertBinaryAsync_WithMultipleBatches_ShouldInsertAll()
     {
         var tableName = CreateTestTableName();

--- a/ClickHouse.Driver.Tests/Copy/InsertBinaryPocoTests.cs
+++ b/ClickHouse.Driver.Tests/Copy/InsertBinaryPocoTests.cs
@@ -1,0 +1,521 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using ClickHouse.Driver.ADO;
+using ClickHouse.Driver.Copy;
+using NUnit.Framework;
+
+namespace ClickHouse.Driver.Tests.Copy;
+
+[TestFixture]
+public class InsertBinaryPocoTests : AbstractConnectionTestFixture
+{
+    private string CreateTestTableName([CallerMemberName] string testName = null)
+        => SanitizeTableName($"test_poco_{testName}_{Guid.NewGuid():N}");
+
+    private class SimplePoco
+    {
+        public ulong Id { get; set; }
+        public string Value { get; set; }
+    }
+
+    private class PocoWithColumnNames
+    {
+        [ClickHouseColumn(Name = "id")]
+        public ulong UserId { get; set; }
+
+        [ClickHouseColumn(Name = "value")]
+        public string UserName { get; set; }
+    }
+
+    private class PocoWithNotMapped
+    {
+        public ulong Id { get; set; }
+        public string Value { get; set; }
+
+        [ClickHouseNotMapped]
+        public string InternalState { get; set; }
+    }
+
+    private class PocoWithExplicitTypes
+    {
+        [ClickHouseColumn(Type = "UInt64")]
+        public ulong Id { get; set; }
+
+        [ClickHouseColumn(Type = "String")]
+        public string Value { get; set; }
+    }
+
+    private class PocoWithPartialTypes
+    {
+        [ClickHouseColumn(Type = "UInt64")]
+        public ulong Id { get; set; }
+
+        // No explicit type — requires schema probe
+        public string Value { get; set; }
+    }
+
+    private class PocoWithWriteOnlyProperty
+    {
+        public ulong Id { get; set; }
+        public string Value { get; set; }
+        public string WriteOnly { set { } }
+    }
+
+    private class PocoWithIndexer
+    {
+        public ulong Id { get; set; }
+        public string Value { get; set; }
+        public string this[int index] => null;
+    }
+
+    private class PocoWithNullable
+    {
+        public ulong Id { get; set; }
+        public string Value { get; set; }
+        public int? OptionalScore { get; set; }
+    }
+
+    // Properties declared in reverse order of the table columns (Value, Id)
+    private class ReversedPropertyOrderPoco
+    {
+        public string Value { get; set; }
+        public ulong Id { get; set; }
+    }
+
+    // Deliberately never registered — used only by the unregistered type test
+    private class UnregisteredPoco
+    {
+        public ulong Id { get; set; }
+    }
+
+    [Test]
+    public void InsertBinaryAsync_WithUnregisteredType_ShouldThrow()
+    {
+        var ex = Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await client.InsertBinaryAsync<UnregisteredPoco>("test_table", Array.Empty<UnregisteredPoco>()));
+
+        Assert.That(ex.Message, Does.Contain("UnregisteredPoco"));
+        Assert.That(ex.Message, Does.Contain("RegisterBinaryInsertType"));
+    }
+
+    [Test]
+    public void InsertBinaryAsync_WithNullTable_ShouldThrow()
+    {
+        client.RegisterBinaryInsertType<SimplePoco>();
+
+        Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await client.InsertBinaryAsync<SimplePoco>(null, Array.Empty<SimplePoco>()));
+    }
+
+    [Test]
+    public void InsertBinaryAsync_WithNullRows_ShouldThrow()
+    {
+        client.RegisterBinaryInsertType<SimplePoco>();
+
+        Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            await client.InsertBinaryAsync<SimplePoco>("test_table", (IEnumerable<SimplePoco>)null));
+    }
+
+    [Test]
+    public async Task InsertBinaryAsync_WithPoco_ShouldRoundTripData()
+    {
+        var tableName = CreateTestTableName();
+        try
+        {
+            await client.ExecuteNonQueryAsync($@"
+                CREATE TABLE IF NOT EXISTS test.{tableName}
+                (Id UInt64, Value String)
+                ENGINE = MergeTree() ORDER BY Id");
+
+            client.RegisterBinaryInsertType<SimplePoco>();
+
+            var rows = Enumerable.Range(1, 10).Select(i => new SimplePoco
+            {
+                Id = (ulong)i,
+                Value = $"Value_{i}",
+            });
+
+            var inserted = await client.InsertBinaryAsync(
+                tableName,
+                rows,
+                new InsertOptions { Database = "test" });
+
+            Assert.That(inserted, Is.EqualTo(10));
+
+            var count = await client.ExecuteScalarAsync(
+                $"SELECT count() FROM test.{tableName}");
+            Assert.That(count, Is.EqualTo(10UL));
+
+            using var reader = await client.ExecuteReaderAsync(
+                $"SELECT Id, Value FROM test.{tableName} ORDER BY Id",
+                options: new QueryOptions { Database = "test" });
+
+            var results = new List<(ulong Id, string Value)>();
+            while (reader.Read())
+            {
+                results.Add(((ulong)reader.GetValue(0), (string)reader.GetValue(1)));
+            }
+
+            Assert.That(results, Has.Count.EqualTo(10));
+            Assert.That(results[0].Id, Is.EqualTo(1UL));
+            Assert.That(results[0].Value, Is.EqualTo("Value_1"));
+            Assert.That(results[9].Id, Is.EqualTo(10UL));
+            Assert.That(results[9].Value, Is.EqualTo("Value_10"));
+        }
+        finally
+        {
+            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
+        }
+    }
+
+    [Test]
+    public async Task InsertBinaryAsync_WithReversedPropertyOrder_ShouldMapCorrectly()
+    {
+        var tableName = CreateTestTableName();
+        try
+        {
+            // Table columns: Id first, Value second
+            await client.ExecuteNonQueryAsync($@"
+                CREATE TABLE IF NOT EXISTS test.{tableName}
+                (Id UInt64, Value String)
+                ENGINE = MergeTree() ORDER BY Id");
+
+            // POCO declares Value first, Id second — opposite of table order
+            client.RegisterBinaryInsertType<ReversedPropertyOrderPoco>();
+
+            var rows = new[]
+            {
+                new ReversedPropertyOrderPoco { Id = 1, Value = "first" },
+                new ReversedPropertyOrderPoco { Id = 2, Value = "second" },
+            };
+
+            var inserted = await client.InsertBinaryAsync(
+                tableName, rows, new InsertOptions { Database = "test" });
+
+            Assert.That(inserted, Is.EqualTo(2));
+
+            using var reader = await client.ExecuteReaderAsync(
+                $"SELECT Id, Value FROM test.{tableName} ORDER BY Id",
+                options: new QueryOptions { Database = "test" });
+
+            Assert.That(reader.Read(), Is.True);
+            Assert.That(reader.GetValue(0), Is.EqualTo(1UL));
+            Assert.That(reader.GetValue(1), Is.EqualTo("first"));
+
+            Assert.That(reader.Read(), Is.True);
+            Assert.That(reader.GetValue(0), Is.EqualTo(2UL));
+            Assert.That(reader.GetValue(1), Is.EqualTo("second"));
+        }
+        finally
+        {
+            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
+        }
+    }
+
+    [Test]
+    public async Task InsertBinaryAsync_WithColumnNameAttribute_ShouldMapCorrectly()
+    {
+        var tableName = CreateTestTableName();
+        try
+        {
+            await client.ExecuteNonQueryAsync($@"
+                CREATE TABLE IF NOT EXISTS test.{tableName}
+                (id UInt64, value String)
+                ENGINE = MergeTree() ORDER BY id");
+
+            client.RegisterBinaryInsertType<PocoWithColumnNames>();
+
+            var rows = new[]
+            {
+                new PocoWithColumnNames { UserId = 1, UserName = "Alice" },
+                new PocoWithColumnNames { UserId = 2, UserName = "Bob" },
+            };
+
+            var inserted = await client.InsertBinaryAsync(
+                tableName, rows, new InsertOptions { Database = "test" });
+
+            Assert.That(inserted, Is.EqualTo(2));
+
+            using var reader = await client.ExecuteReaderAsync(
+                $"SELECT id, value FROM test.{tableName} ORDER BY id",
+                options: new QueryOptions { Database = "test" });
+
+            Assert.That(reader.Read(), Is.True);
+            Assert.That(reader.GetValue(0), Is.EqualTo(1UL));
+            Assert.That(reader.GetValue(1), Is.EqualTo("Alice"));
+
+            Assert.That(reader.Read(), Is.True);
+            Assert.That(reader.GetValue(0), Is.EqualTo(2UL));
+            Assert.That(reader.GetValue(1), Is.EqualTo("Bob"));
+        }
+        finally
+        {
+            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
+        }
+    }
+
+    [Test]
+    public async Task InsertBinaryAsync_WithNotMapped_ShouldExcludeProperty()
+    {
+        var tableName = CreateTestTableName();
+        try
+        {
+            await client.ExecuteNonQueryAsync($@"
+                CREATE TABLE IF NOT EXISTS test.{tableName}
+                (Id UInt64, Value String)
+                ENGINE = MergeTree() ORDER BY Id");
+
+            client.RegisterBinaryInsertType<PocoWithNotMapped>();
+
+            var rows = new[]
+            {
+                new PocoWithNotMapped { Id = 1, Value = "test", InternalState = "should_be_ignored" },
+            };
+
+            var inserted = await client.InsertBinaryAsync(
+                tableName, rows, new InsertOptions { Database = "test" });
+
+            Assert.That(inserted, Is.EqualTo(1));
+
+            var count = await client.ExecuteScalarAsync(
+                $"SELECT count() FROM test.{tableName}");
+            Assert.That(count, Is.EqualTo(1UL));
+        }
+        finally
+        {
+            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
+        }
+    }
+
+    [Test]
+    public async Task InsertBinaryAsync_WithWriteOnlyProperty_ShouldExcludeIt()
+    {
+        var tableName = CreateTestTableName();
+        try
+        {
+            // Table includes a WriteOnly column with a DEFAULT — if the property were
+            // mistakenly included, the insert would fail or write wrong data.
+            await client.ExecuteNonQueryAsync($@"
+                CREATE TABLE IF NOT EXISTS test.{tableName}
+                (Id UInt64, Value String, WriteOnly String DEFAULT 'default_value')
+                ENGINE = MergeTree() ORDER BY Id");
+
+            client.RegisterBinaryInsertType<PocoWithWriteOnlyProperty>();
+
+            var rows = new[]
+            {
+                new PocoWithWriteOnlyProperty { Id = 1, Value = "test", WriteOnly = "ignored" },
+            };
+
+            var inserted = await client.InsertBinaryAsync(
+                tableName, rows, new InsertOptions { Database = "test", Format = RowBinaryFormat.RowBinaryWithDefaults });
+
+            Assert.That(inserted, Is.EqualTo(1));
+
+            using var reader = await client.ExecuteReaderAsync(
+                $"SELECT Id, Value, WriteOnly FROM test.{tableName}",
+                options: new QueryOptions { Database = "test" });
+
+            Assert.That(reader.Read(), Is.True);
+            Assert.That(reader.GetValue(0), Is.EqualTo(1UL));
+            Assert.That(reader.GetValue(1), Is.EqualTo("test"));
+            Assert.That(reader.GetValue(2), Is.EqualTo("default_value"));
+        }
+        finally
+        {
+            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
+        }
+    }
+
+    [Test]
+    public async Task InsertBinaryAsync_WithIndexer_ShouldExcludeIt()
+    {
+        var tableName = CreateTestTableName();
+        try
+        {
+            await client.ExecuteNonQueryAsync($@"
+                CREATE TABLE IF NOT EXISTS test.{tableName}
+                (Id UInt64, Value String)
+                ENGINE = MergeTree() ORDER BY Id");
+
+            client.RegisterBinaryInsertType<PocoWithIndexer>();
+
+            var rows = new[]
+            {
+                new PocoWithIndexer { Id = 1, Value = "test" },
+            };
+
+            var inserted = await client.InsertBinaryAsync(
+                tableName, rows, new InsertOptions { Database = "test" });
+
+            Assert.That(inserted, Is.EqualTo(1));
+
+            using var reader = await client.ExecuteReaderAsync(
+                $"SELECT Id, Value FROM test.{tableName}",
+                options: new QueryOptions { Database = "test" });
+
+            Assert.That(reader.Read(), Is.True);
+            Assert.That(reader.GetValue(0), Is.EqualTo(1UL));
+            Assert.That(reader.GetValue(1), Is.EqualTo("test"));
+        }
+        finally
+        {
+            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
+        }
+    }
+
+    [Test]
+    public async Task InsertBinaryAsync_WithExplicitTypes_ShouldSkipSchemaProbe()
+    {
+        var tableName = CreateTestTableName();
+        try
+        {
+            await client.ExecuteNonQueryAsync($@"
+                CREATE TABLE IF NOT EXISTS test.{tableName}
+                (Id UInt64, Value String)
+                ENGINE = MergeTree() ORDER BY Id");
+
+            client.RegisterBinaryInsertType<PocoWithExplicitTypes>();
+
+            var rows = new[]
+            {
+                new PocoWithExplicitTypes { Id = 42, Value = "explicit" },
+            };
+
+            var inserted = await client.InsertBinaryAsync(
+                tableName, rows, new InsertOptions { Database = "test" });
+
+            Assert.That(inserted, Is.EqualTo(1));
+
+            using var reader = await client.ExecuteReaderAsync(
+                $"SELECT Id, Value FROM test.{tableName}",
+                options: new QueryOptions { Database = "test" });
+
+            Assert.That(reader.Read(), Is.True);
+            Assert.That(reader.GetValue(0), Is.EqualTo(42UL));
+            Assert.That(reader.GetValue(1), Is.EqualTo("explicit"));
+        }
+        finally
+        {
+            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
+        }
+    }
+
+    [Test]
+    public async Task InsertBinaryAsync_WithPartialTypes_ShouldProbeForMissing()
+    {
+        var tableName = CreateTestTableName();
+        try
+        {
+            await client.ExecuteNonQueryAsync($@"
+                CREATE TABLE IF NOT EXISTS test.{tableName}
+                (Id UInt64, Value String)
+                ENGINE = MergeTree() ORDER BY Id");
+
+            client.RegisterBinaryInsertType<PocoWithPartialTypes>();
+
+            var rows = new[]
+            {
+                new PocoWithPartialTypes { Id = 99, Value = "partial" },
+            };
+
+            var inserted = await client.InsertBinaryAsync(
+                tableName, rows, new InsertOptions { Database = "test" });
+
+            Assert.That(inserted, Is.EqualTo(1));
+
+            using var reader = await client.ExecuteReaderAsync(
+                $"SELECT Id, Value FROM test.{tableName}",
+                options: new QueryOptions { Database = "test" });
+
+            Assert.That(reader.Read(), Is.True);
+            Assert.That(reader.GetValue(0), Is.EqualTo(99UL));
+            Assert.That(reader.GetValue(1), Is.EqualTo("partial"));
+        }
+        finally
+        {
+            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
+        }
+    }
+
+    [Test]
+    public async Task InsertBinaryAsync_WithNullableProperties_ShouldInsertNulls()
+    {
+        var tableName = CreateTestTableName();
+        try
+        {
+            await client.ExecuteNonQueryAsync($@"
+                CREATE TABLE IF NOT EXISTS test.{tableName}
+                (Id UInt64, Value String, OptionalScore Nullable(Int32))
+                ENGINE = MergeTree() ORDER BY Id");
+
+            client.RegisterBinaryInsertType<PocoWithNullable>();
+
+            var rows = new[]
+            {
+                new PocoWithNullable { Id = 1, Value = "with_score", OptionalScore = 100 },
+                new PocoWithNullable { Id = 2, Value = "no_score", OptionalScore = null },
+            };
+
+            var inserted = await client.InsertBinaryAsync(
+                tableName, rows, new InsertOptions { Database = "test" });
+
+            Assert.That(inserted, Is.EqualTo(2));
+
+            using var reader = await client.ExecuteReaderAsync(
+                $"SELECT Id, Value, OptionalScore FROM test.{tableName} ORDER BY Id",
+                options: new QueryOptions { Database = "test" });
+
+            Assert.That(reader.Read(), Is.True);
+            Assert.That(reader.GetValue(0), Is.EqualTo(1UL));
+            Assert.That(reader.GetValue(2), Is.EqualTo(100));
+
+            Assert.That(reader.Read(), Is.True);
+            Assert.That(reader.GetValue(0), Is.EqualTo(2UL));
+            Assert.That(reader.IsDBNull(2), Is.True);
+        }
+        finally
+        {
+            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
+        }
+    }
+
+    [Test]
+    public async Task InsertBinaryAsync_WithMultipleBatches_ShouldInsertAll()
+    {
+        var tableName = CreateTestTableName();
+        try
+        {
+            await client.ExecuteNonQueryAsync($@"
+                CREATE TABLE IF NOT EXISTS test.{tableName}
+                (Id UInt64, Value String)
+                ENGINE = MergeTree() ORDER BY Id");
+
+            client.RegisterBinaryInsertType<SimplePoco>();
+
+            var rows = Enumerable.Range(1, 500).Select(i => new SimplePoco
+            {
+                Id = (ulong)i,
+                Value = $"Value_{i}",
+            });
+
+            var inserted = await client.InsertBinaryAsync(
+                tableName,
+                rows,
+                new InsertOptions { Database = "test", BatchSize = 100 });
+
+            Assert.That(inserted, Is.EqualTo(500));
+
+            var count = await client.ExecuteScalarAsync(
+                $"SELECT count() FROM test.{tableName}");
+            Assert.That(count, Is.EqualTo(500UL));
+        }
+        finally
+        {
+            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
+        }
+    }
+}

--- a/ClickHouse.Driver.Tests/Copy/InsertBinaryPocoTests.cs
+++ b/ClickHouse.Driver.Tests/Copy/InsertBinaryPocoTests.cs
@@ -85,6 +85,16 @@ public class InsertBinaryPocoTests : AbstractConnectionTestFixture
         public ulong Id { get; set; }
     }
 
+    // Declares Value as UInt64 but the property is actually a string — type mismatch at serialization time
+    private class PocoWithWrongExplicitType
+    {
+        [ClickHouseColumn(Type = "UInt64")]
+        public ulong Id { get; set; }
+
+        [ClickHouseColumn(Type = "UInt64")]
+        public string Value { get; set; }
+    }
+
     // Deliberately never registered — used only by the unregistered type test
     private class UnregisteredPoco
     {
@@ -117,6 +127,38 @@ public class InsertBinaryPocoTests : AbstractConnectionTestFixture
 
         Assert.ThrowsAsync<ArgumentNullException>(async () =>
             await client.InsertBinaryAsync<SimplePoco>("test_table", (IEnumerable<SimplePoco>)null));
+    }
+
+    [Test]
+    public async Task InsertBinaryAsync_WithWrongExplicitType_ShouldThrowSerializationException()
+    {
+        var tableName = CreateTestTableName();
+        try
+        {
+            await client.ExecuteNonQueryAsync($@"
+                CREATE TABLE IF NOT EXISTS test.{tableName}
+                (Id UInt64, Value UInt64)
+                ENGINE = MergeTree() ORDER BY Id");
+
+            client.RegisterBinaryInsertType<PocoWithWrongExplicitType>();
+
+            var rows = new[]
+            {
+                new PocoWithWrongExplicitType { Id = 1, Value = "not_a_number" },
+            };
+
+            // The type mismatch (string → UInt64) should fail during serialization
+            // and be wrapped in ClickHouseBulkCopySerializationException with row context
+            var ex = Assert.ThrowsAsync<ClickHouseBulkCopySerializationException>(async () =>
+                await client.InsertBinaryAsync(tableName, rows, new InsertOptions { Database = "test" }));
+
+            Assert.That(ex.Row, Is.Not.Null);
+            Assert.That(ex.InnerException, Is.Not.Null);
+        }
+        finally
+        {
+            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
+        }
     }
 
     [Test]
@@ -380,16 +422,18 @@ public class InsertBinaryPocoTests : AbstractConnectionTestFixture
 
             client.RegisterBinaryInsertType<PocoWithExplicitTypes>();
 
+            var queryId = $"test_poco_explicit_skip_{Guid.NewGuid():N}";
             var rows = new[]
             {
                 new PocoWithExplicitTypes { Id = 42, Value = "explicit" },
             };
 
             var inserted = await client.InsertBinaryAsync(
-                tableName, rows, new InsertOptions { Database = "test" });
+                tableName, rows, new InsertOptions { Database = "test", QueryId = queryId });
 
             Assert.That(inserted, Is.EqualTo(1));
 
+            // Verify data round-tripped correctly
             using var reader = await client.ExecuteReaderAsync(
                 $"SELECT Id, Value FROM test.{tableName}",
                 options: new QueryOptions { Database = "test" });
@@ -397,6 +441,16 @@ public class InsertBinaryPocoTests : AbstractConnectionTestFixture
             Assert.That(reader.Read(), Is.True);
             Assert.That(reader.GetValue(0), Is.EqualTo(42UL));
             Assert.That(reader.GetValue(1), Is.EqualTo("explicit"));
+
+            // Verify no schema probe query was sent
+            await client.ExecuteNonQueryAsync("SYSTEM FLUSH LOGS");
+            var probeCount = await client.ExecuteScalarAsync(
+                $"SELECT count() FROM system.query_log " +
+                $"WHERE query_id LIKE '{queryId}%' " +
+                $"AND query LIKE '%WHERE 1=0%' " +
+                $"AND type = 'QueryFinish'");
+            Assert.That(probeCount, Is.EqualTo(0UL),
+                "No schema probe query should be sent when all properties have explicit types");
         }
         finally
         {

--- a/ClickHouse.Driver.Tests/Copy/InsertBinaryPocoTests.cs
+++ b/ClickHouse.Driver.Tests/Copy/InsertBinaryPocoTests.cs
@@ -593,6 +593,53 @@ public class InsertBinaryPocoTests : AbstractConnectionTestFixture
     }
 
     [Test]
+    public async Task InsertBinaryAsync_WithUserProvidedColumnTypes_ShouldTakePrecedenceOverAttributes()
+    {
+        var tableName = CreateTestTableName();
+        try
+        {
+            await client.ExecuteNonQueryAsync($@"
+                CREATE TABLE IF NOT EXISTS test.{tableName}
+                (Id UInt64, Value String)
+                ENGINE = MergeTree() ORDER BY Id");
+
+            // PocoWithExplicitTypes has [ClickHouseColumn(Type = "UInt64")] and [ClickHouseColumn(Type = "String")]
+            // but we override via InsertOptions.ColumnTypes, these should take precedence
+            client.RegisterBinaryInsertType<PocoWithExplicitTypes>();
+
+            var rows = new[]
+            {
+                new PocoWithExplicitTypes { Id = 1, Value = "overridden" },
+            };
+
+            var options = new InsertOptions
+            {
+                Database = "test",
+                ColumnTypes = new Dictionary<string, string>
+                {
+                    ["Id"] = "UInt64",
+                    ["Value"] = "String",
+                },
+            };
+
+            var inserted = await client.InsertBinaryAsync(tableName, rows, options);
+            Assert.That(inserted, Is.EqualTo(1));
+
+            using var reader = await client.ExecuteReaderAsync(
+                $"SELECT Id, Value FROM test.{tableName}",
+                options: new QueryOptions { Database = "test" });
+
+            Assert.That(reader.Read(), Is.True);
+            Assert.That(reader.GetValue(0), Is.EqualTo(1UL));
+            Assert.That(reader.GetValue(1), Is.EqualTo("overridden"));
+        }
+        finally
+        {
+            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
+        }
+    }
+
+    [Test]
     public async Task InsertBinaryAsync_WithPartialTypes_ShouldProbeForMissing()
     {
         var tableName = CreateTestTableName();

--- a/ClickHouse.Driver.Tests/Copy/InsertBinaryPocoTests.cs
+++ b/ClickHouse.Driver.Tests/Copy/InsertBinaryPocoTests.cs
@@ -776,6 +776,66 @@ public class InsertBinaryPocoTests : AbstractConnectionTestFixture
         }
     }
 
+    private class PocoWithReservedWords
+    {
+        public ulong Id { get; set; }
+
+        [ClickHouseColumn(Name = "index")]
+        public uint Index { get; set; }
+
+        [ClickHouseColumn(Name = "key")]
+        public string Key { get; set; }
+
+        [ClickHouseColumn(Name = "order")]
+        public int Order { get; set; }
+    }
+
+    [Test]
+    public async Task InsertBinaryAsync_WithReservedWordColumns_ShouldRoundTripData()
+    {
+        var tableName = CreateTestTableName();
+        try
+        {
+            await client.ExecuteNonQueryAsync($@"
+                CREATE TABLE IF NOT EXISTS test.{tableName}
+                (Id UInt64, `index` UInt32, `key` String, `order` Int32)
+                ENGINE = MergeTree() ORDER BY Id");
+
+            client.RegisterBinaryInsertType<PocoWithReservedWords>();
+
+            var rows = new[]
+            {
+                new PocoWithReservedWords { Id = 1, Index = 10, Key = "first", Order = 100 },
+                new PocoWithReservedWords { Id = 2, Index = 20, Key = "second", Order = 200 },
+            };
+
+            var inserted = await client.InsertBinaryAsync(
+                tableName, rows, new InsertOptions { Database = "test" });
+
+            Assert.That(inserted, Is.EqualTo(2));
+
+            using var reader = await client.ExecuteReaderAsync(
+                $"SELECT Id, `index`, `key`, `order` FROM test.{tableName} ORDER BY Id",
+                options: new QueryOptions { Database = "test" });
+
+            Assert.That(reader.Read(), Is.True);
+            Assert.That(reader.GetValue(0), Is.EqualTo(1UL));
+            Assert.That(reader.GetValue(1), Is.EqualTo(10u));
+            Assert.That(reader.GetValue(2), Is.EqualTo("first"));
+            Assert.That(reader.GetValue(3), Is.EqualTo(100));
+
+            Assert.That(reader.Read(), Is.True);
+            Assert.That(reader.GetValue(0), Is.EqualTo(2UL));
+            Assert.That(reader.GetValue(1), Is.EqualTo(20u));
+            Assert.That(reader.GetValue(2), Is.EqualTo("second"));
+            Assert.That(reader.GetValue(3), Is.EqualTo(200));
+        }
+        finally
+        {
+            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
+        }
+    }
+
     [Test]
     public async Task InsertBinaryAsync_WithMultipleBatches_ShouldInsertAll()
     {

--- a/ClickHouse.Driver/Attributes/ClickHouseColumnAttribute.cs
+++ b/ClickHouse.Driver/Attributes/ClickHouseColumnAttribute.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace ClickHouse.Driver;
+
+/// <summary>
+/// Configures how a property maps to a ClickHouse column during binary insert operations.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property)]
+public sealed class ClickHouseColumnAttribute : Attribute
+{
+    /// <summary>
+    /// Gets or sets the ClickHouse column name this property maps to.
+    /// When not set, the property name is used as-is (case-sensitive match).
+    /// </summary>
+    public string Name { get; set; }
+
+    /// <summary>
+    /// Gets or sets the explicit ClickHouse type string for this column (e.g. "Nullable(String)", "UInt64").
+    /// When all mapped properties specify a type, the schema probe query is skipped entirely.
+    /// </summary>
+    public string Type { get; set; }
+}

--- a/ClickHouse.Driver/Attributes/ClickHouseNotMappedAttribute.cs
+++ b/ClickHouse.Driver/Attributes/ClickHouseNotMappedAttribute.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace ClickHouse.Driver;
+
+/// <summary>
+/// Indicates that a property should be excluded from ClickHouse column mapping.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property)]
+public sealed class ClickHouseNotMappedAttribute : Attribute
+{
+}

--- a/ClickHouse.Driver/ClickHouseClient.cs
+++ b/ClickHouse.Driver/ClickHouseClient.cs
@@ -53,6 +53,7 @@ public sealed class ClickHouseClient : IClickHouseClient
     private readonly ConcurrentDictionary<string, Lazy<ILogger>> loggerCache = new();
     private readonly SchemaResolver schemaResolver;
     private readonly JsonTypeRegistry jsonTypeRegistry = new();
+    private readonly BinaryInsertTypeRegistry binaryInsertTypeRegistry = new();
     private readonly IHttpClientFactory httpClientFactory;
     private readonly string httpClientName;
     private readonly Uri serverUri;
@@ -191,6 +192,11 @@ public sealed class ClickHouseClient : IClickHouseClient
     /// <inheritdoc />
     public void RegisterJsonSerializationType(Type type)
         => jsonTypeRegistry.RegisterType(type);
+
+    /// <inheritdoc />
+    public void RegisterBinaryInsertType<T>()
+        where T : class
+        => binaryInsertTypeRegistry.RegisterType<T>();
 
     /// <inheritdoc/>
     public ClickHouseConnection CreateConnection()
@@ -412,6 +418,200 @@ public sealed class ClickHouseClient : IClickHouseClient
         return InsertBinaryAsync(table, columns, rows, options, onBatchSent: null, cancellationToken);
     }
 
+    /// <inheritdoc />
+    public Task<long> InsertBinaryAsync<T>(
+        string table,
+        IEnumerable<T> rows,
+        InsertOptions options = default,
+        CancellationToken cancellationToken = default)
+        where T : class
+    {
+        if (table is null)
+            throw new InvalidOperationException($"{nameof(table)} is null");
+        if (rows is null)
+            throw new ArgumentNullException(nameof(rows));
+
+        var mapping = binaryInsertTypeRegistry.GetMapping<T>()
+            ?? throw new InvalidOperationException(
+                $"Type '{typeof(T).Name}' is not registered for binary insert. " +
+                $"Call RegisterBinaryInsertType<{typeof(T).Name}>() first.");
+
+        var properties = mapping.Properties;
+
+        options = ApplyPocoColumnAttributes(mapping, options);
+
+        if (mapping.ColumnTypes == null && Array.Exists(properties, p => p.ExplicitClickHouseType != null))
+        {
+            GetLogger(ClickHouseLogCategories.Client)?.LogWarning(
+                "Type '{TypeName}' has [ClickHouseColumn(Type)] on some properties but not all. " +
+                "The schema probe will not be skipped. To skip it, add explicit types to all mapped properties.",
+                typeof(T).Name);
+        }
+
+        return InsertBinaryPocoAsync(table, rows, properties, mapping.Getters, options, cancellationToken);
+    }
+
+    /// <summary>
+    /// Applies column types from the POCO attribute mapping to the insert options,
+    /// allowing the schema probe to be skipped when all properties declare explicit ClickHouse types.
+    /// User-provided <see cref="InsertOptions.ColumnTypes"/> always takes precedence over attribute-derived types.
+    /// </summary>
+    private static InsertOptions ApplyPocoColumnAttributes(PocoTypeMapping mapping, InsertOptions options)
+    {
+        // User-provided ColumnTypes on InsertOptions always takes precedence
+        if (options?.ColumnTypes is { Count: > 0 })
+            return options;
+
+        // Apply pre-built column types (non-null only when ALL properties have explicit types)
+        if (mapping.ColumnTypes != null)
+            return (options ?? new InsertOptions()).WithColumnTypes(mapping.ColumnTypes);
+
+        // Otherwise we're gonna get the schema with a probe query
+        return options;
+    }
+
+    /// <summary>
+    /// Resolved insert metadata shared by both the <c>object[]</c> and POCO insert paths.
+    /// Produced by <see cref="PrepareInsertAsync"/> after validation and schema resolution.
+    /// </summary>
+    private readonly struct InsertPlan
+    {
+        /// <summary>The finalized options (defaulted and validated).</summary>
+        public InsertOptions Options { get; init; }
+
+        /// <summary>The resolved ClickHouse column types, ordered to match the INSERT column list.</summary>
+        public ClickHouseType[] ColumnTypes { get; init; }
+
+        /// <summary>The full INSERT query including column list and FORMAT clause.</summary>
+        public string Query { get; init; }
+
+        /// <summary>Base query ID from which per-batch IDs are derived.</summary>
+        public string BaseQueryId { get; init; }
+    }
+
+    /// <summary>
+    /// Validates insert options, resolves table schema, and builds the INSERT query.
+    /// Shared setup for both <see cref="InsertBinaryAsync(string, IEnumerable{string}, IEnumerable{object[]}, InsertOptions, CancellationToken)"/>
+    /// and <see cref="InsertBinaryAsync{T}(string, IEnumerable{T}, InsertOptions, CancellationToken)"/>.
+    /// </summary>
+    private async Task<InsertPlan> PrepareInsertAsync(
+        string table, IEnumerable<string> columns, InsertOptions options)
+    {
+        options ??= new InsertOptions();
+
+        if (options.BatchSize <= 0)
+            throw new ArgumentOutOfRangeException(nameof(options), "BatchSize must be greater than zero");
+        if (options.MaxDegreeOfParallelism <= 0)
+            throw new ArgumentOutOfRangeException(nameof(options), "MaxDegreeOfParallelism must be greater than zero");
+
+        var useSession = options.UseSession ?? Settings.UseSession;
+        if (useSession && options.MaxDegreeOfParallelism > 1)
+        {
+            throw new InvalidOperationException(
+                $"InsertBinaryAsync is configured with MaxDegreeOfParallelism={options.MaxDegreeOfParallelism} while sessions are enabled. " +
+                "ClickHouse only allows one concurrent query per session. " +
+                "Set MaxDegreeOfParallelism to 1, or disable sessions for this insert by setting InsertOptions.UseSession to false.");
+        }
+
+        var logger = GetLogger(ClickHouseLogCategories.Client);
+        logger?.LogDebug("Loading metadata for table {Table}.", table);
+
+        var (columnNames, columnTypes) = await schemaResolver.ResolveAsync(table, columns, options).ConfigureAwait(false);
+        if (columnNames == null || columnTypes == null)
+            throw new InvalidOperationException("Column names not initialized. Initialization failed.");
+
+        if (logger?.IsEnabled(LogLevel.Debug) ?? false)
+        {
+            logger.LogDebug("Metadata loaded for table {Table}. Columns: {Columns}.", table, string.Join(", ", columnNames ?? Array.Empty<string>()));
+        }
+
+        var query = $"INSERT INTO {table} ({string.Join(", ", columnNames)}) FORMAT {options.Format.ToString()}";
+        var baseQueryId = options.QueryId ?? Guid.NewGuid().ToString();
+
+        return new InsertPlan
+        {
+            Options = options,
+            ColumnTypes = columnTypes,
+            Query = query,
+            BaseQueryId = baseQueryId,
+        };
+    }
+
+    private async Task<long> InsertBinaryPocoAsync<T>(
+        string table,
+        IEnumerable<T> rows,
+        BinaryInsertPropertyInfo[] properties,
+        Func<T, object>[] getters,
+        InsertOptions options,
+        CancellationToken cancellationToken)
+        where T : class
+    {
+        var plan = await PrepareInsertAsync(table, properties.Select(x => x.ColumnName), options).ConfigureAwait(false);
+        var serializer = PocoBatchSerializer.GetByRowBinaryFormat(plan.Options.Format);
+        int queryIdCounter = 0;
+
+        var logger = GetLogger(ClickHouseLogCategories.Client);
+        var isDebugLoggingEnabled = logger?.IsEnabled(LogLevel.Debug) ?? false;
+        Stopwatch stopwatch = null;
+        if (isDebugLoggingEnabled)
+        {
+            stopwatch = Stopwatch.StartNew();
+            logger.LogDebug("Starting bulk copy into {Table} with batch size {BatchSize} and degree {Degree}.", table, plan.Options.BatchSize, plan.Options.MaxDegreeOfParallelism);
+        }
+
+        long totalRowsWritten = 0;
+        var batches = IntoPocoBatches(rows, plan.Query, plan.ColumnTypes, properties, getters, plan.Options.BatchSize);
+
+        await Parallel.ForEachAsync(
+            batches,
+            new ParallelOptions
+            {
+                MaxDegreeOfParallelism = plan.Options.MaxDegreeOfParallelism,
+                CancellationToken = cancellationToken,
+            },
+            async (batch, ct) =>
+            {
+                var batchOptions = plan.Options.WithQueryId($"{plan.BaseQueryId}-{Interlocked.Increment(ref queryIdCounter)}");
+                var count = await SendPocoBatchAsync(table, batch, serializer, batchOptions, ct).ConfigureAwait(false);
+                Interlocked.Add(ref totalRowsWritten, count);
+            }).ConfigureAwait(false);
+
+        if (isDebugLoggingEnabled)
+        {
+            stopwatch.Stop();
+            logger.LogDebug("Bulk copy into {Table} completed in {ElapsedMilliseconds:F2} ms. Total rows: {Rows}.", table, stopwatch.Elapsed.TotalMilliseconds, totalRowsWritten);
+        }
+
+        return totalRowsWritten;
+    }
+
+    private async Task<int> SendPocoBatchAsync<T>(string destinationTable, PocoBatch<T> batch, PocoBatchSerializer serializer, InsertOptions insertOptions, CancellationToken token)
+    {
+        var logger = GetLogger(ClickHouseLogCategories.Client);
+
+        using (batch)
+        {
+            using var stream = MemoryStreamManager.GetStream(nameof(SendPocoBatchAsync), 128 * 1024);
+            await Task.Run(() => serializer.Serialize(batch, stream), token).ConfigureAwait(false);
+
+            stream.Seek(0, SeekOrigin.Begin);
+
+            logger?.LogDebug("Sending batch of {Rows} rows to {Table}.", batch.Size, destinationTable);
+            await PostStreamAsync(null, stream, true, token, insertOptions).ConfigureAwait(false);
+
+            logger?.LogDebug("Batch sent to {Table}. Rows in batch: {BatchRows}.", destinationTable, batch.Size);
+            return batch.Size;
+        }
+    }
+
+    private static IEnumerable<PocoBatch<T>> IntoPocoBatches<T>(IEnumerable<T> rows, string query, ClickHouseType[] types, BinaryInsertPropertyInfo[] properties, Func<T, object>[] getters, int batchSize)
+    {
+        foreach (var (batch, size) in rows.BatchRented(batchSize))
+        {
+            yield return new PocoBatch<T> { Rows = batch, Size = size, Query = query, Types = types, Properties = properties, Getters = getters };
+        }
+    }
+
     /// <summary>
     /// Internal version which takes a callback method, to allow us to maintain backwards
     /// compat with the BatchSent event in BulkCopy.
@@ -429,69 +629,32 @@ public sealed class ClickHouseClient : IClickHouseClient
         if (rows is null)
             throw new ArgumentNullException(nameof(rows));
 
-        // Use default values if none provided
-        options ??= new InsertOptions();
-
-        if (options.BatchSize <= 0)
-            throw new ArgumentOutOfRangeException(nameof(options), "BatchSize must be greater than zero");
-        if (options.MaxDegreeOfParallelism <= 0)
-            throw new ArgumentOutOfRangeException(nameof(options), "MaxDegreeOfParallelism must be greater than zero");
-
-        // ClickHouse only allows one concurrent query per session.
-        // Multiple parallel batches on the same session will cause SESSION_IS_LOCKED errors,
-        // potentially leaving the table in a partially-written state.
-        var useSession = options.UseSession ?? Settings.UseSession;
-        if (useSession && options.MaxDegreeOfParallelism > 1)
-        {
-            throw new InvalidOperationException(
-                $"InsertBinaryAsync is configured with MaxDegreeOfParallelism={options.MaxDegreeOfParallelism} while sessions are enabled. " +
-                "ClickHouse only allows one concurrent query per session. " +
-                "Set MaxDegreeOfParallelism to 1, or disable sessions for this insert by setting InsertOptions.UseSession to false.");
-        }
-
-        var serializer = BatchSerializer.GetByRowBinaryFormat(options.Format);
-
-        // Resolve base query ID upfront; derive unique IDs for each sub-request
-        var baseQueryId = options.QueryId ?? Guid.NewGuid().ToString();
+        var plan = await PrepareInsertAsync(table, columns, options).ConfigureAwait(false);
+        var serializer = BatchSerializer.GetByRowBinaryFormat(plan.Options.Format);
         int queryIdCounter = 0;
 
-        // Load table structure
         var logger = GetLogger(ClickHouseLogCategories.Client);
-        logger?.LogDebug("Loading metadata for table {Table}.", table);
-
-        var (columnNames, columnTypes) = await schemaResolver.ResolveAsync(table, columns, options).ConfigureAwait(false);
-        if (columnNames == null || columnTypes == null)
-            throw new InvalidOperationException("Column names not initialized. Initialization failed.");
-
-        if (logger?.IsEnabled(LogLevel.Debug) ?? false)
-        {
-            logger.LogDebug("Metadata loaded for table {Table}. Columns: {Columns}.", table, string.Join(", ", columnNames ?? Array.Empty<string>()));
-        }
-
-        // Insert
-        var query = $"INSERT INTO {table} ({string.Join(", ", columnNames)}) FORMAT {options.Format.ToString()}";
-
         var isDebugLoggingEnabled = logger?.IsEnabled(LogLevel.Debug) ?? false;
         Stopwatch stopwatch = null;
         if (isDebugLoggingEnabled)
         {
             stopwatch = Stopwatch.StartNew();
-            logger.LogDebug("Starting bulk copy into {Table} with batch size {BatchSize} and degree {Degree}.", table, options.BatchSize, options.MaxDegreeOfParallelism);
+            logger.LogDebug("Starting bulk copy into {Table} with batch size {BatchSize} and degree {Degree}.", table, plan.Options.BatchSize, plan.Options.MaxDegreeOfParallelism);
         }
 
         long totalRowsWritten = 0;
-        var batches = IntoBatches(rows, query, columnTypes, options.BatchSize);
+        var batches = IntoBatches(rows, plan.Query, plan.ColumnTypes, plan.Options.BatchSize);
 
         await Parallel.ForEachAsync(
             batches,
             new ParallelOptions
             {
-                MaxDegreeOfParallelism = options.MaxDegreeOfParallelism,
+                MaxDegreeOfParallelism = plan.Options.MaxDegreeOfParallelism,
                 CancellationToken = cancellationToken,
             },
             async (batch, ct) =>
             {
-                var batchOptions = options.WithQueryId($"{baseQueryId}-{Interlocked.Increment(ref queryIdCounter)}");
+                var batchOptions = plan.Options.WithQueryId($"{plan.BaseQueryId}-{Interlocked.Increment(ref queryIdCounter)}");
                 var count = await SendBatchAsync(table, batch, serializer, batchOptions, onBatchSent, ct).ConfigureAwait(false);
                 Interlocked.Add(ref totalRowsWritten, count);
             }).ConfigureAwait(false);

--- a/ClickHouse.Driver/ClickHouseClient.cs
+++ b/ClickHouse.Driver/ClickHouseClient.cs
@@ -560,7 +560,7 @@ public sealed class ClickHouseClient : IClickHouseClient
         }
 
         long totalRowsWritten = 0;
-        var batches = IntoPocoBatches(rows, plan.Query, plan.ColumnTypes, properties, getters, plan.Options.BatchSize);
+        var batches = IntoPocoBatches(rows, plan);
 
         await Parallel.ForEachAsync(
             batches,
@@ -571,8 +571,8 @@ public sealed class ClickHouseClient : IClickHouseClient
             },
             async (batch, ct) =>
             {
-                var batchOptions = plan.Options.WithQueryId($"{plan.BaseQueryId}-{Interlocked.Increment(ref queryIdCounter)}");
-                var count = await SendPocoBatchAsync(table, batch, serializer, batchOptions, ct).ConfigureAwait(false);
+                var batchOptions = plan.Options.WithQueryId($"{plan.BaseQueryId}-{Interlocked.Increment(ref queryIdCounter)}"); // Avoid duplicate query ids across batches
+                var count = await SendPocoBatchAsync(table, batch, getters, serializer, batchOptions, ct).ConfigureAwait(false);
                 Interlocked.Add(ref totalRowsWritten, count);
             }).ConfigureAwait(false);
 
@@ -585,14 +585,14 @@ public sealed class ClickHouseClient : IClickHouseClient
         return totalRowsWritten;
     }
 
-    private async Task<int> SendPocoBatchAsync<T>(string destinationTable, PocoBatch<T> batch, PocoBatchSerializer serializer, InsertOptions insertOptions, CancellationToken token)
+    private async Task<int> SendPocoBatchAsync<T>(string destinationTable, PocoBatch<T> batch, Func<T, object>[] getters, PocoBatchSerializer serializer, InsertOptions insertOptions, CancellationToken token)
     {
         var logger = GetLogger(ClickHouseLogCategories.Client);
 
         using (batch)
         {
             using var stream = MemoryStreamManager.GetStream(nameof(SendPocoBatchAsync), 128 * 1024);
-            await Task.Run(() => serializer.Serialize(batch, stream), token).ConfigureAwait(false);
+            await Task.Run(() => serializer.Serialize(batch, getters, stream), token).ConfigureAwait(false);
 
             stream.Seek(0, SeekOrigin.Begin);
 
@@ -604,11 +604,11 @@ public sealed class ClickHouseClient : IClickHouseClient
         }
     }
 
-    private static IEnumerable<PocoBatch<T>> IntoPocoBatches<T>(IEnumerable<T> rows, string query, ClickHouseType[] types, BinaryInsertPropertyInfo[] properties, Func<T, object>[] getters, int batchSize)
+    private static IEnumerable<PocoBatch<T>> IntoPocoBatches<T>(IEnumerable<T> rows, InsertPlan plan)
     {
-        foreach (var (batch, size) in rows.BatchRented(batchSize))
+        foreach (var (batch, size) in rows.BatchRented(plan.Options.BatchSize))
         {
-            yield return new PocoBatch<T> { Rows = batch, Size = size, Query = query, Types = types, Properties = properties, Getters = getters };
+            yield return new PocoBatch<T> { Rows = batch, Size = size, Query = plan.Query, Types = plan.ColumnTypes };
         }
     }
 

--- a/ClickHouse.Driver/Copy/BinaryInsertPropertyInfo.cs
+++ b/ClickHouse.Driver/Copy/BinaryInsertPropertyInfo.cs
@@ -1,0 +1,17 @@
+namespace ClickHouse.Driver.Copy;
+
+/// <summary>
+/// Cached metadata for a single POCO property used in binary insert operations.
+/// </summary>
+internal sealed class BinaryInsertPropertyInfo
+{
+    /// <summary>
+    /// Gets the ClickHouse column name this property maps to.
+    /// </summary>
+    public string ColumnName { get; init; }
+
+    /// <summary>
+    /// Gets the explicit ClickHouse type string from <see cref="ClickHouseColumnAttribute.Type"/>, or null if not specified.
+    /// </summary>
+    public string ExplicitClickHouseType { get; init; }
+}

--- a/ClickHouse.Driver/Copy/BinaryInsertTypeMapping.cs
+++ b/ClickHouse.Driver/Copy/BinaryInsertTypeMapping.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+
+namespace ClickHouse.Driver.Copy;
+
+/// <summary>
+/// Pre-computed mapping for a registered POCO type, including property metadata
+/// and an optional column types dictionary for schema probe skipping.
+/// </summary>
+internal abstract class PocoTypeMapping
+{
+    /// <summary>
+    /// The mapped properties for this type.
+    /// </summary>
+    internal BinaryInsertPropertyInfo[] Properties { get; init; }
+
+    /// <summary>
+    /// Pre-built column name → ClickHouse type dictionary, or null if not all properties have explicit types.
+    /// When non-null, the schema probe can be skipped.
+    /// </summary>
+    internal IReadOnlyDictionary<string, string> ColumnTypes { get; init; }
+}
+
+/// <summary>
+/// Generic mapping that holds typed property getters, avoiding a per-row cast in the serialization hot loop.
+/// </summary>
+internal sealed class PocoTypeMapping<T> : PocoTypeMapping
+    where T : class
+{
+    /// <summary>
+    /// Compiled getters that extract each property value from a <typeparamref name="T"/> instance.
+    /// Ordered to match <see cref="PocoTypeMapping.Properties"/>.
+    /// </summary>
+    internal Func<T, object>[] Getters { get; init; }
+}

--- a/ClickHouse.Driver/Copy/BinaryInsertTypeRegistry.cs
+++ b/ClickHouse.Driver/Copy/BinaryInsertTypeRegistry.cs
@@ -17,7 +17,7 @@ internal sealed class BinaryInsertTypeRegistry
 
     /// <summary>
     /// Registers a POCO type for binary insert operations.
-    /// Validates that all mapped properties have types supported by ClickHouse.
+    /// Builds the property-to-column mapping and validates basic mapping constraints.
     /// </summary>
     internal void RegisterType<T>()
         where T : class
@@ -60,16 +60,29 @@ internal sealed class BinaryInsertTypeRegistry
             var columnAttr = property.GetCustomAttribute<ClickHouseColumnAttribute>();
             var columnName = columnAttr?.Name ?? property.Name;
 
+            if (string.IsNullOrWhiteSpace(columnName))
+            {
+                throw new InvalidOperationException(
+                    $"Failed to register type '{type.Name}': property '{property.Name}' has an empty or whitespace column name.");
+            }
+
             if (!usedColumnNames.Add(columnName))
             {
                 throw new InvalidOperationException(
                     $"Failed to register type '{type.Name}': multiple properties map to column '{columnName}'.");
             }
 
+            var explicitType = columnAttr?.Type;
+            if (explicitType != null && string.IsNullOrWhiteSpace(explicitType))
+            {
+                throw new InvalidOperationException(
+                    $"Failed to register type '{type.Name}': property '{property.Name}' has an empty or whitespace ClickHouse type.");
+            }
+
             propInfos.Add(new BinaryInsertPropertyInfo
             {
                 ColumnName = columnName,
-                ExplicitClickHouseType = columnAttr?.Type,
+                ExplicitClickHouseType = explicitType,
             });
 
             getters.Add(CompileGetter<T>(property));

--- a/ClickHouse.Driver/Copy/BinaryInsertTypeRegistry.cs
+++ b/ClickHouse.Driver/Copy/BinaryInsertTypeRegistry.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+using ClickHouse.Driver.Types;
+
+namespace ClickHouse.Driver.Copy;
+
+/// <summary>
+/// Registry for POCO types used with binary insert operations.
+/// Types must be registered before they can be inserted via <c>InsertBinaryAsync&lt;T&gt;</c>.
+/// </summary>
+internal sealed class BinaryInsertTypeRegistry
+{
+    private readonly ConcurrentDictionary<Type, PocoTypeMapping> registeredTypes = new();
+
+    /// <summary>
+    /// Registers a POCO type for binary insert operations.
+    /// Validates that all mapped properties have types supported by ClickHouse.
+    /// </summary>
+    internal void RegisterType<T>()
+        where T : class
+    {
+        if (registeredTypes.ContainsKey(typeof(T)))
+            return;
+
+        registeredTypes[typeof(T)] = BuildMapping<T>();
+    }
+
+    /// <summary>
+    /// Gets the typed mapping for a registered type, or null if not registered.
+    /// </summary>
+    internal PocoTypeMapping<T> GetMapping<T>()
+        where T : class
+        => registeredTypes.TryGetValue(typeof(T), out var mapping) ? (PocoTypeMapping<T>)mapping : null;
+
+    private static PocoTypeMapping<T> BuildMapping<T>()
+        where T : class
+    {
+        var type = typeof(T);
+        var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+        var propInfos = new List<BinaryInsertPropertyInfo>(properties.Length);
+        var getters = new List<Func<T, object>>(properties.Length);
+        var usedColumnNames = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var property in properties)
+        {
+            if (!property.CanRead)
+                continue;
+
+            // Skip indexers
+            if (property.GetIndexParameters().Length > 0)
+                continue;
+
+            // Skip [ClickHouseNotMapped]
+            if (property.GetCustomAttribute<ClickHouseNotMappedAttribute>() != null)
+                continue;
+
+            var columnAttr = property.GetCustomAttribute<ClickHouseColumnAttribute>();
+            var columnName = columnAttr?.Name ?? property.Name;
+
+            if (!usedColumnNames.Add(columnName))
+            {
+                throw new InvalidOperationException(
+                    $"Failed to register type '{type.Name}': multiple properties map to column '{columnName}'.");
+            }
+
+            propInfos.Add(new BinaryInsertPropertyInfo
+            {
+                ColumnName = columnName,
+                ExplicitClickHouseType = columnAttr?.Type,
+            });
+
+            getters.Add(CompileGetter<T>(property));
+        }
+
+        if (propInfos.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"Type '{type.Name}' has no public readable properties that map to ClickHouse columns. " +
+                $"Ensure the type has at least one public property with a getter that is not marked with [ClickHouseNotMapped].");
+        }
+
+        var props = propInfos.ToArray();
+
+        // Pre-build column types dictionary when ALL properties have explicit types.
+        IReadOnlyDictionary<string, string> columnTypes = null;
+        if (Array.TrueForAll(props, p => p.ExplicitClickHouseType != null))
+        {
+            var dict = new Dictionary<string, string>(props.Length, StringComparer.Ordinal);
+            foreach (var prop in props)
+                dict[prop.ColumnName] = prop.ExplicitClickHouseType;
+            columnTypes = dict;
+        }
+
+        return new PocoTypeMapping<T>
+        {
+            Properties = props,
+            ColumnTypes = columnTypes,
+            Getters = getters.ToArray(),
+        };
+    }
+
+    private static Func<T, object> CompileGetter<T>(PropertyInfo property)
+    {
+        var param = Expression.Parameter(typeof(T), "instance");
+        var access = Expression.Property(param, property);
+        var box = Expression.Convert(access, typeof(object));
+        var lambda = Expression.Lambda<Func<T, object>>(box, param);
+        return lambda.Compile();
+    }
+}

--- a/ClickHouse.Driver/Copy/BinaryInsertTypeRegistry.cs
+++ b/ClickHouse.Driver/Copy/BinaryInsertTypeRegistry.cs
@@ -46,7 +46,7 @@ internal sealed class BinaryInsertTypeRegistry
 
         foreach (var property in properties)
         {
-            if (!property.CanRead)
+            if (!property.CanRead || !property.GetMethod.IsPublic)
                 continue;
 
             // Skip indexers

--- a/ClickHouse.Driver/Copy/PocoBatch.cs
+++ b/ClickHouse.Driver/Copy/PocoBatch.cs
@@ -10,8 +10,6 @@ internal struct PocoBatch<T> : IDisposable
     public int Size;
     public string Query;
     public ClickHouseType[] Types;
-    public BinaryInsertPropertyInfo[] Properties;
-    public Func<T, object>[] Getters;
 
     public void Dispose()
     {

--- a/ClickHouse.Driver/Copy/PocoBatch.cs
+++ b/ClickHouse.Driver/Copy/PocoBatch.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Buffers;
+using ClickHouse.Driver.Types;
+
+namespace ClickHouse.Driver.Copy;
+
+internal struct PocoBatch<T> : IDisposable
+{
+    public T[] Rows;
+    public int Size;
+    public string Query;
+    public ClickHouseType[] Types;
+    public BinaryInsertPropertyInfo[] Properties;
+    public Func<T, object>[] Getters;
+
+    public void Dispose()
+    {
+        if (Rows != null)
+        {
+            ArrayPool<T>.Shared.Return(Rows, true);
+            Rows = default;
+        }
+    }
+}

--- a/ClickHouse.Driver/Copy/Serializer/IPocoRowSerializer.cs
+++ b/ClickHouse.Driver/Copy/Serializer/IPocoRowSerializer.cs
@@ -1,0 +1,23 @@
+using System;
+using ClickHouse.Driver.Formats;
+using ClickHouse.Driver.Types;
+
+namespace ClickHouse.Driver.Copy.Serializer;
+
+/// <summary>
+/// Serializes a single POCO row into ClickHouse binary format.
+/// Mirrors <see cref="IRowSerializer"/> but reads values from a typed instance via compiled getters
+/// instead of an <c>object[]</c>.
+/// </summary>
+internal interface IPocoRowSerializer
+{
+    /// <summary>
+    /// Writes one row to the binary stream.
+    /// </summary>
+    /// <typeparam name="T">The POCO type.</typeparam>
+    /// <param name="row">The POCO instance to serialize.</param>
+    /// <param name="getters">Compiled property accessors, ordered to match <paramref name="types"/>.</param>
+    /// <param name="types">The ClickHouse column types for each property.</param>
+    /// <param name="writer">The binary writer to write to.</param>
+    void Serialize<T>(T row, Func<T, object>[] getters, ClickHouseType[] types, ExtendedBinaryWriter writer);
+}

--- a/ClickHouse.Driver/Copy/Serializer/PocoBatchSerializer.cs
+++ b/ClickHouse.Driver/Copy/Serializer/PocoBatchSerializer.cs
@@ -1,0 +1,67 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Text;
+using ClickHouse.Driver.Formats;
+
+namespace ClickHouse.Driver.Copy.Serializer;
+
+/// <summary>
+/// Serializes POCO batches directly without intermediate object[] allocation.
+/// Mirrors <see cref="BatchSerializer"/> but reads property values from POCOs via compiled getters.
+/// </summary>
+internal class PocoBatchSerializer
+{
+    public static PocoBatchSerializer GetByRowBinaryFormat(RowBinaryFormat format)
+    {
+        return format switch
+        {
+            RowBinaryFormat.RowBinary => new PocoBatchSerializer(new PocoRowBinarySerializer()),
+            RowBinaryFormat.RowBinaryWithDefaults => new PocoBatchSerializer(new PocoRowBinaryWithDefaultsSerializer()),
+            _ => throw new NotSupportedException(format.ToString()),
+        };
+    }
+
+    private readonly IPocoRowSerializer rowSerializer;
+
+    private PocoBatchSerializer(IPocoRowSerializer rowSerializer)
+    {
+        this.rowSerializer = rowSerializer;
+    }
+
+    public void Serialize<T>(PocoBatch<T> batch, Stream stream)
+    {
+        using var gzipStream = new BufferedStream(new GZipStream(stream, CompressionLevel.Fastest, true), 256 * 1024);
+        using (var textWriter = new StreamWriter(gzipStream, Encoding.UTF8, 4 * 1024, true))
+        {
+            textWriter.WriteLine(batch.Query);
+        }
+
+        using var writer = new ExtendedBinaryWriter(gzipStream);
+
+        var getters = batch.Getters;
+        var types = batch.Types;
+
+        T current = default;
+        try
+        {
+            for (int i = 0; i < batch.Size; i++)
+            {
+                current = batch.Rows[i];
+                rowSerializer.Serialize(current, getters, types, writer);
+            }
+        }
+        catch (Exception e)
+        {
+            // Materialize the failing row for diagnostics (rare error path)
+            var failedRow = new object[getters.Length];
+            if (current != null)
+            {
+                for (int col = 0; col < getters.Length; col++)
+                    failedRow[col] = getters[col](current);
+            }
+
+            throw new ClickHouseBulkCopySerializationException(failedRow, e);
+        }
+    }
+}

--- a/ClickHouse.Driver/Copy/Serializer/PocoBatchSerializer.cs
+++ b/ClickHouse.Driver/Copy/Serializer/PocoBatchSerializer.cs
@@ -29,7 +29,14 @@ internal class PocoBatchSerializer
         this.rowSerializer = rowSerializer;
     }
 
-    public void Serialize<T>(PocoBatch<T> batch, Stream stream)
+    /// <summary>
+    /// Serializes a batch of POCO rows into the target stream using GZip compression.
+    /// </summary>
+    /// <typeparam name="T">The POCO type.</typeparam>
+    /// <param name="batch">The batch of rows, query text, and resolved column types.</param>
+    /// <param name="getters">Compiled property accessors, ordered to match the batch's column types.</param>
+    /// <param name="stream">The output stream (typically a recyclable memory stream).</param>
+    public void Serialize<T>(PocoBatch<T> batch, Func<T, object>[] getters, Stream stream)
     {
         using var gzipStream = new BufferedStream(new GZipStream(stream, CompressionLevel.Fastest, true), 256 * 1024);
         using (var textWriter = new StreamWriter(gzipStream, Encoding.UTF8, 4 * 1024, true))
@@ -39,7 +46,6 @@ internal class PocoBatchSerializer
 
         using var writer = new ExtendedBinaryWriter(gzipStream);
 
-        var getters = batch.Getters;
         var types = batch.Types;
 
         T current = default;

--- a/ClickHouse.Driver/Copy/Serializer/PocoBatchSerializer.cs
+++ b/ClickHouse.Driver/Copy/Serializer/PocoBatchSerializer.cs
@@ -53,12 +53,23 @@ internal class PocoBatchSerializer
         }
         catch (Exception e)
         {
-            // Materialize the failing row for diagnostics (rare error path)
+            // Best-effort: materialize the failing row for diagnostics.
+            // Getters may throw again, so swallow secondary failures to preserve
+            // the original exception in the wrapper.
             var failedRow = new object[getters.Length];
             if (current != null)
             {
                 for (int col = 0; col < getters.Length; col++)
-                    failedRow[col] = getters[col](current);
+                {
+                    try
+                    {
+                        failedRow[col] = getters[col](current);
+                    }
+                    catch
+                    {
+                        // Ignore, we don't want to throw again inside the catch. Keep the info we got.
+                    }
+                }
             }
 
             throw new ClickHouseBulkCopySerializationException(failedRow, e);

--- a/ClickHouse.Driver/Copy/Serializer/PocoRowBinarySerializer.cs
+++ b/ClickHouse.Driver/Copy/Serializer/PocoRowBinarySerializer.cs
@@ -1,0 +1,16 @@
+using System;
+using ClickHouse.Driver.Formats;
+using ClickHouse.Driver.Types;
+
+namespace ClickHouse.Driver.Copy.Serializer;
+
+internal class PocoRowBinarySerializer : IPocoRowSerializer
+{
+    public void Serialize<T>(T row, Func<T, object>[] getters, ClickHouseType[] types, ExtendedBinaryWriter writer)
+    {
+        for (int col = 0; col < getters.Length; col++)
+        {
+            types[col].Write(writer, getters[col](row));
+        }
+    }
+}

--- a/ClickHouse.Driver/Copy/Serializer/PocoRowBinaryWithDefaultsSerializer.cs
+++ b/ClickHouse.Driver/Copy/Serializer/PocoRowBinaryWithDefaultsSerializer.cs
@@ -1,0 +1,28 @@
+using System;
+using ClickHouse.Driver.Constraints;
+using ClickHouse.Driver.Formats;
+using ClickHouse.Driver.Types;
+
+namespace ClickHouse.Driver.Copy.Serializer;
+
+// https://clickhouse.com/docs/en/interfaces/formats#rowbinarywithdefaults
+internal class PocoRowBinaryWithDefaultsSerializer : IPocoRowSerializer
+{
+    public void Serialize<T>(T row, Func<T, object>[] getters, ClickHouseType[] types, ExtendedBinaryWriter writer)
+    {
+        for (int col = 0; col < getters.Length; col++)
+        {
+            var value = getters[col](row);
+
+            if (value is DBDefault)
+            {
+                writer.Write((byte)1);
+            }
+            else
+            {
+                writer.Write((byte)0);
+                types[col].Write(writer, value);
+            }
+        }
+    }
+}

--- a/ClickHouse.Driver/IClickHouseClient.cs
+++ b/ClickHouse.Driver/IClickHouseClient.cs
@@ -142,6 +142,35 @@ public interface IClickHouseClient : IDisposable
     Task<bool> PingAsync(QueryOptions queryOptions = null, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Inserts POCO objects into a table using the binary protocol.
+    /// The type must be registered via <see cref="RegisterBinaryInsertType{T}"/> first.
+    /// Column names are derived from public properties (or overridden via <see cref="ClickHouseColumnAttribute"/>).
+    /// Unlike the <c>object[]</c> overload, this method does not accept an explicit column list —
+    /// columns are always determined by the registered type's mapped properties. To exclude
+    /// properties, use <see cref="ClickHouseNotMappedAttribute"/>.
+    /// </summary>
+    /// <typeparam name="T">The registered POCO type.</typeparam>
+    /// <param name="table">The destination table name.</param>
+    /// <param name="rows">The POCO instances to insert.</param>
+    /// <param name="options">Optional insert options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The number of rows inserted.</returns>
+    Task<long> InsertBinaryAsync<T>(
+        string table,
+        IEnumerable<T> rows,
+        InsertOptions options = null,
+        CancellationToken cancellationToken = default)
+        where T : class;
+
+    /// <summary>
+    /// Registers a POCO type for binary insert operations.
+    /// Types must be registered before they can be inserted via <see cref="InsertBinaryAsync{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The POCO type to register.</typeparam>
+    void RegisterBinaryInsertType<T>()
+        where T : class;
+
+    /// <summary>
     /// Registers a POCO type for JSON column serialization.
     /// Types must be registered before they can be used in operations with JSON or Dynamic columns.
     /// </summary>

--- a/ClickHouse.Driver/InsertOptions.cs
+++ b/ClickHouse.Driver/InsertOptions.cs
@@ -63,4 +63,25 @@ public sealed class InsertOptions : QueryOptions
             UseSchemaCache = UseSchemaCache,
         };
     }
+
+    internal InsertOptions WithColumnTypes(IReadOnlyDictionary<string, string> columnTypes)
+    {
+        return new InsertOptions
+        {
+            QueryId = QueryId,
+            Database = Database,
+            Roles = Roles,
+            CustomSettings = CustomSettings,
+            CustomHeaders = CustomHeaders,
+            UseSession = UseSession,
+            SessionId = SessionId,
+            BearerToken = BearerToken,
+            MaxExecutionTime = MaxExecutionTime,
+            BatchSize = BatchSize,
+            MaxDegreeOfParallelism = MaxDegreeOfParallelism,
+            Format = Format,
+            ColumnTypes = columnTypes,
+            UseSchemaCache = UseSchemaCache,
+        };
+    }
 }

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -20,6 +20,7 @@ v1.1.0
 ---
 
 **New Features:**
+* **POCO binary inserts**: new `InsertBinaryAsync<T>` overload on `ClickHouseClient` accepts `IEnumerable<T>` directly, mapping public properties to columns automatically. Register types upfront with `RegisterBinaryInsertType<T>()`. Customize column names and ClickHouse types with `[ClickHouseColumn(Name = "...", Type = "...")]`, or exclude properties with `[ClickHouseNotMapped]`. When all properties specify explicit types via the attribute, the schema probe is skipped entirely.
 * `InsertOptions.ColumnTypes`: provide a dictionary of column name → ClickHouse type string to skip the schema probe query (`SELECT ... WHERE 1=0`) entirely. Ideal when the table schema is known at compile time.
 * `InsertOptions.UseSchemaCache`: when `true`, the full table schema is cached per (database, table) for the lifetime of the `ClickHouseClient` instance. Subsequent inserts to the same table reuse the cached schema regardless of which columns are selected, eliminating redundant round-trips.
 

--- a/examples/Insert/Insert_009_PocoInsert.cs
+++ b/examples/Insert/Insert_009_PocoInsert.cs
@@ -1,0 +1,178 @@
+namespace ClickHouse.Driver.Examples;
+
+/// <summary>
+/// Demonstrates inserting data using strongly-typed POCO objects instead of object[] arrays.
+/// Register a type once, then pass IEnumerable&lt;T&gt; directly to InsertBinaryAsync.
+/// </summary>
+public static class PocoInsert
+{
+    public static async Task Run()
+    {
+        using var client = new ClickHouseClient("Host=localhost");
+
+        await BasicPocoInsert(client);
+        await AttributeMappingInsert(client);
+        await ExplicitTypesInsert(client);
+    }
+
+    // Simple POCO with no annotations
+    public class SensorReading
+    {
+        public ulong Id { get; set; }
+        public required string SensorName { get; set; }
+        public double Value { get; set; }
+        public DateTime Timestamp { get; set; }
+    }
+    
+    /// <summary>
+    /// Insert POCO object with no annotations, column names are matched with case sensitivity.
+    /// </summary>
+    private static async Task BasicPocoInsert(ClickHouseClient client)
+    {
+        Console.WriteLine("1. Basic POCO insert:");
+
+        await client.ExecuteNonQueryAsync(@"
+            CREATE TABLE IF NOT EXISTS example_poco_sensors
+            (
+                Id UInt64,
+                SensorName String,
+                Value Float64,
+                Timestamp DateTime
+            )
+            ENGINE = MergeTree()
+            ORDER BY Id
+        ");
+
+        client.RegisterBinaryInsertType<SensorReading>();
+
+        var readings = Enumerable.Range(1, 1000).Select(i => new SensorReading
+        {
+            Id = (ulong)i,
+            SensorName = $"sensor_{i % 10}",
+            Value = Random.Shared.NextDouble() * 100,
+            Timestamp = DateTime.UtcNow.AddSeconds(-i),
+        });
+
+        var rowsInserted = await client.InsertBinaryAsync("example_poco_sensors", readings);
+        Console.WriteLine($"   Inserted {rowsInserted} sensor readings");
+
+        var count = await client.ExecuteScalarAsync("SELECT count() FROM example_poco_sensors");
+        Console.WriteLine($"   Verified: {count} rows in table\n");
+
+        await client.ExecuteNonQueryAsync("DROP TABLE IF EXISTS example_poco_sensors");
+    }
+    
+    // A POCO with attribute customization
+    public class AuditEvent
+    {
+        [ClickHouseColumn(Name = "event_id")]
+        public ulong Id { get; set; }
+
+        [ClickHouseColumn(Name = "event_type", Type = "LowCardinality(String)")]
+        public required string Type { get; set; }
+
+        [ClickHouseColumn(Name = "payload")]
+        public required string Payload { get; set; }
+
+        [ClickHouseColumn(Name = "created_at")]
+        public DateTime CreatedAt { get; set; }
+
+        [ClickHouseNotMapped]
+        public required string InternalTag { get; set; } // Excluded from insert
+    }
+
+    /// <summary>
+    /// Use [ClickHouseColumn] to specify column name and type, and [ClickHouseNotMapped] to exclude properties.
+    /// </summary>
+    private static async Task AttributeMappingInsert(ClickHouseClient client)
+    {
+        Console.WriteLine("2. POCO insert with attribute mapping:");
+
+        await client.ExecuteNonQueryAsync(@"
+            CREATE TABLE IF NOT EXISTS example_poco_audit
+            (
+                event_id UInt64,
+                event_type LowCardinality(String),
+                payload String,
+                created_at DateTime
+            )
+            ENGINE = MergeTree()
+            ORDER BY event_id
+        ");
+
+        client.RegisterBinaryInsertType<AuditEvent>();
+
+        var events = new[]
+        {
+            new AuditEvent
+            {
+                Id = 1, Type = "login", Payload = """{"user": "alice"}""",
+                CreatedAt = DateTime.UtcNow, InternalTag = "ignored",
+            },
+            new AuditEvent
+            {
+                Id = 2, Type = "logout", Payload = """{"user": "bob"}""",
+                CreatedAt = DateTime.UtcNow, InternalTag = "also ignored",
+            },
+        };
+
+        var rowsInserted = await client.InsertBinaryAsync("example_poco_audit", events);
+        Console.WriteLine($"   Inserted {rowsInserted} audit events");
+        Console.WriteLine("   (InternalTag was excluded via [ClickHouseNotMapped])");
+
+        var count = await client.ExecuteScalarAsync("SELECT count() FROM example_poco_audit");
+        Console.WriteLine($"   Verified: {count} rows in table\n");
+
+        await client.ExecuteNonQueryAsync("DROP TABLE IF EXISTS example_poco_audit");
+    }
+
+    // A POCO with explicit types on every property skips the schema probe query entirely
+    public class MetricPoint
+    {
+        [ClickHouseColumn(Type = "UInt64")]
+        public ulong Id { get; set; }
+
+        [ClickHouseColumn(Type = "String")]
+        public required string Name { get; set; }
+
+        [ClickHouseColumn(Type = "Float64")]
+        public double Value { get; set; }
+    }
+    
+    /// <summary>
+    /// When ALL properties have [ClickHouseColumn(Type = "...")], the driver knows the column
+    /// types at compile time and skips the SELECT ... WHERE 1=0 schema probe query.
+    /// </summary>
+    private static async Task ExplicitTypesInsert(ClickHouseClient client)
+    {
+        Console.WriteLine("3. POCO insert with explicit types (no schema probe):");
+
+        await client.ExecuteNonQueryAsync(@"
+            CREATE TABLE IF NOT EXISTS example_poco_metrics
+            (
+                Id UInt64,
+                Name String,
+                Value Float64
+            )
+            ENGINE = MergeTree()
+            ORDER BY Id
+        ");
+
+        client.RegisterBinaryInsertType<MetricPoint>();
+
+        var metrics = Enumerable.Range(1, 500).Select(i => new MetricPoint
+        {
+            Id = (ulong)i,
+            Name = $"cpu.usage.core{i % 8}",
+            Value = Random.Shared.NextDouble() * 100,
+        });
+
+        var rowsInserted = await client.InsertBinaryAsync("example_poco_metrics", metrics);
+        Console.WriteLine($"   Inserted {rowsInserted} metric points (schema probe skipped)");
+
+        var count = await client.ExecuteScalarAsync("SELECT count() FROM example_poco_metrics");
+        Console.WriteLine($"   Verified: {count} rows in table\n");
+
+        await client.ExecuteNonQueryAsync("DROP TABLE IF EXISTS example_poco_metrics");
+    }
+}

--- a/examples/Program.cs
+++ b/examples/Program.cs
@@ -129,6 +129,10 @@ class Program
         await SchemaOptimization.Run();
         WaitForUser(isInteractive);
 
+        Console.WriteLine($"\n\nRunning: {nameof(PocoInsert)}");
+        await PocoInsert.Run();
+        WaitForUser(isInteractive);
+
         // Selecting Data
         Console.WriteLine("\n\n" + new string('=', 70));
         Console.WriteLine("SELECTING DATA");

--- a/examples/README.md
+++ b/examples/README.md
@@ -41,6 +41,7 @@ If something is missing, or you found a mistake in one of these examples, please
 - [Insert_006_EphemeralColumns.cs](Insert/Insert_006_EphemeralColumns.cs) - Using EPHEMERAL columns to transform input data before storage
 - [Insert_007_UpsertsWithReplacingMergeTree.cs](Insert/Insert_007_UpsertsWithReplacingMergeTree.cs) - Upsert patterns using ReplacingMergeTree with version and deleted columns
 - [Insert_008_SchemaOptimization.cs](Insert/Insert_008_SchemaOptimization.cs) - Skipping the schema probe query with `ColumnTypes` or `UseSchemaCache`
+- [Insert_009_PocoInsert.cs](Insert/Insert_009_PocoInsert.cs) - Inserting strongly-typed POCO objects with `InsertBinaryAsync<T>`, attribute mapping, and schema probe optimization
 
 ### Selecting Data
 


### PR DESCRIPTION
Right now the binary insert requires users to provide `object[][]`. This PR lets them use POCOs instead.

 * New `InsertBinaryAsync<T>()` method for inserting.
 * Two new property attributes: `[ClickHouseColumn(Name, Type)]` for setting column name/type, `[ClickHouseNotMapped]` for exclusion. If all properties are covered, we skip the schema probe.
 * Type registration required via `RegisterBinaryInstertType<T>().` This saves the serialization info and compiles property accessors into `Func<T, object>` delegates to avoid reflection when we're reading the properties in the serialization loop.
 * Internally, extracted shared insert prep functionality into `PrepareInsertAsync()`.
 * Added new example..


New benchmark added to compare object[][] and POCO serialization. Current results:

| Method      | Count  | Mean      | Error    | StdDev    | Ratio | RatioSD | Gen0       | Gen1      | Gen2      | Allocated | Alloc Ratio |
|------------ |------- |----------:|---------:|----------:|------:|--------:|-----------:|----------:|----------:|----------:|------------:|
| ObjectArray | 100000 |  47.17 ms | 3.338 ms |  7.185 ms |  1.02 |    0.22 |  2000.0000 | 1000.0000 |         - |  13.76 MB |        1.00 |
| Poco        | 100000 |  51.21 ms | 5.293 ms | 11.839 ms |  1.11 |    0.31 |  2000.0000 | 1000.0000 |         - |     13 MB |        0.94 |
|             |        |           |          |           |       |         |            |           |           |           |             |
| ObjectArray | 500000 | 198.00 ms | 3.673 ms |  7.828 ms |  1.00 |    0.06 | 12000.0000 | 7000.0000 | 2000.0000 |  66.72 MB |        1.00 |
| Poco        | 500000 | 177.00 ms | 2.992 ms |  6.178 ms |  0.90 |    0.05 | 12000.0000 | 7000.0000 | 2000.0000 |  62.91 MB |        0.94 |

Related docs PR: https://github.com/ClickHouse/clickhouse-docs/pull/5919