### PR TITLE
fix datetime formating and enum name parsing bugs

### DIFF
--- a/ClickHouse.Driver.Tests/Types/EnumTypeTests.cs
+++ b/ClickHouse.Driver.Tests/Types/EnumTypeTests.cs
@@ -78,11 +78,8 @@ public class EnumTypeTests
         var typeString = "Enum8('None' = -1, 'DateTime(\\'UTC\\')' = 0, 'String' = 1)";
         var type = (EnumType)TypeConverter.ParseClickHouseType(typeString, TypeSettings.Default);
 
-        Assert.Multiple(() =>
-        {
-            Assert.That(type.Lookup("DateTime('UTC')"), Is.EqualTo(0));
-            Assert.That(type.Lookup(0), Is.EqualTo("DateTime('UTC')"));
-        });
+        Assert.That(type.Lookup("DateTime('UTC')"), Is.EqualTo(0));
+        Assert.That(type.Lookup(0), Is.EqualTo("DateTime('UTC')"));
     }
 
     [Test]
@@ -91,10 +88,7 @@ public class EnumTypeTests
         var typeString = "Enum8('a=b' = 1, 'plain' = 2)";
         var type = (EnumType)TypeConverter.ParseClickHouseType(typeString, TypeSettings.Default);
 
-        Assert.Multiple(() =>
-        {
-            Assert.That(type.Lookup("a=b"), Is.EqualTo(1));
-            Assert.That(type.Lookup(1), Is.EqualTo("a=b"));
-        });
+        Assert.That(type.Lookup("a=b"), Is.EqualTo(1));
+        Assert.That(type.Lookup(1), Is.EqualTo("a=b"));
     }
 }

--- a/ClickHouse.Driver.Tests/Types/EnumTypeTests.cs
+++ b/ClickHouse.Driver.Tests/Types/EnumTypeTests.cs
@@ -71,4 +71,17 @@ public class EnumTypeTests
             Assert.That(enumType.Lookup(1), Is.EqualTo("Inactive"));
         });
     }
+
+    [Test]
+    public void ShouldParseEnumLabelWithEscapedQuotesAndParentheses()
+    {
+        var typeString = "Enum8('None' = -1, 'DateTime(\\'UTC\\')' = 0, 'String' = 1)";
+        var type = (EnumType)TypeConverter.ParseClickHouseType(typeString, TypeSettings.Default);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(type.Lookup("DateTime('UTC')"), Is.EqualTo(0));
+            Assert.That(type.Lookup(0), Is.EqualTo("DateTime('UTC')"));
+        });
+    }
 }

--- a/ClickHouse.Driver.Tests/Types/EnumTypeTests.cs
+++ b/ClickHouse.Driver.Tests/Types/EnumTypeTests.cs
@@ -84,4 +84,17 @@ public class EnumTypeTests
             Assert.That(type.Lookup(0), Is.EqualTo("DateTime('UTC')"));
         });
     }
+
+    [Test]
+    public void ShouldParseEnumLabelWithEqualsSign()
+    {
+        var typeString = "Enum8('a=b' = 1, 'plain' = 2)";
+        var type = (EnumType)TypeConverter.ParseClickHouseType(typeString, TypeSettings.Default);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(type.Lookup("a=b"), Is.EqualTo(1));
+            Assert.That(type.Lookup(1), Is.EqualTo("a=b"));
+        });
+    }
 }

--- a/ClickHouse.Driver.Tests/Types/VariantTests.cs
+++ b/ClickHouse.Driver.Tests/Types/VariantTests.cs
@@ -116,6 +116,24 @@ public class VariantTests : AbstractConnectionTestFixture
 
     [Test]
     [RequiredFeature(Feature.Variant)]
+    [FromVersion(25, 4)]
+    public async Task ParameterizedSelect_VariantStringDateTimeUtc_WithDateTimeValue_ShouldRoundTrip()
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT {var:Variant(String, DateTime('UTC'))}, variantType({var:Variant(String, DateTime('UTC'))})";
+        command.AddParameter("var", new DateTime(2024, 1, 15, 10, 30, 0, DateTimeKind.Utc));
+
+        using var reader = await command.ExecuteReaderAsync();
+        ClassicAssert.IsTrue(reader.Read());
+        var result = (DateTime)reader.GetValue(0);
+        Assert.That(result, Is.EqualTo(new DateTime(2024, 1, 15, 10, 30, 0, DateTimeKind.Utc)));
+        Assert.That(result.Kind, Is.EqualTo(DateTimeKind.Utc));
+        Assert.That(reader.GetString(1), Is.EqualTo("DateTime('UTC')"));
+        ClassicAssert.IsFalse(reader.Read());
+    }
+
+    [Test]
+    [RequiredFeature(Feature.Variant)]
     public async Task InsertBinaryAsync_VariantIPv4IPv6_ShouldRoundTrip()
     {
         var targetTable = "test.test_variant_ip";

--- a/ClickHouse.Driver.Tests/Utilities/TestCases.cs
+++ b/ClickHouse.Driver.Tests/Utilities/TestCases.cs
@@ -396,12 +396,9 @@ public class TestCases
             // 0x31: BFloat16
             new DataTypeSample("BFloat16", typeof(float), "toBFloat16(1.25)", 1.25f),
             // 0x0F: Date
-            // 0x10: Date32
+            new DataTypeSample("Date", typeof(DateTime), "toDate('2024-01-15')", new DateTime(2024, 1, 15)),
             // 0x11: DateTime (UTC)
-            //new DataTypeSample("Date", typeof(DateTime), "toDate('2024-01-15')", new DateTime(2024, 1, 15)),
-            //new DataTypeSample("DateTime('UTC')", typeof(DateTime), "toDateTime('2024-01-15 10:30:00', 'UTC')", new DateTime(2024, 1, 15, 10, 30, 0, DateTimeKind.Unspecified)),
-            //baseTypesToTest.Add(new DataTypeSample("Date32", typeof(DateTime), "toDate32('2024-01-15')", new DateTime(2024, 1, 15)));
-            // No dates or datetimes here because automatic type mapping tests are problematic
+            new DataTypeSample("DateTime('UTC')", typeof(DateTime), "toDateTime('2024-01-15 10:30:00', 'UTC')", new DateTime(2024, 1, 15, 10, 30, 0, DateTimeKind.Utc)),
             // 0x15: String
             new DataTypeSample("String", typeof(string), "'test'", "test"),
             // 0x16: FixedString
@@ -435,6 +432,12 @@ public class TestCases
         {
             // 0x2D: Bool
             baseTypesToTest.Add(new DataTypeSample("Bool", typeof(bool), "CAST(1, 'Bool')", true));
+        }
+
+        if (TestUtilities.SupportedFeatures.HasFlag(Feature.Date32))
+        {
+            // 0x10: Date32
+            baseTypesToTest.Add(new DataTypeSample("Date32", typeof(DateTime), "toDate32('2024-01-15')", new DateTime(2024, 1, 15)));
         }
 
 

--- a/ClickHouse.Driver/Formats/HttpParameterFormatter.cs
+++ b/ClickHouse.Driver/Formats/HttpParameterFormatter.cs
@@ -53,19 +53,13 @@ internal static class HttpParameterFormatter
                 return Convert.ToDecimal(value, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture);
 
             case DateType dt when value is DateTimeOffset @dto:
-                return quote
-                    ? @dto.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture).QuoteSingle()
-                    : @dto.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+                return QuoteIfNeeded(@dto.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture), quote);
 #if NET6_0_OR_GREATER
             case DateType dt when value is DateOnly @do:
-                return quote
-                    ? @do.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture).QuoteSingle()
-                    : @do.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+                return QuoteIfNeeded(@do.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture), quote);
 #endif
             case DateType dt:
-                return quote
-                    ? Convert.ToDateTime(value, CultureInfo.InvariantCulture).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture).QuoteSingle()
-                    : Convert.ToDateTime(value, CultureInfo.InvariantCulture).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+                return QuoteIfNeeded(Convert.ToDateTime(value, CultureInfo.InvariantCulture).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture), quote);
 
             case FixedStringType tt when value is byte[] fsb:
                 return quote ? Encoding.UTF8.GetString(fsb).Escape().QuoteSingle() : Encoding.UTF8.GetString(fsb).Escape();
@@ -87,32 +81,24 @@ internal static class HttpParameterFormatter
                 // Unspecified: send as-is so ClickHouse interprets in parameter timezone
                 // UTC/Local: convert to parameter timezone (or UTC if not specified) to preserve instant
                 if (dt.Kind == DateTimeKind.Unspecified)
-                    return quote ? dt.ToString("s", CultureInfo.InvariantCulture).QuoteSingle() : dt.ToString("s", CultureInfo.InvariantCulture);
-                return quote
-                    ? FormatDateTimeInTargetTimezone(new DateTimeOffset(dt), dtt.TimeZoneOrUtc).QuoteSingle()
-                    : FormatDateTimeInTargetTimezone(new DateTimeOffset(dt), dtt.TimeZoneOrUtc);
+                    return QuoteIfNeeded(dt.ToString("s", CultureInfo.InvariantCulture), quote);
+                return QuoteIfNeeded(FormatDateTimeInTargetTimezone(new DateTimeOffset(dt), dtt.TimeZoneOrUtc), quote);
 
             case DateTimeType dtt when value is DateTimeOffset dto:
                 // DateTimeOffset: convert to parameter timezone (or UTC if not specified) to preserve instant
-                return quote
-                    ? FormatDateTimeInTargetTimezone(dto, dtt.TimeZoneOrUtc).QuoteSingle()
-                    : FormatDateTimeInTargetTimezone(dto, dtt.TimeZoneOrUtc);
+                return QuoteIfNeeded(FormatDateTimeInTargetTimezone(dto, dtt.TimeZoneOrUtc), quote);
 
             case DateTime64Type d64t when value is DateTime dtv:
                 // ClickHouse HTTP parameters expect DateTime64 as ISO-formatted strings.
                 // Unspecified: send as-is so ClickHouse interprets in parameter timezone
                 // UTC/Local: convert to parameter timezone (or UTC if not specified) to preserve instant
                 if (dtv.Kind == DateTimeKind.Unspecified)
-                    return quote ? $"{dtv:yyyy-MM-dd HH:mm:ss.fffffff}".QuoteSingle() : $"{dtv:yyyy-MM-dd HH:mm:ss.fffffff}";
-                return quote
-                    ? FormatDateTime64InTargetTimezone(new DateTimeOffset(dtv), d64t.TimeZoneOrUtc).QuoteSingle()
-                    : FormatDateTime64InTargetTimezone(new DateTimeOffset(dtv), d64t.TimeZoneOrUtc);
+                    return QuoteIfNeeded($"{dtv:yyyy-MM-dd HH:mm:ss.fffffff}", quote);
+                return QuoteIfNeeded(FormatDateTime64InTargetTimezone(new DateTimeOffset(dtv), d64t.TimeZoneOrUtc), quote);
 
             case DateTime64Type d64t when value is DateTimeOffset dto:
                 // DateTimeOffset: convert to parameter timezone (or UTC if not specified) to preserve instant
-                return quote
-                    ? FormatDateTime64InTargetTimezone(dto, d64t.TimeZoneOrUtc).QuoteSingle()
-                    : FormatDateTime64InTargetTimezone(dto, d64t.TimeZoneOrUtc);
+                return QuoteIfNeeded(FormatDateTime64InTargetTimezone(dto, d64t.TimeZoneOrUtc), quote);
 
             case TimeType tt when value is TimeSpan ts:
                 return TimeType.FormatTimeString(ts);
@@ -162,6 +148,9 @@ internal static class HttpParameterFormatter
                 throw new ArgumentException($"Cannot convert {value} to {type}");
         }
     }
+
+    private static string QuoteIfNeeded(string value, bool quote)
+        => quote ? value.QuoteSingle() : value;
 
     /// <summary>
     /// Formats a DateTimeOffset as an ISO string in the target timezone.

--- a/ClickHouse.Driver/Formats/HttpParameterFormatter.cs
+++ b/ClickHouse.Driver/Formats/HttpParameterFormatter.cs
@@ -53,13 +53,16 @@ internal static class HttpParameterFormatter
                 return Convert.ToDecimal(value, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture);
 
             case DateType dt when value is DateTimeOffset @dto:
-                return @dto.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+                return QuoteIfNeeded(@dto.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture), quote, type);
 #if NET6_0_OR_GREATER
             case DateType dt when value is DateOnly @do:
-                return @do.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+                return QuoteIfNeeded(@do.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture), quote, type);
 #endif
             case DateType dt:
-                return Convert.ToDateTime(value, CultureInfo.InvariantCulture).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+                return QuoteIfNeeded(
+                    Convert.ToDateTime(value, CultureInfo.InvariantCulture).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+                    quote,
+                    type);
 
             case FixedStringType tt when value is byte[] fsb:
                 return quote ? Encoding.UTF8.GetString(fsb).Escape().QuoteSingle() : Encoding.UTF8.GetString(fsb).Escape();
@@ -81,24 +84,24 @@ internal static class HttpParameterFormatter
                 // Unspecified: send as-is so ClickHouse interprets in parameter timezone
                 // UTC/Local: convert to parameter timezone (or UTC if not specified) to preserve instant
                 if (dt.Kind == DateTimeKind.Unspecified)
-                    return dt.ToString("s", CultureInfo.InvariantCulture);
-                return FormatDateTimeInTargetTimezone(new DateTimeOffset(dt), dtt.TimeZoneOrUtc);
+                    return QuoteIfNeeded(dt.ToString("s", CultureInfo.InvariantCulture), quote, type);
+                return QuoteIfNeeded(FormatDateTimeInTargetTimezone(new DateTimeOffset(dt), dtt.TimeZoneOrUtc), quote, type);
 
             case DateTimeType dtt when value is DateTimeOffset dto:
                 // DateTimeOffset: convert to parameter timezone (or UTC if not specified) to preserve instant
-                return FormatDateTimeInTargetTimezone(dto, dtt.TimeZoneOrUtc);
+                return QuoteIfNeeded(FormatDateTimeInTargetTimezone(dto, dtt.TimeZoneOrUtc), quote, type);
 
             case DateTime64Type d64t when value is DateTime dtv:
                 // ClickHouse HTTP parameters expect DateTime64 as ISO-formatted strings.
                 // Unspecified: send as-is so ClickHouse interprets in parameter timezone
                 // UTC/Local: convert to parameter timezone (or UTC if not specified) to preserve instant
                 if (dtv.Kind == DateTimeKind.Unspecified)
-                    return $"{dtv:yyyy-MM-dd HH:mm:ss.fffffff}";
-                return FormatDateTime64InTargetTimezone(new DateTimeOffset(dtv), d64t.TimeZoneOrUtc);
+                    return QuoteIfNeeded($"{dtv:yyyy-MM-dd HH:mm:ss.fffffff}", quote, type);
+                return QuoteIfNeeded(FormatDateTime64InTargetTimezone(new DateTimeOffset(dtv), d64t.TimeZoneOrUtc), quote, type);
 
             case DateTime64Type d64t when value is DateTimeOffset dto:
                 // DateTimeOffset: convert to parameter timezone (or UTC if not specified) to preserve instant
-                return FormatDateTime64InTargetTimezone(dto, d64t.TimeZoneOrUtc);
+                return QuoteIfNeeded(FormatDateTime64InTargetTimezone(dto, d64t.TimeZoneOrUtc), quote, type);
 
             case TimeType tt when value is TimeSpan ts:
                 return TimeType.FormatTimeString(ts);
@@ -148,6 +151,19 @@ internal static class HttpParameterFormatter
                 throw new ArgumentException($"Cannot convert {value} to {type}");
         }
     }
+
+    private static bool TypeRequiresQuoting(ClickHouseType type) => type switch
+    {
+        StringType or FixedStringType or Enum8Type or Enum16Type
+            or IPv4Type or IPv6Type or UuidType
+            or DateType or DateTimeType or DateTime64Type => true,
+        LowCardinalityType lct => TypeRequiresQuoting(lct.UnderlyingType),
+        NullableType nt => TypeRequiresQuoting(nt.UnderlyingType),
+        _ => false,
+    };
+
+    private static string QuoteIfNeeded(string value, bool quote, ClickHouseType type)
+        => quote && TypeRequiresQuoting(type) ? value.QuoteSingle() : value;
 
     /// <summary>
     /// Formats a DateTimeOffset as an ISO string in the target timezone.

--- a/ClickHouse.Driver/Formats/HttpParameterFormatter.cs
+++ b/ClickHouse.Driver/Formats/HttpParameterFormatter.cs
@@ -62,7 +62,7 @@ internal static class HttpParameterFormatter
                 return QuoteIfNeeded(Convert.ToDateTime(value, CultureInfo.InvariantCulture).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture), quote);
 
             case FixedStringType tt when value is byte[] fsb:
-                return quote ? Encoding.UTF8.GetString(fsb).Escape().QuoteSingle() : Encoding.UTF8.GetString(fsb).Escape();
+                return QuoteIfNeeded(Encoding.UTF8.GetString(fsb).Escape(), quote);
 
             case StringType st:
             case FixedStringType tt:
@@ -71,7 +71,7 @@ internal static class HttpParameterFormatter
             case IPv4Type ip4:
             case IPv6Type ip6:
             case UuidType uuidType:
-                return quote ? value.ToString().Escape().QuoteSingle() : value.ToString().Escape();
+                return QuoteIfNeeded(value.ToString().Escape(), quote);
 
             case LowCardinalityType lt:
                 return Format(lt.UnderlyingType, value, quote);

--- a/ClickHouse.Driver/Formats/HttpParameterFormatter.cs
+++ b/ClickHouse.Driver/Formats/HttpParameterFormatter.cs
@@ -53,16 +53,19 @@ internal static class HttpParameterFormatter
                 return Convert.ToDecimal(value, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture);
 
             case DateType dt when value is DateTimeOffset @dto:
-                return QuoteIfNeeded(@dto.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture), quote, type);
+                return quote
+                    ? @dto.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture).QuoteSingle()
+                    : @dto.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
 #if NET6_0_OR_GREATER
             case DateType dt when value is DateOnly @do:
-                return QuoteIfNeeded(@do.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture), quote, type);
+                return quote
+                    ? @do.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture).QuoteSingle()
+                    : @do.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
 #endif
             case DateType dt:
-                return QuoteIfNeeded(
-                    Convert.ToDateTime(value, CultureInfo.InvariantCulture).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
-                    quote,
-                    type);
+                return quote
+                    ? Convert.ToDateTime(value, CultureInfo.InvariantCulture).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture).QuoteSingle()
+                    : Convert.ToDateTime(value, CultureInfo.InvariantCulture).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
 
             case FixedStringType tt when value is byte[] fsb:
                 return quote ? Encoding.UTF8.GetString(fsb).Escape().QuoteSingle() : Encoding.UTF8.GetString(fsb).Escape();
@@ -84,24 +87,32 @@ internal static class HttpParameterFormatter
                 // Unspecified: send as-is so ClickHouse interprets in parameter timezone
                 // UTC/Local: convert to parameter timezone (or UTC if not specified) to preserve instant
                 if (dt.Kind == DateTimeKind.Unspecified)
-                    return QuoteIfNeeded(dt.ToString("s", CultureInfo.InvariantCulture), quote, type);
-                return QuoteIfNeeded(FormatDateTimeInTargetTimezone(new DateTimeOffset(dt), dtt.TimeZoneOrUtc), quote, type);
+                    return quote ? dt.ToString("s", CultureInfo.InvariantCulture).QuoteSingle() : dt.ToString("s", CultureInfo.InvariantCulture);
+                return quote
+                    ? FormatDateTimeInTargetTimezone(new DateTimeOffset(dt), dtt.TimeZoneOrUtc).QuoteSingle()
+                    : FormatDateTimeInTargetTimezone(new DateTimeOffset(dt), dtt.TimeZoneOrUtc);
 
             case DateTimeType dtt when value is DateTimeOffset dto:
                 // DateTimeOffset: convert to parameter timezone (or UTC if not specified) to preserve instant
-                return QuoteIfNeeded(FormatDateTimeInTargetTimezone(dto, dtt.TimeZoneOrUtc), quote, type);
+                return quote
+                    ? FormatDateTimeInTargetTimezone(dto, dtt.TimeZoneOrUtc).QuoteSingle()
+                    : FormatDateTimeInTargetTimezone(dto, dtt.TimeZoneOrUtc);
 
             case DateTime64Type d64t when value is DateTime dtv:
                 // ClickHouse HTTP parameters expect DateTime64 as ISO-formatted strings.
                 // Unspecified: send as-is so ClickHouse interprets in parameter timezone
                 // UTC/Local: convert to parameter timezone (or UTC if not specified) to preserve instant
                 if (dtv.Kind == DateTimeKind.Unspecified)
-                    return QuoteIfNeeded($"{dtv:yyyy-MM-dd HH:mm:ss.fffffff}", quote, type);
-                return QuoteIfNeeded(FormatDateTime64InTargetTimezone(new DateTimeOffset(dtv), d64t.TimeZoneOrUtc), quote, type);
+                    return quote ? $"{dtv:yyyy-MM-dd HH:mm:ss.fffffff}".QuoteSingle() : $"{dtv:yyyy-MM-dd HH:mm:ss.fffffff}";
+                return quote
+                    ? FormatDateTime64InTargetTimezone(new DateTimeOffset(dtv), d64t.TimeZoneOrUtc).QuoteSingle()
+                    : FormatDateTime64InTargetTimezone(new DateTimeOffset(dtv), d64t.TimeZoneOrUtc);
 
             case DateTime64Type d64t when value is DateTimeOffset dto:
                 // DateTimeOffset: convert to parameter timezone (or UTC if not specified) to preserve instant
-                return QuoteIfNeeded(FormatDateTime64InTargetTimezone(dto, d64t.TimeZoneOrUtc), quote, type);
+                return quote
+                    ? FormatDateTime64InTargetTimezone(dto, d64t.TimeZoneOrUtc).QuoteSingle()
+                    : FormatDateTime64InTargetTimezone(dto, d64t.TimeZoneOrUtc);
 
             case TimeType tt when value is TimeSpan ts:
                 return TimeType.FormatTimeString(ts);
@@ -151,19 +162,6 @@ internal static class HttpParameterFormatter
                 throw new ArgumentException($"Cannot convert {value} to {type}");
         }
     }
-
-    private static bool TypeRequiresQuoting(ClickHouseType type) => type switch
-    {
-        StringType or FixedStringType or Enum8Type or Enum16Type
-            or IPv4Type or IPv6Type or UuidType
-            or DateType or DateTimeType or DateTime64Type => true,
-        LowCardinalityType lct => TypeRequiresQuoting(lct.UnderlyingType),
-        NullableType nt => TypeRequiresQuoting(nt.UnderlyingType),
-        _ => false,
-    };
-
-    private static string QuoteIfNeeded(string value, bool quote, ClickHouseType type)
-        => quote && TypeRequiresQuoting(type) ? value.QuoteSingle() : value;
 
     /// <summary>
     /// Formats a DateTimeOffset as an ISO string in the target timezone.

--- a/ClickHouse.Driver/Types/EnumType.cs
+++ b/ClickHouse.Driver/Types/EnumType.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Text.RegularExpressions;
 using ClickHouse.Driver.Formats;
 using ClickHouse.Driver.Types.Grammar;
 
@@ -36,8 +37,8 @@ internal class EnumType : ParameterizedType
     {
         var parameters = node.ChildNodes
             .Select(cn => cn.Value)
-            .Select(p => p.Split('='))
-            .ToDictionary(kvp => kvp[0].Trim().Trim('\''), kvp => Convert.ToInt32(kvp[1].Trim(), CultureInfo.InvariantCulture));
+            .Select(ParseEnumMember)
+            .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
 
         string typeName = TypeConverter.ExtractTypeName(node);
 
@@ -61,4 +62,26 @@ internal class EnumType : ParameterizedType
     public override object Read(ExtendedBinaryReader reader) => throw new NotImplementedException();
 
     public override void Write(ExtendedBinaryWriter writer, object value) => throw new NotImplementedException();
+
+    private static KeyValuePair<string, int> ParseEnumMember(string value)
+    {
+        var separatorIndex = value.LastIndexOf('=');
+        if (separatorIndex < 0)
+            throw new FormatException($"Invalid enum member definition: {value}");
+
+        var rawLabel = value[..separatorIndex].Trim();
+        var rawValue = value[(separatorIndex + 1)..].Trim();
+
+        if (rawLabel.Length >= 2 && rawLabel[0] == '\'' && rawLabel[^1] == '\'')
+        {
+            rawLabel = rawLabel[1..^1];
+        }
+
+        return new KeyValuePair<string, int>(
+            UnescapeEnumLabel(rawLabel),
+            Convert.ToInt32(rawValue, CultureInfo.InvariantCulture));
+    }
+
+    private static string UnescapeEnumLabel(string value)
+        => Regex.Unescape(value);
 }

--- a/ClickHouse.Driver/Types/EnumType.cs
+++ b/ClickHouse.Driver/Types/EnumType.cs
@@ -78,10 +78,7 @@ internal class EnumType : ParameterizedType
         }
 
         return new KeyValuePair<string, int>(
-            UnescapeEnumLabel(rawLabel),
+            Regex.Unescape(rawLabel),
             Convert.ToInt32(rawValue, CultureInfo.InvariantCulture));
     }
-
-    private static string UnescapeEnumLabel(string value)
-        => Regex.Unescape(value);
 }

--- a/ClickHouse.Driver/Types/Grammar/Tokenizer.cs
+++ b/ClickHouse.Driver/Types/Grammar/Tokenizer.cs
@@ -9,26 +9,55 @@ public static class Tokenizer
     public static IEnumerable<string> GetTokens(string input)
     {
         var start = 0;
-        var len = input.Length;
+        var inQuotes = false;
+        var escaped = false;
 
-        while (start < len)
+        for (var i = 0; i < input.Length; i++)
         {
-            var nextBreak = input.IndexOfAny(Breaks, start);
-            if (nextBreak == start)
+            var c = input[i];
+            if (inQuotes)
             {
-                start++;
-                yield return input.Substring(nextBreak, 1);
+                if (escaped)
+                {
+                    escaped = false;
+                    continue;
+                }
+
+                if (c == '\\')
+                {
+                    escaped = true;
+                    continue;
+                }
+
+                if (c == '\'')
+                {
+                    inQuotes = false;
+                }
+
+                continue;
             }
-            else if (nextBreak == -1)
+
+            if (c == '\'')
             {
-                yield return input.Substring(start).Trim();
-                yield break;
+                inQuotes = true;
+                continue;
             }
-            else
+
+            if (System.Array.IndexOf(Breaks, c) >= 0)
             {
-                yield return input.Substring(start, nextBreak - start).Trim();
-                start = nextBreak;
+                if (i > start)
+                {
+                    yield return input.Substring(start, i - start).Trim();
+                }
+
+                yield return input.Substring(i, 1);
+                start = i + 1;
             }
+        }
+
+        if (start < input.Length)
+        {
+            yield return input.Substring(start).Trim();
         }
     }
 }


### PR DESCRIPTION
* DateTime formatting in collections was failing to quote the elements properly.
* Enum name parsing did not handle escaped characters properly.