### PR TITLE
Update cross-repo-bug-relay.yml

### DIFF
--- a/.github/workflows/cross-repo-bug-relay.yml
+++ b/.github/workflows/cross-repo-bug-relay.yml
@@ -11,5 +11,5 @@ permissions: {}
 
 jobs:
   relay:
-    uses: ClickHouse/integrations-ai-playground/.github/workflows/cross-repo-bug-relay.yml@main
+    uses: ClickHouse/integrations-shared-workflows/.github/workflows/cross-repo-bug-relay.yml@main
     secrets: inherit


### PR DESCRIPTION
Because this is a public repo, and the other repo is private, the workflow reference doesn't work (even after enabling the config to make the workflows available to other repos in the org).

Fix by making the relay public and referencing that instead,