### PR TITLE
Bugfix: set json read/write setting for binary mode too

### DIFF
--- a/ClickHouse.Driver.Tests/ClickHouseClientQueryOptionsTests.cs
+++ b/ClickHouse.Driver.Tests/ClickHouseClientQueryOptionsTests.cs
@@ -1100,4 +1100,24 @@ public class ClickHouseClientQueryOptionsTests : AbstractConnectionTestFixture
             await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS {tableName}");
         }
     }
+
+    [Test]
+    public async Task ExecuteScalarAsync_CustomSettingOverridesAutoJsonSetting_SettingValueReflectedInQuery()
+    {
+        // Default JsonWriteMode is String, which auto-sets input_format_binary_read_json_as_string=1
+        // Verify that a user can override it via QueryOptions.CustomSettings
+        var options = new QueryOptions
+        {
+            CustomSettings = new Dictionary<string, object>
+            {
+                ["input_format_binary_read_json_as_string"] = 0,
+            },
+        };
+
+        var result = await client.ExecuteScalarAsync(
+            "SELECT value FROM system.settings WHERE name = 'input_format_binary_read_json_as_string'",
+            options: options);
+
+        Assert.That(result, Is.EqualTo("0"));
+    }
 }

--- a/ClickHouse.Driver.Tests/Types/JsonModeTests.cs
+++ b/ClickHouse.Driver.Tests/Types/JsonModeTests.cs
@@ -15,9 +15,10 @@ using NUnit.Framework.Legacy;
 namespace ClickHouse.Driver.Tests.Types;
 
 [TestFixture]
+[Category("Cloud")]
 public class JsonModeTests
 {
-    private ClickHouseConnection GetConnectionWithJsonMode(JsonReadMode readMode = JsonReadMode.Binary, JsonWriteMode writeMode = JsonWriteMode.Binary)
+    private ClickHouseClientSettings GetSettingsWithJsonMode(JsonReadMode readMode = JsonReadMode.Binary, JsonWriteMode writeMode = JsonWriteMode.Binary)
     {
         var builder = TestUtilities.GetConnectionStringBuilder();
         builder.JsonReadMode = readMode;
@@ -28,9 +29,20 @@ public class JsonModeTests
         // Add experimental JSON type support
         settings.CustomSettings["allow_experimental_json_type"] = 1;
 
+        return settings;
+    }
+
+    private ClickHouseConnection GetConnectionWithJsonMode(JsonReadMode readMode = JsonReadMode.Binary, JsonWriteMode writeMode = JsonWriteMode.Binary)
+    {
+        var settings = GetSettingsWithJsonMode(readMode, writeMode);
         var connection = new ClickHouseConnection(settings);
         connection.Open();
         return connection;
+    }
+
+    private ClickHouseClient GetClientWithJsonMode(JsonReadMode readMode = JsonReadMode.Binary, JsonWriteMode writeMode = JsonWriteMode.Binary)
+    {
+        return new ClickHouseClient(GetSettingsWithJsonMode(readMode, writeMode));
     }
 
     [Test]
@@ -501,6 +513,89 @@ public class JsonModeTests
 
         Assert.That(settings.JsonReadMode, Is.EqualTo(JsonReadMode.Binary));
         Assert.That(settings.JsonWriteMode, Is.EqualTo(JsonWriteMode.String));
+    }
+
+    [Test]
+    public async Task JsonWriteMode_String_ShouldSetInputFormatSetting()
+    {
+        using var connection = GetConnectionWithJsonMode(writeMode: JsonWriteMode.String);
+
+        using var reader = await connection.ExecuteReaderAsync(
+            "SELECT value FROM system.settings WHERE name = 'input_format_binary_read_json_as_string'");
+        Assert.That(reader.Read(), Is.True);
+        Assert.That(reader.GetString(0), Is.EqualTo("1"));
+    }
+
+    [Test]
+    public async Task JsonWriteMode_Binary_ShouldExplicitlyDisableInputFormatSetting()
+    {
+        using var connection = GetConnectionWithJsonMode(writeMode: JsonWriteMode.Binary);
+
+        using var reader = await connection.ExecuteReaderAsync(
+            "SELECT value FROM system.settings WHERE name = 'input_format_binary_read_json_as_string'");
+        Assert.That(reader.Read(), Is.True);
+        Assert.That(reader.GetString(0), Is.EqualTo("0"));
+    }
+
+    [Test]
+    public async Task JsonWriteMode_None_ShouldNotSetInputFormatSetting()
+    {
+        using var client = GetClientWithJsonMode(writeMode: JsonWriteMode.None);
+
+        // Run a query with a known query ID so we can find it in the query log
+        var queryId = $"json_write_none_test_{Guid.NewGuid():N}";
+        var options = new QueryOptions { QueryId = queryId };
+        await client.ExecuteScalarAsync("SELECT 1", options: options);
+
+        await client.ExecuteNonQueryAsync("SYSTEM FLUSH LOGS");
+
+        var result = await client.ExecuteScalarAsync(
+            $"SELECT Settings['input_format_binary_read_json_as_string'] FROM system.query_log " +
+            $"WHERE query_id = '{queryId}' AND type = 'QueryFinish' LIMIT 1");
+
+        Assert.That(result, Is.EqualTo(""), "None mode should not send the setting to the server");
+    }
+
+    [Test]
+    public async Task JsonReadMode_String_ShouldSetOutputFormatSetting()
+    {
+        using var connection = GetConnectionWithJsonMode(readMode: JsonReadMode.String);
+
+        using var reader = await connection.ExecuteReaderAsync(
+            "SELECT value FROM system.settings WHERE name = 'output_format_binary_write_json_as_string'");
+        Assert.That(reader.Read(), Is.True);
+        Assert.That(reader.GetString(0), Is.EqualTo("1"));
+    }
+
+    [Test]
+    public async Task JsonReadMode_Binary_ShouldExplicitlyDisableOutputFormatSetting()
+    {
+        using var connection = GetConnectionWithJsonMode(readMode: JsonReadMode.Binary);
+
+        using var reader = await connection.ExecuteReaderAsync(
+            "SELECT value FROM system.settings WHERE name = 'output_format_binary_write_json_as_string'");
+        Assert.That(reader.Read(), Is.True);
+        Assert.That(reader.GetString(0), Is.EqualTo("0"));
+    }
+
+    [Test]
+    public async Task JsonReadMode_None_ShouldNotSetOutputFormatSetting()
+    {
+        using var client = GetClientWithJsonMode(readMode: JsonReadMode.None);
+
+        // Run a query with a known query ID so we can find it in the query log
+        var queryId = $"json_read_none_test_{Guid.NewGuid():N}";
+        var options = new QueryOptions { QueryId = queryId };
+        await client.ExecuteScalarAsync("SELECT 1", options: options);
+
+        await client.ExecuteNonQueryAsync("SYSTEM FLUSH LOGS");
+
+        // The query_log Settings map should NOT contain output_format_binary_write_json_as_string
+        var result = await client.ExecuteScalarAsync(
+            $"SELECT Settings['output_format_binary_write_json_as_string'] FROM system.query_log " +
+            $"WHERE query_id = '{queryId}' AND type = 'QueryFinish' LIMIT 1");
+
+        Assert.That(result, Is.EqualTo(""), "None mode should not send the setting to the server");
     }
 
     #region JSON Roundtrip Tests

--- a/ClickHouse.Driver.Tests/Types/JsonModeTests.cs
+++ b/ClickHouse.Driver.Tests/Types/JsonModeTests.cs
@@ -63,11 +63,8 @@ public class JsonModeTests
         var parsed = JsonNode.Parse(jsonString);
         Assert.That((string)parsed["name"], Is.EqualTo("John"));
 
-        // ClickHouse 25.3 returns numbers as strings in this scenario
-        if (TestUtilities.ServerVersion == Version.Parse("25.3"))
-            Assert.That(int.Parse(parsed["age"].ToString()), Is.EqualTo(30));
-        else
-            Assert.That(parsed["age"].GetValue<int>(), Is.EqualTo(30));
+        // In string read mode, the server may return numbers as quoted strings
+        Assert.That(int.Parse(parsed["age"].ToString()), Is.EqualTo(30));
     }
 
     [Test]
@@ -226,11 +223,8 @@ public class JsonModeTests
         var parsed = JsonNode.Parse((string)result);
         Assert.That((string)parsed["key"], Is.EqualTo("value"));
 
-        // ClickHouse 25.3 returns numbers as strings in this scenario
-        if (TestUtilities.ServerVersion == Version.Parse("25.3"))
-            Assert.That(int.Parse(parsed["num"].ToString()), Is.EqualTo(42));
-        else
-            Assert.That((int)parsed["num"], Is.EqualTo(42));
+        // In string read mode, the server may return numbers as quoted strings
+        Assert.That(int.Parse(parsed["num"].ToString()), Is.EqualTo(42));
     }
 
     [Test]
@@ -667,11 +661,8 @@ public class JsonModeTests
         var resultParsed = JsonNode.Parse(result);
         Assert.That(resultParsed["name"].GetValue<string>(), Is.EqualTo(originalParsed["name"].GetValue<string>()));
 
-        // ClickHouse 25.3 returns numbers as strings in this scenario
-        if (TestUtilities.ServerVersion == Version.Parse("25.3"))
-            Assert.That(long.Parse(resultParsed["value"].ToString()), Is.EqualTo(originalParsed["value"].GetValue<long>()));
-        else
-            Assert.That(resultParsed["value"].GetValue<long>(), Is.EqualTo(originalParsed["value"].GetValue<long>()));
+        // In string read mode, the server may return numbers as quoted strings
+        Assert.That(long.Parse(resultParsed["value"].ToString()), Is.EqualTo(long.Parse(originalParsed["value"].ToString())));
 
         await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {tableName}");
     }

--- a/ClickHouse.Driver/ClickHouseUriBuilder.cs
+++ b/ClickHouse.Driver/ClickHouseUriBuilder.cs
@@ -80,10 +80,15 @@ internal class ClickHouseUriBuilder
         parameters.Set("query_id", GetEffectiveQueryId());
 
         // Inject JSON format settings based on mode - do this before sqlQueryParameters to allow for overrides
-        if (JsonReadMode == JsonReadMode.String)
+        // None skips the setting entirely (for readonly connections or older servers)
+        if (JsonReadMode == JsonReadMode.Binary)
+            parameters.Set("output_format_binary_write_json_as_string", "0");
+        else if (JsonReadMode == JsonReadMode.String)
             parameters.Set("output_format_binary_write_json_as_string", "1");
 
-        if (JsonWriteMode == JsonWriteMode.String)
+        if (JsonWriteMode == JsonWriteMode.Binary)
+            parameters.Set("input_format_binary_read_json_as_string", "0");
+        else if (JsonWriteMode == JsonWriteMode.String)
             parameters.Set("input_format_binary_read_json_as_string", "1");
 
         foreach (var parameter in sqlQueryParameters)

--- a/ClickHouse.Driver/Json/JsonReadMode.cs
+++ b/ClickHouse.Driver/Json/JsonReadMode.cs
@@ -21,7 +21,7 @@ public enum JsonReadMode
 
     /// <summary>
     /// No server settings are automatically applied. Use this for readonly connections
-    /// where setting server parameters is not allowed. Behavior is same as Binary.
+    /// where setting server parameters is not allowed. Read behavior is same as Binary.
     /// Does not set output_format_binary_write_json_as_string.
     /// </summary>
     None = 2,

--- a/ClickHouse.Driver/Json/JsonReadMode.cs
+++ b/ClickHouse.Driver/Json/JsonReadMode.cs
@@ -7,6 +7,7 @@ public enum JsonReadMode
 {
     /// <summary>
     /// JSON is returned in binary format from the server and parsed into JsonObject.
+    /// Explicitly sets output_format_binary_write_json_as_string=0.
     /// </summary>
     Binary = 0,
 

--- a/ClickHouse.Driver/Json/JsonWriteMode.cs
+++ b/ClickHouse.Driver/Json/JsonWriteMode.cs
@@ -8,6 +8,7 @@ public enum JsonWriteMode
     /// <summary>
     /// JSON is written in binary format. Only registered POCO types are supported.
     /// Use RegisterJsonSerializationType to register types with custom path mappings.
+    /// Explicitly sets input_format_binary_read_json_as_string=0.
     /// </summary>
     Binary = 0,
 

--- a/ClickHouse.Driver/Json/JsonWriteMode.cs
+++ b/ClickHouse.Driver/Json/JsonWriteMode.cs
@@ -23,7 +23,7 @@ public enum JsonWriteMode
 
     /// <summary>
     /// No server settings are automatically applied. Use this for readonly connections
-    /// where setting server parameters is not allowed. Behavior is same as Binary.
+    /// where setting server parameters is not allowed. Write behavior is same as Binary.
     /// Does not set input_format_binary_read_json_as_string.
     /// </summary>
     None = 2,


### PR DESCRIPTION
Previously, setting JsonReadMode = String set the setting output_format_binary_write_json_as_string = 1. But JsonReadMode = Binary did not set it to 0, and relied on the server default to work. But the server setting is not necessarily 0, so this needs to be set explicitly.