### PR TITLE
Fix StressHouse benchmark workflow: grant pull-requests: write

### DIFF
--- a/.github/workflows/stresshouse-benchmark-compare.yml
+++ b/.github/workflows/stresshouse-benchmark-compare.yml
@@ -23,6 +23,15 @@ on:
         required: true
         type: string
 
+# The reusable workflow posts a sticky results comment on the PR, so it declares
+# pull-requests: write. A reusable workflow can't use more than the caller grants,
+# and this repo's default GITHUB_TOKEN is read-only — so grant it explicitly here,
+# or the call is rejected at validation ("requesting 'pull-requests: write', but is
+# only allowed 'pull-requests: none'").
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   benchmark:
     # Comment path: only on PRs, only `/benchmark-compare`, only from someone

--- a/.github/workflows/stresshouse-benchmark-compare.yml
+++ b/.github/workflows/stresshouse-benchmark-compare.yml
@@ -23,11 +23,6 @@ on:
         required: true
         type: string
 
-# The reusable workflow posts a sticky results comment on the PR, so it declares
-# pull-requests: write. A reusable workflow can't use more than the caller grants,
-# and this repo's default GITHUB_TOKEN is read-only — so grant it explicitly here,
-# or the call is rejected at validation ("requesting 'pull-requests: write', but is
-# only allowed 'pull-requests: none'").
 permissions:
   contents: read
   pull-requests: write


### PR DESCRIPTION
The `/benchmark-compare` workflow fails at validation with:

> Invalid workflow file … `.github/workflows/stresshouse-benchmark-compare.yml` (Line: 27): Error calling workflow '…/clickhouse-benchmark.yml@main'. The workflow is requesting `pull-requests: write`, but is only allowed `pull-requests: none`.

**Cause:** the shared reusable workflow declares `pull-requests: write` (it posts the results comment on the PR). A reusable workflow can't use more permissions than the caller grants, and this repo's default `GITHUB_TOKEN` is read-only — so the caller was implicitly granting `pull-requests: none`, and the call is rejected before any job starts (`startup_failure`).

**Fix:** declare the permissions explicitly on the caller:
```yaml
permissions:
  contents: read
  pull-requests: write
```

Not a secrets issue — `WORKFLOW_AUTH_PUBLIC_APP_ID` / `WORKFLOW_AUTH_PUBLIC_PRIVATE_KEY` are present as org secrets and forwarded via `secrets: inherit`.

The copy-paste templates in `clickhouse-client-benchmarks/docs/client-workflows/` are being updated with the same block so other client repos don't hit this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)