### PR TITLE
Auto-start ClickHouse via Testcontainers when CLICKHOUSE_CONNECTION is unset

### DIFF
--- a/.github/workflows/reusable.yml
+++ b/.github/workflows/reusable.yml
@@ -23,18 +23,7 @@ jobs:
   build-and-test:
     name: Build & Test
     runs-on: ubuntu-22.04
-    timeout-minutes: 5
-
-    services:
-      clickhouse:
-        image: clickhouse/clickhouse-server:${{ inputs.clickhouse-version }}
-        ports:
-          - 8123:8123
-        env:
-          CLICKHOUSE_DB: test
-          CLICKHOUSE_USER: test
-          CLICKHOUSE_PASSWORD: test1234
-          CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: "1"
+    timeout-minutes: 10
 
     steps:
       - name: Checkout
@@ -64,9 +53,7 @@ jobs:
       - name: Test
         run: dotnet test ClickHouse.Driver.Tests/ClickHouse.Driver.Tests.csproj --framework ${{ inputs.framework }} --configuration Release --verbosity normal --logger GitHubActions /clp:ErrorsOnly ${{ inputs.coverage && '/p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:SkipAutoProps=true' || '' }}
         env:
-          CLICKHOUSE_CONNECTION: Host=localhost;Port=8123;Username=test;Password=test1234
           CLICKHOUSE_VERSION: ${{ inputs.clickhouse-version }}
-          CLICKHOUSE_TEST_ENVIRONMENT: local_single_node
 
       - uses: codecov/codecov-action@v6
         if: inputs.coverage

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -11,18 +11,7 @@ jobs:
   integration:
     name: Integration Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 5
-
-    services:
-      clickhouse:
-        image: clickhouse/clickhouse-server:latest
-        ports:
-          - 8123:8123
-        env:
-          CLICKHOUSE_DB: test
-          CLICKHOUSE_USER: test
-          CLICKHOUSE_PASSWORD: test1234
-          CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: "1"
+    timeout-minutes: 10
 
     steps:
       - name: Checkout
@@ -47,6 +36,4 @@ jobs:
       - name: Test
         run: dotnet test ClickHouse.Driver.IntegrationTests/ClickHouse.Driver.IntegrationTests.csproj --framework net10.0 --configuration Release --verbosity normal --logger GitHubActions  /clp:ErrorsOnly /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:SkipAutoProps=true
         env:
-          CLICKHOUSE_CONNECTION: Host=localhost;Port=8123;Username=test;Password=test1234
           CLICKHOUSE_VERSION: latest
-          CLICKHOUSE_TEST_ENVIRONMENT: local_single_node

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,15 @@ The solution includes three test projects:
 
 ### Running unit tests
 
-Tests require a running ClickHouse server. The easiest way is to use Docker. Running the tests requires setting up an environment variable with a valid connection string, eg
+Tests require a ClickHouse server. By default, the test suite uses [Testcontainers](https://testcontainers.com/) to automatically start and manage a ClickHouse container for you - all you need is a running Docker daemon.
+
+```bash
+dotnet test ClickHouse.Driver.Tests/ClickHouse.Driver.Tests.csproj --framework net9.0 -c Release
+```
+
+#### Using an existing ClickHouse instance
+
+If you'd rather point the tests at an already-running ClickHouse instance, set `CLICKHOUSE_CONNECTION` to a valid connection string. When this variable is set, Testcontainers is skipped:
 
 ```bash
 # Windows (PowerShell)
@@ -66,29 +74,13 @@ $env:CLICKHOUSE_CONNECTION="Host=localhost;Port=8123;Username=default"
 export CLICKHOUSE_CONNECTION="Host=localhost;Port=8123;Username=default"
 ```
 
-#### Start ClickHouse in Docker
+A matching Docker command, if you want to run your own instance:
 
 ```bash
 docker run --rm -d \
   -p 8123:8123 \
   -e CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1 \
   --name clickhouse-dev clickhouse/clickhouse-server:latest
-```
-
-
-#### Run the tests
-
-Run all tests on .NET 9.0:
-
-```bash
-dotnet test ClickHouse.Driver.Tests/ClickHouse.Driver.Tests.csproj --framework net9.0 -c Release
-```
-
-
-#### Stop the ClickHouse container
-
-```bash
-docker stop clickhouse-dev
 ```
 
 ### Running integration tests
@@ -133,20 +125,14 @@ Results will be saved in the `results/` directory.
 
 ### Testing against different ClickHouse versions
 
-To test against a specific ClickHouse version:
+To pin tests to a specific ClickHouse version, set `CLICKHOUSE_VERSION`. Testcontainers will pull the matching `clickhouse/clickhouse-server:<version>` image:
 
 ```bash
-docker run --rm -d \
-  -p 8123:8123 \
-  -e CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1 \
-  --name clickhouse-dev clickhouse/clickhouse-server:25.3
-
-# Set the version environment variable
 export CLICKHOUSE_VERSION="25.3"
-
-# Run tests
 dotnet test ClickHouse.Driver.Tests/ClickHouse.Driver.Tests.csproj --framework net9.0 -c Release
 ```
+
+If you're using your own ClickHouse instance via `CLICKHOUSE_CONNECTION`, `CLICKHOUSE_VERSION` is still honored for feature-flag detection — otherwise the server version is queried at startup.
 
 ## CI/CD
 

--- a/ClickHouse.Driver.IntegrationTests/ClickHouse.Driver.IntegrationTests.csproj
+++ b/ClickHouse.Driver.IntegrationTests/ClickHouse.Driver.IntegrationTests.csproj
@@ -28,7 +28,6 @@
     <PackageReference Include="NUnit" Version="4.3.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
-    <PackageReference Include="Testcontainers.ClickHouse" Version="4.11.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ClickHouse.Driver.IntegrationTests/ClickHouse.Driver.IntegrationTests.csproj
+++ b/ClickHouse.Driver.IntegrationTests/ClickHouse.Driver.IntegrationTests.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="NUnit" Version="4.3.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+    <PackageReference Include="Testcontainers.ClickHouse" Version="4.11.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ClickHouse.Driver.IntegrationTests/TestContainerFixture.cs
+++ b/ClickHouse.Driver.IntegrationTests/TestContainerFixture.cs
@@ -1,0 +1,17 @@
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tests;
+using NUnit.Framework;
+
+namespace ClickHouse.Driver.IntegrationTests;
+
+[SetUpFixture]
+public class TestContainerFixture
+{
+    [OneTimeTearDown]
+    public async Task TearDown()
+    {
+        var container = TestUtilities.TestContainer;
+        if (container is not null)
+            await container.DisposeAsync();
+    }
+}

--- a/ClickHouse.Driver.Tests/ClickHouse.Driver.Tests.csproj
+++ b/ClickHouse.Driver.Tests/ClickHouse.Driver.Tests.csproj
@@ -41,6 +41,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="OpenTelemetry" Version="1.15.2" />
+    <PackageReference Include="Testcontainers.ClickHouse" Version="4.11.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ClickHouse.Driver.Tests/TestContainerFixture.cs
+++ b/ClickHouse.Driver.Tests/TestContainerFixture.cs
@@ -1,0 +1,16 @@
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace ClickHouse.Driver.Tests;
+
+[SetUpFixture]
+public class TestContainerFixture
+{
+    [OneTimeTearDown]
+    public async Task TearDown()
+    {
+        var container = TestUtilities.TestContainer;
+        if (container is not null)
+            await container.DisposeAsync();
+    }
+}

--- a/ClickHouse.Driver.Tests/Utilities/TestUtilities.cs
+++ b/ClickHouse.Driver.Tests/Utilities/TestUtilities.cs
@@ -212,7 +212,7 @@ public static class TestUtilities
 
     private static readonly Lazy<ClickHouseContainer?> _container = new(StartContainerIfNeeded);
 
-    internal static ClickHouseContainer? TestContainer => _container.IsValueCreated ? _container.Value : null;
+    public static ClickHouseContainer? TestContainer => _container.IsValueCreated ? _container.Value : null;
 
     private static ClickHouseContainer? StartContainerIfNeeded()
     {
@@ -232,7 +232,19 @@ public static class TestUtilities
             .WithEnvironment("CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT", "1")
             .Build();
 
-        container.StartAsync().GetAwaiter().GetResult();
+        try
+        {
+            container.StartAsync().GetAwaiter().GetResult();
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException(
+                "Failed to start a ClickHouse container via Testcontainers. " +
+                "Ensure Docker is installed and running, or set CLICKHOUSE_CONNECTION " +
+                "to point at an existing ClickHouse instance.",
+                ex);
+        }
+
         return container;
     }
 

--- a/ClickHouse.Driver.Tests/Utilities/TestUtilities.cs
+++ b/ClickHouse.Driver.Tests/Utilities/TestUtilities.cs
@@ -12,6 +12,7 @@ using ClickHouse.Driver.Numerics;
 using ClickHouse.Driver.Utility;
 using System.Text.Json.Nodes;
 using NUnit.Framework.Constraints;
+using Testcontainers.ClickHouse;
 
 namespace ClickHouse.Driver.Tests;
 
@@ -184,11 +185,55 @@ public static class TestUtilities
 
     public static ClickHouseConnectionStringBuilder GetConnectionStringBuilder()
     {
-        // Connection string must be provided pointing to a test ClickHouse server
-        var devConnectionString = Environment.GetEnvironmentVariable("CLICKHOUSE_CONNECTION") ??
-            throw new InvalidOperationException("Must set CLICKHOUSE_CONNECTION environment variable pointing at ClickHouse server");
+        var envConnectionString = Environment.GetEnvironmentVariable("CLICKHOUSE_CONNECTION");
+        if (!string.IsNullOrEmpty(envConnectionString))
+            return new ClickHouseConnectionStringBuilder(envConnectionString);
 
-        return new ClickHouseConnectionStringBuilder(devConnectionString);
+        var container = _container.Value ??
+            throw new InvalidOperationException(
+                "Must set CLICKHOUSE_CONNECTION environment variable pointing at ClickHouse server, " +
+                "or run with Docker available so Testcontainers can start a container automatically.");
+
+        return new ClickHouseConnectionStringBuilder
+        {
+            Host = container.Hostname,
+            Port = (ushort)container.GetMappedPublicPort(ClickHouseHttpPort),
+            Username = ContainerUsername,
+            Password = ContainerPassword,
+        };
+    }
+
+    // Lazily starts a ClickHouse container when CLICKHOUSE_CONNECTION is not provided.
+    // Must be lazy (not a [SetUpFixture]) because IApplyToTest attributes (FromVersion,
+    // RequiredFeature) touch ServerVersion during test-building, before any OneTimeSetUp runs.
+    internal const int ClickHouseHttpPort = 8123;
+    private const string ContainerUsername = "default";
+    private const string ContainerPassword = "clickhouse";
+
+    private static readonly Lazy<ClickHouseContainer?> _container = new(StartContainerIfNeeded);
+
+    internal static ClickHouseContainer? TestContainer => _container.IsValueCreated ? _container.Value : null;
+
+    private static ClickHouseContainer? StartContainerIfNeeded()
+    {
+        if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CLICKHOUSE_CONNECTION")))
+            return null;
+
+        if (GetClickHouseTestEnvironment() != TestEnv.LocalSingleNode)
+            return null;
+
+        var version = Environment.GetEnvironmentVariable("CLICKHOUSE_VERSION");
+        var tag = string.IsNullOrEmpty(version) ? "latest" : version;
+
+        var container = new ClickHouseBuilder()
+            .WithImage($"clickhouse/clickhouse-server:{tag}")
+            .WithUsername(ContainerUsername)
+            .WithPassword(ContainerPassword)
+            .WithEnvironment("CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT", "1")
+            .Build();
+
+        container.StartAsync().GetAwaiter().GetResult();
+        return container;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
Tests auto-start a ClickHouse container via Testcontainers when CLICKHOUSE_CONNECTION is unset, removing the need for a pre-running local instance. Honours CLICKHOUSE_VERSION to pin the image tag exactly. Existing env-var path (Cloud, macOS, Windows/WSL) preserved unchanged. 

This is partially mentioned in: https://github.com/ClickHouse/clickhouse-cs/issues/5 

## CI changes — sanity check please                                                                                                                                                    
- `reusable.yml` and `tests-integration.yml`: removed the `services.clickhouse` block and `CLICKHOUSE_CONNECTION` / `CLICKHOUSE_TEST_ENVIRONMENT` env vars (otherwise CI would spin up two ClickHouse instances). 
- Kept `CLICKHOUSE_VERSION` so the version matrix still pins the image. Bumped `timeout-minutes` 5 → 10 for image-pull headroom on cold runners.              
- `tests-cloud.yml`, `tests-macos.yml`, `tests-windows.yml`: untouched — they still set `CLICKHOUSE_CONNECTION` and go through the fallback path.

Happy to pull these out if you'd like the code changes to land first!

## Checklist
- [X] Verified locally: full suite (8759 pass, 143 skipped - pre-existing gates, no new skips) runs against auto-provisioned container on net9.0 and net10.0; version pinning confirmed with CLICKHOUSE_VERSION=25.8; env-var fallback preserved.   
- No client behaviour changes for `CHANGELOG.md`.