### PR TITLE
refact: % We know for sure that it's an array. There's no need to tre…

### DIFF
--- a/ClickHouse.Driver/Copy/Serializer/BatchSerializer.cs
+++ b/ClickHouse.Driver/Copy/Serializer/BatchSerializer.cs
@@ -36,18 +36,14 @@ internal class BatchSerializer : IBatchSerializer
         using var writer = new ExtendedBinaryWriter(gzipStream);
 
         object[] row = null;
-        int counter = 0;
-        var enumerator = batch.Rows.GetEnumerator();
         try
         {
-            while (enumerator.MoveNext())
+            var rows = batch.Rows.AsSpan()[..batch.Size];
+            var types = batch.Types;
+            for (int i = 0; i < rows.Length; i++)
             {
-                row = (object[])enumerator.Current;
-                rowSerializer.Serialize(row, batch.Types, writer);
-
-                counter++;
-                if (counter >= batch.Size)
-                    break; // We've reached the batch size
+                row = rows[i];
+                rowSerializer.Serialize(row, types, writer);
             }
         }
         catch (Exception e)


### PR DESCRIPTION
We know for sure that it's an array. There's no need to treat it as an IEnumerable.

## Summary
IEnumerable allocates more memory and is slower to process. Furthermore, we check `counter >=` during each iteration, which is also unnecessary.