### PR TITLE
TCP C: Add handshake, version negotiation, and version-based feature gates

### DIFF
--- a/ClickHouse.Driver.Tcp.Tests/Protocol/HandshakeTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Protocol/HandshakeTests.cs
@@ -1,0 +1,120 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Protocol;
+
+namespace ClickHouse.Driver.Tcp.Tests.Protocol;
+
+// These cover only the handshake logic that live integration tests can't reach: version-gated decoding
+// against a revision no supported server negotiates, and the nested-exception chain (has_nested is always
+// false on the wire today). The happy-path encode/decode and orchestration are exercised end to end by the
+// integration suite.
+[TestFixture]
+public class HandshakeTests
+{
+    private static readonly CancellationToken None = CancellationToken.None;
+
+    private static ClickHouseBinaryReader ReaderOver(byte[] bytes) => new(new MemoryStream(bytes), 16384);
+
+    private static async Task<byte[]> WriteAsync(Action<ClickHouseBinaryWriter> write)
+    {
+        using var ms = new MemoryStream();
+        using (var writer = new ClickHouseBinaryWriter(ms))
+        {
+            write(writer);
+            await writer.FlushAsync(None);
+        }
+
+        return ms.ToArray();
+    }
+
+    [Test]
+    public void ToString_CredentialsAreSet_RedactsSecretsAndIncludesIdentity()
+    {
+        const string password = "distinctive-secret-password";
+        const string quotaKey = "distinctive-secret-quota-key";
+        var parameters = new ClientHandshakeParameters
+        {
+            ClientName = "test-client",
+            VersionMajor = 12,
+            VersionMinor = 34,
+            Database = "test-database",
+            Username = "test-user",
+            Password = password,
+            QuotaKey = quotaKey,
+        };
+
+        string description = parameters.ToString();
+        Assert.Multiple(() =>
+        {
+            Assert.That(description, Does.Contain(nameof(ClientHandshakeParameters)));
+            Assert.That(description, Does.Contain("test-client"));
+            Assert.That(description, Does.Contain("12.34"));
+            Assert.That(description, Does.Contain("test-database"));
+            Assert.That(description, Does.Contain("test-user"));
+            Assert.That(description, Does.Not.Contain(password));
+            Assert.That(description, Does.Not.Contain(quotaKey));
+            Assert.That(description, Does.Contain("<redacted>"));
+        });
+    }
+
+    [Test]
+    public async Task ReadServerHelloAsync_OlderRevision_SkipsGatedFields()
+    {
+        // At revision 54000 the timezone (54058), display_name (54372) and version_patch (54401) gates are all
+        // inactive, so the server writes none of them — and the decoder must not try to read them.
+        byte[] body = await WriteAsync(w =>
+        {
+            w.WriteString("OldServer");
+            w.WriteVarUInt(21);
+            w.WriteVarUInt(1);
+            w.WriteVarUInt(54000);
+        });
+
+        using var reader = ReaderOver(body);
+        ServerHandshake server = await Handshake.ReadServerHelloAsync(reader, None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(server.Revision, Is.EqualTo(54000));
+            Assert.That(server.Timezone, Is.Empty);
+            Assert.That(server.DisplayName, Is.Empty);
+            Assert.That(server.VersionPatch, Is.EqualTo(0));
+            Assert.That(server.Negotiated.Version, Is.EqualTo(54000));
+        });
+
+        // The decode must have consumed exactly the four always-present fields — no more (which would throw
+        // here) and no fewer (proven by the stream now being at its end).
+        Assert.ThrowsAsync<EndOfStreamException>(async () => await reader.ReadByteAsync(None));
+    }
+
+    [Test]
+    public async Task ExceptionReadAsync_NestedChain_LinksInnerException()
+    {
+        byte[] body = await WriteAsync(w =>
+        {
+            w.WriteInt32(10);
+            w.WriteString("DB::Exception");
+            w.WriteString("outer");
+            w.WriteString("outer stack");
+            w.WriteBool(true); // has_nested → another frame follows
+            w.WriteInt32(20);
+            w.WriteString("DB::NestedException");
+            w.WriteString("inner cause");
+            w.WriteString("inner stack");
+            w.WriteBool(false);
+        });
+
+        using var reader = ReaderOver(body);
+        ClickHouseServerException ex = await ClickHouseServerException.ReadAsync(reader, None);
+
+        Assert.That(ex.Code, Is.EqualTo(10));
+        Assert.That(ex.Message, Is.EqualTo("outer"));
+        var inner = ex.InnerException as ClickHouseServerException;
+        Assert.That(inner, Is.Not.Null);
+        Assert.That(inner!.Code, Is.EqualTo(20));
+        Assert.That(inner.Message, Is.EqualTo("inner cause"));
+        Assert.That(inner.InnerException, Is.Null);
+    }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Protocol/NegotiatedProtocolTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Protocol/NegotiatedProtocolTests.cs
@@ -1,0 +1,71 @@
+using ClickHouse.Driver.Tcp.Protocol;
+
+namespace ClickHouse.Driver.Tcp.Tests.Protocol;
+
+[TestFixture]
+public class NegotiatedProtocolTests
+{
+    [Test]
+    public void Version_ServerAboveClient_IsClampedToClientCeiling()
+    {
+        var negotiated = new NegotiatedProtocol(serverRevision: 54473);
+        Assert.That(negotiated.Version, Is.EqualTo(NegotiatedProtocol.ClientTcpProtocolVersion));
+        Assert.That(negotiated.Version, Is.EqualTo(54460));
+    }
+
+    [Test]
+    public void Version_ServerBelowClient_TakesServerRevision()
+    {
+        var negotiated = new NegotiatedProtocol(serverRevision: 54000);
+        Assert.That(negotiated.Version, Is.EqualTo(54000));
+    }
+
+    [Test]
+    public void Supports_FeatureAtOrBelowNegotiatedVersion_IsTrue()
+    {
+        var negotiated = new NegotiatedProtocol(serverRevision: 54460);
+        Assert.Multiple(() =>
+        {
+            Assert.That(negotiated.Supports(ProtocolFeature.Timezone), Is.True);      // 54058
+            Assert.That(negotiated.Supports(ProtocolFeature.DisplayName), Is.True);   // 54372
+            Assert.That(negotiated.Supports(ProtocolFeature.VersionPatch), Is.True);  // 54401
+            Assert.That(negotiated.Supports(ProtocolFeature.Addendum), Is.True);      // 54458
+        });
+    }
+
+    [Test]
+    public void Supports_FeatureAboveNegotiatedVersion_IsFalse()
+    {
+        // Features gated above the client ceiling are never active, even against a newer server (the
+        // negotiated version is clamped to the ceiling).
+        var negotiated = new NegotiatedProtocol(serverRevision: 54473);
+        Assert.Multiple(() =>
+        {
+            Assert.That(negotiated.Supports(ProtocolFeature.ChunkedProtocol), Is.False);   // 54470
+            Assert.That(negotiated.Supports(ProtocolFeature.ParallelReplicas), Is.False);  // 54471
+        });
+    }
+
+    [Test]
+    public void Supports_FeatureExactlyAtNegotiatedVersion_IsTrue()
+    {
+        // A feature is active at >= its introducing version, so the introducing version itself qualifies while
+        // one below does not.
+        Assert.Multiple(() =>
+        {
+            Assert.That(new NegotiatedProtocol(54058).Supports(ProtocolFeature.Timezone), Is.True);
+            Assert.That(new NegotiatedProtocol(54057).Supports(ProtocolFeature.Timezone), Is.False);
+        });
+    }
+
+    [Test]
+    public void Supports_OlderServer_GatesOutNewerFields()
+    {
+        var negotiated = new NegotiatedProtocol(serverRevision: 54000);
+        Assert.Multiple(() =>
+        {
+            Assert.That(negotiated.Supports(ProtocolFeature.Timezone), Is.False);     // 54058 > 54000
+            Assert.That(negotiated.Supports(ProtocolFeature.VersionPatch), Is.False); // 54401 > 54000
+        });
+    }
+}

--- a/ClickHouse.Driver.Tcp/Protocol/ClickHouseServerException.cs
+++ b/ClickHouse.Driver.Tcp/Protocol/ClickHouseServerException.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ClickHouse.Driver.Tcp.Protocol;
+
+/// <summary>
+/// An error returned by the server as an Exception packet. Carries the server-side error code, exception
+/// class name, and stack trace alongside the message. Nested server exceptions are chained through
+/// <see cref="Exception.InnerException"/>.
+/// </summary>
+internal sealed class ClickHouseServerException : Exception
+{
+    // A corrupt or hostile server could stream an endless nested chain; cap it so a bad response can't drive
+    // unbounded allocation. Far more frames than any legitimate server produces (nesting is usually 0 or 1).
+    private const int MaxNestedFrames = 256;
+
+    /// <summary>Initializes a new instance of the <see cref="ClickHouseServerException"/> class.</summary>
+    /// <param name="code">The server-side error code.</param>
+    /// <param name="name">The server exception class name (e.g. <c>"DB::Exception"</c>).</param>
+    /// <param name="message">The human-readable error message.</param>
+    /// <param name="serverStackTrace">The server-side stack trace.</param>
+    /// <param name="innerException">The nested server exception, or null for the innermost frame.</param>
+    public ClickHouseServerException(int code, string name, string message, string serverStackTrace, Exception innerException = null)
+        : base(message, innerException)
+    {
+        Code = code;
+        Name = name;
+        ServerStackTrace = serverStackTrace;
+    }
+
+    /// <summary>The server-side error code.</summary>
+    public int Code { get; }
+
+    /// <summary>The server exception class name (e.g. <c>"DB::Exception"</c>).</summary>
+    public string Name { get; }
+
+    /// <summary>The server-side stack trace.</summary>
+    public string ServerStackTrace { get; }
+
+    /// <summary>
+    /// Decodes an Exception packet body (the bytes after the packet type code): <c>Int32 code</c>,
+    /// <c>String name</c>, <c>String message</c>, <c>String stack_trace</c>, <c>Bool has_nested</c>. When
+    /// <c>has_nested</c> is set, the nested exception follows and becomes the inner exception.
+    /// </summary>
+    /// <param name="reader">The reader positioned at the start of the Exception body.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>The decoded exception, with any nested exceptions chained as inner exceptions.</returns>
+    public static async ValueTask<ClickHouseServerException> ReadAsync(ClickHouseBinaryReader reader, CancellationToken cancellationToken)
+    {
+        var frames = new List<(int Code, string Name, string Message, string StackTrace)>();
+        bool hasNested;
+        do
+        {
+            int code = await reader.ReadInt32Async(cancellationToken).ConfigureAwait(false);
+            string name = await reader.ReadStringAsync(cancellationToken).ConfigureAwait(false);
+            string message = await reader.ReadStringAsync(cancellationToken).ConfigureAwait(false);
+            string stackTrace = await reader.ReadStringAsync(cancellationToken).ConfigureAwait(false);
+            hasNested = await reader.ReadBoolAsync(cancellationToken).ConfigureAwait(false);
+            frames.Add((code, name, message, stackTrace));
+            if (frames.Count > MaxNestedFrames)
+            {
+                throw new InvalidDataException($"Server exception chain exceeds the supported maximum of {MaxNestedFrames} frames (corrupt stream).");
+            }
+        }
+        while (hasNested);
+
+        // Frames are read outermost-first; rebuild from the innermost so each wraps the next as its cause.
+        ClickHouseServerException current = null;
+        for (int i = frames.Count - 1; i >= 0; i--)
+        {
+            (int code, string name, string message, string stackTrace) = frames[i];
+            current = new ClickHouseServerException(code, name, message, stackTrace, current);
+        }
+
+        return current;
+    }
+}

--- a/ClickHouse.Driver.Tcp/Protocol/ClientHandshakeParameters.cs
+++ b/ClickHouse.Driver.Tcp/Protocol/ClientHandshakeParameters.cs
@@ -1,0 +1,37 @@
+using System.Globalization;
+
+namespace ClickHouse.Driver.Tcp.Protocol;
+
+/// <summary>
+/// Client-supplied values for the handshake: the ClientHello fields plus the Addendum's quota key. The
+/// connection layer builds this from client options; the handshake code treats it as opaque input.
+/// </summary>
+internal sealed class ClientHandshakeParameters
+{
+    /// <summary>Informational client identifier (ClientHello field 1). Does not affect negotiation.</summary>
+    required public string ClientName { get; init; }
+
+    /// <summary>Informational client major version (ClientHello field 2).</summary>
+    public int VersionMajor { get; init; }
+
+    /// <summary>Informational client minor version (ClientHello field 3).</summary>
+    public int VersionMinor { get; init; }
+
+    /// <summary>Default database (ClientHello field 5).</summary>
+    public string Database { get; init; } = "default";
+
+    /// <summary>Username for authentication (ClientHello field 6).</summary>
+    required public string Username { get; init; }
+
+    /// <summary>Password, sent in plaintext and protected only by TLS (ClientHello field 7).</summary>
+    public string Password { get; init; } = string.Empty;
+
+    /// <summary>Keyed-quota resource key (Addendum field 1). Empty when the client uses no keyed quota.</summary>
+    public string QuotaKey { get; init; } = string.Empty;
+
+    /// <inheritdoc/>
+    public override string ToString()
+        => string.Create(
+            CultureInfo.InvariantCulture,
+            $"{nameof(ClientHandshakeParameters)} {{ ClientName = {ClientName}, Version = {VersionMajor}.{VersionMinor}, Database = {Database}, Username = {Username}, Password = <redacted>, QuotaKey = <redacted> }}");
+}

--- a/ClickHouse.Driver.Tcp/Protocol/Handshake.cs
+++ b/ClickHouse.Driver.Tcp/Protocol/Handshake.cs
@@ -1,0 +1,133 @@
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ClickHouse.Driver.Tcp.Protocol;
+
+/// <summary>
+/// Encodes and decodes the connection handshake — ClientHello, ServerHello, and the Addendum — and runs the
+/// exchange end to end. At the current negotiation ceiling there is no chunk framing, so every message rides
+/// straight on the buffered reader/writer.
+/// </summary>
+internal static class Handshake
+{
+    /// <summary>Writes the ClientHello packet (type code plus its seven fields). Does not flush.</summary>
+    /// <param name="writer">The writer to encode into.</param>
+    /// <param name="parameters">The client-supplied handshake values.</param>
+    public static void WriteClientHello(ClickHouseBinaryWriter writer, ClientHandshakeParameters parameters)
+    {
+        writer.WriteClientPacketType(ClientPacketType.Hello);
+        writer.WriteString(parameters.ClientName);
+        writer.WriteVarUInt((ulong)parameters.VersionMajor);
+        writer.WriteVarUInt((ulong)parameters.VersionMinor);
+        writer.WriteVarUInt(NegotiatedProtocol.ClientTcpProtocolVersion);
+        writer.WriteString(parameters.Database);
+        writer.WriteString(parameters.Username);
+        writer.WriteString(parameters.Password);
+    }
+
+    /// <summary>
+    /// Decodes the ServerHello body (the bytes after a <see cref="ServerPacketType.Hello"/> type code).
+    /// Version-gated fields are read only when the negotiated version — computed from the server's reported
+    /// revision — activates them, so an unexpected revision reads exactly the fields the server wrote.
+    /// </summary>
+    /// <param name="reader">The reader positioned at the start of the ServerHello body.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>The decoded server handshake.</returns>
+    public static async ValueTask<ServerHandshake> ReadServerHelloAsync(ClickHouseBinaryReader reader, CancellationToken cancellationToken)
+    {
+        string serverName = await reader.ReadStringAsync(cancellationToken).ConfigureAwait(false);
+        int versionMajor = (int)await reader.ReadVarUIntAsync(cancellationToken).ConfigureAwait(false);
+        int versionMinor = (int)await reader.ReadVarUIntAsync(cancellationToken).ConfigureAwait(false);
+
+        // Guard the revision before narrowing: a corrupt value with bit 31 set would wrap negative, drive the
+        // negotiated version negative, and silently skip every gated field below — desyncing the stream.
+        ulong revisionRaw = await reader.ReadVarUIntAsync(cancellationToken).ConfigureAwait(false);
+        if (revisionRaw > int.MaxValue)
+        {
+            throw new InvalidDataException($"Server reported an implausible protocol revision {revisionRaw} (corrupt stream).");
+        }
+
+        int revision = (int)revisionRaw;
+        var negotiated = new NegotiatedProtocol(revision);
+
+        // The negotiated version is capped at the client ceiling, below every field between the revision and
+        // the timezone (the parallel-replicas version gates at 54471). Anyone raising the ceiling must decode
+        // that field here, immediately after the revision, before the timezone.
+        string timezone = negotiated.Supports(ProtocolFeature.Timezone)
+            ? await reader.ReadStringAsync(cancellationToken).ConfigureAwait(false)
+            : string.Empty;
+        string displayName = negotiated.Supports(ProtocolFeature.DisplayName)
+            ? await reader.ReadStringAsync(cancellationToken).ConfigureAwait(false)
+            : string.Empty;
+        int versionPatch = negotiated.Supports(ProtocolFeature.VersionPatch)
+            ? (int)await reader.ReadVarUIntAsync(cancellationToken).ConfigureAwait(false)
+            : 0;
+
+        // Everything beyond version_patch (chunked prefs, password rules, nonce, server settings, ...) gates
+        // above the ceiling and is therefore absent.
+        return new ServerHandshake
+        {
+            ServerName = serverName,
+            VersionMajor = versionMajor,
+            VersionMinor = versionMinor,
+            Revision = revision,
+            Timezone = timezone,
+            DisplayName = displayName,
+            VersionPatch = versionPatch,
+        };
+    }
+
+    /// <summary>
+    /// Writes the Addendum. It has no packet type prefix — the fields go on the wire raw. At the current
+    /// ceiling this reduces to the quota key; the chunked-framing and parallel-replicas fields gate higher.
+    /// Does not flush.
+    /// </summary>
+    /// <param name="writer">The writer to encode into.</param>
+    /// <param name="quotaKey">The keyed-quota resource key (empty when unused).</param>
+    public static void WriteAddendum(ClickHouseBinaryWriter writer, string quotaKey)
+        => writer.WriteString(quotaKey);
+
+    /// <summary>
+    /// Runs the full handshake: sends ClientHello, reads the reply, and — on success — sends the Addendum
+    /// when the negotiated version calls for it. A server Exception reply is decoded and thrown; any other
+    /// reply is a protocol violation.
+    /// </summary>
+    /// <param name="reader">The reader over the server stream.</param>
+    /// <param name="writer">The writer over the client stream.</param>
+    /// <param name="parameters">The client-supplied handshake values.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>The decoded server handshake, including the negotiated version.</returns>
+    /// <exception cref="ClickHouseServerException">The server rejected the handshake (e.g. authentication failure).</exception>
+    /// <exception cref="InvalidDataException">The server sent neither Hello nor Exception.</exception>
+    public static async ValueTask<ServerHandshake> PerformAsync(
+        ClickHouseBinaryReader reader,
+        ClickHouseBinaryWriter writer,
+        ClientHandshakeParameters parameters,
+        CancellationToken cancellationToken)
+    {
+        WriteClientHello(writer, parameters);
+        await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
+
+        ServerPacketType reply = await reader.ReadServerPacketTypeAsync(cancellationToken).ConfigureAwait(false);
+        switch (reply)
+        {
+            case ServerPacketType.Hello:
+                break;
+            case ServerPacketType.Exception:
+                throw await ClickHouseServerException.ReadAsync(reader, cancellationToken).ConfigureAwait(false);
+            default:
+                throw new InvalidDataException($"Unexpected packet type {reply} ({(ulong)reply}) during handshake; expected Hello or Exception.");
+        }
+
+        ServerHandshake server = await ReadServerHelloAsync(reader, cancellationToken).ConfigureAwait(false);
+
+        if (server.Negotiated.Supports(ProtocolFeature.Addendum))
+        {
+            WriteAddendum(writer, parameters.QuotaKey);
+            await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        return server;
+    }
+}

--- a/ClickHouse.Driver.Tcp/Protocol/NegotiatedProtocol.cs
+++ b/ClickHouse.Driver.Tcp/Protocol/NegotiatedProtocol.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace ClickHouse.Driver.Tcp.Protocol;
+
+/// <summary>
+/// The protocol version agreed for a connection — <c>min(client, server)</c> — and the single authority for
+/// which version-gated wire fields are present. Every conditional read/write keys off <see cref="Supports"/>.
+/// </summary>
+internal readonly struct NegotiatedProtocol
+{
+    /// <summary>
+    /// The protocol version this client advertises in ClientHello, and the ceiling for negotiation.
+    /// </summary>
+    public const int ClientTcpProtocolVersion = 54460;
+
+    /// <summary>Computes the negotiated version from the revision the server reported in ServerHello.</summary>
+    /// <param name="serverRevision">The server's protocol revision (ServerHello field 4).</param>
+    public NegotiatedProtocol(int serverRevision) => Version = Math.Min(ClientTcpProtocolVersion, serverRevision);
+
+    /// <summary>The agreed protocol version: <c>min(client, server)</c>.</summary>
+    public int Version { get; }
+
+    /// <summary>Whether <paramref name="feature"/> is active at the negotiated version.</summary>
+    /// <param name="feature">The feature to test.</param>
+    /// <returns><c>true</c> when the negotiated version is at least the feature's introducing version.</returns>
+    public bool Supports(ProtocolFeature feature) => Version >= (int)feature;
+}

--- a/ClickHouse.Driver.Tcp/Protocol/ProtocolFeature.cs
+++ b/ClickHouse.Driver.Tcp/Protocol/ProtocolFeature.cs
@@ -1,0 +1,28 @@
+namespace ClickHouse.Driver.Tcp.Protocol;
+
+/// <summary>
+/// Protocol features, each identified by the protocol version that introduced it. A feature is active when
+/// the negotiated version is at least this value; every version-conditional read or write consults
+/// <see cref="NegotiatedProtocol.Supports"/> rather than an inline magic number. Mirrors ClickHouse's
+/// <c>DBMS_MIN_REVISION_WITH_*</c> constants.
+/// </summary>
+internal enum ProtocolFeature
+{
+    /// <summary>ServerHello carries a <c>timezone</c> string.</summary>
+    Timezone = 54058,
+
+    /// <summary>ServerHello carries a <c>display_name</c> string.</summary>
+    DisplayName = 54372,
+
+    /// <summary>ServerHello carries a <c>version_patch</c> VarUInt.</summary>
+    VersionPatch = 54401,
+
+    /// <summary>The client sends an Addendum after the handshake exchange.</summary>
+    Addendum = 54458,
+
+    /// <summary>Per-packet chunk framing wraps every packet body; preferences are exchanged in ServerHello and Addendum.</summary>
+    ChunkedProtocol = 54470,
+
+    /// <summary>Both sides exchange a parallel-replicas coordination protocol version (ServerHello field 4a, Addendum tail).</summary>
+    ParallelReplicas = 54471,
+}

--- a/ClickHouse.Driver.Tcp/Protocol/ServerHandshake.cs
+++ b/ClickHouse.Driver.Tcp/Protocol/ServerHandshake.cs
@@ -1,0 +1,32 @@
+namespace ClickHouse.Driver.Tcp.Protocol;
+
+/// <summary>
+/// The server identity and protocol details decoded from ServerHello. The timezone and display name are
+/// blank when the negotiated version predates the features that introduced them.
+/// </summary>
+internal sealed record ServerHandshake
+{
+    /// <summary>Server identifier (e.g. <c>"ClickHouse"</c>).</summary>
+    required public string ServerName { get; init; }
+
+    /// <summary>Server major version.</summary>
+    required public int VersionMajor { get; init; }
+
+    /// <summary>Server minor version.</summary>
+    required public int VersionMinor { get; init; }
+
+    /// <summary>The server's protocol revision, as reported in ServerHello.</summary>
+    required public int Revision { get; init; }
+
+    /// <summary>Server patch version, or 0 when not present at the negotiated version.</summary>
+    public int VersionPatch { get; init; }
+
+    /// <summary>Server timezone (e.g. <c>"UTC"</c>), or empty when not present. Used for DateTime offset resolution.</summary>
+    public string Timezone { get; init; } = string.Empty;
+
+    /// <summary>Human-readable server name, or empty when not present.</summary>
+    public string DisplayName { get; init; } = string.Empty;
+
+    /// <summary>The version negotiated with this server: <c>min(client, <see cref="Revision"/>)</c>.</summary>
+    public NegotiatedProtocol Negotiated => new(Revision);
+}


### PR DESCRIPTION
Implements the connection handshake for the native-TCP client. Stacked on the packet-envelope PR.

## What's here
- **ClientHello / ServerHello / Addendum** encode + decode (`Handshake.cs`), plus `PerformAsync` that runs the exchange end to end: send ClientHello → dispatch the reply (Hello / Exception / protocol violation) → send the Addendum.
- **Version negotiation + feature gates** (`NegotiatedProtocol`, `ProtocolFeature`): negotiated version = `min(client, server)`; every version-conditional field keys off a single `Supports(feature)` map rather than scattered magic numbers.
- **Server Exception decode** (`ClickHouseServerException`): code + name + message + stack trace, nested frames chained as `InnerException`, so a rejected handshake (e.g. bad auth) surfaces cleanly.
- DTOs: `ClientHandshakeParameters` (credentials/identity — populated from client options in a later epic) and `ServerHandshake` (decoded server info + negotiated version).

## Key decisions
- Advertise protocol **54460**; every supported server (≥ 25.8) negotiates down to this constant, so there's a single wire layout to implement.
- ServerHello decode gates on the **negotiated (clamped)** version, not the raw revision — it reads exactly the fields the server wrote and can't desync.
- Deferred (gated > 54460, never active here): chunked framing, compression, parallel replicas, SSH.

## Testing
Unit tests are limited to logic the integration suite can't reach: version gating against an older revision no supported server negotiates, the `>=` gate boundary, and nested-exception chaining (`has_nested` is always false on the wire today). Happy-path encode/decode and orchestration will be covered by integration tests. 148 TCP tests pass, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
