### PR TITLE
BinaryImport

### DIFF
--- a/ClickHouse.Driver.Benchmark/BinaryImportBenchmark.cs
+++ b/ClickHouse.Driver.Benchmark/BinaryImportBenchmark.cs
@@ -34,7 +34,8 @@ public class BinaryImportBenchmark
     [GlobalSetup]
     public async Task Setup()
     {
-        var connectionString = "Host=127.0.0.1;Port=59264;Database=default;Username=clickhouse;Password=f8Nkn2sDe56rw";
+        var connectionString = Environment.GetEnvironmentVariable("CLICKHOUSE_CONNECTION")
+            ?? "Host=localhost";
         client = new ClickHouseClient(connectionString);
 
         await client.ExecuteNonQueryAsync("CREATE DATABASE IF NOT EXISTS test");

--- a/ClickHouse.Driver.Benchmark/BinaryImportBenchmark.cs
+++ b/ClickHouse.Driver.Benchmark/BinaryImportBenchmark.cs
@@ -1,4 +1,5 @@
 using BenchmarkDotNet.Attributes;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/ClickHouse.Driver.Benchmark/BinaryImportBenchmark.cs
+++ b/ClickHouse.Driver.Benchmark/BinaryImportBenchmark.cs
@@ -1,5 +1,4 @@
 using BenchmarkDotNet.Attributes;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -17,9 +16,6 @@ public class BinaryImportBenchmark
 {
     private ClickHouseClient client;
     private const string TableName = "test.benchmark_binary_import";
-
-    private SensorReading[] _pocoRows;
-    private object[][] _objectRows;
 
     public class SensorReading
     {
@@ -42,49 +38,62 @@ public class BinaryImportBenchmark
         await client.ExecuteNonQueryAsync($"CREATE TABLE IF NOT EXISTS {TableName} (Id Int64, Name String, Value Float64) ENGINE Null");
 
         client.RegisterBinaryInsertType<SensorReading>();
-
-        _pocoRows = GeneratePocoRows(Count).ToArray();
-        _objectRows = GenerateObjectArrayRows(Count).ToArray();
     }
 
     [GlobalCleanup]
     public void Cleanup()
     {
         client?.Dispose();
-
-        _pocoRows = null;
-        _objectRows = null;
     }
 
     [Benchmark(Baseline = true)]
     public async Task ObjectArray()
     {
         var columns = new[] { "Id", "Name", "Value" };
-        await client.InsertBinaryAsync(TableName, columns, _objectRows);
+        var objectRows = GenerateObjectArrayRows(Count).ToArray();
+
+        await client.InsertBinaryAsync(TableName, columns, objectRows);
     }
 
     [Benchmark]
     public async Task Poco()
     {
-        await client.InsertBinaryAsync(TableName, _pocoRows);
+        var pocoRows = GeneratePocoRows(Count).ToArray();
+
+        await client.InsertBinaryAsync(TableName, pocoRows);
     }
 
     [Benchmark]
     public async Task BinaryImport()
     {
         var import = await client.StartInsertAsync(TableName, ["Id", "Name", "Value"]);
-        using var batch = import.StartNewBatch();
+        var batch = import.StartNewBatch();
 
-        foreach (var row in _pocoRows)
+        var itemsInBatch = 0;
+        for (int i = 0; i < Count; i++)
         {
-            batch.WriteData(0, row.Id);
-            batch.WriteData(1, row.Name);
-            batch.WriteData(2, row.Value);
+            itemsInBatch++;
+            batch.WriteData(0, (long)i);
+            batch.WriteData(1, $"sensor_{i % 10}");
+            batch.WriteData(2, (double)i * 0.1);
+
+            if (itemsInBatch == 100_000)
+            {
+                batch.CompleteWrite();
+                await import.SendBatchAsync(batch);
+
+                batch.Dispose();
+                batch = import.StartNewBatch();
+                itemsInBatch = 0;
+            }
         }
 
-        batch.CompleteWrite();
-
-        await import.SendBatchAsync(batch);
+        if (batch != null && itemsInBatch != 0)
+        {
+            batch.CompleteWrite();
+            await import.SendBatchAsync(batch);
+            batch.Dispose();
+        }
     }
 
     private static IEnumerable<object[]> GenerateObjectArrayRows(int count)

--- a/ClickHouse.Driver.Benchmark/BinaryImportBenchmark.cs
+++ b/ClickHouse.Driver.Benchmark/BinaryImportBenchmark.cs
@@ -1,0 +1,100 @@
+using BenchmarkDotNet.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace ClickHouse.Driver.Benchmark;
+
+/// <summary>
+/// Compares BinaryImport insert performance against the object[]/POCO path.
+/// Insert the same data into an ENGINE Null table
+/// so the measurement is purely client-side serialization + network overhead.
+/// </summary>
+[Config(typeof(ComparisonConfig))]
+[MemoryDiagnoser(true)]
+public class BinaryImportBenchmark
+{
+    private ClickHouseClient client;
+    private const string TableName = "test.benchmark_binary_import";
+
+    private SensorReading[] _pocoRows;
+    private object[][] _objectRows;
+
+    public class SensorReading
+    {
+        public long Id { get; set; }
+        public string Name { get; set; }
+        public double Value { get; set; }
+    }
+
+    [Params(100_000, 500_000)]
+    public int Count { get; set; }
+
+    [GlobalSetup]
+    public async Task Setup()
+    {
+        var connectionString = "Host=127.0.0.1;Port=59264;Database=default;Username=clickhouse;Password=f8Nkn2sDe56rw";
+        client = new ClickHouseClient(connectionString);
+
+        await client.ExecuteNonQueryAsync("CREATE DATABASE IF NOT EXISTS test");
+        await client.ExecuteNonQueryAsync($"CREATE TABLE IF NOT EXISTS {TableName} (Id Int64, Name String, Value Float64) ENGINE Null");
+
+        client.RegisterBinaryInsertType<SensorReading>();
+
+        _pocoRows = GeneratePocoRows(Count).ToArray();
+        _objectRows = GenerateObjectArrayRows(Count).ToArray();
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        client?.Dispose();
+
+        _pocoRows = null;
+        _objectRows = null;
+    }
+
+    [Benchmark(Baseline = true)]
+    public async Task ObjectArray()
+    {
+        var columns = new[] { "Id", "Name", "Value" };
+        await client.InsertBinaryAsync(TableName, columns, _objectRows);
+    }
+
+    [Benchmark]
+    public async Task Poco()
+    {
+        await client.InsertBinaryAsync(TableName, _pocoRows);
+    }
+
+    [Benchmark]
+    public async Task BinaryImport()
+    {
+        var import = await client.StartInsertAsync(TableName, ["Id", "Name", "Value"]);
+        using var batch = import.StartNewBatch();
+
+        foreach (var row in _pocoRows)
+        {
+            batch.WriteData(0, row.Id);
+            batch.WriteData(1, row.Name);
+            batch.WriteData(2, row.Value);
+        }
+
+        batch.CompleteWrite();
+
+        await import.SendBatchAsync(batch);
+    }
+
+    private static IEnumerable<object[]> GenerateObjectArrayRows(int count)
+    {
+        for (int i = 0; i < count; i++)
+            yield return new object[] { (long)i, $"sensor_{i % 10}", (double)i * 0.1 };
+    }
+
+    private static IEnumerable<SensorReading> GeneratePocoRows(int count)
+    {
+        for (int i = 0; i < count; i++)
+            yield return new SensorReading { Id = i, Name = $"sensor_{i % 10}", Value = i * 0.1 };
+    }
+}

--- a/ClickHouse.Driver.Benchmark/BinaryImportBenchmark.cs
+++ b/ClickHouse.Driver.Benchmark/BinaryImportBenchmark.cs
@@ -89,10 +89,14 @@ public class BinaryImportBenchmark
             }
         }
 
-        if (batch != null && itemsInBatch != 0)
+        if (batch != null)
         {
-            batch.CompleteWrite();
-            await import.SendBatchAsync(batch);
+            if (itemsInBatch != 0)
+            {
+                batch.CompleteWrite();
+                await import.SendBatchAsync(batch);
+            }
+
             batch.Dispose();
         }
     }

--- a/ClickHouse.Driver.Tests/BinaryImport/BinaryImportTests.cs
+++ b/ClickHouse.Driver.Tests/BinaryImport/BinaryImportTests.cs
@@ -1,0 +1,71 @@
+﻿using ClickHouse.Driver.Utility;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace ClickHouse.Driver.Tests.BinaryImport;
+
+internal class BinaryImportTests : AbstractConnectionTestFixture
+{
+    [Test]
+    public async Task ShouldExecuteInsertWithLessColumns()
+    {
+        var targetTable = $"test.bi_multiple_columns";
+
+        await connection.ExecuteStatementAsync($"TRUNCATE TABLE IF EXISTS {targetTable}");
+        await connection.ExecuteStatementAsync($"CREATE TABLE IF NOT EXISTS {targetTable} (value1 Nullable(UInt8), value2 Nullable(Float32), value3 Nullable(Int8)) ENGINE Memory");
+
+        var import = await connection.ClickHouseClient.StartInsertAsync(targetTable, ["value2"]);
+        using var batch = import.StartNewBatch();
+        using var batch2 = import.StartNewBatch();
+
+        var expectValues = new List<float>();
+        for (int i = 0; i < 10; i++)
+        {
+            expectValues.Add(i);
+        }
+
+        for (int i = 0; i < 5; i++)
+        {
+            float value2 = expectValues[i];
+            batch.WriteData(0, value2);
+        }
+
+        batch.CompleteWrite();
+
+        for (int i = 5; i < 10; i++)
+        {
+            float value2 = expectValues[i];
+            batch2.WriteData(0, value2);
+        }
+
+        batch2.CompleteWrite();
+
+        var send1 = import.SendBatchAsync(batch, default);
+        var send2 = import.SendBatchAsync(batch2, default);
+
+        await Task.WhenAll(send1, send2);
+
+        var actualValues = new List<float>();
+
+        using (var reader = await connection.ExecuteReaderAsync($"SELECT * from {targetTable}"))
+        {
+            while (reader.Read())
+            {
+                var value = reader.GetFloat("value2");
+                actualValues.Add(value);
+            }
+        }
+
+        var actual = actualValues.OrderBy(o => o).ToArray();
+
+        Assert.That(actual, Has.Length.EqualTo(expectValues.Count));
+        for (int i = 0; i < actual.Length; i++)
+        {
+            var expectValue = expectValues[i];
+            var actualValue = actual[i];
+            Assert.That(actualValue, Is.EqualTo(expectValue));
+        }
+    }
+}

--- a/ClickHouse.Driver.Tests/Types/FixedStringTypeTests.cs
+++ b/ClickHouse.Driver.Tests/Types/FixedStringTypeTests.cs
@@ -56,7 +56,7 @@ public class FixedStringTypeTests
         using var stream = new MemoryStream();
         using var writer = new ExtendedBinaryWriter(stream);
 
-        var ex = Assert.Throws<ArgumentException>(() => type.Write(writer, null));
+        var ex = Assert.Throws<ArgumentException>(() => type.Write<object>(writer, null));
 
         Assert.That(ex.Message, Does.Contain("null"));
     }

--- a/ClickHouse.Driver.Tests/Types/TimeTypeTests.cs
+++ b/ClickHouse.Driver.Tests/Types/TimeTypeTests.cs
@@ -150,7 +150,7 @@ public class TimeTypeTests
         using var stream = new MemoryStream();
         using var writer = new ExtendedBinaryWriter(stream);
 
-        Assert.Throws<NotSupportedException>(() => type.Write(writer, null));
+        Assert.Throws<NotSupportedException>(() => type.Write<object>(writer, null));
     }
 
     [Test]

--- a/ClickHouse.Driver/ClickHouseClient.cs
+++ b/ClickHouse.Driver/ClickHouseClient.cs
@@ -1062,11 +1062,6 @@ public sealed class ClickHouseClient : IClickHouseClient
                 this.writer = writer;
             }
 
-            ~BatchData()
-            {
-                Dispose(false);
-            }
-
             public void WriteData<T>(int columnIndex, T value)
             {
 #pragma warning disable CA1513 // Use ObjectDisposedException throw helper

--- a/ClickHouse.Driver/ClickHouseClient.cs
+++ b/ClickHouse.Driver/ClickHouseClient.cs
@@ -459,9 +459,7 @@ public sealed class ClickHouseClient : IClickHouseClient
         IEnumerable<string> columns,
         InsertOptions options = default)
     {
-        if (table is null)
-            throw new InvalidOperationException($"{nameof(table)} is null");
-
+        ArgumentNullException.ThrowIfNull(table);
         var plan = await PrepareInsertAsync(table, columns, options).ConfigureAwait(false);
 
         return new BinaryImport(this, plan);

--- a/ClickHouse.Driver/ClickHouseClient.cs
+++ b/ClickHouse.Driver/ClickHouseClient.cs
@@ -1010,8 +1010,7 @@ public sealed class ClickHouseClient : IClickHouseClient
                 throw;
             }
 
-            var batchData = new BatchData(stream, gzipStream, writer);
-            batchData.SetColumns(insertPlan.ColumnTypes);
+            var batchData = new BatchData(insertPlan.ColumnTypes, stream, gzipStream, writer);
 
             return batchData;
         }
@@ -1040,7 +1039,7 @@ public sealed class ClickHouseClient : IClickHouseClient
 
         public sealed class BatchData : IDisposable
         {
-            private ClickHouseType[] columnTypes;
+            private readonly ClickHouseType[] columnTypes;
 
             private bool disposed;
 
@@ -1048,11 +1047,17 @@ public sealed class ClickHouseClient : IClickHouseClient
             private BufferedStream gzipStream;
             private ExtendedBinaryWriter writer;
 
-            public BatchData(
+            private BatchData()
+            {
+            }
+
+            internal BatchData(
+                ClickHouseType[] columnTypes,
                 RecyclableMemoryStream stream,
                 BufferedStream gzipStream,
                 ExtendedBinaryWriter writer)
             {
+                this.columnTypes = columnTypes;
                 this.stream = stream;
                 this.gzipStream = gzipStream;
                 this.writer = writer;
@@ -1091,11 +1096,6 @@ public sealed class ClickHouseClient : IClickHouseClient
                 this.gzipStream = null;
             }
 
-            internal void SetColumns(ClickHouseType[] columnTypes)
-            {
-                this.columnTypes = columnTypes;
-            }
-
             private bool WriteIsComplete()
             {
                 return this.writer == null && this.gzipStream == null;
@@ -1114,18 +1114,6 @@ public sealed class ClickHouseClient : IClickHouseClient
                 return stream;
             }
 
-            public void Clear()
-            {
-                this.writer?.Dispose();
-                this.writer = null;
-
-                this.gzipStream?.Dispose();
-                this.gzipStream = null;
-
-                this.stream?.Dispose();
-                this.stream = null;
-            }
-
             public void Dispose()
             {
                 Dispose(true);
@@ -1136,7 +1124,18 @@ public sealed class ClickHouseClient : IClickHouseClient
             {
                 if (disposed) return;
 
-                Clear();
+                if (disposing)
+                {
+                    this.writer?.Dispose();
+                    this.writer = null;
+
+                    this.gzipStream?.Dispose();
+                    this.gzipStream = null;
+
+                    this.stream?.Dispose();
+                    this.stream = null;
+                }
+
                 disposed = true;
             }
         }

--- a/ClickHouse.Driver/ClickHouseClient.cs
+++ b/ClickHouse.Driver/ClickHouseClient.cs
@@ -1018,22 +1018,23 @@ public sealed class ClickHouseClient : IClickHouseClient
 
         public async Task SendBatchAsync(BatchData batchData, CancellationToken token)
         {
-            batchData.CompleteWrite();
-            var stream = batchData.GetStream();
-
-            // Seek to beginning as after writing it's at end
-            stream.Seek(0, SeekOrigin.Begin);
-
-            // Async sending
             try
             {
+                batchData.CompleteWrite();
+                using var stream = batchData.GetStream();
+
+                // Seek to beginning as after writing it's at end
+                stream.Seek(0, SeekOrigin.Begin);
+
                 var content = new StreamContent(stream);
                 var batchOptions = insertPlan.Options.WithQueryId($"{insertPlan.BaseQueryId}-{Interlocked.Increment(ref queryIdCounter)}");
+
+                // Async sending
                 await clickHouseClient.PostStreamAsync(null, content, true, batchOptions, token).ConfigureAwait(false);
             }
             finally
             {
-                batchData.Clear();
+                batchData.Dispose();
             }
         }
 
@@ -1107,7 +1108,10 @@ public sealed class ClickHouseClient : IClickHouseClient
                     throw new InvalidOperationException($"Call {nameof(CompleteWrite)} before get Stream");
                 }
 
-                return this.stream;
+                var stream = this.stream;
+                this.stream = null;
+
+                return stream;
             }
 
             public void Clear()

--- a/ClickHouse.Driver/ClickHouseClient.cs
+++ b/ClickHouse.Driver/ClickHouseClient.cs
@@ -1011,6 +1011,8 @@ public sealed class ClickHouseClient : IClickHouseClient
             }
 
             var batchData = new BatchData(stream, gzipStream, writer);
+            batchData.SetColumns(insertPlan.ColumnTypes);
+
             return batchData;
         }
 
@@ -1035,7 +1037,7 @@ public sealed class ClickHouseClient : IClickHouseClient
 
         public class BatchData : IBatchData, IDisposable
         {
-            private readonly ClickHouseType[] columnTypes;
+            private ClickHouseType[] columnTypes;
 
             private bool disposed;
 
@@ -1056,6 +1058,11 @@ public sealed class ClickHouseClient : IClickHouseClient
             ~BatchData()
             {
                 Dispose(false);
+            }
+
+            internal void SetColumns(ClickHouseType[] columnTypes)
+            {
+                this.columnTypes = columnTypes;
             }
 
             public void WriteData(int columnIndex, object value)

--- a/ClickHouse.Driver/ClickHouseClient.cs
+++ b/ClickHouse.Driver/ClickHouseClient.cs
@@ -1019,7 +1019,10 @@ public sealed class ClickHouseClient : IClickHouseClient
         public async Task SendBatchAsync(IBatchData batchData, CancellationToken token)
         {
             // Seek to beginning as after writing it's at end
-            var stream = ((BatchData)batchData).GetStream();
+            var bd = (BatchData)batchData;
+            bd.CompleteWrite();
+
+            var stream = bd.GetStream();
             stream.Seek(0, SeekOrigin.Begin);
 
             // Async sending
@@ -1042,7 +1045,7 @@ public sealed class ClickHouseClient : IClickHouseClient
             void Clear();
         }
 
-        public class BatchData : IBatchData, IDisposable
+        public sealed class BatchData : IBatchData, IDisposable
         {
             private ClickHouseType[] columnTypes;
 
@@ -1067,18 +1070,51 @@ public sealed class ClickHouseClient : IClickHouseClient
                 Dispose(false);
             }
 
+            public void WriteData(int columnIndex, object value)
+            {
+#pragma warning disable CA1513 // Use ObjectDisposedException throw helper
+                if (disposed)
+                {
+                    throw new ObjectDisposedException(nameof(BatchData));
+                }
+#pragma warning restore CA1513 // Use ObjectDisposedException throw helper
+
+                columnTypes[columnIndex].Write(this.writer, value);
+            }
+
+            internal void CompleteWrite()
+            {
+#pragma warning disable CA1513 // Use ObjectDisposedException throw helper
+                if (disposed)
+                {
+                    throw new ObjectDisposedException(nameof(BatchData));
+                }
+#pragma warning restore CA1513 // Use ObjectDisposedException throw helper
+
+                this.writer?.Dispose();
+                this.writer = null;
+
+                this.gzipStream?.Dispose();
+                this.gzipStream = null;
+            }
+
             internal void SetColumns(ClickHouseType[] columnTypes)
             {
                 this.columnTypes = columnTypes;
             }
 
-            public void WriteData(int columnIndex, object value)
+            private bool WriteIsComplete()
             {
-                columnTypes[columnIndex].Write(this.writer, value);
+                return this.writer == null && this.gzipStream == null;
             }
 
-            public RecyclableMemoryStream GetStream()
+            internal RecyclableMemoryStream GetStream()
             {
+                if (!WriteIsComplete())
+                {
+                    throw new InvalidOperationException($"Call {nameof(CompleteWrite)} before get Stream");
+                }
+
                 return this.stream;
             }
 

--- a/ClickHouse.Driver/ClickHouseClient.cs
+++ b/ClickHouse.Driver/ClickHouseClient.cs
@@ -1068,7 +1068,7 @@ public sealed class ClickHouseClient : IClickHouseClient
                 Dispose(false);
             }
 
-            public void WriteData(int columnIndex, object value)
+            public void WriteData<T>(int columnIndex, T value)
             {
 #pragma warning disable CA1513 // Use ObjectDisposedException throw helper
                 if (disposed)

--- a/ClickHouse.Driver/ClickHouseClient.cs
+++ b/ClickHouse.Driver/ClickHouseClient.cs
@@ -1016,13 +1016,12 @@ public sealed class ClickHouseClient : IClickHouseClient
             return batchData;
         }
 
-        public async Task SendBatchAsync(IBatchData batchData, CancellationToken token)
+        public async Task SendBatchAsync(BatchData batchData, CancellationToken token)
         {
-            // Seek to beginning as after writing it's at end
-            var bd = (BatchData)batchData;
-            bd.CompleteWrite();
+            batchData.CompleteWrite();
+            var stream = batchData.GetStream();
 
-            var stream = bd.GetStream();
+            // Seek to beginning as after writing it's at end
             stream.Seek(0, SeekOrigin.Begin);
 
             // Async sending
@@ -1038,14 +1037,7 @@ public sealed class ClickHouseClient : IClickHouseClient
             }
         }
 
-        public interface IBatchData
-        {
-            void WriteData(int columnIndex, object value);
-
-            void Clear();
-        }
-
-        public sealed class BatchData : IBatchData, IDisposable
+        public sealed class BatchData : IDisposable
         {
             private ClickHouseType[] columnTypes;
 

--- a/ClickHouse.Driver/ClickHouseClient.cs
+++ b/ClickHouse.Driver/ClickHouseClient.cs
@@ -961,9 +961,9 @@ public sealed class ClickHouseClient : IClickHouseClient
 
     public class BinaryImport
     {
-        private readonly ClickHouseClient clickHouseClient;
         private readonly InsertPlan insertPlan;
 
+        private ClickHouseClient clickHouseClient;
         private int queryIdCounter;
 
         internal BinaryImport(
@@ -974,28 +974,125 @@ public sealed class ClickHouseClient : IClickHouseClient
             this.insertPlan = insertPlan;
         }
 
-        public async Task SendBatchAsync(
-            Action<ExtendedBinaryWriter, ClickHouseType[]> writeBatchAction,
-            CancellationToken token)
+        public BatchData StartNewBatch()
         {
-            using var stream = clickHouseClient.MemoryStreamManager.GetStream(nameof(SendBatchAsync), 128 * 1024);
-            using var gzipStream = new BufferedStream(new GZipStream(stream, CompressionLevel.Fastest, true), 256 * 1024);
-            using (var textWriter = new StreamWriter(gzipStream, Encoding.UTF8, 4 * 1024, true))
+            RecyclableMemoryStream stream = null;
+            BufferedStream gzipStream = null;
+            ExtendedBinaryWriter writer = null;
+            try
             {
-                textWriter.WriteLine(insertPlan.Query);
+                stream = clickHouseClient.MemoryStreamManager.GetStream(nameof(SendBatchAsync), 128 * 1024);
+                gzipStream = new BufferedStream(new GZipStream(stream, CompressionLevel.Fastest, true), 256 * 1024);
+                using (var textWriter = new StreamWriter(gzipStream, Encoding.UTF8, 4 * 1024, true))
+                {
+                    textWriter.WriteLine(insertPlan.Query);
+                }
+
+                writer = new ExtendedBinaryWriter(gzipStream);
+            }
+            catch
+            {
+                if (writer != null)
+                {
+                    writer.Dispose();
+                }
+
+                if (gzipStream != null)
+                {
+                    gzipStream.Dispose();
+                }
+
+                if (stream != null)
+                {
+                    stream.Dispose();
+                }
+
+                throw;
             }
 
-            using var writer = new ExtendedBinaryWriter(gzipStream);
-            writeBatchAction(writer, insertPlan.ColumnTypes);
+            var batchData = new BatchData(stream, gzipStream, writer);
+            return batchData;
+        }
 
+        public async Task SendBatchAsync(IBatchData batchData, CancellationToken token)
+        {
             // Seek to beginning as after writing it's at end
+            var stream = ((BatchData)batchData).GetStream();
             stream.Seek(0, SeekOrigin.Begin);
-
-            var batchOptions = insertPlan.Options.WithQueryId($"{insertPlan.BaseQueryId}-{Interlocked.Increment(ref queryIdCounter)}");
 
             // Async sending
             var content = new StreamContent(stream);
+            var batchOptions = insertPlan.Options.WithQueryId($"{insertPlan.BaseQueryId}-{Interlocked.Increment(ref queryIdCounter)}");
             await clickHouseClient.PostStreamAsync(null, content, true, batchOptions, token).ConfigureAwait(false);
+        }
+
+        public interface IBatchData
+        {
+            void WriteData(int columnIndex, object value);
+
+            void Clear();
+        }
+
+        public class BatchData : IBatchData, IDisposable
+        {
+            private readonly ClickHouseType[] columnTypes;
+
+            private bool disposed;
+
+            private RecyclableMemoryStream stream;
+            private BufferedStream gzipStream;
+            private ExtendedBinaryWriter writer;
+
+            public BatchData(
+                RecyclableMemoryStream stream,
+                BufferedStream gzipStream,
+                ExtendedBinaryWriter writer)
+            {
+                this.stream = stream;
+                this.gzipStream = gzipStream;
+                this.writer = writer;
+            }
+
+            ~BatchData()
+            {
+                Dispose(false);
+            }
+
+            public void WriteData(int columnIndex, object value)
+            {
+                columnTypes[columnIndex].Write(this.writer, value);
+            }
+
+            public RecyclableMemoryStream GetStream()
+            {
+                return this.stream;
+            }
+
+            public void Clear()
+            {
+                this.writer?.Dispose();
+                this.writer = null;
+
+                this.gzipStream?.Dispose();
+                this.gzipStream = null;
+
+                this.stream?.Dispose();
+                this.stream = null;
+            }
+
+            public void Dispose()
+            {
+                Dispose(true);
+                GC.SuppressFinalize(this);
+            }
+
+            public void Dispose(bool disposing)
+            {
+                if (disposed) return;
+
+                Clear();
+                disposed = true;
+            }
         }
     }
 }

--- a/ClickHouse.Driver/ClickHouseClient.cs
+++ b/ClickHouse.Driver/ClickHouseClient.cs
@@ -1119,7 +1119,7 @@ public sealed class ClickHouseClient : IClickHouseClient
                 GC.SuppressFinalize(this);
             }
 
-            public void Dispose(bool disposing)
+            private void Dispose(bool disposing)
             {
                 if (disposed) return;
 

--- a/ClickHouse.Driver/ClickHouseClient.cs
+++ b/ClickHouse.Driver/ClickHouseClient.cs
@@ -982,7 +982,7 @@ public sealed class ClickHouseClient : IClickHouseClient
             ExtendedBinaryWriter writer = null;
             try
             {
-                stream = clickHouseClient.MemoryStreamManager.GetStream(nameof(SendBatchAsync), 128 * 1024);
+                stream = clickHouseClient.MemoryStreamManager.GetStream(nameof(StartNewBatch), 128 * 1024);
                 gzipStream = new BufferedStream(new GZipStream(stream, CompressionLevel.Fastest, true), 256 * 1024);
                 using (var textWriter = new StreamWriter(gzipStream, Encoding.UTF8, 4 * 1024, true))
                 {

--- a/ClickHouse.Driver/ClickHouseClient.cs
+++ b/ClickHouse.Driver/ClickHouseClient.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -453,6 +454,19 @@ public sealed class ClickHouseClient : IClickHouseClient
         return InsertBinaryPocoAsync(table, rows, properties, mapping.Getters, options, cancellationToken);
     }
 
+    public async Task<BinaryImport> StartInsertAsync(
+        string table,
+        IEnumerable<string> columns,
+        InsertOptions options = default)
+    {
+        if (table is null)
+            throw new InvalidOperationException($"{nameof(table)} is null");
+
+        var plan = await PrepareInsertAsync(table, columns, options).ConfigureAwait(false);
+
+        return new BinaryImport(this, plan);
+    }
+
     /// <summary>
     /// Applies column types from the POCO attribute mapping to the insert options,
     /// allowing the schema probe to be skipped when all properties declare explicit ClickHouse types.
@@ -476,7 +490,7 @@ public sealed class ClickHouseClient : IClickHouseClient
     /// Resolved insert metadata shared by both the <c>object[]</c> and POCO insert paths.
     /// Produced by <see cref="PrepareInsertAsync"/> after validation and schema resolution.
     /// </summary>
-    private readonly struct InsertPlan
+    internal readonly struct InsertPlan
     {
         /// <summary>The finalized options (defaulted and validated).</summary>
         public InsertOptions Options { get; init; }
@@ -943,5 +957,45 @@ public sealed class ClickHouseClient : IClickHouseClient
         return string.Equals(headerName, "Connection", StringComparison.OrdinalIgnoreCase) ||
                string.Equals(headerName, "Authorization", StringComparison.OrdinalIgnoreCase) ||
                string.Equals(headerName, "User-Agent", StringComparison.OrdinalIgnoreCase);
+    }
+
+    public class BinaryImport
+    {
+        private readonly ClickHouseClient clickHouseClient;
+        private readonly InsertPlan insertPlan;
+
+        private int queryIdCounter;
+
+        internal BinaryImport(
+            ClickHouseClient clickHouseClient,
+            InsertPlan insertPlan)
+        {
+            this.clickHouseClient = clickHouseClient;
+            this.insertPlan = insertPlan;
+        }
+
+        public async Task SendBatchAsync(
+            Action<ExtendedBinaryWriter, ClickHouseType[]> writeBatchAction,
+            CancellationToken token)
+        {
+            using var stream = clickHouseClient.MemoryStreamManager.GetStream(nameof(SendBatchAsync), 128 * 1024);
+            using var gzipStream = new BufferedStream(new GZipStream(stream, CompressionLevel.Fastest, true), 256 * 1024);
+            using (var textWriter = new StreamWriter(gzipStream, Encoding.UTF8, 4 * 1024, true))
+            {
+                textWriter.WriteLine(insertPlan.Query);
+            }
+
+            using var writer = new ExtendedBinaryWriter(gzipStream);
+            writeBatchAction(writer, insertPlan.ColumnTypes);
+
+            // Seek to beginning as after writing it's at end
+            stream.Seek(0, SeekOrigin.Begin);
+
+            var batchOptions = insertPlan.Options.WithQueryId($"{insertPlan.BaseQueryId}-{Interlocked.Increment(ref queryIdCounter)}");
+
+            // Async sending
+            var content = new StreamContent(stream);
+            await clickHouseClient.PostStreamAsync(null, content, true, batchOptions, token).ConfigureAwait(false);
+        }
     }
 }

--- a/ClickHouse.Driver/ClickHouseClient.cs
+++ b/ClickHouse.Driver/ClickHouseClient.cs
@@ -1015,7 +1015,7 @@ public sealed class ClickHouseClient : IClickHouseClient
             return batchData;
         }
 
-        public async Task SendBatchAsync(BatchData batchData, CancellationToken token)
+        public async Task SendBatchAsync(BatchData batchData, CancellationToken token = default)
         {
             try
             {
@@ -1080,7 +1080,7 @@ public sealed class ClickHouseClient : IClickHouseClient
                 columnTypes[columnIndex].Write(this.writer, value);
             }
 
-            internal void CompleteWrite()
+            public void CompleteWrite()
             {
 #pragma warning disable CA1513 // Use ObjectDisposedException throw helper
                 if (disposed)

--- a/ClickHouse.Driver/ClickHouseClient.cs
+++ b/ClickHouse.Driver/ClickHouseClient.cs
@@ -1023,9 +1023,16 @@ public sealed class ClickHouseClient : IClickHouseClient
             stream.Seek(0, SeekOrigin.Begin);
 
             // Async sending
-            var content = new StreamContent(stream);
-            var batchOptions = insertPlan.Options.WithQueryId($"{insertPlan.BaseQueryId}-{Interlocked.Increment(ref queryIdCounter)}");
-            await clickHouseClient.PostStreamAsync(null, content, true, batchOptions, token).ConfigureAwait(false);
+            try
+            {
+                var content = new StreamContent(stream);
+                var batchOptions = insertPlan.Options.WithQueryId($"{insertPlan.BaseQueryId}-{Interlocked.Increment(ref queryIdCounter)}");
+                await clickHouseClient.PostStreamAsync(null, content, true, batchOptions, token).ConfigureAwait(false);
+            }
+            finally
+            {
+                batchData.Clear();
+            }
         }
 
         public interface IBatchData

--- a/ClickHouse.Driver/Formats/ExtendedBinaryReader.cs
+++ b/ClickHouse.Driver/Formats/ExtendedBinaryReader.cs
@@ -3,7 +3,7 @@ using System.Text;
 
 namespace ClickHouse.Driver.Formats;
 
-internal class ExtendedBinaryReader : BinaryReader
+public class ExtendedBinaryReader : BinaryReader
 {
     private readonly PeekableStreamWrapper streamWrapper;
 

--- a/ClickHouse.Driver/Formats/ExtendedBinaryReader.cs
+++ b/ClickHouse.Driver/Formats/ExtendedBinaryReader.cs
@@ -3,7 +3,7 @@ using System.Text;
 
 namespace ClickHouse.Driver.Formats;
 
-public class ExtendedBinaryReader : BinaryReader
+internal class ExtendedBinaryReader : BinaryReader
 {
     private readonly PeekableStreamWrapper streamWrapper;
 

--- a/ClickHouse.Driver/Types/AbstractBigIntegerType.cs
+++ b/ClickHouse.Driver/Types/AbstractBigIntegerType.cs
@@ -25,7 +25,7 @@ internal abstract class AbstractBigIntegerType : IntegerType
 
     public abstract override string ToString();
 
-    public override void Write(ExtendedBinaryWriter writer, object value)
+    public override void Write<T>(ExtendedBinaryWriter writer, T value)
     {
         var bigInt = value switch
         {

--- a/ClickHouse.Driver/Types/AbstractDateTimeType.cs
+++ b/ClickHouse.Driver/Types/AbstractDateTimeType.cs
@@ -21,7 +21,7 @@ internal static class DateTimeConversions
 
 internal abstract class AbstractDateTimeType : ParameterizedType
 {
-    public DateTimeOffset CoerceToDateTimeOffset(object value)
+    public DateTimeOffset CoerceToDateTimeOffset<T>(T value)
     {
         return value switch
         {

--- a/ClickHouse.Driver/Types/AggregateFunctionType.cs
+++ b/ClickHouse.Driver/Types/AggregateFunctionType.cs
@@ -22,7 +22,7 @@ internal class AggregateFunctionType : ParameterizedType
 
     public override string ToString() => throw new AggregateFunctionException(Function);
 
-    public override void Write(ExtendedBinaryWriter writer, object value) => throw new AggregateFunctionException(Function);
+    public override void Write<T>(ExtendedBinaryWriter writer, T value) => throw new AggregateFunctionException(Function);
 
     [Serializable]
     public class AggregateFunctionException : Exception

--- a/ClickHouse.Driver/Types/ArrayType.cs
+++ b/ClickHouse.Driver/Types/ArrayType.cs
@@ -34,7 +34,7 @@ internal class ArrayType : ParameterizedType
         return data;
     }
 
-    public override void Write(ExtendedBinaryWriter writer, object value)
+    public override void Write<T>(ExtendedBinaryWriter writer, T value)
     {
         if (value is null || value is DBNull)
         {

--- a/ClickHouse.Driver/Types/BFloat16Type.cs
+++ b/ClickHouse.Driver/Types/BFloat16Type.cs
@@ -14,7 +14,7 @@ namespace ClickHouse.Driver.Types;
 /// Conversion is performed by truncating/extending the bit representation. The top 16 bits of a Float32
 /// are equivalent to a BFloat16.
 /// </remarks>
-internal class BFloat16Type : FloatType
+internal sealed class BFloat16Type : FloatType
 {
     public override Type FrameworkType => typeof(float);
 
@@ -27,10 +27,14 @@ internal class BFloat16Type : FloatType
         return BitConverter.UInt32BitsToSingle(float32Bits);
     }
 
-    public override void Write(ExtendedBinaryWriter writer, object value)
+    public override void Write<T>(ExtendedBinaryWriter writer, T value)
     {
+        if (value is not float floatValue)
+        {
+            floatValue = Convert.ToSingle(value, CultureInfo.InvariantCulture);
+        }
+
         // Convert float to BFloat16 by truncating to top 16 bits
-        float floatValue = Convert.ToSingle(value, CultureInfo.InvariantCulture);
         uint float32Bits = BitConverter.SingleToUInt32Bits(floatValue);
         ushort bfloat16Bits = (ushort)(float32Bits >> 16);
         writer.Write(bfloat16Bits);

--- a/ClickHouse.Driver/Types/BooleanType.cs
+++ b/ClickHouse.Driver/Types/BooleanType.cs
@@ -11,5 +11,15 @@ internal class BooleanType : ClickHouseType
 
     public override string ToString() => "Bool";
 
-    public override void Write(ExtendedBinaryWriter writer, object value) => writer.Write((bool)value);
+    public override void Write<T>(ExtendedBinaryWriter writer, T value)
+    {
+        if (value is bool bValue)
+        {
+            writer.Write(bValue);
+        }
+        else
+        {
+            writer.Write((bool)(object)value);
+        }
+    }
 }

--- a/ClickHouse.Driver/Types/ClickHouseType.cs
+++ b/ClickHouse.Driver/Types/ClickHouseType.cs
@@ -3,7 +3,7 @@ using ClickHouse.Driver.Formats;
 
 namespace ClickHouse.Driver.Types;
 
-internal abstract class ClickHouseType
+public abstract class ClickHouseType
 {
     public abstract Type FrameworkType { get; }
 

--- a/ClickHouse.Driver/Types/ClickHouseType.cs
+++ b/ClickHouse.Driver/Types/ClickHouseType.cs
@@ -9,7 +9,7 @@ internal abstract class ClickHouseType
 
     public abstract object Read(ExtendedBinaryReader reader);
 
-    public abstract void Write(ExtendedBinaryWriter writer, object value);
+    public abstract void Write<T>(ExtendedBinaryWriter writer, T value);
 
     public abstract override string ToString();
 
@@ -18,7 +18,7 @@ internal abstract class ClickHouseType
     /// The default checks exact type equality against <see cref="FrameworkType"/>.
     /// Override for types that share a FrameworkType but need value-based disambiguation (e.g. IPv4 vs IPv6).
     /// </summary>
-    public virtual bool CanWrite(object value) => FrameworkType == value?.GetType();
+    public virtual bool CanWrite<T>(T value) => FrameworkType == value?.GetType();
 
     protected static object ClearDBNull(object value) => value is DBNull ? null : value;
 }

--- a/ClickHouse.Driver/Types/ClickHouseType.cs
+++ b/ClickHouse.Driver/Types/ClickHouseType.cs
@@ -3,7 +3,7 @@ using ClickHouse.Driver.Formats;
 
 namespace ClickHouse.Driver.Types;
 
-public abstract class ClickHouseType
+internal abstract class ClickHouseType
 {
     public abstract Type FrameworkType { get; }
 

--- a/ClickHouse.Driver/Types/Date32Type.cs
+++ b/ClickHouse.Driver/Types/Date32Type.cs
@@ -14,7 +14,7 @@ internal class Date32Type : DateType
 
     public override ParameterizedType Parse(SyntaxTreeNode typeName, Func<SyntaxTreeNode, ClickHouseType> parseClickHouseTypeFunc, TypeSettings settings) => throw new NotImplementedException();
 
-    public override void Write(ExtendedBinaryWriter writer, object value)
+    public override void Write<T>(ExtendedBinaryWriter writer, T value)
     {
         writer.Write(CoerceToDateTimeOffset(value).ToUnixTimeDays());
     }

--- a/ClickHouse.Driver/Types/DateTime64Type.cs
+++ b/ClickHouse.Driver/Types/DateTime64Type.cs
@@ -44,7 +44,7 @@ internal class DateTime64Type : AbstractDateTimeType
 
     public override object Read(ExtendedBinaryReader reader) => FromClickHouseTicks(reader.ReadInt64());
 
-    public override void Write(ExtendedBinaryWriter writer, object value)
+    public override void Write<T>(ExtendedBinaryWriter writer, T value)
     {
         writer.Write(ToClickHouseTicks(Instant.FromDateTimeOffset(CoerceToDateTimeOffset(value))));
     }

--- a/ClickHouse.Driver/Types/DateTimeType.cs
+++ b/ClickHouse.Driver/Types/DateTimeType.cs
@@ -23,7 +23,7 @@ internal class DateTimeType : AbstractDateTimeType
 
     public override object Read(ExtendedBinaryReader reader) => ToDateTime(Instant.FromUnixTimeSeconds(reader.ReadUInt32()));
 
-    public override void Write(ExtendedBinaryWriter writer, object value)
+    public override void Write<T>(ExtendedBinaryWriter writer, T value)
     {
         writer.Write((int)CoerceToDateTimeOffset(value).ToUnixTimeSeconds());
     }

--- a/ClickHouse.Driver/Types/DateType.cs
+++ b/ClickHouse.Driver/Types/DateType.cs
@@ -14,7 +14,7 @@ internal class DateType : AbstractDateTimeType
 
     public override ParameterizedType Parse(SyntaxTreeNode typeName, Func<SyntaxTreeNode, ClickHouseType> parseClickHouseTypeFunc, TypeSettings settings) => throw new NotImplementedException();
 
-    public override void Write(ExtendedBinaryWriter writer, object value)
+    public override void Write<T>(ExtendedBinaryWriter writer, T value)
     {
         writer.Write(Convert.ToUInt16(CoerceToDateTimeOffset(value).ToUnixTimeDays()));
     }

--- a/ClickHouse.Driver/Types/DecimalType.cs
+++ b/ClickHouse.Driver/Types/DecimalType.cs
@@ -87,7 +87,7 @@ internal class DecimalType : ParameterizedType
 
     public override string ToString() => $"{Name}({Precision}, {Scale})";
 
-    public override void Write(ExtendedBinaryWriter writer, object value)
+    public override void Write<T>(ExtendedBinaryWriter writer, T value)
     {
         try
         {

--- a/ClickHouse.Driver/Types/DynamicType.cs
+++ b/ClickHouse.Driver/Types/DynamicType.cs
@@ -26,13 +26,14 @@ internal class DynamicType : ClickHouseType
     /// Writes a value with its type header for dynamic type encoding.
     /// The type is inferred from the value's .NET type and cached.
     /// </summary>
-    public override void Write(ExtendedBinaryWriter writer, object value)
+    public override void Write<T>(ExtendedBinaryWriter writer, T value)
     {
         if (value is null || value is DBNull)
         {
             writer.Write(BinaryTypeIndex.Nothing);
             return;
         }
+
         var inferredType = GetCachedInferredType(value.GetType());
         BinaryTypeDescriptionWriter.WriteTypeHeader(writer, inferredType);
         inferredType.Write(writer, value);

--- a/ClickHouse.Driver/Types/Enum16Type.cs
+++ b/ClickHouse.Driver/Types/Enum16Type.cs
@@ -18,7 +18,7 @@ internal class Enum16Type : EnumType
 
     public override object Read(ExtendedBinaryReader reader) => Lookup(reader.ReadInt16());
 
-    public override void Write(ExtendedBinaryWriter writer, object value)
+    public override void Write<T>(ExtendedBinaryWriter writer, T value)
     {
         var enumIndex = value is string enumStr ? (short)Lookup(enumStr) : Convert.ToInt16(value, CultureInfo.InvariantCulture);
         writer.Write(enumIndex);

--- a/ClickHouse.Driver/Types/Enum8Type.cs
+++ b/ClickHouse.Driver/Types/Enum8Type.cs
@@ -16,7 +16,7 @@ internal class Enum8Type : EnumType
 
     public override object Read(ExtendedBinaryReader reader) => Lookup(reader.ReadSByte());
 
-    public override void Write(ExtendedBinaryWriter writer, object value)
+    public override void Write<T>(ExtendedBinaryWriter writer, T value)
     {
         var enumIndex = value is string enumStr ? (sbyte)Lookup(enumStr) : Convert.ToSByte(value, CultureInfo.InvariantCulture);
         writer.Write(enumIndex);

--- a/ClickHouse.Driver/Types/EnumType.cs
+++ b/ClickHouse.Driver/Types/EnumType.cs
@@ -61,7 +61,7 @@ internal class EnumType : ParameterizedType
 
     public override object Read(ExtendedBinaryReader reader) => throw new NotImplementedException();
 
-    public override void Write(ExtendedBinaryWriter writer, object value) => throw new NotImplementedException();
+    public override void Write<T>(ExtendedBinaryWriter writer, T value) => throw new NotImplementedException();
 
     private static KeyValuePair<string, int> ParseEnumMember(string value)
     {

--- a/ClickHouse.Driver/Types/FixedStringType.cs
+++ b/ClickHouse.Driver/Types/FixedStringType.cs
@@ -38,7 +38,7 @@ internal class FixedStringType : ParameterizedType
         return Encoding.UTF8.GetString(bytes);
     }
 
-    public override void Write(ExtendedBinaryWriter writer, object value)
+    public override void Write<T>(ExtendedBinaryWriter writer, T value)
     {
         if (value is string s)
         {

--- a/ClickHouse.Driver/Types/Float32Type.cs
+++ b/ClickHouse.Driver/Types/Float32Type.cs
@@ -12,5 +12,13 @@ internal class Float32Type : FloatType
 
     public override string ToString() => "Float32";
 
-    public override void Write(ExtendedBinaryWriter writer, object value) => writer.Write(Convert.ToSingle(value, CultureInfo.InvariantCulture));
+    public override void Write<T>(ExtendedBinaryWriter writer, T value)
+    {
+        if (value is not float floatValue)
+        {
+            floatValue = Convert.ToSingle(value, CultureInfo.InvariantCulture);
+        }
+
+        writer.Write(floatValue);
+    }
 }

--- a/ClickHouse.Driver/Types/Float64Type.cs
+++ b/ClickHouse.Driver/Types/Float64Type.cs
@@ -12,5 +12,13 @@ internal class Float64Type : FloatType
 
     public override string ToString() => "Float64";
 
-    public override void Write(ExtendedBinaryWriter writer, object value) => writer.Write(Convert.ToDouble(value, CultureInfo.InvariantCulture));
+    public override void Write<T>(ExtendedBinaryWriter writer, T value)
+    {
+        if (value is not double doubleValue)
+        {
+            doubleValue = Convert.ToDouble(value, CultureInfo.InvariantCulture);
+        }
+
+        writer.Write(doubleValue);
+    }
 }

--- a/ClickHouse.Driver/Types/IPv4Type.cs
+++ b/ClickHouse.Driver/Types/IPv4Type.cs
@@ -17,12 +17,16 @@ internal class IPv4Type : ClickHouseType
 
     public override string ToString() => "IPv4";
 
-    public override bool CanWrite(object value)
+    public override bool CanWrite<T>(T value)
         => value is IPAddress ip && ip.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork;
 
-    public override void Write(ExtendedBinaryWriter writer, object value)
+    public override void Write<T>(ExtendedBinaryWriter writer, T value)
     {
-        var address4 = value is IPAddress a ? a : IPAddress.Parse((string)value);
+        if (value is not IPAddress address4)
+        {
+            address4 = IPAddress.Parse((string)(object)value);
+        }
+
         if (address4.AddressFamily != System.Net.Sockets.AddressFamily.InterNetwork)
         {
             throw new ArgumentException($"Expected IPv4, got {address4.AddressFamily}");

--- a/ClickHouse.Driver/Types/IPv6Type.cs
+++ b/ClickHouse.Driver/Types/IPv6Type.cs
@@ -12,12 +12,16 @@ internal class IPv6Type : ClickHouseType
 
     public override string ToString() => "IPv6";
 
-    public override bool CanWrite(object value)
+    public override bool CanWrite<T>(T value)
         => value is IPAddress ip && ip.AddressFamily == System.Net.Sockets.AddressFamily.InterNetworkV6;
 
-    public override void Write(ExtendedBinaryWriter writer, object value)
+    public override void Write<T>(ExtendedBinaryWriter writer, T value)
     {
-        var address6 = value is IPAddress a ? a : IPAddress.Parse((string)value);
+        if (value is not IPAddress address6)
+        {
+            address6 = IPAddress.Parse((string)(object)value);
+        }
+
         if (address6.AddressFamily != System.Net.Sockets.AddressFamily.InterNetworkV6)
         {
             throw new ArgumentException($"Expected IPv6, got {address6.AddressFamily}");

--- a/ClickHouse.Driver/Types/Int16Type.cs
+++ b/ClickHouse.Driver/Types/Int16Type.cs
@@ -12,5 +12,13 @@ internal class Int16Type : IntegerType
 
     public override string ToString() => "Int16";
 
-    public override void Write(ExtendedBinaryWriter writer, object value) => writer.Write(Convert.ToInt16(value, CultureInfo.InvariantCulture));
+    public override void Write<T>(ExtendedBinaryWriter writer, T value)
+    {
+        if (value is not short shortValue)
+        {
+            shortValue = Convert.ToInt16(value, CultureInfo.InvariantCulture);
+        }
+
+        writer.Write(shortValue);
+    }
 }

--- a/ClickHouse.Driver/Types/Int32Type.cs
+++ b/ClickHouse.Driver/Types/Int32Type.cs
@@ -12,5 +12,13 @@ internal class Int32Type : IntegerType
 
     public override string ToString() => "Int32";
 
-    public override void Write(ExtendedBinaryWriter writer, object value) => writer.Write(Convert.ToInt32(value, CultureInfo.InvariantCulture));
+    public override void Write<T>(ExtendedBinaryWriter writer, T value)
+    {
+        if (value is not int intValue)
+        {
+            intValue = Convert.ToInt32(value, CultureInfo.InvariantCulture);
+        }
+
+        writer.Write(intValue);
+    }
 }

--- a/ClickHouse.Driver/Types/Int64Type.cs
+++ b/ClickHouse.Driver/Types/Int64Type.cs
@@ -12,5 +12,13 @@ internal class Int64Type : IntegerType
 
     public override string ToString() => "Int64";
 
-    public override void Write(ExtendedBinaryWriter writer, object value) => writer.Write(Convert.ToInt64(value, CultureInfo.InvariantCulture));
+    public override void Write<T>(ExtendedBinaryWriter writer, T value)
+    {
+        if (value is not long longValue)
+        {
+            longValue = Convert.ToInt64(value, CultureInfo.InvariantCulture);
+        }
+
+        writer.Write(longValue);
+    }
 }

--- a/ClickHouse.Driver/Types/Int8Type.cs
+++ b/ClickHouse.Driver/Types/Int8Type.cs
@@ -12,5 +12,13 @@ internal class Int8Type : IntegerType
 
     public override object Read(ExtendedBinaryReader reader) => reader.ReadSByte();
 
-    public override void Write(ExtendedBinaryWriter writer, object value) => writer.Write(Convert.ToSByte(value, CultureInfo.InvariantCulture));
+    public override void Write<T>(ExtendedBinaryWriter writer, T value)
+    {
+        if (value is not sbyte sbyteValue)
+        {
+            sbyteValue = Convert.ToSByte(value, CultureInfo.InvariantCulture);
+        }
+
+        writer.Write(sbyteValue);
+    }
 }

--- a/ClickHouse.Driver/Types/JsonType.cs
+++ b/ClickHouse.Driver/Types/JsonType.cs
@@ -145,7 +145,7 @@ internal class JsonType : ParameterizedType
 
     public override string ToString() => Name;
 
-    public override void Write(ExtendedBinaryWriter writer, object value)
+    public override void Write<T>(ExtendedBinaryWriter writer, T value)
     {
         // String mode: serialize everything to JSON string, let server parse
         if (TypeSettings.jsonWriteMode == JsonWriteMode.String)
@@ -287,7 +287,7 @@ internal class JsonType : ParameterizedType
         if ((value is null || value is DBNull) && hintedType is NullableType)
         {
             // Nullable types handle null via their own Write method (writes byte 1)
-            hintedType.Write(writer, null);
+            hintedType.Write<object>(writer, null);
             return;
         }
 

--- a/ClickHouse.Driver/Types/LowCardinalityType.cs
+++ b/ClickHouse.Driver/Types/LowCardinalityType.cs
@@ -24,5 +24,8 @@ internal class LowCardinalityType : ParameterizedType
 
     public override object Read(ExtendedBinaryReader reader) => UnderlyingType.Read(reader);
 
-    public override void Write(ExtendedBinaryWriter writer, object value) => UnderlyingType.Write(writer, value);
+    public override void Write<T>(ExtendedBinaryWriter writer, T value)
+    {
+        UnderlyingType.Write(writer, value);
+    }
 }

--- a/ClickHouse.Driver/Types/MapType.cs
+++ b/ClickHouse.Driver/Types/MapType.cs
@@ -59,7 +59,7 @@ internal class MapType : ParameterizedType
 
     public override string ToString() => $"{Name}({keyType}, {valueType})";
 
-    public override void Write(ExtendedBinaryWriter writer, object value)
+    public override void Write<T>(ExtendedBinaryWriter writer, T value)
     {
         var dict = (IDictionary)value;
         writer.Write7BitEncodedInt(dict.Count);

--- a/ClickHouse.Driver/Types/NestedType.cs
+++ b/ClickHouse.Driver/Types/NestedType.cs
@@ -45,7 +45,7 @@ internal class NestedType : TupleType
         return data;
     }
 
-    public override void Write(ExtendedBinaryWriter writer, object value)
+    public override void Write<T>(ExtendedBinaryWriter writer, T value)
     {
         if (value is null || value is DBNull)
         {
@@ -57,7 +57,7 @@ internal class NestedType : TupleType
         writer.Write7BitEncodedInt(collection.Count);
         for (var i = 0; i < collection.Count; i++)
         {
-            base.Write(writer, collection[i]);
+            base.Write<object>(writer, collection[i]);
         }
     }
 }

--- a/ClickHouse.Driver/Types/NothingType.cs
+++ b/ClickHouse.Driver/Types/NothingType.cs
@@ -11,5 +11,5 @@ internal class NothingType : ClickHouseType
 
     public override string ToString() => "Nothing";
 
-    public override void Write(ExtendedBinaryWriter writer, object value) { }
+    public override void Write<T>(ExtendedBinaryWriter writer, T value) { }
 }

--- a/ClickHouse.Driver/Types/NullableType.cs
+++ b/ClickHouse.Driver/Types/NullableType.cs
@@ -31,7 +31,7 @@ internal class NullableType : ParameterizedType
 
     public override string ToString() => $"{Name}({UnderlyingType})";
 
-    public override void Write(ExtendedBinaryWriter writer, object value)
+    public override void Write<T>(ExtendedBinaryWriter writer, T value)
     {
         if (value == null || value is DBNull)
         {

--- a/ClickHouse.Driver/Types/ObjectType.cs
+++ b/ClickHouse.Driver/Types/ObjectType.cs
@@ -24,5 +24,5 @@ internal class ObjectType : ParameterizedType
 
     public override string ToString() => $"{Name}({UnderlyingType})";
 
-    public override void Write(ExtendedBinaryWriter writer, object value) => UnderlyingType.Write(writer, value);
+    public override void Write<T>(ExtendedBinaryWriter writer, T value) => UnderlyingType.Write(writer, value);
 }

--- a/ClickHouse.Driver/Types/PointType.cs
+++ b/ClickHouse.Driver/Types/PointType.cs
@@ -10,11 +10,17 @@ internal class PointType : TupleType
         UnderlyingTypes = new[] { new Float64Type(), new Float64Type() };
     }
 
-    public override void Write(ExtendedBinaryWriter writer, object value)
+    public override void Write<T>(ExtendedBinaryWriter writer, T value)
     {
         if (value is System.Drawing.Point p)
-            value = Tuple.Create(p.X, p.Y);
-        base.Write(writer, value);
+        {
+            var tuple = Tuple.Create(p.X, p.Y);
+            base.Write(writer, tuple);
+        }
+        else
+        {
+            base.Write(writer, value);
+        }
     }
 
     public override string ToString() => "Point";

--- a/ClickHouse.Driver/Types/QBitType.cs
+++ b/ClickHouse.Driver/Types/QBitType.cs
@@ -60,7 +60,7 @@ internal class QBitType : ParameterizedType
         return data;
     }
 
-    public override void Write(ExtendedBinaryWriter writer, object value)
+    public override void Write<T>(ExtendedBinaryWriter writer, T value)
     {
         // QBit wire format is just Array(ElementType)
         UnderlyingArrayType.Write(writer, value);

--- a/ClickHouse.Driver/Types/SimpleAggregateFunctionType.cs
+++ b/ClickHouse.Driver/Types/SimpleAggregateFunctionType.cs
@@ -27,5 +27,5 @@ internal class SimpleAggregateFunctionType : ParameterizedType
 
     public override string ToString() => $"{Name}({AggregateFunction}, {UnderlyingType})";
 
-    public override void Write(ExtendedBinaryWriter writer, object value) => UnderlyingType.Write(writer, value);
+    public override void Write<T>(ExtendedBinaryWriter writer, T value) => UnderlyingType.Write(writer, value);
 }

--- a/ClickHouse.Driver/Types/StringType.cs
+++ b/ClickHouse.Driver/Types/StringType.cs
@@ -25,7 +25,7 @@ internal class StringType : ClickHouseType
 
     public override string ToString() => "String";
 
-    public override void Write(ExtendedBinaryWriter writer, object value)
+    public override void Write<T>(ExtendedBinaryWriter writer, T value)
     {
         if (value is string s)
         {

--- a/ClickHouse.Driver/Types/Time64Type.cs
+++ b/ClickHouse.Driver/Types/Time64Type.cs
@@ -120,7 +120,7 @@ internal class Time64Type : ParameterizedType
         return Time64Type.FromClickHouseDecimal(fractionalSeconds);
     }
 
-    public override void Write(ExtendedBinaryWriter writer, object value)
+    public override void Write<T>(ExtendedBinaryWriter writer, T value)
     {
         var timeSpan = CoerceToTimeSpan(value);
         var fractionalSeconds = ToClickHouseDecimal(timeSpan);
@@ -133,7 +133,7 @@ internal class Time64Type : ParameterizedType
         decimalType.Write(writer, clickHouseDecimal);
     }
 
-    private static TimeSpan CoerceToTimeSpan(object value)
+    private static TimeSpan CoerceToTimeSpan<T>(T value)
     {
         return value switch
         {

--- a/ClickHouse.Driver/Types/TimeType.cs
+++ b/ClickHouse.Driver/Types/TimeType.cs
@@ -32,7 +32,7 @@ internal class TimeType : ClickHouseType
         return TimeSpan.FromSeconds(seconds);
     }
 
-    public override void Write(ExtendedBinaryWriter writer, object value)
+    public override void Write<T>(ExtendedBinaryWriter writer, T value)
     {
         var seconds = CoerceToSeconds(value);
 
@@ -42,7 +42,7 @@ internal class TimeType : ClickHouseType
         writer.Write(seconds);
     }
 
-    private static int CoerceToSeconds(object value)
+    private static int CoerceToSeconds<T>(T value)
     {
         return value switch
         {

--- a/ClickHouse.Driver/Types/TupleType.cs
+++ b/ClickHouse.Driver/Types/TupleType.cs
@@ -87,7 +87,7 @@ internal class TupleType : ParameterizedType
         return MakeTuple(contents);
     }
 
-    public override void Write(ExtendedBinaryWriter writer, object value)
+    public override void Write<T>(ExtendedBinaryWriter writer, T value)
     {
         if (value is ITuple tuple)
         {

--- a/ClickHouse.Driver/Types/UInt16Type.cs
+++ b/ClickHouse.Driver/Types/UInt16Type.cs
@@ -12,5 +12,13 @@ internal class UInt16Type : IntegerType
 
     public override string ToString() => "UInt16";
 
-    public override void Write(ExtendedBinaryWriter writer, object value) => writer.Write(Convert.ToUInt16(value, CultureInfo.InvariantCulture));
+    public override void Write<T>(ExtendedBinaryWriter writer, T value)
+    {
+        if (value is not ushort ushortValue)
+        {
+            ushortValue = Convert.ToUInt16(value, CultureInfo.InvariantCulture);
+        }
+
+        writer.Write(ushortValue);
+    }
 }

--- a/ClickHouse.Driver/Types/UInt32Type.cs
+++ b/ClickHouse.Driver/Types/UInt32Type.cs
@@ -12,5 +12,13 @@ internal class UInt32Type : IntegerType
 
     public override string ToString() => "UInt32";
 
-    public override void Write(ExtendedBinaryWriter writer, object value) => writer.Write(Convert.ToUInt32(value, CultureInfo.InvariantCulture));
+    public override void Write<T>(ExtendedBinaryWriter writer, T value)
+    {
+        if (value is not uint uintValue)
+        {
+            uintValue = Convert.ToUInt32(value, CultureInfo.InvariantCulture);
+        }
+
+        writer.Write(uintValue);
+    }
 }

--- a/ClickHouse.Driver/Types/UInt64Type.cs
+++ b/ClickHouse.Driver/Types/UInt64Type.cs
@@ -12,5 +12,13 @@ internal class UInt64Type : IntegerType
 
     public override string ToString() => "UInt64";
 
-    public override void Write(ExtendedBinaryWriter writer, object value) => writer.Write(Convert.ToUInt64(value, CultureInfo.InvariantCulture));
+    public override void Write<T>(ExtendedBinaryWriter writer, T value)
+    {
+        if (value is not ulong ulongValue)
+        {
+            ulongValue = Convert.ToUInt64(value, CultureInfo.InvariantCulture);
+        }
+
+        writer.Write(ulongValue);
+    }
 }

--- a/ClickHouse.Driver/Types/UInt8Type.cs
+++ b/ClickHouse.Driver/Types/UInt8Type.cs
@@ -12,5 +12,13 @@ internal class UInt8Type : IntegerType
 
     public override string ToString() => "UInt8";
 
-    public override void Write(ExtendedBinaryWriter writer, object value) => writer.Write(Convert.ToByte(value, CultureInfo.InvariantCulture));
+    public override void Write<T>(ExtendedBinaryWriter writer, T value)
+    {
+        if (value is not byte byteValue)
+        {
+            byteValue = Convert.ToByte(value, CultureInfo.InvariantCulture);
+        }
+
+        writer.Write(byteValue);
+    }
 }

--- a/ClickHouse.Driver/Types/UuidType.cs
+++ b/ClickHouse.Driver/Types/UuidType.cs
@@ -21,9 +21,13 @@ internal class UuidType : ClickHouseType
 
     public override string ToString() => "UUID";
 
-    public override void Write(ExtendedBinaryWriter writer, object value)
+    public override void Write<T>(ExtendedBinaryWriter writer, T value)
     {
-        var guid = ExtractGuid(value);
+        if (value is not Guid guid)
+        {
+            guid = new Guid((string)(object)value);
+        }
+
         var bytes = guid.ToByteArray();
         Array.Reverse(bytes, 8, 8);
         writer.Write(bytes, 6, 2);
@@ -31,6 +35,4 @@ internal class UuidType : ClickHouseType
         writer.Write(bytes, 0, 4);
         writer.Write(bytes, 8, 8);
     }
-
-    private static Guid ExtractGuid(object data) => data is Guid g ? g : new Guid((string)data);
 }

--- a/ClickHouse.Driver/Types/VariantType.cs
+++ b/ClickHouse.Driver/Types/VariantType.cs
@@ -34,7 +34,7 @@ internal class VariantType : ParameterizedType
         return type.Read(reader);
     }
 
-    public (int, ClickHouseType) GetMatchingType(object value)
+    public (int, ClickHouseType) GetMatchingType<T>(T value)
     {
         for (int i = 0; i < UnderlyingTypes.Length; i++)
         {
@@ -46,7 +46,7 @@ internal class VariantType : ParameterizedType
         throw new ArgumentException("Could not find matching type for variant", nameof(value));
     }
 
-    public override void Write(ExtendedBinaryWriter writer, object value)
+    public override void Write<T>(ExtendedBinaryWriter writer, T value)
     {
         if (value is null or DBNull)
         {


### PR DESCRIPTION
Implementation of sending data packets manual.

Usage:

```chsarp

var import = await client.StartInsertAsync(tableName, columns);

using var batch1 = import.StartNewBatch();
// fill batch 1
batch1.WriteData(0, 1);
batch1.WriteData(1, "my product value");
batch1.WriteData(2, "my category value");

batch1.CompleteWrite();

var sendTask = import.SendBatchAsync(batch1);

using var batch2 = import.StartNewBatch();
// fill batch 2
batch2.WriteData(0, 2);
batch2.WriteData(1, "my product value");
batch2.WriteData(2, "my category value");

batch2.CompleteWrite();

var sendTask2 = import.SendBatchAsync(batch2);

await Task.WhenAll(sendTask, sendTask2);

```

Thus, creating packages is the prerogative of the library user, not the library itself. How they choose to do so is entirely up to them. PR for example, to show what I mean.

No attributes needed, no object[] array needed. Where the developer gets the data to write to `Write` is his problem and solution.

Based on the benchmark results, 'BinaryImport' is faster and consumes less memory for any collection size.

Benchmark result:

| Method       | Count  | Mean      | Error     | StdDev    | Median    | Ratio | RatioSD | Gen0      | Gen1      | Gen2      | Allocated | Alloc Ratio |
|------------- |------- |----------:|----------:|----------:|----------:|------:|--------:|----------:|----------:|----------:|----------:|------------:|
| **ObjectArray**  | **100000** | **113.19 ms** |  **4.358 ms** |  **9.287 ms** | **114.23 ms** |  **1.01** |    **0.11** | **1000.0000** |         **-** |         **-** |  **14.53 MB** |        **1.00** |
| Poco         | 100000 | 112.13 ms |  5.806 ms | 12.745 ms | 111.68 ms |  1.00 |    0.14 | 1000.0000 |         - |         - |  13.76 MB |        0.95 |
| BinaryImport | 100000 |  94.73 ms |  4.412 ms |  9.776 ms |  89.33 ms |  0.84 |    0.11 |         - |         - |         - |   4.87 MB |        0.34 |
|              |        |           |           |           |           |       |         |           |           |           |           |             |
| **ObjectArray**  | **500000** | **679.48 ms** | **13.408 ms** | **29.988 ms** | **677.99 ms** |  **1.00** |    **0.06** | **9000.0000** | **8000.0000** | **1000.0000** |  **70.54 MB** |        **1.00** |
| Poco         | 500000 | 655.85 ms | 13.758 ms | 30.198 ms | 657.03 ms |  0.97 |    0.06 | 9000.0000 | 7000.0000 | 2000.0000 |  66.73 MB |        0.95 |
| BinaryImport | 500000 | 543.13 ms | 12.932 ms | 28.386 ms | 549.10 ms |  0.80 |    0.05 | 2000.0000 |         - |         - |  21.21 MB |        0.30 |


#328

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new streaming/batched insert path and refactors ClickHouse binary type serialization to use generic `Write<T>`/`CanWrite<T>`, which could affect all binary inserts if any type coercion or null-handling behavior changes.
> 
> **Overview**
> Adds a new `ClickHouseClient.StartInsertAsync` API that returns a `BinaryImport` helper, letting callers manually build and send multiple gzipped RowBinary batches via `BatchData.WriteData`/`SendBatchAsync` with per-batch query IDs.
> 
> Refactors the binary type system to use generic `Write<T>` (and `CanWrite<T>` where applicable) across many `ClickHouseType` implementations, with minor coercion tweaks (e.g., numeric/UUID/IP parsing) and corresponding test updates for null cases. Adds a benchmark comparing `BinaryImport` to existing `object[]` and POCO binary insert paths, plus a new test covering inserts with a subset of table columns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b459199d2e3d5c3b11473d7233eb6c971d3a070b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->