### PR TITLE
Move test database creation to assembly-level OneTimeSetUp

### DIFF
--- a/ClickHouse.Driver.Tests/AbstractConnectionTestFixture.cs
+++ b/ClickHouse.Driver.Tests/AbstractConnectionTestFixture.cs
@@ -15,7 +15,6 @@ public abstract class AbstractConnectionTestFixture : IDisposable
     {
         client = TestUtilities.GetTestClickHouseClient();
         connection = client.CreateConnection();
-        client.ExecuteNonQueryAsync("CREATE DATABASE IF NOT EXISTS test;").GetAwaiter().GetResult();
     }
 
     protected static string SanitizeTableName(string input)

--- a/ClickHouse.Driver.Tests/TestContainerFixture.cs
+++ b/ClickHouse.Driver.Tests/TestContainerFixture.cs
@@ -6,6 +6,16 @@ namespace ClickHouse.Driver.Tests;
 [SetUpFixture]
 public class TestContainerFixture
 {
+    [OneTimeSetUp]
+    public async Task SetUp()
+    {
+        // Creating the test database here (rather than per-fixture) avoids hammering
+        // the distributed DDL queue on multi-replica deployments,
+        // which was causing issues with the cloud tests.
+        using var client = TestUtilities.GetTestClickHouseClient();
+        await client.ExecuteNonQueryAsync("CREATE DATABASE IF NOT EXISTS test");
+    }
+
     [OneTimeTearDown]
     public async Task TearDown()
     {


### PR DESCRIPTION
## Summary
- Each test fixture's constructor was issuing `CREATE DATABASE IF NOT EXISTS test`. On ClickHouse Cloud, the distributed DDL queue serializes per-replica and the coordinator waits on every replica, so concurrent fixtures push tail latency past `distributed_ddl_task_timeout` and tests fail with `HttpClient.Timeout` of 120s.
- Move the DDL into the existing `TestContainerFixture` `[SetUpFixture]` as a `[OneTimeSetUp]` so it runs once per test assembly.