### PR TITLE
Temporarily disable BearerAuthenticationTests

### DIFF
--- a/ClickHouse.Driver.Tests/ADO/BearerAuthenticationTests.cs
+++ b/ClickHouse.Driver.Tests/ADO/BearerAuthenticationTests.cs
@@ -14,6 +14,7 @@ namespace ClickHouse.Driver.Tests.ADO;
 [TestFixture]
 [Category("Cloud")]
 [Category("JWT")]
+[Ignore("Temporarily disabled while JWT test environment is being repaired")]
 public class BearerAuthenticationTests
 {
     private string connectionString;


### PR DESCRIPTION
Set up a new cloud service to fix the flaky cloud tests, but we don't have a JWT for that service. Disable JWT tests temporarily to make CI green for now.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change; no production or auth code paths are modified.
> 
> **Overview**
> Adds a fixture-level NUnit **`[Ignore]`** on **`BearerAuthenticationTests`** so the Cloud/JWT integration suite is skipped in CI until a JWT is available for the repaired cloud test environment.
> 
> No driver or authentication logic changes—only test execution is affected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25dc1d69d8464664b8b8cdca3e54bc9e0e910bc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->