### PR TITLE
Add new setting allowing users to add custom metadata to user agent string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 v1.4.0
 ---
 
+**New Features:**
+* **Application-identity tagging in User-Agent**: new `ClickHouseClientSettings.ApplicationInfo` property: an `IReadOnlyDictionary<string, string>` of free-form tags (e.g. `app`, `ver`, `env`) appended to the HTTP `User-Agent` header as a comment token (e.g. `(app:MyApp; ver:2.3.1; env:prod)`).
+
 **Bug Fixes:**
 * **Breaking Change**: Fixed timezone shift for `@`-style `DateTime`/`DateTimeOffset` parameters on non-UTC servers (issue #350). When a parameter's ClickHouse type was inferred (no explicit `{name:Type}` hint in SQL and no `parameter.ClickHouseType` set), the driver previously emitted a bare `DateTime` hint and the server parsed the wire wall-clock in `session_timezone`/server tz — silently shifting instant-bearing values by the server's offset. Inferred types for `DateTime { Kind: Utc or Local }` and `DateTimeOffset` are now sent as `DateTime('UTC')`, preserving the instant across any server timezone. Explicit hints (`{name:DateTime}` in SQL or `parameter.ClickHouseType`) are untouched, users who specify the type continue to own timezone correctness.
 

--- a/ClickHouse.Driver.Tests/ADO/ApplicationInfoTests.cs
+++ b/ClickHouse.Driver.Tests/ADO/ApplicationInfoTests.cs
@@ -71,7 +71,7 @@ public class ApplicationInfoTests : AbstractConnectionTestFixture
 
         var ua = UserAgentString(c);
 
-        Assert.That(ua, Does.Contain("raw:a|b|c|d|e|f|g|h i"));
+        Assert.That(ua, Does.Contain("raw:a|b|c|d|e|f:g|h i"));
         Assert.That(ua, Does.Not.Contain("a(b)"));
     }
 

--- a/ClickHouse.Driver.Tests/ADO/ApplicationInfoTests.cs
+++ b/ClickHouse.Driver.Tests/ADO/ApplicationInfoTests.cs
@@ -1,0 +1,288 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using ClickHouse.Driver.ADO;
+
+namespace ClickHouse.Driver.Tests.ADO;
+
+[TestFixture]
+public class ApplicationInfoTests : AbstractConnectionTestFixture
+{
+    private static string UserAgentString(ClickHouseClient c)
+    {
+        var headers = new HttpRequestMessage().Headers;
+        c.AddDefaultHttpHeaders(headers);
+        return headers.UserAgent.ToString();
+    }
+
+    [Test]
+    public void AddDefaultHttpHeaders_WithoutApplicationInfo_EmitsSystemOnlyToken()
+    {
+        var settings = TestUtilities.GetTestClickHouseClientSettings();
+        using var c = new ClickHouseClient(settings);
+
+        var headers = new HttpRequestMessage().Headers;
+        c.AddDefaultHttpHeaders(headers);
+        var ua = headers.UserAgent.ToString();
+
+        Assert.That(headers.UserAgent.Count, Is.EqualTo(2));
+        Assert.That(ua, Does.Not.Contain("()"));
+        // System tags must still appear in the merged comment token even when ApplicationInfo is empty.
+        Assert.That(ua, Does.Contain("platform:"));
+        Assert.That(ua, Does.Contain("os:"));
+        Assert.That(ua, Does.Contain("arch:"));
+    }
+
+    [Test]
+    public void AddDefaultHttpHeaders_WithApplicationInfo_AppendsCommentToken()
+    {
+        var baseSettings = TestUtilities.GetTestClickHouseClientSettings();
+        var settings = new ClickHouseClientSettings(baseSettings)
+        {
+            ApplicationInfo = new Dictionary<string, string>
+            {
+                ["app"] = "TestApp",
+                ["ver"] = "1.0",
+            },
+        };
+        using var c = new ClickHouseClient(settings);
+
+        var ua = UserAgentString(c);
+
+        Assert.That(ua, Does.Contain("app:TestApp; ver:1.0)"));
+        Assert.That(
+            ua.IndexOf("ClickHouse.Driver/", StringComparison.Ordinal),
+            Is.LessThan(ua.IndexOf("app:TestApp", StringComparison.Ordinal)));
+    }
+
+    [Test]
+    public void ApplicationInfo_ValuesAreSanitized()
+    {
+        var baseSettings = TestUtilities.GetTestClickHouseClientSettings();
+        var settings = new ClickHouseClientSettings(baseSettings)
+        {
+            ApplicationInfo = new Dictionary<string, string>
+            {
+                ["raw"] = "a(b)c\\d;e,f:g\th i",
+            },
+        };
+        using var c = new ClickHouseClient(settings);
+
+        var ua = UserAgentString(c);
+
+        Assert.That(ua, Does.Contain("raw:a|b|c|d|e|f|g|h i"));
+        Assert.That(ua, Does.Not.Contain("a(b)"));
+    }
+
+    [Test]
+    public void ApplicationInfo_EmptyValueEntriesAreSkipped()
+    {
+        var baseSettings = TestUtilities.GetTestClickHouseClientSettings();
+        var settings = new ClickHouseClientSettings(baseSettings)
+        {
+            ApplicationInfo = new Dictionary<string, string>
+            {
+                ["app"] = "Real",
+                ["empty"] = "",
+            },
+        };
+        using var c = new ClickHouseClient(settings);
+
+        var ua = UserAgentString(c);
+
+        Assert.That(ua, Does.Contain("app:Real"));
+        Assert.That(ua, Does.Not.Contain("empty:"));
+    }
+
+    [Test]
+    public void ApplicationInfo_AllEmptyValues_EmitsSystemOnlyToken()
+    {
+        var baseSettings = TestUtilities.GetTestClickHouseClientSettings();
+        var settings = new ClickHouseClientSettings(baseSettings)
+        {
+            ApplicationInfo = new Dictionary<string, string>
+            {
+                ["a"] = "",
+                ["b"] = "",
+            },
+        };
+        using var c = new ClickHouseClient(settings);
+
+        var headers = new HttpRequestMessage().Headers;
+        c.AddDefaultHttpHeaders(headers);
+        var ua = headers.UserAgent.ToString();
+
+        Assert.That(headers.UserAgent.Count, Is.EqualTo(2));
+        Assert.That(ua, Does.Contain("platform:"));
+        Assert.That(ua, Does.Not.Contain("a:"));
+        Assert.That(ua, Does.Not.Contain("b:"));
+    }
+
+    [Test]
+    public void ApplicationInfo_InvalidKey_ThrowsOnClientConstruction()
+    {
+        var baseSettings = TestUtilities.GetTestClickHouseClientSettings();
+        var settings = new ClickHouseClientSettings(baseSettings)
+        {
+            ApplicationInfo = new Dictionary<string, string>
+            {
+                ["bad key"] = "value",
+            },
+        };
+
+        var ex = Assert.Throws<ArgumentException>(() => new ClickHouseClient(settings));
+        Assert.That(ex.Message, Does.Contain("User-Agent tag key"));
+    }
+
+    [Test]
+    public void ApplicationInfo_EmptyKey_ThrowsOnClientConstruction()
+    {
+        var baseSettings = TestUtilities.GetTestClickHouseClientSettings();
+        var settings = new ClickHouseClientSettings(baseSettings)
+        {
+            ApplicationInfo = new Dictionary<string, string>
+            {
+                [""] = "value",
+            },
+        };
+
+        Assert.Throws<ArgumentException>(() => new ClickHouseClient(settings));
+    }
+
+    [Test]
+    public void ApplicationInfo_NullDictionary_DoesNotThrow()
+    {
+        var baseSettings = TestUtilities.GetTestClickHouseClientSettings();
+        var settings = new ClickHouseClientSettings(baseSettings)
+        {
+            ApplicationInfo = null,
+        };
+
+        Assert.DoesNotThrow(() => new ClickHouseClient(settings));
+
+        using var c = new ClickHouseClient(settings);
+        var headers = new HttpRequestMessage().Headers;
+        c.AddDefaultHttpHeaders(headers);
+        Assert.That(headers.UserAgent.Count, Is.EqualTo(2));
+    }
+
+    [Test]
+    public void ApplicationInfo_CopyConstructor_WithNullSource_ProducesEmptyDict()
+    {
+        var original = new ClickHouseClientSettings { ApplicationInfo = null };
+
+        var copy = new ClickHouseClientSettings(original);
+
+        Assert.That(copy.ApplicationInfo, Is.Not.Null);
+        Assert.That(copy.ApplicationInfo, Is.Empty);
+    }
+
+    [Test]
+    public void ApplicationInfo_OverlongKey_ThrowsOnClientConstruction()
+    {
+        var baseSettings = TestUtilities.GetTestClickHouseClientSettings();
+        var settings = new ClickHouseClientSettings(baseSettings)
+        {
+            ApplicationInfo = new Dictionary<string, string>
+            {
+                [new string('a', 33)] = "value",
+            },
+        };
+
+        Assert.Throws<ArgumentException>(() => new ClickHouseClient(settings));
+    }
+
+    [Test]
+    public void ApplicationInfo_NonAsciiValue_IsUrlEncoded()
+    {
+        var baseSettings = TestUtilities.GetTestClickHouseClientSettings();
+        var settings = new ClickHouseClientSettings(baseSettings)
+        {
+            ApplicationInfo = new Dictionary<string, string>
+            {
+                ["app"] = "caf\u00e9", // "café"
+            },
+        };
+        using var c = new ClickHouseClient(settings);
+
+        var ua = UserAgentString(c);
+
+        Assert.That(ua, Does.Contain("app:caf%C3%A9"));
+    }
+
+    [Test]
+    public void ApplicationInfo_ControlCharsInValue_AreReplacedWithPipe()
+    {
+        var baseSettings = TestUtilities.GetTestClickHouseClientSettings();
+        var settings = new ClickHouseClientSettings(baseSettings)
+        {
+            ApplicationInfo = new Dictionary<string, string>
+            {
+                ["ctl"] = "a\nb\rc\u0001d\u007Fe",
+            },
+        };
+        using var c = new ClickHouseClient(settings);
+
+        var ua = UserAgentString(c);
+
+        Assert.That(ua, Does.Contain("ctl:a|b|c|d|e"));
+    }
+
+    [Test]
+    public void ApplicationInfo_ValueLongerThan256Chars_IsTruncated()
+    {
+        var baseSettings = TestUtilities.GetTestClickHouseClientSettings();
+        var longValue = new string('x', 500);
+        var settings = new ClickHouseClientSettings(baseSettings)
+        {
+            ApplicationInfo = new Dictionary<string, string>
+            {
+                ["app"] = longValue,
+            },
+        };
+        using var c = new ClickHouseClient(settings);
+
+        var ua = UserAgentString(c);
+
+        var start = ua.IndexOf("app:", StringComparison.Ordinal);
+        Assert.That(start, Is.GreaterThanOrEqualTo(0));
+        var end = ua.IndexOf(')', start);
+        var emittedValue = ua.Substring(start + "app:".Length, end - (start + "app:".Length));
+        Assert.That(emittedValue.Length, Is.EqualTo(256));
+        Assert.That(emittedValue, Is.EqualTo(new string('x', 256)));
+    }
+
+    [Test]
+    public async Task ApplicationInfo_AppearsInSystemQueryLog()
+    {
+        var marker = $"appinfo_{Guid.NewGuid():N}";
+        var baseSettings = TestUtilities.GetTestClickHouseClientSettings();
+        var settings = new ClickHouseClientSettings(baseSettings)
+        {
+            ApplicationInfo = new Dictionary<string, string>
+            {
+                ["app"] = marker,
+                ["ver"] = "1.0",
+            },
+        };
+        using var tagged = new ClickHouseClient(settings);
+
+        await tagged.ExecuteScalarAsync($"SELECT 1 /* {marker} */");
+
+        // SYSTEM FLUSH LOGS is synchronous and forces the query_log buffer to disk,
+        // so the row is visible immediately afterwards — no polling/sleep needed.
+        await client.ExecuteNonQueryAsync("SYSTEM FLUSH LOGS");
+
+        object scalar = await client.ExecuteScalarAsync(
+            $"SELECT http_user_agent FROM system.query_log " +
+            $"WHERE query LIKE '%{marker}%' AND type = 'QueryFinish' " +
+            $"ORDER BY event_time DESC LIMIT 1");
+
+        Assert.That(scalar, Is.Not.Null, "Expected a query_log row for the marker but found none.");
+        Assert.That(scalar, Is.Not.EqualTo(DBNull.Value), "Expected a non-null http_user_agent.");
+        var ua = (string)scalar;
+        Assert.That(ua, Does.Contain($"app:{marker}"));
+        Assert.That(ua, Does.Contain("ver:1.0"));
+    }
+}

--- a/ClickHouse.Driver.Tests/ADO/ClickHouseClientSettingsTests.cs
+++ b/ClickHouse.Driver.Tests/ADO/ClickHouseClientSettingsTests.cs
@@ -640,6 +640,12 @@ public class ClickHouseClientSettingsTests
                 var copyDict = copyValue as IDictionary<string, string>;
                 Assert.That(copyDict, Is.EquivalentTo(originalDict), "Custom headers should be copied");
             }
+            else if (property.Name == nameof(ClickHouseClientSettings.ApplicationInfo))
+            {
+                var originalDict = originalValue as IDictionary<string, string>;
+                var copyDict = copyValue as IDictionary<string, string>;
+                Assert.That(copyDict, Is.EquivalentTo(originalDict), "ApplicationInfo should be copied");
+            }
             else if (property.PropertyType.IsValueType || property.PropertyType == typeof(string))
             {
                 // Value types and strings should be equal

--- a/ClickHouse.Driver.Tests/Utility/DictionaryExtensionsTests.cs
+++ b/ClickHouse.Driver.Tests/Utility/DictionaryExtensionsTests.cs
@@ -1,0 +1,111 @@
+using System.Collections.Generic;
+using ClickHouse.Driver.Utility;
+
+namespace ClickHouse.Driver.Tests.Utility;
+
+[TestFixture]
+public class DictionaryExtensionsTests
+{
+    [Test]
+    public void EntriesEqual_BothNull_ReturnsTrue()
+    {
+        IReadOnlyDictionary<string, string> a = null;
+        IReadOnlyDictionary<string, string> b = null;
+
+        Assert.That(a.EntriesEqual(b), Is.True);
+    }
+
+    [Test]
+    public void EntriesEqual_NullAndEmpty_ReturnsTrueBothDirections()
+    {
+        IReadOnlyDictionary<string, string> a = null;
+        IReadOnlyDictionary<string, string> b = new Dictionary<string, string>();
+
+        Assert.That(a.EntriesEqual(b), Is.True);
+        Assert.That(b.EntriesEqual(a), Is.True);
+    }
+
+    [Test]
+    public void EntriesEqual_NullAndNonEmpty_ReturnsFalseBothDirections()
+    {
+        IReadOnlyDictionary<string, string> a = null;
+        IReadOnlyDictionary<string, string> b = new Dictionary<string, string> { ["x"] = "1" };
+
+        Assert.That(a.EntriesEqual(b), Is.False);
+        Assert.That(b.EntriesEqual(a), Is.False);
+    }
+
+    [Test]
+    public void EntriesEqual_BothEmpty_ReturnsTrue()
+    {
+        IReadOnlyDictionary<string, string> a = new Dictionary<string, string>();
+        IReadOnlyDictionary<string, string> b = new Dictionary<string, string>();
+
+        Assert.That(a.EntriesEqual(b), Is.True);
+    }
+
+    [Test]
+    public void EntriesEqual_SameContentDifferentInsertionOrder_ReturnsTrue()
+    {
+        IReadOnlyDictionary<string, string> a = new Dictionary<string, string> { ["x"] = "1", ["y"] = "2" };
+        IReadOnlyDictionary<string, string> b = new Dictionary<string, string> { ["y"] = "2", ["x"] = "1" };
+
+        Assert.That(a.EntriesEqual(b), Is.True);
+    }
+
+    [Test]
+    public void EntriesEqual_SameKeyDifferentValue_ReturnsFalse()
+    {
+        IReadOnlyDictionary<string, string> a = new Dictionary<string, string> { ["x"] = "1" };
+        IReadOnlyDictionary<string, string> b = new Dictionary<string, string> { ["x"] = "2" };
+
+        Assert.That(a.EntriesEqual(b), Is.False);
+    }
+
+    [Test]
+    public void EntriesEqual_DifferentKeys_ReturnsFalse()
+    {
+        IReadOnlyDictionary<string, string> a = new Dictionary<string, string> { ["x"] = "1" };
+        IReadOnlyDictionary<string, string> b = new Dictionary<string, string> { ["y"] = "1" };
+
+        Assert.That(a.EntriesEqual(b), Is.False);
+    }
+
+    [Test]
+    public void EntriesEqual_DifferentCounts_ReturnsFalse()
+    {
+        IReadOnlyDictionary<string, string> a = new Dictionary<string, string> { ["x"] = "1" };
+        IReadOnlyDictionary<string, string> b = new Dictionary<string, string> { ["x"] = "1", ["y"] = "2" };
+
+        Assert.That(a.EntriesEqual(b), Is.False);
+    }
+
+    [Test]
+    public void EntriesEqual_IntValues_UsesValueEquality()
+    {
+        IReadOnlyDictionary<string, int> a = new Dictionary<string, int> { ["x"] = 1, ["y"] = 2 };
+        IReadOnlyDictionary<string, int> b = new Dictionary<string, int> { ["x"] = 1, ["y"] = 2 };
+
+        Assert.That(a.EntriesEqual(b), Is.True);
+    }
+
+    [Test]
+    public void EntriesEqual_NullValues_ComparedByDefaultComparer()
+    {
+        IReadOnlyDictionary<string, string> a = new Dictionary<string, string> { ["x"] = null };
+        IReadOnlyDictionary<string, string> b = new Dictionary<string, string> { ["x"] = null };
+
+        Assert.That(a.EntriesEqual(b), Is.True);
+
+        IReadOnlyDictionary<string, string> c = new Dictionary<string, string> { ["x"] = "v" };
+        Assert.That(a.EntriesEqual(c), Is.False);
+    }
+
+    [Test]
+    public void EntriesEqual_SameReference_ReturnsTrue()
+    {
+        IReadOnlyDictionary<string, string> a = new Dictionary<string, string> { ["x"] = "1" };
+
+        Assert.That(a.EntriesEqual(a), Is.True);
+    }
+}

--- a/ClickHouse.Driver/ADO/ClickHouseClientSettings.cs
+++ b/ClickHouse.Driver/ADO/ClickHouseClientSettings.cs
@@ -284,9 +284,10 @@ public class ClickHouseClientSettings : IEquatable<ClickHouseClientSettings>
     /// </para>
     /// <para>
     /// <b>Values</b> are sanitized to keep the header RFC 7230-compliant and capped at
-    /// 256 characters (longer values are truncated). Non-ASCII characters are URL-encoded;
-    /// structural characters (<c>( ) \ ; ,</c>) and control characters become <c>|</c>.
-    /// Spaces are preserved. Entries whose value is empty after sanitization are skipped.
+    /// 256 characters (longer values are truncated). If a value contains non-ASCII characters,
+    /// the entire value is URL-encoded (which also encodes spaces as <c>+</c> and punctuation).
+    /// After that, any remaining structural characters (<c>( ) \ ; ,</c>) and control characters
+    /// are replaced with <c>|</c>.
     /// </para>
     /// <para>
     /// The dictionary's contents are read when <see cref="ClickHouseClient"/> is constructed

--- a/ClickHouse.Driver/ADO/ClickHouseClientSettings.cs
+++ b/ClickHouse.Driver/ADO/ClickHouseClientSettings.cs
@@ -79,6 +79,11 @@ public class ClickHouseClientSettings : IEquatable<ClickHouseClientSettings>
         // Deep copy the CustomHeaders dictionary
         CustomHeaders = new Dictionary<string, string>(other.CustomHeaders.ToDictionary(x => x.Key, x => x.Value));
 
+        // Deep copy the ApplicationInfo dictionary (null is treated as empty)
+        ApplicationInfo = other.ApplicationInfo == null
+            ? new Dictionary<string, string>()
+            : new Dictionary<string, string>(other.ApplicationInfo.ToDictionary(x => x.Key, x => x.Value));
+
         // Copy JSON mode settings
         JsonReadMode = other.JsonReadMode;
         JsonWriteMode = other.JsonWriteMode;
@@ -267,6 +272,32 @@ public class ClickHouseClientSettings : IEquatable<ClickHouseClientSettings>
     public IReadOnlyDictionary<string, string> CustomHeaders { get; init; } = new Dictionary<string, string>();
 
     /// <summary>
+    /// Gets or sets application-identity tags appended to the HTTP User-Agent header as
+    /// a comment token (e.g. <c>(app:MyApp; ver:2.3.1; env:prod)</c>).
+    /// <para>
+    /// <b>Keys</b> must match <c>[A-Za-z0-9_.-]</c> and be 1–32 characters long; invalid keys
+    /// throw <see cref="ArgumentException"/> when the client is constructed. The driver
+    /// emits its own tags (<c>platform</c>, <c>os</c>, <c>lv</c>, <c>arch</c>) in the same
+    /// comment token; supplying any of these as keys here appends a second entry with the
+    /// same name rather than overriding the driver's value.
+    /// </para>
+    /// <para>
+    /// <b>Values</b> are sanitized to keep the header RFC 7230-compliant and capped at
+    /// 256 characters (longer values are truncated). Non-ASCII characters are URL-encoded;
+    /// structural characters (<c>( ) \ ; , :</c>) and control characters become <c>|</c>.
+    /// Spaces are preserved. Entries whose value is empty after sanitization are skipped.
+    /// </para>
+    /// <para>
+    /// The dictionary's contents are read when <see cref="ClickHouseClient"/> is constructed
+    /// and the resulting <c>User-Agent</c> token is cached on the client. Mutating the
+    /// dictionary you passed in <em>after</em> the client has been constructed has no effect
+    /// on subsequent requests and is not supported, pass a fresh settings instance instead.
+    /// </para>
+    /// Default: empty dictionary (no token appended).
+    /// </summary>
+    public IReadOnlyDictionary<string, string> ApplicationInfo { get; init; } = new Dictionary<string, string>();
+
+    /// <summary>
     /// Gets or sets how JSON columns are returned when reading data.
     /// Binary (default): Returns System.Text.Json.Nodes.JsonObject
     /// String: Returns the raw JSON string (requires server setting output_format_binary_write_json_as_string=1)
@@ -394,8 +425,22 @@ public class ClickHouseClientSettings : IEquatable<ClickHouseClientSettings>
                ParameterTypeResolver == other.ParameterTypeResolver &&
                ParameterFormatter == other.ParameterFormatter &&
                Roles.SequenceEqual(other.Roles) &&
-               CustomHeaders.Count == other.CustomHeaders.Count &&
-               CustomHeaders.All(kvp => other.CustomHeaders.TryGetValue(kvp.Key, out var value) && kvp.Value == value);
+               DictionaryEquals(CustomHeaders, other.CustomHeaders) &&
+               DictionaryEquals(ApplicationInfo, other.ApplicationInfo);
+    }
+
+    private static bool DictionaryEquals<TKey, TValue>(IReadOnlyDictionary<TKey, TValue> a, IReadOnlyDictionary<TKey, TValue> b)
+    {
+        var countA = a?.Count ?? 0;
+        var countB = b?.Count ?? 0;
+        if (countA != countB) return false;
+
+        foreach (var kvp in a)
+        {
+            if (!b.TryGetValue(kvp.Key, out var v) || !EqualityComparer<TValue>.Default.Equals(kvp.Value, v))
+                return false;
+        }
+        return true;
     }
 
     /// <summary>
@@ -441,9 +486,15 @@ public class ClickHouseClientSettings : IEquatable<ClickHouseClientSettings>
         {
             hash.Add(role);
         }
-        foreach (var kvp in CustomHeaders)
+        if (CustomHeaders != null)
         {
-            hash.Add(HashCode.Combine(kvp.Key, kvp.Value));
+            foreach (var kvp in CustomHeaders)
+                hash.Add(HashCode.Combine(kvp.Key, kvp.Value));
+        }
+        if (ApplicationInfo != null)
+        {
+            foreach (var kvp in ApplicationInfo)
+                hash.Add(HashCode.Combine(kvp.Key, kvp.Value));
         }
         return hash.ToHashCode();
     }

--- a/ClickHouse.Driver/ADO/ClickHouseClientSettings.cs
+++ b/ClickHouse.Driver/ADO/ClickHouseClientSettings.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using ClickHouse.Driver.ADO.Parameters;
+using ClickHouse.Driver.Utility;
 using Microsoft.Extensions.Logging;
 
 namespace ClickHouse.Driver.ADO;
@@ -284,7 +285,7 @@ public class ClickHouseClientSettings : IEquatable<ClickHouseClientSettings>
     /// <para>
     /// <b>Values</b> are sanitized to keep the header RFC 7230-compliant and capped at
     /// 256 characters (longer values are truncated). Non-ASCII characters are URL-encoded;
-    /// structural characters (<c>( ) \ ; , :</c>) and control characters become <c>|</c>.
+    /// structural characters (<c>( ) \ ; ,</c>) and control characters become <c>|</c>.
     /// Spaces are preserved. Entries whose value is empty after sanitization are skipped.
     /// </para>
     /// <para>
@@ -293,7 +294,7 @@ public class ClickHouseClientSettings : IEquatable<ClickHouseClientSettings>
     /// dictionary you passed in <em>after</em> the client has been constructed has no effect
     /// on subsequent requests and is not supported, pass a fresh settings instance instead.
     /// </para>
-    /// Default: empty dictionary (no token appended).
+    /// Default: empty dictionary (no additional tags appended).
     /// </summary>
     public IReadOnlyDictionary<string, string> ApplicationInfo { get; init; } = new Dictionary<string, string>();
 
@@ -425,22 +426,8 @@ public class ClickHouseClientSettings : IEquatable<ClickHouseClientSettings>
                ParameterTypeResolver == other.ParameterTypeResolver &&
                ParameterFormatter == other.ParameterFormatter &&
                Roles.SequenceEqual(other.Roles) &&
-               DictionaryEquals(CustomHeaders, other.CustomHeaders) &&
-               DictionaryEquals(ApplicationInfo, other.ApplicationInfo);
-    }
-
-    private static bool DictionaryEquals<TKey, TValue>(IReadOnlyDictionary<TKey, TValue> a, IReadOnlyDictionary<TKey, TValue> b)
-    {
-        var countA = a?.Count ?? 0;
-        var countB = b?.Count ?? 0;
-        if (countA != countB) return false;
-
-        foreach (var kvp in a)
-        {
-            if (!b.TryGetValue(kvp.Key, out var v) || !EqualityComparer<TValue>.Default.Equals(kvp.Value, v))
-                return false;
-        }
-        return true;
+               CustomHeaders.EntriesEqual(other.CustomHeaders) &&
+               ApplicationInfo.EntriesEqual(other.ApplicationInfo);
     }
 
     /// <summary>

--- a/ClickHouse.Driver/ClickHouseClient.cs
+++ b/ClickHouse.Driver/ClickHouseClient.cs
@@ -59,6 +59,7 @@ public sealed class ClickHouseClient : IClickHouseClient
     private readonly string httpClientName;
     private readonly Uri serverUri;
     private readonly ILoggerFactory loggerFactory;
+    private readonly UserAgentProvider userAgentProvider;
 
     private static readonly RecyclableMemoryStreamManager CommonMemoryStreamManager = new(new RecyclableMemoryStreamManager.Options
     {
@@ -137,6 +138,7 @@ public sealed class ClickHouseClient : IClickHouseClient
 
         httpClientFactory = CreateHttpClientFactory(settings);
         schemaResolver = new SchemaResolver(this);
+        userAgentProvider = new UserAgentProvider(Settings.ApplicationInfo);
     }
 
     /// <summary>
@@ -840,8 +842,6 @@ public sealed class ClickHouseClient : IClickHouseClient
     /// </summary>
     internal void AddDefaultHttpHeaders(HttpRequestHeaders headers, QueryOptions queryOverride = null)
     {
-        var userAgentInfo = UserAgentProvider.Info;
-
         // Priority: override > connection-level bearer token > basic auth
         var bearerToken = queryOverride?.BearerToken ?? Settings.BearerToken;
         if (!string.IsNullOrEmpty(bearerToken))
@@ -855,8 +855,8 @@ public sealed class ClickHouseClient : IClickHouseClient
                 Convert.ToBase64String(Encoding.UTF8.GetBytes($"{Settings.Username}:{Settings.Password}")));
         }
 
-        headers.UserAgent.Add(userAgentInfo.DriverProductInfo);
-        headers.UserAgent.Add(userAgentInfo.SystemProductInfo);
+        headers.UserAgent.Add(userAgentProvider.DriverProductInfo);
+        headers.UserAgent.Add(userAgentProvider.MetadataProductInfo);
         headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
         headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/csv"));
         headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/octet-stream"));

--- a/ClickHouse.Driver/PublicAPI/PublicAPI.Unshipped.txt
+++ b/ClickHouse.Driver/PublicAPI/PublicAPI.Unshipped.txt
@@ -15,6 +15,8 @@ ClickHouse.Driver.ADO.ClickHouseClientSettings.Roles.get -> System.Collections.G
 ClickHouse.Driver.ADO.ClickHouseClientSettings.Roles.init -> void
 ClickHouse.Driver.ADO.ClickHouseClientSettings.CustomHeaders.get -> System.Collections.Generic.IReadOnlyDictionary<string, string>
 ClickHouse.Driver.ADO.ClickHouseClientSettings.CustomHeaders.init -> void
+ClickHouse.Driver.ADO.ClickHouseClientSettings.ApplicationInfo.get -> System.Collections.Generic.IReadOnlyDictionary<string, string>
+ClickHouse.Driver.ADO.ClickHouseClientSettings.ApplicationInfo.init -> void
 ClickHouse.Driver.ADO.ClickHouseClientSettings.Equals(ClickHouse.Driver.ADO.ClickHouseClientSettings other) -> bool
 ClickHouse.Driver.ADO.ClickHouseClientSettings.Host.get -> string
 ClickHouse.Driver.ADO.ClickHouseClientSettings.Host.init -> void

--- a/ClickHouse.Driver/Utility/DictionaryExtensions.cs
+++ b/ClickHouse.Driver/Utility/DictionaryExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Collections.Specialized;
 
 namespace ClickHouse.Driver.Utility;
 
@@ -31,5 +30,29 @@ internal static class DictionaryExtensions
         {
             dictionary.Remove(key);
         }
+    }
+
+    /// <summary>
+    /// Compares two read-only dictionaries entry by entry. Treats <c>null</c> and an empty
+    /// dictionary as equivalent. Value comparison uses
+    /// <see cref="EqualityComparer{TValue}.Default"/> — not deep: nested collections or
+    /// objects are compared via their own <c>Equals</c> implementation (reference equality
+    /// for reference types unless overridden).
+    /// </summary>
+    public static bool EntriesEqual<TKey, TValue>(
+        this IReadOnlyDictionary<TKey, TValue> a,
+        IReadOnlyDictionary<TKey, TValue> b)
+    {
+        var countA = a?.Count ?? 0;
+        var countB = b?.Count ?? 0;
+        if (countA != countB) return false;
+        if (countA == 0) return true; // both null/empty
+
+        foreach (var kvp in a)
+        {
+            if (!b.TryGetValue(kvp.Key, out var v) || !EqualityComparer<TValue>.Default.Equals(kvp.Value, v))
+                return false;
+        }
+        return true;
     }
 }

--- a/ClickHouse.Driver/Utility/UserAgentProvider.cs
+++ b/ClickHouse.Driver/Utility/UserAgentProvider.cs
@@ -137,7 +137,6 @@ internal sealed class UserAgentProvider
                 case '\\':
                 case ';':
                 case ',':
-                case ':':
                     sb.Append('|');
                     continue;
             }

--- a/ClickHouse.Driver/Utility/UserAgentProvider.cs
+++ b/ClickHouse.Driver/Utility/UserAgentProvider.cs
@@ -1,93 +1,167 @@
 using System;
-using System.Linq;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Text;
 
 namespace ClickHouse.Driver.Utility;
 
 /// <summary>
-/// Provides cached user agent information for HTTP headers.
-/// System information is looked up once and cached for the lifetime of the application.
+/// Per-client User-Agent token holder. Exposes <see cref="DriverProductInfo"/> and
+/// <see cref="MetadataProductInfo"/> as the two <see cref="ProductInfoHeaderValue"/>
+/// items the client adds to the <c>User-Agent</c> header. The driver/runtime parts are
+/// initialized once per process; the metadata comment token (system tags + caller-supplied
+/// <c>ApplicationInfo</c>) is built once per instance.
 /// </summary>
-internal static class UserAgentProvider
+internal sealed class UserAgentProvider
 {
-    private static readonly Lazy<CachedUserAgentInfo> LazyInfo = new Lazy<CachedUserAgentInfo>(() => new CachedUserAgentInfo());
+    private const int MaxKeyLength = 32;
+    private const int MaxValueLength = 256;
 
-    public static CachedUserAgentInfo Info => LazyInfo.Value;
+    private static readonly ProductInfoHeaderValue StaticDriverProductInfo;
+    private static readonly IReadOnlyDictionary<string, string> StaticSystemTags;
 
-    internal sealed class CachedUserAgentInfo
+    static UserAgentProvider()
     {
-        public CachedUserAgentInfo()
+        ProductInfoHeaderValue driver = null;
+        IReadOnlyDictionary<string, string> tags = null;
+        try
         {
-            try
+            var versionAndHash = Assembly
+                .GetExecutingAssembly()
+                .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+                .InformationalVersion ?? "unknown";
+            var version = versionAndHash.Split('+')[0];
+            driver = new ProductInfoHeaderValue("ClickHouse.Driver", version);
+
+            tags = new Dictionary<string, string>
             {
-                // Get assembly version
-                string versionAndHash = Assembly
-                    .GetExecutingAssembly()
-                    .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
-                    .InformationalVersion ?? "unknown";
-                var version = versionAndHash.Split('+')[0];
-                DriverProductInfo = new ProductInfoHeaderValue("ClickHouse.Driver", version);
-
-                // Get OS information
-                var osPlatform = Environment.OSVersion.Platform.ToString();
-                var osDescription = ContainsNonAscii(System.Runtime.InteropServices.RuntimeInformation.OSDescription) // Some OSs have weird characters in here, which are not allowed in headers!
-                    ? WebUtility.UrlEncode(System.Runtime.InteropServices.RuntimeInformation.OSDescription)
-                    : System.Runtime.InteropServices.RuntimeInformation.OSDescription;
-                var architecture = System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture.ToString();
-
-                // Sanitize
-                osPlatform = SanitizeString(osPlatform);
-                osDescription = SanitizeString(osDescription);
-                architecture = SanitizeString(architecture);
-
-                // Get runtime information
-                var runtime = Environment.Version.ToString();
-
-                // Pre-build ProductInfoHeaderValue objects
-                SystemProductInfo = new ProductInfoHeaderValue($"(platform:{osPlatform}; os:{osDescription}; lv:{runtime}; arch:{architecture})");
-            }
-            catch
-            {
-                // If anything fails during initialization, create fallback values
-                DriverProductInfo ??= new ProductInfoHeaderValue("ClickHouse.Driver", "unknown");
-                SystemProductInfo = new ProductInfoHeaderValue("(platform:unknown; os:unknown; lv:unknown; arch:unknown)");
-            }
+                ["platform"] = Environment.OSVersion.Platform.ToString(),
+                ["os"] = RuntimeInformation.OSDescription,
+                ["lv"] = Environment.Version.ToString(),
+                ["arch"] = RuntimeInformation.ProcessArchitecture.ToString(),
+            };
+        }
+        catch
+        {
+            // Falls through to the fallback values below.
         }
 
-        private static bool ContainsNonAscii(string value)
+        StaticDriverProductInfo = driver ?? new ProductInfoHeaderValue("ClickHouse.Driver", "unknown");
+        StaticSystemTags = tags ?? new Dictionary<string, string>
         {
-            if (value is null)
-            {
-                return false;
-            }
+            ["platform"] = "unknown",
+            ["os"] = "unknown",
+            ["lv"] = "unknown",
+            ["arch"] = "unknown",
+        };
+    }
 
-            return value.Any(c => (int)c > 0x7f);
+    public UserAgentProvider(IReadOnlyDictionary<string, string> applicationInfo)
+    {
+        MetadataProductInfo = BuildMetadataHeader(StaticSystemTags, applicationInfo);
+    }
+
+    /// <summary>
+    /// Driver product token, e.g. <c>ClickHouse.Driver/1.0.0</c>. Shared across all instances.
+    /// </summary>
+    public ProductInfoHeaderValue DriverProductInfo => StaticDriverProductInfo;
+
+    /// <summary>
+    /// Comment-style metadata token built from the runtime/OS tags and any caller-supplied
+    /// <c>ApplicationInfo</c> (e.g. <c>(platform:Unix; os:...; lv:...; arch:...; app:MyApp)</c>).
+    /// </summary>
+    public ProductInfoHeaderValue MetadataProductInfo { get; }
+
+    private static ProductInfoHeaderValue BuildMetadataHeader(
+        IReadOnlyDictionary<string, string> systemTags,
+        IReadOnlyDictionary<string, string> applicationInfo)
+    {
+        var sb = new StringBuilder();
+        sb.Append('(');
+        AppendEntries(sb, systemTags);
+        AppendEntries(sb, applicationInfo);
+        sb.Append(')');
+        return new ProductInfoHeaderValue(sb.ToString());
+    }
+
+    private static void AppendEntries(StringBuilder sb, IReadOnlyDictionary<string, string> info)
+    {
+        if (info == null || info.Count == 0)
+            return;
+
+        foreach (var kvp in info)
+        {
+            ValidateKey(kvp.Key);
+            var sanitized = SanitizeValue(kvp.Value);
+            if (string.IsNullOrEmpty(sanitized))
+                continue;
+            // Length == 1 means we've only written the opening '('; no separator needed yet.
+            if (sb.Length > 1) sb.Append("; ");
+            sb.Append(kvp.Key).Append(':').Append(sanitized);
+        }
+    }
+
+    private static void ValidateKey(string key)
+    {
+        if (string.IsNullOrEmpty(key))
+            throw new ArgumentException("User-Agent tag keys cannot be null or empty.", nameof(key));
+        if (key.Length > MaxKeyLength)
+            throw new ArgumentException($"User-Agent tag key '{key}' exceeds maximum length of {MaxKeyLength}.", nameof(key));
+        for (int i = 0; i < key.Length; i++)
+        {
+            var c = key[i];
+            bool ok = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_' || c == '.' || c == '-';
+            if (!ok)
+                throw new ArgumentException($"User-Agent tag key '{key}' contains disallowed character '{c}'. Allowed: [A-Za-z0-9_.-].", nameof(key));
+        }
+    }
+
+    private static string SanitizeValue(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+            return string.Empty;
+
+        if (ContainsNonAscii(value))
+            value = WebUtility.UrlEncode(value);
+
+        var sb = new StringBuilder(value.Length);
+        foreach (var ch in value)
+        {
+            switch (ch)
+            {
+                case '(':
+                case ')':
+                case '\\':
+                case ';':
+                case ',':
+                case ':':
+                    sb.Append('|');
+                    continue;
+            }
+            if (ch < 0x20 || ch == 0x7F)
+            {
+                sb.Append('|');
+                continue;
+            }
+            sb.Append(ch);
         }
 
-        /// <summary>
-        /// To avoid parsing issues, we want to remove any semicolons
-        /// </summary>
-        private static string SanitizeString(string value)
+        var sanitized = sb.ToString();
+        if (sanitized.Length > MaxValueLength)
+            sanitized = sanitized.Substring(0, MaxValueLength);
+        return sanitized;
+    }
+
+    private static bool ContainsNonAscii(string value)
+    {
+        if (value is null) return false;
+        for (int i = 0; i < value.Length; i++)
         {
-            if (value is null)
-            {
-                return string.Empty;
-            }
-
-            return value.Replace(';', '|');
+            if (value[i] > 0x7F) return true;
         }
-
-        /// <summary>
-        /// Gets the driver ProductInfoHeaderValue (e.g., "ClickHouse.Driver/1.0.0").
-        /// </summary>
-        public ProductInfoHeaderValue DriverProductInfo { get; }
-
-        /// <summary>
-        /// Gets the system ProductInfoHeaderValue with platform, OS, runtime, and architecture information.
-        /// </summary>
-        public ProductInfoHeaderValue SystemProductInfo { get; }
+        return false;
     }
 }

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,6 +1,9 @@
 v1.4.0
 ---
 
+**New Features:**
+* **Application-identity tagging in User-Agent**: new `ClickHouseClientSettings.ApplicationInfo` property: an `IReadOnlyDictionary<string, string>` of free-form tags (e.g. `app`, `ver`, `env`) appended to the HTTP `User-Agent` header as a comment token (e.g. `(app:MyApp; ver:2.3.1; env:prod)`).
+
 **Bug Fixes:**
 * **Breaking Change**: Fixed timezone shift for `@`-style `DateTime`/`DateTimeOffset` parameters on non-UTC servers (issue #350). When a parameter's ClickHouse type was inferred (no explicit `{name:Type}` hint in SQL and no `parameter.ClickHouseType` set), the driver previously emitted a bare `DateTime` hint and the server parsed the wire wall-clock in `session_timezone`/server tz — silently shifting instant-bearing values by the server's offset. Inferred types for `DateTime { Kind: Utc or Local }` and `DateTimeOffset` are now sent as `DateTime('UTC')`, preserving the instant across any server timezone. Explicit hints (`{name:DateTime}` in SQL or `parameter.ClickHouseType`) are untouched, users who specify the type continue to own timezone correctness.
 


### PR DESCRIPTION
Adds a new ApplicationInfo property to the client settings that allows users to add metadata to the user agent string. Keys/Values are validated/sanitized.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive HTTP metadata only; no query, auth, or data-path changes beyond header formatting, with broad unit/integration coverage.
> 
> **Overview**
> Adds **`ClickHouseClientSettings.ApplicationInfo`**: optional `app` / `ver` / `env`-style tags merged into the HTTP **`User-Agent`** comment token alongside existing runtime tags (`platform`, `os`, `lv`, `arch`), e.g. `(app:MyApp; ver:2.3.1; …)`.
> 
> **`UserAgentProvider`** is now **per-client** (built at `ClickHouseClient` construction) instead of a process-wide static; keys are validated (`[A-Za-z0-9_.-]`, max 32 chars, invalid keys throw on construct), values are sanitized/truncated (256 chars, URL-encode non-ASCII, strip structural chars). Settings **copy**, **equals**, and **hash** include `ApplicationInfo` via new **`EntriesEqual`** on dictionaries. Release notes and public API surface are updated; integration test asserts tags appear in **`system.query_log.http_user_agent`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70bb32bfa44915bf0053ae3b0469d33a5be31ed5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->