### PR TITLE
TCP A: Wire primitives & buffered I/O

### DIFF
--- a/.github/workflows/tests-tcp.yml
+++ b/.github/workflows/tests-tcp.yml
@@ -1,0 +1,70 @@
+name: TCP Tests
+
+# Runs the ClickHouse.Driver.Tcp test suite, gated on changes to the TCP projects only.
+# The TCP project is standalone (no reference to ClickHouse.Driver), so its build/test closure is just
+# the two TCP projects plus the shared package versions.
+on:
+  push:
+    branches: [main, tcp-client] # tcp-client is the long-lived feature branch that the per-epic PRs stack onto
+    paths:
+      - "ClickHouse.Driver.Tcp/**"
+      - "ClickHouse.Driver.Tcp.Tests/**"
+      - "Directory.Packages.props"
+      - ".github/workflows/tests-tcp.yml"
+  pull_request:
+    branches: [main, tcp-client]
+    paths:
+      - "ClickHouse.Driver.Tcp/**"
+      - "ClickHouse.Driver.Tcp.Tests/**"
+      - "Directory.Packages.props"
+      - ".github/workflows/tests-tcp.yml"
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch, tag, or commit SHA to run on"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: TCP Tests (${{ matrix.framework }})
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        framework: ["net8.0", "net9.0", "net10.0"] # TCP library targets net8.0+ only
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - uses: actions/cache@v6
+        name: Cache NuGet
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', 'Directory.Packages.props') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: |
+            8.x
+            9.x
+            10.x
+
+      - name: Test
+        run: >
+          dotnet test ClickHouse.Driver.Tcp.Tests/ClickHouse.Driver.Tcp.Tests.csproj
+          --framework ${{ matrix.framework }}
+          --configuration Release
+          --verbosity normal
+          --logger GitHubActions
+          /clp:ErrorsOnly

--- a/ClickHouse.Driver.Tcp.Tests/Numerics/Int256Tests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Numerics/Int256Tests.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Numerics;
+using ClickHouse.Driver.Tcp.Numerics;
+
+namespace ClickHouse.Driver.Tcp.Tests.Numerics;
+
+[TestFixture]
+public class Int256Tests
+{
+    [Test]
+    public void UInt256_ReadWrite_RoundTripsLittleEndian()
+    {
+        var value = UInt256.FromBigInteger((BigInteger.One << 129) + 7);
+        Span<byte> buffer = stackalloc byte[UInt256.Size];
+        value.WriteLittleEndian(buffer);
+        Assert.That(UInt256.ReadLittleEndian(buffer), Is.EqualTo(value));
+    }
+
+    [Test]
+    public void UInt256_One_IsLittleEndian()
+    {
+        Span<byte> buffer = stackalloc byte[UInt256.Size];
+        UInt256.FromBigInteger(1).WriteLittleEndian(buffer);
+        Assert.That(buffer[0], Is.EqualTo(1));
+        for (int i = 1; i < UInt256.Size; i++)
+        {
+            Assert.That(buffer[i], Is.EqualTo(0), $"byte {i}");
+        }
+    }
+
+    [Test]
+    public void UInt256_Max_RoundTrips()
+    {
+        BigInteger max = (BigInteger.One << 256) - 1;
+        var value = UInt256.FromBigInteger(max);
+        Assert.That(value.ToBigInteger(), Is.EqualTo(max));
+        Assert.That(value.ToString(), Is.EqualTo(max.ToString()));
+    }
+
+    [Test]
+    public void UInt256_Negative_Throws()
+        => Assert.Throws<OverflowException>(() => UInt256.FromBigInteger(-1));
+
+    [Test]
+    public void UInt256_Comparison_Works()
+    {
+        var small = UInt256.FromBigInteger(1);
+        var big = UInt256.FromBigInteger(BigInteger.One << 200);
+        Assert.That(small, Is.LessThan(big));
+        Assert.That(big, Is.GreaterThan(small));
+        Assert.That(small == UInt256.FromBigInteger(1), Is.True);
+    }
+
+    [TestCaseSource(nameof(SignedValues))]
+    public void Int256_RoundTrips(string decimalValue)
+    {
+        BigInteger n = BigInteger.Parse(decimalValue);
+        var value = Int256.FromBigInteger(n);
+        Assert.That(value.ToBigInteger(), Is.EqualTo(n));
+        Assert.That(value.ToString(), Is.EqualTo(decimalValue));
+
+        Span<byte> buffer = stackalloc byte[Int256.Size];
+        value.WriteLittleEndian(buffer);
+        Assert.That(Int256.ReadLittleEndian(buffer), Is.EqualTo(value));
+    }
+
+    [Test]
+    public void Int256_MinusOne_IsAllOnes()
+    {
+        Span<byte> buffer = stackalloc byte[Int256.Size];
+        Int256.FromBigInteger(-1).WriteLittleEndian(buffer);
+        foreach (byte b in buffer)
+        {
+            Assert.That(b, Is.EqualTo(0xFF));
+        }
+    }
+
+    [Test]
+    public void Int256_Sign_And_Comparison()
+    {
+        var negative = Int256.FromBigInteger(-(BigInteger.One << 100));
+        var positive = Int256.FromBigInteger(BigInteger.One << 100);
+        Assert.That(negative.IsNegative, Is.True);
+        Assert.That(positive.IsNegative, Is.False);
+        Assert.That(negative, Is.LessThan(positive));
+        Assert.That(negative, Is.LessThan(Int256.Zero));
+    }
+
+    [Test]
+    public void Int256_OutOfRange_Throws()
+    {
+        Assert.Throws<OverflowException>(() => Int256.FromBigInteger(BigInteger.One << 255));
+        Assert.Throws<OverflowException>(() => Int256.FromBigInteger(-(BigInteger.One << 255) - 1));
+    }
+
+    [TestCase(64)]
+    [TestCase(128)]
+    [TestCase(192)]
+    [TestCase(255)]
+    public void UInt256_PowerOfTwo_HasBitAtExpectedLittleEndianOffset(int exponent)
+    {
+        var value = UInt256.FromBigInteger(BigInteger.One << exponent);
+        Span<byte> buffer = stackalloc byte[UInt256.Size];
+        value.WriteLittleEndian(buffer);
+
+        int byteIndex = exponent / 8;
+        byte expectedByte = (byte)(1 << (exponent % 8));
+        for (int i = 0; i < UInt256.Size; i++)
+        {
+            Assert.That(buffer[i], Is.EqualTo(i == byteIndex ? expectedByte : (byte)0), $"byte {i}");
+        }
+    }
+
+    [Test]
+    public void UInt256_EqualsObject_DifferentType_ReturnsFalse()
+        => Assert.That(UInt256.FromBigInteger(1).Equals("not a uint256"), Is.False);
+
+    [Test]
+    public void UInt256_CompareTo_EqualValues_ReturnsZero()
+        => Assert.That(UInt256.FromBigInteger(12345).CompareTo(UInt256.FromBigInteger(12345)), Is.EqualTo(0));
+
+    [Test]
+    public void Int256_EqualsObject_DifferentType_ReturnsFalse()
+        => Assert.That(Int256.FromBigInteger(-1).Equals(42), Is.False);
+
+    [TestCase("-2", "-1", -1)]
+    [TestCase("-1", "-2", 1)]
+    [TestCase("-5", "-5", 0)]
+    [TestCase("-1", "1", -1)]
+    [TestCase("1", "-1", 1)]
+    public void Int256_CompareTo_SignedOrdering(string a, string b, int expectedSign)
+    {
+        int cmp = Int256.FromBigInteger(BigInteger.Parse(a)).CompareTo(Int256.FromBigInteger(BigInteger.Parse(b)));
+        Assert.That(Math.Sign(cmp), Is.EqualTo(expectedSign));
+    }
+
+    [Test]
+    public void Int256_CompareTo_LargeSameSignNegatives_ComparesHighLimb()
+    {
+        var more = Int256.FromBigInteger(-(BigInteger.One << 193));
+        var less = Int256.FromBigInteger(-(BigInteger.One << 192));
+        Assert.That(more, Is.LessThan(less)); // -2^193 < -2^192
+    }
+
+    private static readonly string[] SignedValues =
+    {
+        "0",
+        "1",
+        "-1",
+        "1606938044258990275541962092341162602522202993782792835301376", // 2^200
+        "-1606938044258990275541962092341162602522202993782792835301376",
+        "57896044618658097711785492504343953926634992332820282019728792003956564819967", // 2^255 - 1 (max)
+        "-57896044618658097711785492504343953926634992332820282019728792003956564819968", // -2^255 (min)
+    };
+}

--- a/ClickHouse.Driver.Tcp.Tests/Protocol/ClickHouseBinaryReaderWriterTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Protocol/ClickHouseBinaryReaderWriterTests.cs
@@ -1,0 +1,376 @@
+using System;
+using System.IO;
+using System.Numerics;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Numerics;
+using ClickHouse.Driver.Tcp.Protocol;
+using ClickHouse.Driver.Tcp.Tests.Utilities;
+
+namespace ClickHouse.Driver.Tcp.Tests.Protocol;
+
+[TestFixture]
+public class ClickHouseBinaryReaderWriterTests
+{
+    private static readonly CancellationToken None = CancellationToken.None;
+
+    // Writes via the writer into a MemoryStream and returns the produced bytes.
+    private static async Task<byte[]> WriteAsync(Action<ClickHouseBinaryWriter> write)
+    {
+        using var ms = new MemoryStream();
+        using (var writer = new ClickHouseBinaryWriter(ms))
+        {
+            write(writer);
+            await writer.FlushAsync(None);
+        }
+
+        return ms.ToArray();
+    }
+
+    private static ClickHouseBinaryReader ReaderOver(byte[] bytes, int bufferSize = 16384)
+        => new(new MemoryStream(bytes), bufferSize);
+
+    [Test]
+    public async Task WriteVarUInt_KnownValues_ProducesSpecBytes()
+    {
+        // Native-format spec: 300 encodes as AC 02.
+        var bytes = await WriteAsync(w => w.WriteVarUInt(300));
+        CollectionAssert.AreEqual(new byte[] { 0xAC, 0x02 }, bytes);
+    }
+
+    [TestCase(0UL)]
+    [TestCase(1UL)]
+    [TestCase(127UL)]
+    [TestCase(128UL)]
+    [TestCase(300UL)]
+    [TestCase(16383UL)]
+    [TestCase(16384UL)]
+    [TestCase(2097151UL)]
+    [TestCase(ulong.MaxValue)]
+    public async Task VarUInt_RoundTrips(ulong value)
+    {
+        var bytes = await WriteAsync(w => w.WriteVarUInt(value));
+        using var reader = ReaderOver(bytes);
+        Assert.That(await reader.ReadVarUIntAsync(None), Is.EqualTo(value));
+    }
+
+    [Test]
+    public async Task WriteUInt32_One_IsLittleEndian()
+    {
+        var bytes = await WriteAsync(w => w.WriteUInt32(1));
+        CollectionAssert.AreEqual(new byte[] { 0x01, 0x00, 0x00, 0x00 }, bytes);
+    }
+
+    [Test]
+    public async Task WriteInt32_MinusOne_IsAllOnes()
+    {
+        var bytes = await WriteAsync(w => w.WriteInt32(-1));
+        CollectionAssert.AreEqual(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF }, bytes);
+    }
+
+    [Test]
+    public async Task WriteUInt32_Sequence_MatchesSpecExample()
+    {
+        // Native-format spec example: a UInt32 column holding [1, 256, 65536].
+        var bytes = await WriteAsync(w =>
+        {
+            w.WriteUInt32(1);
+            w.WriteUInt32(256);
+            w.WriteUInt32(65536);
+        });
+        CollectionAssert.AreEqual(
+            new byte[] { 0x01, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00 },
+            bytes);
+    }
+
+    [Test]
+    public async Task String_Ab_MatchesSpecBytes()
+    {
+        var bytes = await WriteAsync(w => w.WriteString("ab"));
+        CollectionAssert.AreEqual(new byte[] { 0x02, 0x61, 0x62 }, bytes);
+    }
+
+    [Test]
+    public async Task String_Empty_IsSingleZeroByte()
+    {
+        var bytes = await WriteAsync(w => w.WriteString(string.Empty));
+        CollectionAssert.AreEqual(new byte[] { 0x00 }, bytes);
+        using var reader = ReaderOver(bytes);
+        Assert.That(await reader.ReadStringAsync(None), Is.EqualTo(string.Empty));
+    }
+
+    [TestCase("")]
+    [TestCase("ab")]
+    [TestCase("héllo ☃ world")]
+    public async Task String_RoundTrips(string value)
+    {
+        var bytes = await WriteAsync(w => w.WriteString(value));
+        using var reader = ReaderOver(bytes);
+        Assert.That(await reader.ReadStringAsync(None), Is.EqualTo(value));
+    }
+
+    [Test]
+    public async Task StringBytes_PreservesNonUtf8AndEmbeddedNul()
+    {
+        byte[] raw = { 0x00, 0xFF, 0x10, 0x00 };
+        var bytes = await WriteAsync(w => w.WriteString(raw));
+        using var reader = ReaderOver(bytes);
+        CollectionAssert.AreEqual(raw, await reader.ReadStringBytesAsync(None));
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public async Task Bool_RoundTrips(bool value)
+    {
+        var bytes = await WriteAsync(w => w.WriteBool(value));
+        Assert.That(bytes, Is.EqualTo(new[] { value ? (byte)1 : (byte)0 }));
+        using var reader = ReaderOver(bytes);
+        Assert.That(await reader.ReadBoolAsync(None), Is.EqualTo(value));
+    }
+
+    [Test]
+    public async Task FixedWidth_RoundTripAcrossAllWidths()
+    {
+        var bytes = await WriteAsync(w =>
+        {
+            w.WriteUInt8(200);
+            w.WriteInt8(-100);
+            w.WriteUInt16(60000);
+            w.WriteInt16(-30000);
+            w.WriteUInt32(4_000_000_000);
+            w.WriteInt32(-2_000_000_000);
+            w.WriteUInt64(ulong.MaxValue);
+            w.WriteInt64(long.MinValue);
+            w.WriteFloat32(3.5f);
+            w.WriteFloat64(-1.25);
+        });
+
+        using var reader = ReaderOver(bytes);
+        Assert.That(await reader.ReadUInt8Async(None), Is.EqualTo(200));
+        Assert.That(await reader.ReadInt8Async(None), Is.EqualTo(-100));
+        Assert.That(await reader.ReadUInt16Async(None), Is.EqualTo(60000));
+        Assert.That(await reader.ReadInt16Async(None), Is.EqualTo(-30000));
+        Assert.That(await reader.ReadUInt32Async(None), Is.EqualTo(4_000_000_000));
+        Assert.That(await reader.ReadInt32Async(None), Is.EqualTo(-2_000_000_000));
+        Assert.That(await reader.ReadUInt64Async(None), Is.EqualTo(ulong.MaxValue));
+        Assert.That(await reader.ReadInt64Async(None), Is.EqualTo(long.MinValue));
+        Assert.That(await reader.ReadFloat32Async(None), Is.EqualTo(3.5f));
+        Assert.That(await reader.ReadFloat64Async(None), Is.EqualTo(-1.25));
+    }
+
+    [Test]
+    public async Task WriteUInt128_One_IsLittleEndian()
+    {
+        var bytes = await WriteAsync(w => w.WriteUInt128(1));
+        var expected = new byte[16];
+        expected[0] = 1;
+        CollectionAssert.AreEqual(expected, bytes);
+    }
+
+    [Test]
+    public async Task WriteInt128_MinusOne_IsAllOnes()
+    {
+        var bytes = await WriteAsync(w => w.WriteInt128(-1));
+        var expected = new byte[16];
+        Array.Fill(expected, (byte)0xFF);
+        CollectionAssert.AreEqual(expected, bytes);
+    }
+
+    [Test]
+    public async Task WriteUInt128_HighHalf_LandsInUpperBytes()
+    {
+        // 2^64 → byte 8 = 0x01, everything else 0 (proves low/high ulong ordering independently of the reader).
+        var bytes = await WriteAsync(w => w.WriteUInt128((UInt128)1 << 64));
+        var expected = new byte[16];
+        expected[8] = 1;
+        CollectionAssert.AreEqual(expected, bytes);
+    }
+
+    [Test]
+    public async Task Writer_WriteBytes_LargerThanBuffer_GrowsAndPreservesData()
+    {
+        byte[] payload = new byte[1000];
+        for (int i = 0; i < payload.Length; i++)
+        {
+            payload[i] = (byte)(i * 17);
+        }
+
+        using var ms = new MemoryStream();
+        using (var writer = new ClickHouseBinaryWriter(ms, bufferSize: 32))
+        {
+            writer.WriteBytes(payload); // exceeds the 32-byte buffer, forcing growth
+            await writer.FlushAsync(None);
+        }
+
+        CollectionAssert.AreEqual(payload, ms.ToArray());
+    }
+
+    [Test]
+    public async Task Writer_ManySmallWrites_ExceedingBuffer_GrowAndRoundTrip()
+    {
+        using var ms = new MemoryStream();
+        using (var writer = new ClickHouseBinaryWriter(ms, bufferSize: 32))
+        {
+            for (ulong i = 0; i < 100; i++)
+            {
+                writer.WriteUInt64(i);
+            }
+
+            await writer.FlushAsync(None);
+        }
+
+        using var reader = ReaderOver(ms.ToArray());
+        for (ulong i = 0; i < 100; i++)
+        {
+            Assert.That(await reader.ReadUInt64Async(None), Is.EqualTo(i));
+        }
+    }
+
+    [Test]
+    public async Task ReadStringAsync_InvalidUtf8_DecodesToReplacementCharacter()
+    {
+        byte[] invalid = { 0xFF, 0xFE, 0x80 };
+        var bytes = await WriteAsync(w => w.WriteString(invalid));
+        using var reader = ReaderOver(bytes);
+        string decoded = await reader.ReadStringAsync(None);
+        Assert.That(decoded, Does.Contain("�"), "invalid UTF-8 should surface as the replacement char");
+    }
+
+    [Test]
+    public async Task Wide_Integers_RoundTrip()
+    {
+        UInt128 u128 = (UInt128)ulong.MaxValue + 12345;
+        Int128 i128 = -((Int128)ulong.MaxValue + 12345);
+        var u256 = UInt256.FromBigInteger((BigInteger.One << 200) + 42);
+        var i256 = Int256.FromBigInteger(-((BigInteger.One << 200) + 42));
+
+        var bytes = await WriteAsync(w =>
+        {
+            w.WriteUInt128(u128);
+            w.WriteInt128(i128);
+            w.WriteUInt256(u256);
+            w.WriteInt256(i256);
+        });
+
+        using var reader = ReaderOver(bytes);
+        Assert.That(await reader.ReadUInt128Async(None), Is.EqualTo(u128));
+        Assert.That(await reader.ReadInt128Async(None), Is.EqualTo(i128));
+        Assert.That(await reader.ReadUInt256Async(None), Is.EqualTo(u256));
+        Assert.That(await reader.ReadInt256Async(None), Is.EqualTo(i256));
+    }
+
+    [Test]
+    public async Task ReadBytes_SpansBufferBoundary_WithTinyBuffer()
+    {
+        // A 4 KB payload read through a 64-byte buffer forces many refills.
+        byte[] payload = new byte[4096];
+        for (int i = 0; i < payload.Length; i++)
+        {
+            payload[i] = (byte)(i * 31);
+        }
+
+        var bytes = await WriteAsync(w => w.WriteString(payload));
+        using var reader = ReaderOver(bytes, bufferSize: 64);
+        CollectionAssert.AreEqual(payload, await reader.ReadStringBytesAsync(None));
+    }
+
+    [Test]
+    public void ReadPastEnd_Throws()
+    {
+        using var reader = ReaderOver(new byte[] { 0x01 });
+        Assert.ThrowsAsync<EndOfStreamException>(async () =>
+        {
+            await reader.ReadUInt32Async(None);
+        });
+    }
+
+    [Test]
+    public void VarUInt_Overlong_Throws()
+    {
+        // 11 continuation bytes: never terminates within the 10-byte limit.
+        byte[] overlong = new byte[11];
+        for (int i = 0; i < overlong.Length; i++)
+        {
+            overlong[i] = 0x80;
+        }
+
+        using var reader = ReaderOver(overlong);
+        Assert.ThrowsAsync<InvalidDataException>(async () =>
+        {
+            await reader.ReadVarUIntAsync(None);
+        });
+    }
+
+    [Test]
+    public async Task ReadVarUIntAsync_MaximumUInt64Encoding_ReturnsMaximumValue()
+    {
+        byte[] maximum = { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01 };
+
+        using var reader = ReaderOver(maximum);
+        Assert.That(await reader.ReadVarUIntAsync(None), Is.EqualTo(ulong.MaxValue));
+    }
+
+    [Test]
+    public async Task ReadVarUIntAsync_TenthByteRequiresRefill_ReturnsMaximumValue()
+    {
+        byte[] maximum = { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01 };
+        var stream = new ChunkedStream(maximum, maxChunk: 9);
+
+        using var reader = new ClickHouseBinaryReader(stream, bufferSize: 32);
+        Assert.That(await reader.ReadVarUIntAsync(None), Is.EqualTo(ulong.MaxValue));
+        Assert.That(stream.ReadCount, Is.EqualTo(2));
+    }
+
+    [Test]
+    public async Task ReadVarUIntAsync_NonCanonicalTenByteZero_ReturnsZero()
+    {
+        byte[] nonCanonicalZero = { 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x00 };
+
+        using var reader = ReaderOver(nonCanonicalZero);
+        Assert.That(await reader.ReadVarUIntAsync(None), Is.Zero);
+    }
+
+    [TestCase(0x02)]
+    [TestCase(0x7F)]
+    [TestCase(0x80)]
+    [TestCase(0x81)]
+    public void ReadVarUIntAsync_InvalidTenthByte_ThrowsInvalidDataException(byte tenthByte)
+    {
+        byte[] overflowing = { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, tenthByte };
+
+        using var reader = ReaderOver(overflowing);
+        Assert.ThrowsAsync<InvalidDataException>(async () => await reader.ReadVarUIntAsync(None));
+    }
+
+    [Test]
+    public async Task ReadStringAsync_LengthExceedsMaximum_ThrowsBeforeAllocating()
+    {
+        // A length prefix past the cap must be rejected up front, not drive a huge allocation. The body is
+        // absent on purpose: the guard has to fire before any attempt to read it.
+        byte[] oversizedPrefix = await WriteAsync(w => w.WriteVarUInt((1UL << 30) + 1));
+
+        using var reader = ReaderOver(oversizedPrefix);
+        Assert.ThrowsAsync<InvalidDataException>(async () =>
+        {
+            await reader.ReadStringAsync(None);
+        });
+    }
+
+    [Test]
+    public void Writer_FlushAsync_AfterDispose_ThrowsObjectDisposed()
+    {
+        var writer = new ClickHouseBinaryWriter(new MemoryStream());
+        writer.Dispose();
+        Assert.ThrowsAsync<ObjectDisposedException>(async () => await writer.FlushAsync(None));
+    }
+
+    [Test]
+    public void Writer_WriteRequiringGrowth_AfterDispose_ThrowsObjectDisposed()
+    {
+        // After dispose the backing buffer is empty, so any write hits the grow path — which must throw rather
+        // than rent a fresh buffer that Dispose would never return to the pool.
+        var writer = new ClickHouseBinaryWriter(new MemoryStream());
+        writer.Dispose();
+        Assert.Throws<ObjectDisposedException>(() => writer.WriteByte(0x01));
+    }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Protocol/ReadBufferTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Protocol/ReadBufferTests.cs
@@ -1,0 +1,409 @@
+using System;
+using System.Buffers.Binary;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Protocol;
+using ClickHouse.Driver.Tcp.Tests.Utilities;
+
+namespace ClickHouse.Driver.Tcp.Tests.Protocol;
+
+[TestFixture]
+public class ReadBufferTests
+{
+    private static readonly CancellationToken None = CancellationToken.None;
+
+    private static byte[] Pattern(int length)
+    {
+        byte[] data = new byte[length];
+        for (int i = 0; i < length; i++)
+        {
+            data[i] = (byte)((i * 37) + 11);
+        }
+
+        return data;
+    }
+
+    private static ReadBuffer Over(byte[] data, int capacity = 64, int maxChunk = int.MaxValue)
+        => new(new ChunkedStream(data, maxChunk), capacity);
+
+    // Returns the actual backing capacity for a given requested capacity (pooling may round it up).
+    private static int ActualCapacity(int requested)
+    {
+        using var probe = new ReadBuffer(new MemoryStream(), requested);
+        return probe.Capacity;
+    }
+
+    // ---- Construction & validation ------------------------------------------------------------
+
+    [Test]
+    public void Constructor_NullStream_Throws()
+        => Assert.Throws<ArgumentNullException>(() => new ReadBuffer(null!));
+
+    [TestCase(0)]
+    [TestCase(1)]
+    [TestCase(31)]
+    [TestCase(-1)]
+    public void Constructor_CapacityBelowMinimum_Throws(int capacity)
+        => Assert.Throws<ArgumentOutOfRangeException>(() => new ReadBuffer(new MemoryStream(), capacity));
+
+    [Test]
+    public void Constructor_MinimumCapacity_IsAccepted()
+    {
+        using var buffer = new ReadBuffer(new MemoryStream(), ReadBuffer.MaxContiguous);
+        Assert.That(buffer.Capacity, Is.GreaterThanOrEqualTo(ReadBuffer.MaxContiguous));
+        Assert.That(buffer.Buffered, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void MaxContiguous_IsThirtyTwo() => Assert.That(ReadBuffer.MaxContiguous, Is.EqualTo(32));
+
+    // ---- EnsureAsync --------------------------------------------------------------------------
+
+    [Test]
+    public async Task EnsureAsync_Zero_IsNoOpEvenOnEmptyStream()
+    {
+        using var buffer = new ReadBuffer(new MemoryStream(Array.Empty<byte>()), 64);
+        await buffer.EnsureAsync(0, None);
+        Assert.That(buffer.Buffered, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void EnsureAsync_BeyondCapacity_Throws()
+    {
+        using var buffer = Over(Pattern(256));
+        Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await buffer.EnsureAsync(buffer.Capacity + 1, None));
+    }
+
+    [Test]
+    public async Task EnsureAsync_ExactCapacity_FillsWholeBuffer()
+    {
+        using var buffer = Over(Pattern(256), capacity: 64);
+        await buffer.EnsureAsync(buffer.Capacity, None);
+        Assert.That(buffer.Buffered, Is.EqualTo(buffer.Capacity));
+    }
+
+    [Test]
+    public async Task EnsureAsync_AlreadySatisfied_DoesNotRead()
+    {
+        var stream = new ChunkedStream(Pattern(256));
+        using var buffer = new ReadBuffer(stream, 64);
+        await buffer.EnsureAsync(10, None);
+        int reads = stream.ReadCount;
+        int count = buffer.Buffered;
+
+        await buffer.EnsureAsync(count, None); // already have this many
+
+        Assert.That(stream.ReadCount, Is.EqualTo(reads), "no additional stream read expected");
+        Assert.That(buffer.Buffered, Is.EqualTo(count));
+    }
+
+    [Test]
+    public async Task EnsureAsync_PartialStreamReads_LoopUntilSatisfied()
+    {
+        // maxChunk = 1 forces one read per byte.
+        var stream = new ChunkedStream(Pattern(64), maxChunk: 1);
+        using var buffer = new ReadBuffer(stream, 64);
+
+        await buffer.EnsureAsync(20, None);
+
+        Assert.That(buffer.Buffered, Is.GreaterThanOrEqualTo(20));
+        Assert.That(stream.ReadCount, Is.EqualTo(20));
+    }
+
+    [Test]
+    public void EnsureAsync_StreamEndsEarly_Throws()
+    {
+        using var buffer = new ReadBuffer(new MemoryStream(new byte[] { 1, 2, 3 }), 64);
+        Assert.ThrowsAsync<EndOfStreamException>(async () => await buffer.EnsureAsync(8, None));
+    }
+
+    [Test]
+    public void EnsureAsync_CancelledToken_Throws()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        using var buffer = new ReadBuffer(new ChunkedStream(Pattern(64), honorCancellation: true), 64);
+        Assert.CatchAsync<OperationCanceledException>(async () => await buffer.EnsureAsync(8, cts.Token));
+    }
+
+    // ---- ReadByte -----------------------------------------------------------------------------
+
+    [Test]
+    public async Task ReadByte_SequentialThroughManyRefills_ReturnsEveryByteInOrder()
+    {
+        byte[] source = Pattern(500);
+        using var buffer = Over(source, capacity: 40, maxChunk: 13);
+        for (int i = 0; i < source.Length; i++)
+        {
+            await buffer.EnsureAsync(1, None);
+            Assert.That(buffer.ReadByte(), Is.EqualTo(source[i]), $"byte {i}");
+        }
+    }
+
+    [Test]
+    public async Task ReadByte_DecrementsCount()
+    {
+        using var buffer = Over(Pattern(64));
+        await buffer.EnsureAsync(4, None);
+        int before = buffer.Buffered;
+        buffer.ReadByte();
+        Assert.That(buffer.Buffered, Is.EqualTo(before - 1));
+    }
+
+    // ---- ReadSpan -----------------------------------------------------------------------------
+
+    [Test]
+    public async Task ReadSpan_Contiguous_ReturnsExactBytes([Range(1, 32)] int n)
+    {
+        byte[] source = Pattern(n);
+        using var buffer = new ReadBuffer(new MemoryStream(source), 64);
+        await buffer.EnsureAsync(n, None);
+        CollectionAssert.AreEqual(source, buffer.ReadSpan(n).ToArray());
+    }
+
+    [Test]
+    public async Task ReadSpan_AboveMaxContiguous_Throws()
+    {
+        using var buffer = Over(Pattern(256), capacity: 64);
+        await buffer.EnsureAsync(ReadBuffer.MaxContiguous, None);
+        Assert.Throws<ArgumentOutOfRangeException>(() => buffer.ReadSpan(ReadBuffer.MaxContiguous + 1));
+    }
+
+    [TestCase(2)]
+    [TestCase(3)]
+    [TestCase(8)]
+    [TestCase(16)]
+    [TestCase(31)]
+    [TestCase(32)]
+    public async Task ReadSpan_RequestNearEnd_CompactsToFrontAndReturnsContiguousBytes(int n)
+    {
+        int capacity = ActualCapacity(64);
+        byte[] source = Pattern(capacity + n);
+        using var buffer = new ReadBuffer(new MemoryStream(source), capacity);
+
+        // Consume down to n-1 unconsumed bytes with the head near the end, so the next n-byte request cannot
+        // fit at the current head and forces a compaction to the front.
+        await buffer.EnsureAsync(capacity, None);
+        for (int i = 0; i < capacity - (n - 1); i++)
+        {
+            buffer.ReadByte();
+        }
+
+        await buffer.EnsureAsync(n, None);
+        byte[] actual = buffer.ReadSpan(n).ToArray();
+        CollectionAssert.AreEqual(source.AsSpan(capacity - (n - 1), n).ToArray(), actual);
+    }
+
+    [Test]
+    public async Task ReadSpan_ConsumingToCapacity_ResetsAndContinues()
+    {
+        int capacity = ActualCapacity(64);
+        byte[] source = Pattern(capacity + 8);
+        using var buffer = new ReadBuffer(new MemoryStream(source), capacity);
+
+        await buffer.EnsureAsync(capacity, None);
+        await buffer.ReadIntoAsync(new byte[capacity - 4], None); // consume all but the last 4
+        buffer.ReadSpan(4).ToArray();                             // consumes exactly to the end → head resets to 0
+        Assert.That(buffer.Buffered, Is.EqualTo(0));
+
+        await buffer.EnsureAsync(8, None);            // continues from the stream after the reset
+        CollectionAssert.AreEqual(source.AsSpan(capacity, 8).ToArray(), buffer.ReadSpan(8).ToArray());
+    }
+
+    // ---- ReadIntoAsync ------------------------------------------------------------------------
+
+    [Test]
+    public async Task ReadIntoAsync_EmptyDestination_IsNoOp()
+    {
+        using var buffer = new ReadBuffer(new MemoryStream(Array.Empty<byte>()), 64);
+        await buffer.ReadIntoAsync(Memory<byte>.Empty, None);
+        Assert.That(buffer.Buffered, Is.EqualTo(0));
+    }
+
+    [Test]
+    public async Task ReadIntoAsync_ServedEntirelyFromBuffer()
+    {
+        byte[] source = Pattern(64);
+        using var buffer = new ReadBuffer(new MemoryStream(source), 64);
+        await buffer.EnsureAsync(40, None);
+
+        byte[] destination = new byte[20];
+        await buffer.ReadIntoAsync(destination, None);
+        CollectionAssert.AreEqual(source.AsSpan(0, 20).ToArray(), destination);
+    }
+
+    [Test]
+    public async Task ReadIntoAsync_ServedFromBuffer_AfterCompaction()
+    {
+        int capacity = ActualCapacity(64);
+        byte[] source = Pattern(capacity * 2);
+        using var buffer = new ReadBuffer(new MemoryStream(source), capacity);
+
+        await buffer.EnsureAsync(capacity, None);
+        await buffer.ReadIntoAsync(new byte[capacity - 8], None); // head near the end, 8 bytes left
+        await buffer.EnsureAsync(24, None);                       // refill compacts the 8 bytes to the front
+
+        byte[] destination = new byte[24];          // drains a single contiguous run of 24 buffered bytes
+        await buffer.ReadIntoAsync(destination, None);
+        CollectionAssert.AreEqual(source.AsSpan(capacity - 8, 24).ToArray(), destination);
+    }
+
+    [Test]
+    public async Task ReadIntoAsync_PartialFromBufferThenStream()
+    {
+        byte[] source = Pattern(2000);
+        using var buffer = Over(source, capacity: 64, maxChunk: 50);
+        await buffer.EnsureAsync(10, None);
+
+        byte[] destination = new byte[1500];
+        await buffer.ReadIntoAsync(destination, None);
+        CollectionAssert.AreEqual(source.AsSpan(0, 1500).ToArray(), destination);
+    }
+
+    [Test]
+    public async Task ReadIntoAsync_EmptyBuffer_AllFromStream()
+    {
+        byte[] source = Pattern(1000);
+        using var buffer = new ReadBuffer(new MemoryStream(source), 64);
+
+        byte[] destination = new byte[1000];
+        await buffer.ReadIntoAsync(destination, None);
+        CollectionAssert.AreEqual(source, destination);
+    }
+
+    [Test]
+    public async Task ReadIntoAsync_LargerThanCapacity()
+    {
+        byte[] source = Pattern(10000);
+        using var buffer = Over(source, capacity: 64, maxChunk: 37);
+        byte[] destination = new byte[10000];
+        await buffer.ReadIntoAsync(destination, None);
+        CollectionAssert.AreEqual(source, destination);
+    }
+
+    [Test]
+    public void ReadIntoAsync_StreamEndsEarly_Throws()
+    {
+        using var buffer = new ReadBuffer(new MemoryStream(new byte[] { 1, 2, 3 }), 64);
+        Assert.ThrowsAsync<EndOfStreamException>(async () => await buffer.ReadIntoAsync(new byte[8], None));
+    }
+
+    [Test]
+    public async Task ReadIntoAsync_ContinuityAfterDirectRead()
+    {
+        byte[] source = Pattern(4000);
+        using var buffer = Over(source, capacity: 64, maxChunk: 100);
+
+        await buffer.EnsureAsync(5, None);
+        byte[] first = new byte[2000];
+        await buffer.ReadIntoAsync(first, None);          // drains buffer + direct stream read
+        CollectionAssert.AreEqual(source.AsSpan(0, 2000).ToArray(), first);
+
+        // Buffer must be reusable and continue exactly where the direct read left off.
+        await buffer.EnsureAsync(8, None);
+        CollectionAssert.AreEqual(source.AsSpan(2000, 8).ToArray(), buffer.ReadSpan(8).ToArray());
+    }
+
+    [Test]
+    public void ReadIntoAsync_CancelledToken_Throws()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        using var buffer = new ReadBuffer(new ChunkedStream(Pattern(64), honorCancellation: true), 64);
+        Assert.CatchAsync<OperationCanceledException>(async () => await buffer.ReadIntoAsync(new byte[8], cts.Token));
+    }
+
+    // ---- Mixed / stress ------------------------------------------------------------------------
+
+    [Test]
+    public async Task Repeated_MisalignedReads_ManyCompactions_StayCorrect()
+    {
+        const int count = 200;
+        byte[] source = Pattern(1 + (8 * count) + 4);
+        using var buffer = Over(source, capacity: 40, maxChunk: 40);
+
+        await buffer.EnsureAsync(1, None);
+        buffer.ReadByte();
+
+        for (int k = 0; k < count; k++)
+        {
+            await buffer.EnsureAsync(8, None);
+            ulong actual = BinaryPrimitives.ReadUInt64LittleEndian(buffer.ReadSpan(8));
+            ulong expected = BinaryPrimitives.ReadUInt64LittleEndian(source.AsSpan(1 + (8 * k), 8));
+            Assert.That(actual, Is.EqualTo(expected), $"value {k}");
+        }
+    }
+
+    [TestCase(48, 7)]
+    [TestCase(32, 1)]
+    [TestCase(64, 1000)]
+    [TestCase(100, 3)]
+    public async Task Interleaved_Operations_StayCorrect(int capacity, int maxChunk)
+    {
+        byte[] source = Pattern(12000);
+        using var buffer = Over(source, capacity, maxChunk);
+        var rng = new Random(20260707);
+        int pos = 0;
+
+        while (pos < source.Length)
+        {
+            int remaining = source.Length - pos;
+            switch (rng.Next(3))
+            {
+                case 0:
+                    await buffer.EnsureAsync(1, None);
+                    Assert.That(buffer.ReadByte(), Is.EqualTo(source[pos]), $"byte at {pos}");
+                    pos += 1;
+                    break;
+
+                case 1:
+                    int n = Math.Min(rng.Next(1, ReadBuffer.MaxContiguous + 1), remaining);
+                    await buffer.EnsureAsync(n, None);
+                    Assert.That(buffer.ReadSpan(n).SequenceEqual(source.AsSpan(pos, n)), Is.True, $"span at {pos} len {n}");
+                    pos += n;
+                    break;
+
+                default:
+                    int m = Math.Min(rng.Next(1, 300), remaining);
+                    byte[] destination = new byte[m];
+                    await buffer.ReadIntoAsync(destination, None);
+                    Assert.That(destination.AsSpan().SequenceEqual(source.AsSpan(pos, m)), Is.True, $"block at {pos} len {m}");
+                    pos += m;
+                    break;
+            }
+        }
+
+        Assert.That(pos, Is.EqualTo(source.Length));
+    }
+
+    // ---- Dispose ------------------------------------------------------------------------------
+
+    [Test]
+    public void Dispose_Twice_DoesNotThrow()
+    {
+        var buffer = new ReadBuffer(new MemoryStream(Pattern(64)), 64);
+        buffer.Dispose();
+        Assert.DoesNotThrow(() => buffer.Dispose());
+    }
+
+    // ---- Count tracking -----------------------------------------------------------------------
+
+    [Test]
+    public async Task Count_TracksAcrossOperations()
+    {
+        byte[] source = Pattern(200);
+        using var buffer = Over(source, capacity: 64, maxChunk: 64);
+
+        Assert.That(buffer.Buffered, Is.EqualTo(0));
+        await buffer.EnsureAsync(10, None);
+        int afterEnsure = buffer.Buffered;
+        Assert.That(afterEnsure, Is.GreaterThanOrEqualTo(10));
+
+        buffer.ReadByte();
+        Assert.That(buffer.Buffered, Is.EqualTo(afterEnsure - 1));
+
+        buffer.ReadSpan(4).ToArray();
+        Assert.That(buffer.Buffered, Is.EqualTo(afterEnsure - 5));
+    }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/ChunkedStream.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/ChunkedStream.cs
@@ -1,0 +1,75 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ClickHouse.Driver.Tcp.Tests.Utilities;
+
+/// <summary>
+/// A read-only test stream over a byte array that returns at most <c>maxChunk</c> bytes per read, so tests
+/// can exercise partial fills and buffer refill loops the way a real socket would. Optionally observes
+/// cancellation.
+/// </summary>
+internal sealed class ChunkedStream : Stream
+{
+    private readonly byte[] data;
+    private readonly int maxChunk;
+    private readonly bool honorCancellation;
+    private int position;
+
+    public ChunkedStream(byte[] data, int maxChunk = int.MaxValue, bool honorCancellation = false)
+    {
+        this.data = data;
+        this.maxChunk = maxChunk < 1 ? 1 : maxChunk;
+        this.honorCancellation = honorCancellation;
+    }
+
+    public int ReadCount { get; private set; }
+
+    public override bool CanRead => true;
+
+    public override bool CanSeek => false;
+
+    public override bool CanWrite => false;
+
+    public override long Length => data.Length;
+
+    public override long Position
+    {
+        get => position;
+        set => throw new NotSupportedException();
+    }
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        int n = Math.Min(Math.Min(maxChunk, count), data.Length - position);
+        Array.Copy(data, position, buffer, offset, n);
+        position += n;
+        ReadCount++;
+        return n;
+    }
+
+    public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        if (honorCancellation)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+        }
+
+        int n = Math.Min(Math.Min(maxChunk, buffer.Length), data.Length - position);
+        data.AsSpan(position, n).CopyTo(buffer.Span);
+        position += n;
+        ReadCount++;
+        return ValueTask.FromResult(n);
+    }
+
+    public override void Flush()
+    {
+    }
+
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+    public override void SetLength(long value) => throw new NotSupportedException();
+
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+}

--- a/ClickHouse.Driver.Tcp/AssemblyInfo.cs
+++ b/ClickHouse.Driver.Tcp/AssemblyInfo.cs
@@ -1,3 +1,8 @@
-﻿using System.Reflection;
+using System.Reflection;
+using System.Runtime.CompilerServices;
 
 [assembly:AssemblyKeyFile("../sgKey.snk")]
+
+// The test project needs the internal wire types (reader/writer/buffer). Strong-named assemblies require
+// the friend's full public key here (this is the sgKey.snk public key).
+[assembly:InternalsVisibleTo("ClickHouse.Driver.Tcp.Tests, PublicKey=00240000048000009400000006020000002400005253413100040000010001000968a6468f9d0397a051f167a25dcee773c674cf7a67629f78e884d232df23ff773fbfaba602e03eede6056b39bd6a4cddcd7e5b3ca9484bd83401d14a5e9ac5c98cbe676a1e89149816f5304f617b658440b2bd775e5ece71b5a38ceeb88e844869a376ceea71cbb6393b2ac14e506b92267a3cbcd6e7dc93ff6c750d53a5c7")]

--- a/ClickHouse.Driver.Tcp/ClickHouse.Driver.Tcp.csproj
+++ b/ClickHouse.Driver.Tcp/ClickHouse.Driver.Tcp.csproj
@@ -9,6 +9,8 @@
     <AnalysisMode>Recommended</AnalysisMode>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel>latest</AnalysisLevel>
+    <!-- SA0001: doc comments are present but the XML doc file isn't generated yet (deferred to Epic R). -->
+    <NoWarn>$(NoWarn);SA0001</NoWarn>
     <!-- Not published on its own; its assembly is packed into the ClickHouse.Driver package. -->
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/ClickHouse.Driver.Tcp/Numerics/Int256.cs
+++ b/ClickHouse.Driver.Tcp/Numerics/Int256.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Buffers.Binary;
+using System.Globalization;
+using System.Numerics;
+
+namespace ClickHouse.Driver.Tcp.Numerics;
+
+/// <summary>
+/// A signed 256-bit integer (two's complement), the CLR representation of ClickHouse <c>Int256</c>.
+/// Stored as four little-endian 64-bit limbs.
+/// </summary>
+public readonly struct Int256 : IEquatable<Int256>, IComparable<Int256>
+{
+    /// <summary>The number of bytes in the little-endian wire representation.</summary>
+    public const int Size = 32;
+
+    private const ulong SignBit = 0x8000_0000_0000_0000UL;
+
+    // Limbs, least-significant first; e3 holds the sign bit.
+    private readonly ulong e0;
+    private readonly ulong e1;
+    private readonly ulong e2;
+    private readonly ulong e3;
+
+    /// <summary>Initializes a new instance from four 64-bit limbs, least-significant first.</summary>
+    public Int256(ulong e0, ulong e1, ulong e2, ulong e3)
+    {
+        this.e0 = e0;
+        this.e1 = e1;
+        this.e2 = e2;
+        this.e3 = e3;
+    }
+
+    /// <summary>The zero value.</summary>
+    public static Int256 Zero => default;
+
+    /// <summary>True when the value is negative.</summary>
+    public bool IsNegative => (e3 & SignBit) != 0;
+
+    /// <summary>Reads a little-endian <see cref="Int256"/> from a 32-byte span.</summary>
+    public static Int256 ReadLittleEndian(ReadOnlySpan<byte> source)
+    {
+        if (source.Length < Size)
+        {
+            throw new ArgumentException($"Need at least {Size} bytes.", nameof(source));
+        }
+
+        return new Int256(
+            BinaryPrimitives.ReadUInt64LittleEndian(source.Slice(0, 8)),
+            BinaryPrimitives.ReadUInt64LittleEndian(source.Slice(8, 8)),
+            BinaryPrimitives.ReadUInt64LittleEndian(source.Slice(16, 8)),
+            BinaryPrimitives.ReadUInt64LittleEndian(source.Slice(24, 8)));
+    }
+
+    /// <summary>Writes this value little-endian into a 32-byte span.</summary>
+    public void WriteLittleEndian(Span<byte> destination)
+    {
+        if (destination.Length < Size)
+        {
+            throw new ArgumentException($"Need at least {Size} bytes.", nameof(destination));
+        }
+
+        BinaryPrimitives.WriteUInt64LittleEndian(destination.Slice(0, 8), e0);
+        BinaryPrimitives.WriteUInt64LittleEndian(destination.Slice(8, 8), e1);
+        BinaryPrimitives.WriteUInt64LittleEndian(destination.Slice(16, 8), e2);
+        BinaryPrimitives.WriteUInt64LittleEndian(destination.Slice(24, 8), e3);
+    }
+
+    /// <summary>Converts this value to a signed <see cref="BigInteger"/>.</summary>
+    public BigInteger ToBigInteger()
+    {
+        BigInteger magnitude = ((BigInteger)e3 << 192) | ((BigInteger)e2 << 128) | ((BigInteger)e1 << 64) | e0;
+        return IsNegative ? magnitude - (BigInteger.One << 256) : magnitude;
+    }
+
+    /// <summary>Creates an <see cref="Int256"/> from a <see cref="BigInteger"/> in the representable range.</summary>
+    public static Int256 FromBigInteger(BigInteger value)
+    {
+        BigInteger max = (BigInteger.One << 255) - 1;
+        BigInteger min = -(BigInteger.One << 255);
+        if (value < min || value > max)
+        {
+            throw new OverflowException("Value does not fit in Int256.");
+        }
+
+        BigInteger bits = value.Sign < 0 ? value + (BigInteger.One << 256) : value;
+        const ulong mask = ulong.MaxValue;
+        return new Int256(
+            (ulong)(bits & mask),
+            (ulong)((bits >> 64) & mask),
+            (ulong)((bits >> 128) & mask),
+            (ulong)((bits >> 192) & mask));
+    }
+
+    /// <inheritdoc/>
+    public bool Equals(Int256 other) => e0 == other.e0 && e1 == other.e1 && e2 == other.e2 && e3 == other.e3;
+
+    /// <inheritdoc/>
+    public override bool Equals(object obj) => obj is Int256 other && Equals(other);
+
+    /// <inheritdoc/>
+    public override int GetHashCode() => HashCode.Combine(e0, e1, e2, e3);
+
+    /// <inheritdoc/>
+    public int CompareTo(Int256 other)
+    {
+        bool thisNeg = IsNegative;
+        bool otherNeg = other.IsNegative;
+        if (thisNeg != otherNeg)
+        {
+            return thisNeg ? -1 : 1;
+        }
+
+        // Same sign: unsigned limb comparison yields the correct signed order in two's complement.
+        if (e3 != other.e3)
+        {
+            return e3 < other.e3 ? -1 : 1;
+        }
+
+        if (e2 != other.e2)
+        {
+            return e2 < other.e2 ? -1 : 1;
+        }
+
+        if (e1 != other.e1)
+        {
+            return e1 < other.e1 ? -1 : 1;
+        }
+
+        if (e0 != other.e0)
+        {
+            return e0 < other.e0 ? -1 : 1;
+        }
+
+        return 0;
+    }
+
+    /// <inheritdoc/>
+    public override string ToString() => ToBigInteger().ToString(CultureInfo.InvariantCulture);
+
+    public static bool operator ==(Int256 left, Int256 right) => left.Equals(right);
+
+    public static bool operator !=(Int256 left, Int256 right) => !left.Equals(right);
+
+    public static bool operator <(Int256 left, Int256 right) => left.CompareTo(right) < 0;
+
+    public static bool operator >(Int256 left, Int256 right) => left.CompareTo(right) > 0;
+
+    public static bool operator <=(Int256 left, Int256 right) => left.CompareTo(right) <= 0;
+
+    public static bool operator >=(Int256 left, Int256 right) => left.CompareTo(right) >= 0;
+}

--- a/ClickHouse.Driver.Tcp/Numerics/UInt256.cs
+++ b/ClickHouse.Driver.Tcp/Numerics/UInt256.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Buffers.Binary;
+using System.Globalization;
+using System.Numerics;
+
+namespace ClickHouse.Driver.Tcp.Numerics;
+
+/// <summary>
+/// An unsigned 256-bit integer, the CLR representation of ClickHouse <c>UInt256</c>.
+/// Stored as four little-endian 64-bit limbs. The BCL has no native 256-bit type, so this
+/// fills the gap (128-bit uses <see cref="UInt128"/>).
+/// </summary>
+public readonly struct UInt256 : IEquatable<UInt256>, IComparable<UInt256>
+{
+    /// <summary>The number of bytes in the little-endian wire representation.</summary>
+    public const int Size = 32;
+
+    // Limbs, least-significant first.
+    private readonly ulong e0;
+    private readonly ulong e1;
+    private readonly ulong e2;
+    private readonly ulong e3;
+
+    /// <summary>Initializes a new instance from four 64-bit limbs, least-significant first.</summary>
+    public UInt256(ulong e0, ulong e1, ulong e2, ulong e3)
+    {
+        this.e0 = e0;
+        this.e1 = e1;
+        this.e2 = e2;
+        this.e3 = e3;
+    }
+
+    /// <summary>The zero value.</summary>
+    public static UInt256 Zero => default;
+
+    /// <summary>Reads a little-endian <see cref="UInt256"/> from a 32-byte span.</summary>
+    public static UInt256 ReadLittleEndian(ReadOnlySpan<byte> source)
+    {
+        if (source.Length < Size)
+        {
+            throw new ArgumentException($"Need at least {Size} bytes.", nameof(source));
+        }
+
+        return new UInt256(
+            BinaryPrimitives.ReadUInt64LittleEndian(source.Slice(0, 8)),
+            BinaryPrimitives.ReadUInt64LittleEndian(source.Slice(8, 8)),
+            BinaryPrimitives.ReadUInt64LittleEndian(source.Slice(16, 8)),
+            BinaryPrimitives.ReadUInt64LittleEndian(source.Slice(24, 8)));
+    }
+
+    /// <summary>Writes this value little-endian into a 32-byte span.</summary>
+    public void WriteLittleEndian(Span<byte> destination)
+    {
+        if (destination.Length < Size)
+        {
+            throw new ArgumentException($"Need at least {Size} bytes.", nameof(destination));
+        }
+
+        BinaryPrimitives.WriteUInt64LittleEndian(destination.Slice(0, 8), e0);
+        BinaryPrimitives.WriteUInt64LittleEndian(destination.Slice(8, 8), e1);
+        BinaryPrimitives.WriteUInt64LittleEndian(destination.Slice(16, 8), e2);
+        BinaryPrimitives.WriteUInt64LittleEndian(destination.Slice(24, 8), e3);
+    }
+
+    /// <summary>Converts this value to a non-negative <see cref="BigInteger"/>.</summary>
+    public BigInteger ToBigInteger()
+        => ((BigInteger)e3 << 192) | ((BigInteger)e2 << 128) | ((BigInteger)e1 << 64) | e0;
+
+    /// <summary>Creates a <see cref="UInt256"/> from a non-negative <see cref="BigInteger"/>.</summary>
+    public static UInt256 FromBigInteger(BigInteger value)
+    {
+        if (value.Sign < 0)
+        {
+            throw new OverflowException("UInt256 cannot represent a negative value.");
+        }
+
+        if (value > (BigInteger.One << 256) - 1)
+        {
+            throw new OverflowException("Value does not fit in UInt256.");
+        }
+
+        const ulong mask = ulong.MaxValue;
+        return new UInt256(
+            (ulong)(value & mask),
+            (ulong)((value >> 64) & mask),
+            (ulong)((value >> 128) & mask),
+            (ulong)((value >> 192) & mask));
+    }
+
+    /// <inheritdoc/>
+    public bool Equals(UInt256 other) => e0 == other.e0 && e1 == other.e1 && e2 == other.e2 && e3 == other.e3;
+
+    /// <inheritdoc/>
+    public override bool Equals(object obj) => obj is UInt256 other && Equals(other);
+
+    /// <inheritdoc/>
+    public override int GetHashCode() => HashCode.Combine(e0, e1, e2, e3);
+
+    /// <inheritdoc/>
+    public int CompareTo(UInt256 other)
+    {
+        if (e3 != other.e3)
+        {
+            return e3 < other.e3 ? -1 : 1;
+        }
+
+        if (e2 != other.e2)
+        {
+            return e2 < other.e2 ? -1 : 1;
+        }
+
+        if (e1 != other.e1)
+        {
+            return e1 < other.e1 ? -1 : 1;
+        }
+
+        if (e0 != other.e0)
+        {
+            return e0 < other.e0 ? -1 : 1;
+        }
+
+        return 0;
+    }
+
+    /// <inheritdoc/>
+    public override string ToString() => ToBigInteger().ToString(CultureInfo.InvariantCulture);
+
+    public static bool operator ==(UInt256 left, UInt256 right) => left.Equals(right);
+
+    public static bool operator !=(UInt256 left, UInt256 right) => !left.Equals(right);
+
+    public static bool operator <(UInt256 left, UInt256 right) => left.CompareTo(right) < 0;
+
+    public static bool operator >(UInt256 left, UInt256 right) => left.CompareTo(right) > 0;
+
+    public static bool operator <=(UInt256 left, UInt256 right) => left.CompareTo(right) <= 0;
+
+    public static bool operator >=(UInt256 left, UInt256 right) => left.CompareTo(right) >= 0;
+}

--- a/ClickHouse.Driver.Tcp/Protocol/ClickHouseBinaryReader.cs
+++ b/ClickHouse.Driver.Tcp/Protocol/ClickHouseBinaryReader.cs
@@ -1,0 +1,294 @@
+using System;
+using System.Buffers;
+using System.Buffers.Binary;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Numerics;
+
+namespace ClickHouse.Driver.Tcp.Protocol;
+
+/// <summary>
+/// Decodes ClickHouse native-protocol wire primitives. Buffering and stream I/O are delegated to
+/// a <see cref="ReadBuffer"/>; this type only turns buffered bytes into values. Not thread-safe —
+/// one per connection, which processes a single query at a time.
+/// </summary>
+internal sealed class ClickHouseBinaryReader : IDisposable
+{
+    private const int MaxVarUIntBytes = 10;
+
+    // A corrupt or hostile stream can declare an arbitrary length prefix; cap it so a bad value can't drive a
+    // multi-gigabyte allocation/rent. 1 GiB is far larger than any legitimate native-protocol String field.
+    private const int MaxStringLength = 1 << 30;
+
+    private readonly ReadBuffer buffer;
+    private readonly bool ownsBuffer;
+    private bool disposed;
+
+    // Decodes a fixed-width value from a span whose length equals the value's byte width. These are cached
+    // static delegates, so ReadFixedAsync costs one indirect call and no per-read allocation.
+    private delegate T SpanDecoder<T>(ReadOnlySpan<byte> source);
+
+    private static readonly SpanDecoder<ushort> DecodeUInt16 = BinaryPrimitives.ReadUInt16LittleEndian;
+    private static readonly SpanDecoder<short> DecodeInt16 = BinaryPrimitives.ReadInt16LittleEndian;
+    private static readonly SpanDecoder<uint> DecodeUInt32 = BinaryPrimitives.ReadUInt32LittleEndian;
+    private static readonly SpanDecoder<int> DecodeInt32 = BinaryPrimitives.ReadInt32LittleEndian;
+    private static readonly SpanDecoder<ulong> DecodeUInt64 = BinaryPrimitives.ReadUInt64LittleEndian;
+    private static readonly SpanDecoder<long> DecodeInt64 = BinaryPrimitives.ReadInt64LittleEndian;
+    private static readonly SpanDecoder<float> DecodeFloat32 = BinaryPrimitives.ReadSingleLittleEndian;
+    private static readonly SpanDecoder<double> DecodeFloat64 = BinaryPrimitives.ReadDoubleLittleEndian;
+    private static readonly SpanDecoder<UInt128> DecodeUInt128 = DecodeUInt128Value;
+    private static readonly SpanDecoder<Int128> DecodeInt128 = static source => unchecked((Int128)DecodeUInt128Value(source));
+    private static readonly SpanDecoder<UInt256> DecodeUInt256 = UInt256.ReadLittleEndian;
+    private static readonly SpanDecoder<Int256> DecodeInt256 = Int256.ReadLittleEndian;
+
+    /// <summary>Initializes a reader over <paramref name="stream"/>, creating and owning its buffer.</summary>
+    /// <param name="stream">The source stream to read from.</param>
+    /// <param name="bufferSize">Requested read-buffer capacity in bytes.</param>
+    public ClickHouseBinaryReader(Stream stream, int bufferSize = 16384)
+        : this(new ReadBuffer(stream, bufferSize), ownsBuffer: true)
+    {
+    }
+
+    /// <summary>Initializes a reader over an existing buffer (which the caller owns unless stated otherwise).</summary>
+    /// <param name="buffer">The byte buffer to read from.</param>
+    /// <param name="ownsBuffer">When true, disposing the reader disposes the buffer.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
+    public ClickHouseBinaryReader(ReadBuffer buffer, bool ownsBuffer = false)
+    {
+        this.buffer = buffer ?? throw new ArgumentNullException(nameof(buffer));
+        this.ownsBuffer = ownsBuffer;
+    }
+
+    /// <summary>Reads a single byte.</summary>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>The byte read.</returns>
+    public async ValueTask<byte> ReadByteAsync(CancellationToken cancellationToken)
+    {
+        await buffer.EnsureAsync(1, cancellationToken).ConfigureAwait(false);
+        return buffer.ReadByte();
+    }
+
+    /// <summary>Reads exactly <paramref name="destination"/>.Length bytes.</summary>
+    /// <param name="destination">The region to fill completely with the bytes read.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>A task that completes when the destination has been filled.</returns>
+    public ValueTask ReadBytesAsync(Memory<byte> destination, CancellationToken cancellationToken)
+        => buffer.ReadIntoAsync(destination, cancellationToken);
+
+    /// <summary>Reads a LEB-128 variable-length unsigned integer (native-format VarUInt).</summary>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>The decoded value.</returns>
+    /// <exception cref="InvalidDataException">The encoding exceeds 10 bytes or the range of <see cref="ulong"/>.</exception>
+    public async ValueTask<ulong> ReadVarUIntAsync(CancellationToken cancellationToken)
+    {
+        ulong result = 0;
+        for (int i = 0; i < MaxVarUIntBytes - 1; i++)
+        {
+            // Await only at a buffer boundary; when the bytes are already buffered (the common case) this
+            // decodes with zero awaits. VarUInt is on the hottest read path (every length/count/offset).
+            if (buffer.Buffered == 0)
+            {
+                await buffer.EnsureAsync(1, cancellationToken).ConfigureAwait(false);
+            }
+
+            byte b = buffer.ReadByte();
+            result |= (ulong)(b & 0x7F) << (7 * i);
+            if ((b & 0x80) == 0)
+            {
+                return result;
+            }
+        }
+
+        if (buffer.Buffered == 0)
+        {
+            await buffer.EnsureAsync(1, cancellationToken).ConfigureAwait(false);
+        }
+
+        byte last = buffer.ReadByte();
+        if ((last & 0xFE) != 0)
+        {
+            throw new InvalidDataException("VarUInt exceeds the UInt64 range (corrupt stream).");
+        }
+
+        return result | ((ulong)last << 63);
+    }
+
+    /// <summary>
+    /// Reads a native-format String: a VarUInt length prefix followed by that many UTF-8 bytes.
+    /// ClickHouse <c>String</c> is byte-oriented and not required to be valid UTF-8; invalid sequences decode
+    /// to the Unicode replacement character (U+FFFD). Use <see cref="ReadStringBytesAsync"/> for a lossless
+    /// byte-for-byte read.
+    /// </summary>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>The decoded string.</returns>
+    /// <exception cref="InvalidDataException">The declared length exceeds the supported maximum.</exception>
+    public async ValueTask<string> ReadStringAsync(CancellationToken cancellationToken)
+    {
+        int length = await ReadStringLengthAsync(cancellationToken).ConfigureAwait(false);
+        if (length == 0)
+        {
+            return string.Empty;
+        }
+
+        byte[] rented = ArrayPool<byte>.Shared.Rent(length);
+        try
+        {
+            await buffer.ReadIntoAsync(rented.AsMemory(0, length), cancellationToken).ConfigureAwait(false);
+            return Encoding.UTF8.GetString(rented, 0, length);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(rented);
+        }
+    }
+
+    /// <summary>Reads a native-format String as raw bytes (ClickHouse <c>String</c> is byte-oriented, not necessarily UTF-8).</summary>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>The raw string bytes.</returns>
+    /// <exception cref="InvalidDataException">The declared length exceeds the supported maximum.</exception>
+    public async ValueTask<byte[]> ReadStringBytesAsync(CancellationToken cancellationToken)
+    {
+        int length = await ReadStringLengthAsync(cancellationToken).ConfigureAwait(false);
+        if (length == 0)
+        {
+            return Array.Empty<byte>();
+        }
+
+        byte[] result = new byte[length];
+        await buffer.ReadIntoAsync(result, cancellationToken).ConfigureAwait(false);
+        return result;
+    }
+
+    /// <summary>Reads a single-byte boolean (<c>0x00</c> false, non-zero true).</summary>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>The decoded boolean.</returns>
+    public async ValueTask<bool> ReadBoolAsync(CancellationToken cancellationToken)
+        => await ReadByteAsync(cancellationToken).ConfigureAwait(false) != 0;
+
+    /// <summary>Reads an unsigned 8-bit integer.</summary>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>The value read.</returns>
+    public ValueTask<byte> ReadUInt8Async(CancellationToken cancellationToken) => ReadByteAsync(cancellationToken);
+
+    /// <summary>Reads a signed 8-bit integer.</summary>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>The value read.</returns>
+    public async ValueTask<sbyte> ReadInt8Async(CancellationToken cancellationToken)
+        => unchecked((sbyte)await ReadByteAsync(cancellationToken).ConfigureAwait(false));
+
+    /// <summary>Reads a little-endian unsigned 16-bit integer.</summary>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>The value read.</returns>
+    public ValueTask<ushort> ReadUInt16Async(CancellationToken cancellationToken) => ReadFixedAsync(2, DecodeUInt16, cancellationToken);
+
+    /// <summary>Reads a little-endian signed 16-bit integer.</summary>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>The value read.</returns>
+    public ValueTask<short> ReadInt16Async(CancellationToken cancellationToken) => ReadFixedAsync(2, DecodeInt16, cancellationToken);
+
+    /// <summary>Reads a little-endian unsigned 32-bit integer.</summary>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>The value read.</returns>
+    public ValueTask<uint> ReadUInt32Async(CancellationToken cancellationToken) => ReadFixedAsync(4, DecodeUInt32, cancellationToken);
+
+    /// <summary>Reads a little-endian signed 32-bit integer.</summary>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>The value read.</returns>
+    public ValueTask<int> ReadInt32Async(CancellationToken cancellationToken) => ReadFixedAsync(4, DecodeInt32, cancellationToken);
+
+    /// <summary>Reads a little-endian unsigned 64-bit integer.</summary>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>The value read.</returns>
+    public ValueTask<ulong> ReadUInt64Async(CancellationToken cancellationToken) => ReadFixedAsync(8, DecodeUInt64, cancellationToken);
+
+    /// <summary>Reads a little-endian signed 64-bit integer.</summary>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>The value read.</returns>
+    public ValueTask<long> ReadInt64Async(CancellationToken cancellationToken) => ReadFixedAsync(8, DecodeInt64, cancellationToken);
+
+    /// <summary>Reads a little-endian unsigned 128-bit integer.</summary>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>The value read.</returns>
+    public ValueTask<UInt128> ReadUInt128Async(CancellationToken cancellationToken) => ReadFixedAsync(16, DecodeUInt128, cancellationToken);
+
+    /// <summary>Reads a little-endian signed 128-bit integer.</summary>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>The value read.</returns>
+    public ValueTask<Int128> ReadInt128Async(CancellationToken cancellationToken) => ReadFixedAsync(16, DecodeInt128, cancellationToken);
+
+    /// <summary>Reads a little-endian unsigned 256-bit integer.</summary>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>The value read.</returns>
+    public ValueTask<UInt256> ReadUInt256Async(CancellationToken cancellationToken) => ReadFixedAsync(UInt256.Size, DecodeUInt256, cancellationToken);
+
+    /// <summary>Reads a little-endian signed 256-bit integer.</summary>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>The value read.</returns>
+    public ValueTask<Int256> ReadInt256Async(CancellationToken cancellationToken) => ReadFixedAsync(Int256.Size, DecodeInt256, cancellationToken);
+
+    /// <summary>Reads a little-endian IEEE 754 single-precision float.</summary>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>The value read.</returns>
+    public ValueTask<float> ReadFloat32Async(CancellationToken cancellationToken) => ReadFixedAsync(4, DecodeFloat32, cancellationToken);
+
+    /// <summary>Reads a little-endian IEEE 754 double-precision float.</summary>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>The value read.</returns>
+    public ValueTask<double> ReadFloat64Async(CancellationToken cancellationToken) => ReadFixedAsync(8, DecodeFloat64, cancellationToken);
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        disposed = true;
+        if (ownsBuffer)
+        {
+            buffer.Dispose();
+        }
+    }
+
+    /// <summary>Reads a VarUInt string-length prefix and validates it against the supported maximum.</summary>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>The length in bytes.</returns>
+    /// <exception cref="InvalidDataException">The declared length exceeds <see cref="MaxStringLength"/>.</exception>
+    private async ValueTask<int> ReadStringLengthAsync(CancellationToken cancellationToken)
+    {
+        ulong length = await ReadVarUIntAsync(cancellationToken).ConfigureAwait(false);
+        if (length > MaxStringLength)
+        {
+            throw new InvalidDataException($"String length {length} exceeds the supported maximum of {MaxStringLength} bytes (corrupt stream).");
+        }
+
+        return (int)length;
+    }
+
+    /// <summary>
+    /// Ensures <paramref name="size"/> bytes are buffered, then decodes them from a single contiguous span.
+    /// Centralizing the ensure-then-read pairing here means each fixed-width reader is a one-liner and can't
+    /// get the contract wrong.
+    /// </summary>
+    /// <typeparam name="T">The value type produced by <paramref name="decode"/>.</typeparam>
+    /// <param name="size">The number of bytes the value occupies on the wire.</param>
+    /// <param name="decode">Decodes the value from a span of exactly <paramref name="size"/> bytes.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>The decoded value.</returns>
+    private async ValueTask<T> ReadFixedAsync<T>(int size, SpanDecoder<T> decode, CancellationToken cancellationToken)
+    {
+        await buffer.EnsureAsync(size, cancellationToken).ConfigureAwait(false);
+        return decode(buffer.ReadSpan(size));
+    }
+
+    /// <summary>Decodes a little-endian unsigned 128-bit integer from a 16-byte span.</summary>
+    /// <param name="source">A span of at least 16 bytes.</param>
+    /// <returns>The decoded value.</returns>
+    private static UInt128 DecodeUInt128Value(ReadOnlySpan<byte> source)
+        => new UInt128(
+            BinaryPrimitives.ReadUInt64LittleEndian(source.Slice(8, 8)),
+            BinaryPrimitives.ReadUInt64LittleEndian(source.Slice(0, 8)));
+}

--- a/ClickHouse.Driver.Tcp/Protocol/ClickHouseBinaryWriter.cs
+++ b/ClickHouse.Driver.Tcp/Protocol/ClickHouseBinaryWriter.cs
@@ -1,0 +1,283 @@
+using System;
+using System.Buffers;
+using System.Buffers.Binary;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Numerics;
+
+namespace ClickHouse.Driver.Tcp.Protocol;
+
+/// <summary>
+/// Buffered writer for ClickHouse native-protocol wire primitives over a <see cref="Stream"/>.
+/// Accumulates into an internal buffer and flushes explicitly at packet boundaries so the caller controls
+/// when bytes hit the wire. Not thread-safe — one per connection.
+/// </summary>
+internal sealed class ClickHouseBinaryWriter : IDisposable
+{
+    private readonly Stream stream;
+    private byte[] buffer;
+    private int position;
+    private bool disposed;
+
+    /// <summary>Initializes a new writer over <paramref name="stream"/>.</summary>
+    /// <param name="stream">The destination stream to write to.</param>
+    /// <param name="bufferSize">Initial buffer capacity in bytes; must be at least 32. Buffer can grow if necessary.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="stream"/> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="bufferSize"/> is below 32.</exception>
+    public ClickHouseBinaryWriter(Stream stream, int bufferSize = 16384)
+    {
+        this.stream = stream ?? throw new ArgumentNullException(nameof(stream));
+        if (bufferSize < 32)
+        {
+            throw new ArgumentOutOfRangeException(nameof(bufferSize), "Buffer must hold at least one 32-byte value.");
+        }
+
+        buffer = ArrayPool<byte>.Shared.Rent(bufferSize);
+    }
+
+    /// <summary>The number of bytes buffered and not yet flushed.</summary>
+    public int BufferedBytes => position;
+
+    /// <summary>Writes a single byte.</summary>
+    /// <param name="value">The byte to write.</param>
+    public void WriteByte(byte value)
+    {
+        EnsureCapacity(1);
+        buffer[position++] = value;
+    }
+
+    /// <summary>Writes a single-byte boolean (canonically <c>0x01</c> / <c>0x00</c>).</summary>
+    /// <param name="value">The boolean to write.</param>
+    public void WriteBool(bool value) => WriteByte(value ? (byte)1 : (byte)0);
+
+    /// <summary>Writes raw bytes verbatim (no length prefix).</summary>
+    /// <param name="value">The bytes to write.</param>
+    public void WriteBytes(ReadOnlySpan<byte> value)
+    {
+        EnsureCapacity(value.Length);
+        value.CopyTo(buffer.AsSpan(position));
+        position += value.Length;
+    }
+
+    /// <summary>Writes a LEB-128 variable-length unsigned integer (native-format VarUInt).</summary>
+    /// <param name="value">The value to write.</param>
+    public void WriteVarUInt(ulong value)
+    {
+        EnsureCapacity(10);
+        while (value >= 0x80)
+        {
+            buffer[position++] = unchecked((byte)(value | 0x80));
+            value >>= 7;
+        }
+
+        buffer[position++] = unchecked((byte)value);
+    }
+
+    /// <summary>Writes a native-format String: a VarUInt length prefix followed by the UTF-8 bytes.</summary>
+    /// <param name="value">The string to write.</param>
+    public void WriteString(string value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+
+        // Encode once (the length prefix needs the byte count up front, so writing straight into the buffer
+        // would require a second UTF-8 pass). Small strings use the stack; larger ones a pooled scratch.
+        int maxBytes = Encoding.UTF8.GetMaxByteCount(value.Length);
+        if (maxBytes <= 256)
+        {
+            Span<byte> scratch = stackalloc byte[256];
+            WriteEncodedString(value, scratch);
+        }
+        else
+        {
+            byte[] rented = ArrayPool<byte>.Shared.Rent(maxBytes);
+            try
+            {
+                WriteEncodedString(value, rented);
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(rented);
+            }
+        }
+    }
+
+    /// <summary>Writes a native-format String from raw bytes (VarUInt length prefix + bytes).</summary>
+    /// <param name="value">The raw string bytes to write.</param>
+    public void WriteString(ReadOnlySpan<byte> value)
+    {
+        WriteVarUInt((ulong)value.Length);
+        WriteBytes(value);
+    }
+
+    /// <summary>Encodes <paramref name="value"/> as UTF-8 into <paramref name="scratch"/>, then writes a length-prefixed String.</summary>
+    /// <param name="value">The string to encode.</param>
+    /// <param name="scratch">Scratch space large enough for the UTF-8 encoding of <paramref name="value"/>.</param>
+    private void WriteEncodedString(string value, Span<byte> scratch)
+    {
+        int written = Encoding.UTF8.GetBytes(value, scratch);
+        WriteVarUInt((ulong)written);
+        WriteBytes(scratch.Slice(0, written));
+    }
+
+    /// <summary>Writes an unsigned 8-bit integer.</summary>
+    /// <param name="value">The value to write.</param>
+    public void WriteUInt8(byte value) => WriteByte(value);
+
+    /// <summary>Writes a signed 8-bit integer.</summary>
+    /// <param name="value">The value to write.</param>
+    public void WriteInt8(sbyte value) => WriteByte(unchecked((byte)value));
+
+    /// <summary>Writes a little-endian unsigned 16-bit integer.</summary>
+    /// <param name="value">The value to write.</param>
+    public void WriteUInt16(ushort value)
+    {
+        EnsureCapacity(2);
+        BinaryPrimitives.WriteUInt16LittleEndian(buffer.AsSpan(position, 2), value);
+        position += 2;
+    }
+
+    /// <summary>Writes a little-endian signed 16-bit integer.</summary>
+    /// <param name="value">The value to write.</param>
+    public void WriteInt16(short value)
+    {
+        EnsureCapacity(2);
+        BinaryPrimitives.WriteInt16LittleEndian(buffer.AsSpan(position, 2), value);
+        position += 2;
+    }
+
+    /// <summary>Writes a little-endian unsigned 32-bit integer.</summary>
+    /// <param name="value">The value to write.</param>
+    public void WriteUInt32(uint value)
+    {
+        EnsureCapacity(4);
+        BinaryPrimitives.WriteUInt32LittleEndian(buffer.AsSpan(position, 4), value);
+        position += 4;
+    }
+
+    /// <summary>Writes a little-endian signed 32-bit integer.</summary>
+    /// <param name="value">The value to write.</param>
+    public void WriteInt32(int value)
+    {
+        EnsureCapacity(4);
+        BinaryPrimitives.WriteInt32LittleEndian(buffer.AsSpan(position, 4), value);
+        position += 4;
+    }
+
+    /// <summary>Writes a little-endian unsigned 64-bit integer.</summary>
+    /// <param name="value">The value to write.</param>
+    public void WriteUInt64(ulong value)
+    {
+        EnsureCapacity(8);
+        BinaryPrimitives.WriteUInt64LittleEndian(buffer.AsSpan(position, 8), value);
+        position += 8;
+    }
+
+    /// <summary>Writes a little-endian signed 64-bit integer.</summary>
+    /// <param name="value">The value to write.</param>
+    public void WriteInt64(long value)
+    {
+        EnsureCapacity(8);
+        BinaryPrimitives.WriteInt64LittleEndian(buffer.AsSpan(position, 8), value);
+        position += 8;
+    }
+
+    /// <summary>Writes a little-endian unsigned 128-bit integer.</summary>
+    /// <param name="value">The value to write.</param>
+    public void WriteUInt128(UInt128 value)
+    {
+        EnsureCapacity(16);
+        BinaryPrimitives.WriteUInt64LittleEndian(buffer.AsSpan(position, 8), (ulong)value);
+        BinaryPrimitives.WriteUInt64LittleEndian(buffer.AsSpan(position + 8, 8), (ulong)(value >> 64));
+        position += 16;
+    }
+
+    /// <summary>Writes a little-endian signed 128-bit integer.</summary>
+    /// <param name="value">The value to write.</param>
+    public void WriteInt128(Int128 value) => WriteUInt128(unchecked((UInt128)value));
+
+    /// <summary>Writes a little-endian unsigned 256-bit integer.</summary>
+    /// <param name="value">The value to write.</param>
+    public void WriteUInt256(UInt256 value)
+    {
+        EnsureCapacity(UInt256.Size);
+        value.WriteLittleEndian(buffer.AsSpan(position, UInt256.Size));
+        position += UInt256.Size;
+    }
+
+    /// <summary>Writes a little-endian signed 256-bit integer.</summary>
+    /// <param name="value">The value to write.</param>
+    public void WriteInt256(Int256 value)
+    {
+        EnsureCapacity(Int256.Size);
+        value.WriteLittleEndian(buffer.AsSpan(position, Int256.Size));
+        position += Int256.Size;
+    }
+
+    /// <summary>Writes a little-endian IEEE 754 single-precision float.</summary>
+    /// <param name="value">The value to write.</param>
+    public void WriteFloat32(float value)
+    {
+        EnsureCapacity(4);
+        BinaryPrimitives.WriteSingleLittleEndian(buffer.AsSpan(position, 4), value);
+        position += 4;
+    }
+
+    /// <summary>Writes a little-endian IEEE 754 double-precision float.</summary>
+    /// <param name="value">The value to write.</param>
+    public void WriteFloat64(double value)
+    {
+        EnsureCapacity(8);
+        BinaryPrimitives.WriteDoubleLittleEndian(buffer.AsSpan(position, 8), value);
+        position += 8;
+    }
+
+    /// <summary>Flushes buffered bytes to the underlying stream and flushes the stream.</summary>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <exception cref="ObjectDisposedException">The writer has been disposed.</exception>
+    public async ValueTask FlushAsync(CancellationToken cancellationToken)
+    {
+        ObjectDisposedException.ThrowIf(disposed, this);
+        if (position > 0)
+        {
+            await stream.WriteAsync(buffer.AsMemory(0, position), cancellationToken).ConfigureAwait(false);
+            position = 0;
+        }
+
+        await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        disposed = true;
+        ArrayPool<byte>.Shared.Return(buffer);
+        buffer = Array.Empty<byte>();
+    }
+
+    /// <summary>Ensures the buffer has room for at least <paramref name="count"/> more bytes, growing it if needed.</summary>
+    /// <param name="count">The number of additional bytes about to be written.</param>
+    /// <exception cref="ObjectDisposedException">The writer has been disposed (checked only on the grow path).</exception>
+    private void EnsureCapacity(int count)
+    {
+        if (position + count <= buffer.Length)
+        {
+            return;
+        }
+
+        // Slow path only. Guard here (not on the per-write fast path above) so a use-after-dispose can't rent a
+        // fresh buffer that Dispose's short-circuit would then never return to the pool.
+        ObjectDisposedException.ThrowIf(disposed, this);
+        int newSize = Math.Max(buffer.Length * 2, position + count);
+        byte[] grown = ArrayPool<byte>.Shared.Rent(newSize);
+        Array.Copy(buffer, grown, position);
+        ArrayPool<byte>.Shared.Return(buffer);
+        buffer = grown;
+    }
+}

--- a/ClickHouse.Driver.Tcp/Protocol/ReadBuffer.cs
+++ b/ClickHouse.Driver.Tcp/Protocol/ReadBuffer.cs
@@ -1,0 +1,200 @@
+using System;
+using System.Buffers;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ClickHouse.Driver.Tcp.Protocol;
+
+/// <summary>
+/// A fixed-capacity read buffer over an underlying <see cref="Stream"/>. Consumed space is reclaimed by
+/// advancing the head; the run is only shifted back to the front when a small fixed-width read would otherwise
+/// run past the end of the backing array.
+///
+/// <para>
+/// The buffer lets callers read Spans of at most <see cref="MaxContiguous"/> bytes, via
+/// <see cref="ReadSpan"/>. Bulk payloads (strings, whole columns) go through <see cref="ReadIntoAsync"/>,
+/// which drains the buffered prefix and then reads the remainder straight from the stream into the caller's
+/// destination — so <see cref="Capacity"/> bounds the largest contiguous scalar, not the largest payload.
+/// </para>
+///
+/// <para>Not thread-safe. One per connection.</para>
+/// </summary>
+internal sealed class ReadBuffer : IDisposable
+{
+    /// <summary>The largest single contiguous value the buffer can serve via <see cref="ReadSpan"/>.</summary>
+    public const int MaxContiguous = 32;
+
+    private readonly Stream stream;
+    private byte[] buffer;
+    private int capacity;
+    private int head;      // index of the first valid byte
+    private int buffered;  // number of valid bytes; the run is [head, head + buffered) and never wraps
+    private bool disposed;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReadBuffer"/> class.
+    /// </summary>
+    /// <param name="stream">The source stream (a network stream in production, any stream in tests).</param>
+    /// <param name="capacity">Requested capacity in bytes; must be at least <see cref="MaxContiguous"/>.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="stream"/> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="capacity"/> is below <see cref="MaxContiguous"/>.</exception>
+    public ReadBuffer(Stream stream, int capacity = 16384)
+    {
+        this.stream = stream ?? throw new ArgumentNullException(nameof(stream));
+        if (capacity < MaxContiguous)
+        {
+            throw new ArgumentOutOfRangeException(nameof(capacity), $"Capacity must be at least {MaxContiguous} bytes.");
+        }
+
+        buffer = ArrayPool<byte>.Shared.Rent(capacity);
+        this.capacity = buffer.Length; // Rent may return a larger array; use all of it.
+    }
+
+    /// <summary>The number of bytes currently buffered and unconsumed.</summary>
+    public int Buffered => buffered;
+
+    /// <summary>The actual backing capacity in bytes (may exceed the requested size due to pooling).</summary>
+    public int Capacity => capacity;
+
+    /// <summary>Ensures at least <paramref name="needed"/> bytes are buffered and contiguous at the head, pulling from the stream as required.</summary>
+    /// <param name="needed">The number of contiguous bytes that must be available; must not exceed <see cref="Capacity"/>.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="needed"/> exceeds the buffer capacity.</exception>
+    /// <exception cref="EndOfStreamException">The stream ended before enough bytes arrived.</exception>
+    public async ValueTask EnsureAsync(int needed, CancellationToken cancellationToken)
+    {
+        if (needed > capacity)
+        {
+            throw new ArgumentOutOfRangeException(nameof(needed), $"Cannot buffer {needed} contiguous bytes; capacity is {capacity}.");
+        }
+        ArgumentOutOfRangeException.ThrowIfNegative(needed);
+
+        if (needed <= buffered)
+        {
+            return; // Already satisfied — do not touch the head (no read, no shift).
+        }
+
+        // Make room for `needed` contiguous bytes at the head before filling. This is the only place bytes move.
+        if (buffered == 0)
+        {
+            head = 0; // Nothing buffered: reset to the front for free (no copy).
+        }
+        else if (capacity - head < needed)
+        {
+            // The head is close enough to the end that `needed` bytes can't fit there. The run is small in this
+            // case (buffered <= capacity - head < needed), so this copies fewer than `needed` bytes.
+            Array.Copy(buffer, head, buffer, 0, buffered);
+            head = 0;
+        }
+
+        while (buffered < needed)
+        {
+            await FillOnceAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>Consumes one byte. Caller must first ensure at least one byte is buffered.</summary>
+    /// <returns>The consumed byte.</returns>
+    public byte ReadByte()
+    {
+        byte value = buffer[head];
+        Advance(1);
+        return value;
+    }
+
+    /// <summary>
+    /// Consumes <paramref name="count"/> contiguous bytes (at most <see cref="MaxContiguous"/>) as a direct
+    /// slice of the backing array — no copy. The returned span is valid only until the next buffer operation.
+    /// Caller must first ensure the bytes are buffered (via <see cref="EnsureAsync"/>).
+    /// </summary>
+    /// <param name="count">The number of contiguous bytes to consume; must not exceed <see cref="MaxContiguous"/>.</param>
+    /// <returns>A span over the consumed bytes, valid only until the next buffer operation.</returns>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="count"/> exceeds <see cref="MaxContiguous"/>.</exception>
+    public ReadOnlySpan<byte> ReadSpan(int count)
+    {
+        if (count > MaxContiguous)
+        {
+            throw new ArgumentOutOfRangeException(nameof(count), $"ReadSpan serves at most {MaxContiguous} bytes; use ReadIntoAsync for larger reads.");
+        }
+
+        // Relies on the caller's prior EnsureAsync(count). This method is sync (a span can't cross an await), so it cannot
+        // buffer on its own.
+        ReadOnlySpan<byte> result = buffer.AsSpan(head, count);
+        Advance(count);
+        return result;
+    }
+
+    /// <summary>
+    /// Fills <paramref name="destination"/> completely: drains the buffered prefix first, then reads any
+    /// remainder straight from the stream into the caller's memory (no intermediate copy).
+    /// </summary>
+    /// <param name="destination">The region to fill completely with consumed bytes.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <exception cref="EndOfStreamException">The stream ended before the destination was filled.</exception>
+    public async ValueTask ReadIntoAsync(Memory<byte> destination, CancellationToken cancellationToken)
+    {
+        if (buffered > 0 && !destination.IsEmpty)
+        {
+            int fromBuffer = Math.Min(destination.Length, buffered);
+            buffer.AsMemory(head, fromBuffer).CopyTo(destination);
+            Advance(fromBuffer);
+            destination = destination.Slice(fromBuffer);
+        }
+
+        while (!destination.IsEmpty)
+        {
+            int read = await stream.ReadAsync(destination, cancellationToken).ConfigureAwait(false);
+            if (read == 0)
+            {
+                throw new EndOfStreamException("Unexpected end of stream while reading from ClickHouse.");
+            }
+
+            destination = destination.Slice(read);
+        }
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        disposed = true;
+        ArrayPool<byte>.Shared.Return(buffer);
+        buffer = Array.Empty<byte>();
+        capacity = 0;
+    }
+
+    /// <summary>Advances the head past consumed bytes, resetting to the front when the buffer empties.</summary>
+    /// <param name="n">The number of bytes just consumed.</param>
+    private void Advance(int n)
+    {
+        head += n;
+        buffered -= n;
+        if (buffered == 0)
+        {
+            head = 0; // Empty: reset to the front so the next fill has the whole array as one contiguous run.
+        }
+    }
+
+    /// <summary>
+    /// Reads one chunk from the stream into the free run at the tail and grows the buffered count. EnsureAsync
+    /// guarantees there is free tail space (head + buffered &lt; capacity) whenever this is called.
+    /// </summary>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <exception cref="EndOfStreamException">The stream ended before any byte arrived.</exception>
+    private async ValueTask FillOnceAsync(CancellationToken cancellationToken)
+    {
+        int writeStart = head + buffered;
+        int read = await stream.ReadAsync(buffer.AsMemory(writeStart, capacity - writeStart), cancellationToken).ConfigureAwait(false);
+        if (read == 0)
+        {
+            throw new EndOfStreamException("Unexpected end of stream while reading from ClickHouse.");
+        }
+
+        buffered += read;
+    }
+}


### PR DESCRIPTION
* Adds a circular read buffer for our reader to use.
* Adds stream reader and writer for use with the TCP streams.
* Adds Int256/UInt256 classes. Very lean (no arithmetic), but also much faster than BigInteger.
* Basic CI testing for TCP client.