### PR TITLE
TCP E: Blocks, packet bodies, type parsing, and the first columnar SELECT

### DIFF
--- a/.github/workflows/tests-tcp.yml
+++ b/.github/workflows/tests-tcp.yml
@@ -2,22 +2,28 @@ name: TCP Tests
 
 # Runs the ClickHouse.Driver.Tcp test suite, gated on changes to the TCP projects only.
 # The TCP project is standalone (no reference to ClickHouse.Driver), so its build/test closure is just
-# the two TCP projects plus the shared package versions.
+# the two TCP projects plus the shared package versions and the CI wiring itself.
 on:
   push:
-    branches: [main, tcp-client] # tcp-client is the long-lived feature branch that the per-epic PRs stack onto
-    paths:
-      - "ClickHouse.Driver.Tcp/**"
-      - "ClickHouse.Driver.Tcp.Tests/**"
-      - "Directory.Packages.props"
-      - ".github/workflows/tests-tcp.yml"
-  pull_request:
+    # Only the long-lived integration branches run on push (validating what landed). The per-epic tcp/**
+    # branches are validated by the pull_request trigger below; keeping them off push avoids a duplicate
+    # run every time a commit is pushed to an epic branch that already has an open PR.
     branches: [main, tcp-client]
     paths:
       - "ClickHouse.Driver.Tcp/**"
       - "ClickHouse.Driver.Tcp.Tests/**"
       - "Directory.Packages.props"
       - ".github/workflows/tests-tcp.yml"
+      - ".github/workflows/reusable-tcp.yml"
+  pull_request:
+    # Matches the PR's base branch, so a PR stacked onto another tcp/** epic branch triggers too.
+    branches: [main, tcp-client, "tcp/**"]
+    paths:
+      - "ClickHouse.Driver.Tcp/**"
+      - "ClickHouse.Driver.Tcp.Tests/**"
+      - "Directory.Packages.props"
+      - ".github/workflows/tests-tcp.yml"
+      - ".github/workflows/reusable-tcp.yml"
   workflow_dispatch:
     inputs:
       ref:
@@ -29,42 +35,31 @@ permissions:
   contents: read
 
 jobs:
-  test:
-    name: TCP Tests (${{ matrix.framework }})
-    runs-on: ubuntu-22.04
-    timeout-minutes: 10
+  regress-clickhouse-tcp:
+    name: ClickHouse regression (TCP)
+    uses: ./.github/workflows/reusable-tcp.yml
+    with:
+      clickhouse-version: ${{ matrix.version }}
+      ref: ${{ inputs.ref }}
     strategy:
       fail-fast: false
       matrix:
-        framework: ["net8.0", "net9.0", "net10.0"] # TCP library targets net8.0+ only
+        version:
+          - "latest"
+          - "26.6"
+          - "26.5"
+          - "26.4"
+          - "26.3"
+          - "25.8"
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-
-      - uses: actions/cache@v6
-        name: Cache NuGet
-        with:
-          path: ~/.nuget/packages
-          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', 'Directory.Packages.props') }}
-          restore-keys: |
-            ${{ runner.os }}-nuget-
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: |
-            8.x
-            9.x
-            10.x
-
-      - name: Test
-        run: >
-          dotnet test ClickHouse.Driver.Tcp.Tests/ClickHouse.Driver.Tcp.Tests.csproj
-          --framework ${{ matrix.framework }}
-          --configuration Release
-          --verbosity normal
-          --logger GitHubActions
-          /clp:ErrorsOnly
+  regress-dotnet-tcp:
+    name: .NET regression (TCP)
+    # Framework axis: each TFM runs against clickhouse-version 'latest' (the reusable default).
+    uses: ./.github/workflows/reusable-tcp.yml
+    with:
+      framework: ${{ matrix.framework }}
+      ref: ${{ inputs.ref }}
+    strategy:
+      fail-fast: false
+      matrix:
+        framework: ["net10.0", "net9.0", "net8.0"] # TCP library targets net8.0+ only

--- a/ClickHouse.Driver.Tcp.Tests/Format/BlockInfoTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Format/BlockInfoTests.cs
@@ -1,0 +1,75 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Format;
+using ClickHouse.Driver.Tcp.Protocol;
+
+namespace ClickHouse.Driver.Tcp.Tests.Format;
+
+[TestFixture]
+public class BlockInfoTests
+{
+    private static readonly CancellationToken None = CancellationToken.None;
+
+    [Test]
+    public async Task WriteBlockInfo_Default_ProducesFieldTaggedBytes()
+    {
+        // field 1 + is_overflows=0, field 2 + bucket=-1 (Int32), terminator 0.
+        byte[] bytes = await WriteAsync(w => BlockWriter.WriteBlockInfo(w, BlockInfo.Default));
+        CollectionAssert.AreEqual(new byte[] { 0x01, 0x00, 0x02, 0xFF, 0xFF, 0xFF, 0xFF, 0x00 }, bytes);
+    }
+
+    [Test]
+    public async Task ReadBlockInfoAsync_Default_DecodesStandardValues()
+    {
+        byte[] bytes = await WriteAsync(w => BlockWriter.WriteBlockInfo(w, BlockInfo.Default));
+        using var reader = ReaderOver(bytes);
+
+        BlockInfo info = await BlockReader.ReadBlockInfoAsync(reader, None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(info.IsOverflows, Is.False);
+            Assert.That(info.BucketNumber, Is.EqualTo(-1));
+        });
+    }
+
+    [Test]
+    public async Task ReadBlockInfoAsync_CustomValues_RoundTrips()
+    {
+        byte[] bytes = await WriteAsync(w => BlockWriter.WriteBlockInfo(w, new BlockInfo(isOverflows: true, bucketNumber: 5)));
+        using var reader = ReaderOver(bytes);
+
+        BlockInfo info = await BlockReader.ReadBlockInfoAsync(reader, None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(info.IsOverflows, Is.True);
+            Assert.That(info.BucketNumber, Is.EqualTo(5));
+        });
+    }
+
+    [Test]
+    public async Task ReadBlockInfoAsync_UnknownFieldId_ThrowsProtocol()
+    {
+        byte[] bytes = await WriteAsync(w => w.WriteVarUInt(3)); // no field id 3 is defined
+        using var reader = ReaderOver(bytes);
+
+        Assert.ThrowsAsync<ClickHouseProtocolException>(async () => await BlockReader.ReadBlockInfoAsync(reader, None));
+    }
+
+    private static async Task<byte[]> WriteAsync(Action<ClickHouseBinaryWriter> write)
+    {
+        using var ms = new MemoryStream();
+        using (var writer = new ClickHouseBinaryWriter(ms))
+        {
+            write(writer);
+            await writer.FlushAsync(None);
+        }
+
+        return ms.ToArray();
+    }
+
+    private static ClickHouseBinaryReader ReaderOver(byte[] bytes) => new(new MemoryStream(bytes));
+}

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpConnectionIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpConnectionIntegrationTests.cs
@@ -67,7 +67,7 @@ public class ClickHouseTcpConnectionIntegrationTests
             await ClickHouseTcpConnection.ConnectAsync(
                 TcpServerFixture.Host,
                 1,
-                new ClientHandshakeParameters { ClientName = "test", Username = "default" },
+                new ClientHandshakeParameters { Username = "default" },
                 None));
     }
 }

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpConnectionMetadataIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpConnectionMetadataIntegrationTests.cs
@@ -1,0 +1,185 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Format;
+using ClickHouse.Driver.Tcp.Protocol;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Tests.Integration;
+
+// Drives each interleaved metadata packet from a real server and asserts its handler fires, validating the
+// decoders against real server output rather than only hand-authored bytes. A yielded Block is borrowed, and so
+// is a block handed to a block handler — everything needed is copied out inside the callback.
+//
+// Not covered here: TableColumns (the server sends it for external-table/defaults scenarios that a plain query
+// does not create, and the client discards it anyway) and PartUUIDs (needs part-level query deduplication on a
+// replicated table). Both remain covered by the scripted-byte unit tests.
+[TestFixture]
+[Category("Integration")]
+public class ClickHouseTcpConnectionMetadataIntegrationTests
+{
+    private static readonly CancellationToken None = CancellationToken.None;
+
+    private static async Task DrainAsync(ClickHouseTcpConnection connection, string sql, MetadataHandlers handlers, IReadOnlyDictionary<string, string> settings = null)
+    {
+        await foreach (Block block in connection.QueryAsync(sql, settings: settings, handlers: handlers, cancellationToken: None))
+        {
+            _ = block.RowCount;
+        }
+    }
+
+    [Test]
+    public async Task QueryAsync_ScanningManyRows_InvokesProgressWithRowsRead()
+    {
+        await using var connection = await TcpServerFixture.ConnectAsync(None);
+
+        int progressCount = 0;
+        ulong maxRows = 0;
+        await DrainAsync(connection, "SELECT sum(number) FROM numbers(2000000)", new MetadataHandlers
+        {
+            OnProgress = p =>
+            {
+                progressCount++;
+                if (p.Rows > maxRows)
+                {
+                    maxRows = p.Rows;
+                }
+            },
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(progressCount, Is.GreaterThan(0), "at least one Progress packet");
+            Assert.That(maxRows, Is.GreaterThan(0UL), "Progress reports rows read");
+            Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+        });
+    }
+
+    [Test]
+    public async Task QueryAsync_AnyQuery_InvokesProfileInfo()
+    {
+        await using var connection = await TcpServerFixture.ConnectAsync(None);
+
+        int count = 0;
+        ulong rows = 0;
+        await DrainAsync(connection, "SELECT number FROM numbers(10)", new MetadataHandlers
+        {
+            OnProfileInfo = info =>
+            {
+                count++;
+                rows = info.Rows;
+            },
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(count, Is.GreaterThan(0), "ProfileInfo summary is sent");
+            Assert.That(rows, Is.EqualTo(10UL));
+            Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+        });
+    }
+
+    [Test]
+    public async Task QueryAsync_AnyQuery_InvokesProfileEvents()
+    {
+        await using var connection = await TcpServerFixture.ConnectAsync(None);
+
+        int blocks = 0;
+        await DrainAsync(connection, "SELECT number FROM numbers(10)", new MetadataHandlers
+        {
+            OnProfileEvents = block =>
+            {
+                if (block.RowCount > 0)
+                {
+                    blocks++;
+                }
+            },
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(blocks, Is.GreaterThan(0), "the server sends a ProfileEvents block");
+            Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+        });
+    }
+
+    [Test]
+    public async Task QueryAsync_GroupByWithTotals_InvokesTotalsOnce()
+    {
+        await using var connection = await TcpServerFixture.ConnectAsync(None);
+
+        int totalsCount = 0;
+        int totalsRows = 0;
+        ulong totalCount = 0;
+        await DrainAsync(
+            connection,
+            "SELECT number % 3 AS k, count() AS c FROM numbers(100) GROUP BY k WITH TOTALS",
+            new MetadataHandlers
+            {
+                OnTotals = block =>
+                {
+                    totalsCount++;
+                    totalsRows = block.RowCount;
+                    totalCount = ((IColumn<ulong>)block[1]).Values[0];
+                },
+            });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(totalsCount, Is.EqualTo(1), "exactly one Totals block");
+            Assert.That(totalsRows, Is.EqualTo(1), "the totals row");
+            Assert.That(totalCount, Is.EqualTo(100UL), "the grand total count");
+            Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+        });
+    }
+
+    [Test]
+    public async Task QueryAsync_ExtremesSetting_InvokesExtremesWithMinAndMax()
+    {
+        await using var connection = await TcpServerFixture.ConnectAsync(None);
+
+        int extremesCount = 0;
+        ulong[] rows = null;
+        await DrainAsync(
+            connection,
+            "SELECT number FROM numbers(10)",
+            new MetadataHandlers
+            {
+                OnExtremes = block =>
+                {
+                    extremesCount++;
+                    rows = ((IColumn<ulong>)block[0]).Values.ToArray();
+                },
+            },
+            settings: new Dictionary<string, string> { ["extremes"] = "1" });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(extremesCount, Is.EqualTo(1), "exactly one Extremes block");
+            Assert.That(rows, Is.EqualTo(new ulong[] { 0, 9 }), "min then max");
+            Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+        });
+    }
+
+    [Test]
+    public async Task QueryAsync_TraceLogsSetting_InvokesLog()
+    {
+        await using var connection = await TcpServerFixture.ConnectAsync(None);
+
+        int logRows = 0;
+        await DrainAsync(
+            connection,
+            "SELECT sum(number) FROM numbers(100000)",
+            new MetadataHandlers
+            {
+                OnLog = block => logRows += block.RowCount,
+            },
+            settings: new Dictionary<string, string> { ["send_logs_level"] = "trace" });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(logRows, Is.GreaterThan(0), "the server streams trace-level log rows");
+            Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+        });
+    }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpConnectionQueryIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpConnectionQueryIntegrationTests.cs
@@ -1,0 +1,207 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Format;
+using ClickHouse.Driver.Tcp.Numerics;
+using ClickHouse.Driver.Tcp.Protocol;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Tests.Integration;
+
+// A yielded Block is borrowed — valid only for its iteration — so every test reads or copies what it needs
+// inside the await foreach, never retaining the block.
+[TestFixture]
+[Category("Integration")]
+public class ClickHouseTcpConnectionQueryIntegrationTests
+{
+    private static readonly CancellationToken None = CancellationToken.None;
+
+    [Test]
+    public async Task QueryAsync_SelectLiteralInteger_ReturnsSingleUInt8()
+    {
+        await using var connection = await TcpServerFixture.ConnectAsync(None);
+
+        int blockCount = 0;
+        string typeName = null;
+        byte value = 0;
+        await foreach (Block block in connection.QueryAsync("SELECT 1", cancellationToken: None))
+        {
+            blockCount++;
+            typeName = block[0].TypeName;
+            value = ((IColumn<byte>)block[0]).Values[0];
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(blockCount, Is.EqualTo(1));
+            Assert.That(typeName, Is.EqualTo("UInt8"));
+            Assert.That(value, Is.EqualTo((byte)1));
+            Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+        });
+    }
+
+    [Test]
+    public async Task QueryAsync_SelectStringLiteral_ReturnsString()
+    {
+        await using var connection = await TcpServerFixture.ConnectAsync(None);
+
+        string value = null;
+        await foreach (Block block in connection.QueryAsync("SELECT 'hello'", cancellationToken: None))
+        {
+            value = ((IColumn<string>)block[0]).Values[0];
+        }
+
+        Assert.That(value, Is.EqualTo("hello"));
+    }
+
+    [Test]
+    public async Task QueryAsync_NumbersWithToString_ReturnsUInt64AndStringColumns()
+    {
+        await using var connection = await TcpServerFixture.ConnectAsync(None);
+
+        var numbers = new List<ulong>();
+        var strings = new List<string>();
+        await foreach (Block block in connection.QueryAsync("SELECT number, toString(number) FROM system.numbers LIMIT 5", cancellationToken: None))
+        {
+            numbers.AddRange(((IColumn<ulong>)block[0]).Values.ToArray());
+            strings.AddRange(((IColumn<string>)block[1]).Values.ToArray());
+        }
+
+        Assert.Multiple(() =>
+        {
+            CollectionAssert.AreEqual(new ulong[] { 0, 1, 2, 3, 4 }, numbers);
+            CollectionAssert.AreEqual(new[] { "0", "1", "2", "3", "4" }, strings);
+        });
+    }
+
+    [Test]
+    public async Task QueryAsync_AllIntegerWidths_RoundTripEachValue()
+    {
+        await using var connection = await TcpServerFixture.ConnectAsync(None);
+
+        int blockCount = 0;
+        byte u8 = 0;
+        sbyte i8 = 0;
+        ushort u16 = 0;
+        short i16 = 0;
+        uint u32 = 0;
+        int i32 = 0;
+        ulong u64 = 0;
+        long i64 = 0;
+        UInt128 u128 = 0;
+        Int128 i128 = 0;
+        BigInteger u256 = 0;
+        BigInteger i256 = 0;
+        await foreach (Block row in connection.QueryAsync(
+            "SELECT toUInt8(1), toInt8(-1), toUInt16(2), toInt16(-2), toUInt32(3), toInt32(-3), " +
+            "toUInt64(4), toInt64(-4), toUInt128(5), toInt128(-5), toUInt256(6), toInt256(-6)",
+            cancellationToken: None))
+        {
+            blockCount++;
+            u8 = ((IColumn<byte>)row[0]).Values[0];
+            i8 = ((IColumn<sbyte>)row[1]).Values[0];
+            u16 = ((IColumn<ushort>)row[2]).Values[0];
+            i16 = ((IColumn<short>)row[3]).Values[0];
+            u32 = ((IColumn<uint>)row[4]).Values[0];
+            i32 = ((IColumn<int>)row[5]).Values[0];
+            u64 = ((IColumn<ulong>)row[6]).Values[0];
+            i64 = ((IColumn<long>)row[7]).Values[0];
+            u128 = ((IColumn<UInt128>)row[8]).Values[0];
+            i128 = ((IColumn<Int128>)row[9]).Values[0];
+            u256 = ((IColumn<UInt256>)row[10]).Values[0].ToBigInteger();
+            i256 = ((IColumn<Int256>)row[11]).Values[0].ToBigInteger();
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(blockCount, Is.EqualTo(1));
+            Assert.That(u8, Is.EqualTo((byte)1));
+            Assert.That(i8, Is.EqualTo((sbyte)-1));
+            Assert.That(u16, Is.EqualTo((ushort)2));
+            Assert.That(i16, Is.EqualTo((short)-2));
+            Assert.That(u32, Is.EqualTo(3u));
+            Assert.That(i32, Is.EqualTo(-3));
+            Assert.That(u64, Is.EqualTo(4ul));
+            Assert.That(i64, Is.EqualTo(-4L));
+            Assert.That(u128, Is.EqualTo((UInt128)5));
+            Assert.That(i128, Is.EqualTo((Int128)(-5)));
+            Assert.That(u256, Is.EqualTo(new BigInteger(6)));
+            Assert.That(i256, Is.EqualTo(new BigInteger(-6)));
+        });
+    }
+
+    [Test]
+    public async Task QueryAsync_LargeResultWithSmallBlocks_StreamsAllRowsAcrossBlocks()
+    {
+        await using var connection = await TcpServerFixture.ConnectAsync(None);
+        var settings = new Dictionary<string, string> { ["max_block_size"] = "1000" };
+
+        int blockCount = 0;
+        long rows = 0;
+        BigInteger sum = BigInteger.Zero;
+        await foreach (Block block in connection.QueryAsync("SELECT number FROM system.numbers LIMIT 100000", settings, cancellationToken: None))
+        {
+            blockCount++;
+            foreach (ulong value in ((IColumn<ulong>)block[0]).Values)
+            {
+                rows++;
+                sum += value;
+            }
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(blockCount, Is.GreaterThan(1), "small max_block_size should split the result into multiple blocks");
+            Assert.That(rows, Is.EqualTo(100000));
+            Assert.That(sum, Is.EqualTo(new BigInteger(4999950000))); // 0 + 1 + ... + 99999
+            Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+        });
+    }
+
+    [Test]
+    public async Task QueryAsync_EmptyResult_YieldsNoRowBearingBlocksAndStaysReady()
+    {
+        await using var connection = await TcpServerFixture.ConnectAsync(None);
+
+        int blockCount = 0;
+        await foreach (Block block in connection.QueryAsync("SELECT 1 WHERE 0", cancellationToken: None))
+        {
+            _ = block;
+            blockCount++;
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(blockCount, Is.EqualTo(0));
+            Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+        });
+    }
+
+    [Test]
+    public async Task QueryAsync_ServerError_ThrowsThenConnectionIsReusable()
+    {
+        await using var connection = await TcpServerFixture.ConnectAsync(None);
+
+        var thrown = Assert.ThrowsAsync<ClickHouseServerException>(async () =>
+        {
+            await foreach (Block block in connection.QueryAsync("SELECT * FROM table_that_does_not_exist_xyz", cancellationToken: None))
+            {
+                _ = block;
+            }
+        });
+        Assert.That(thrown.Code, Is.GreaterThan(0));
+
+        // The Exception is a complete response, so the same connection can run another query.
+        Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+
+        byte value = 0;
+        await foreach (Block block in connection.QueryAsync("SELECT 1", cancellationToken: None))
+        {
+            value = ((IColumn<byte>)block[0]).Values[0];
+        }
+
+        Assert.That(value, Is.EqualTo((byte)1));
+    }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Integration/TcpServerFixture.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/TcpServerFixture.cs
@@ -80,7 +80,6 @@ public sealed class TcpServerFixture
             Port,
             new ClientHandshakeParameters
             {
-                ClientName = "ClickHouse.Driver.Tcp.Tests",
                 Username = username ?? Username,
                 Password = password ?? Password,
             },

--- a/ClickHouse.Driver.Tcp.Tests/Protocol/ClickHouseTcpConnectionQueryTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Protocol/ClickHouseTcpConnectionQueryTests.cs
@@ -1,0 +1,597 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Format;
+using ClickHouse.Driver.Tcp.Protocol;
+using ClickHouse.Driver.Tcp.Tests.Utilities;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Tests.Protocol;
+
+// Drives QueryAsync over a scripted server stream: the response shapes and failure modes a live server
+// can't be made to produce on demand. A real SELECT round-trip is covered by the integration suite.
+[TestFixture]
+public class ClickHouseTcpConnectionQueryTests
+{
+    private static readonly CancellationToken None = CancellationToken.None;
+
+    private static readonly ClientHandshakeParameters Handshake = new()
+    {
+        Username = "default",
+    };
+
+    [Test]
+    public async Task QueryAsync_DrainsResponse_YieldsRowBearingBlocksAndReturnsToReady()
+    {
+        byte[] script = Concat(
+            await ServerHelloBytesAsync(54476),
+            await DataPacketAsync(Array.Empty<ulong>()),   // schema header (0 rows) — not yielded
+            await DataPacketAsync(new ulong[] { 1, 2, 3 }),
+            await ProgressPacketAsync(),
+            await ProfileEventsPacketAsync(),               // always-present block, consumed and discarded
+            EndOfStreamPacket());
+        using var connection = await ConnectedAsync(script);
+
+        var rows = await MaterializeAsync(connection);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(rows, Has.Count.EqualTo(1));
+            CollectionAssert.AreEqual(new ulong[] { 1, 2, 3 }, rows[0]);
+            Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+        });
+    }
+
+    [Test]
+    public async Task QueryAsync_MultipleRowBearingBlocks_YieldsAllInOrder()
+    {
+        byte[] script = Concat(
+            await ServerHelloBytesAsync(54476),
+            await DataPacketAsync(new ulong[] { 1, 2 }),
+            await DataPacketAsync(new ulong[] { 3, 4 }),
+            EndOfStreamPacket());
+        using var connection = await ConnectedAsync(script);
+
+        var rows = await MaterializeAsync(connection);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(rows, Has.Count.EqualTo(2));
+            CollectionAssert.AreEqual(new ulong[] { 1, 2 }, rows[0]);
+            CollectionAssert.AreEqual(new ulong[] { 3, 4 }, rows[1]);
+        });
+    }
+
+    [Test]
+    public async Task QueryAsync_ServerExceptionMidStream_ThrowsButStaysReusable()
+    {
+        byte[] script = Concat(
+            await ServerHelloBytesAsync(54476),
+            await DataPacketAsync(new ulong[] { 7 }),
+            await ExceptionPacketAsync(241, "memory limit exceeded"));
+        using var connection = await ConnectedAsync(script);
+
+        var rows = new List<ulong[]>();
+        var thrown = Assert.ThrowsAsync<ClickHouseServerException>(async () =>
+        {
+            await foreach (Block block in connection.QueryAsync("SELECT 1", cancellationToken: None))
+            {
+                rows.Add(((IColumn<ulong>)block[0]).Values.ToArray());
+            }
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(thrown.Code, Is.EqualTo(241));
+            Assert.That(thrown.Message, Is.EqualTo("memory limit exceeded"));
+            Assert.That(rows, Has.Count.EqualTo(1)); // the block before the exception was still surfaced
+            CollectionAssert.AreEqual(new ulong[] { 7 }, rows[0]);
+            Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+        });
+    }
+
+    [Test]
+    public async Task QueryAsync_UnexpectedPacket_ThrowsProtocolAndTerminates()
+    {
+        byte[] script = Concat(
+            await ServerHelloBytesAsync(54476),
+            PacketBytes(ServerPacketType.Pong)); // never valid in a query response
+        using var connection = await ConnectedAsync(script);
+
+        Assert.ThrowsAsync<ClickHouseProtocolException>(async () => await DrainAsync(connection));
+        Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Terminated));
+    }
+
+    [Test]
+    public async Task QueryAsync_TransportEndsMidResponse_Terminates()
+    {
+        // A Data packet type with no block body: the read for the block name hits end of stream.
+        byte[] script = Concat(
+            await ServerHelloBytesAsync(54476),
+            await BytesAsync(w => w.WriteVarUInt((ulong)ServerPacketType.Data)));
+        using var connection = await ConnectedAsync(script);
+
+        Assert.ThrowsAsync<EndOfStreamException>(async () => await DrainAsync(connection));
+        Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Terminated));
+    }
+
+    [Test]
+    public async Task QueryAsync_EnumerationAbandonedBeforeEndOfStream_Terminates()
+    {
+        byte[] script = Concat(
+            await ServerHelloBytesAsync(54476),
+            await DataPacketAsync(new ulong[] { 1 }),
+            await DataPacketAsync(new ulong[] { 2 }),
+            EndOfStreamPacket());
+        using var connection = await ConnectedAsync(script);
+
+        await foreach (Block block in connection.QueryAsync("SELECT 1", cancellationToken: None))
+        {
+            _ = block;
+            break; // stop after the first block, leaving the response partway read
+        }
+
+        Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Terminated));
+    }
+
+    [Test]
+    public async Task QueryAsync_TokenAlreadyCancelled_ThrowsWithoutClaimingConnection()
+    {
+        var transport = new ScriptedDuplexStream(await ServerHelloBytesAsync(54476));
+        using var connection = new ClickHouseTcpConnection(transport, socket: null);
+        await connection.HandshakeAsync(Handshake, None);
+        byte[] writtenBeforeQuery = transport.Written;
+
+        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        {
+            await foreach (Block block in connection.QueryAsync("SELECT 1", cancellationToken: new CancellationToken(canceled: true)))
+            {
+                _ = block;
+            }
+        });
+
+        // A pre-cancelled query must not claim the connection or send anything, leaving it Ready and reusable.
+        Assert.Multiple(() =>
+        {
+            Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+            Assert.That(transport.Written, Is.EqualTo(writtenBeforeQuery));
+        });
+    }
+
+    [Test]
+    public async Task QueryAsync_ParametersOnProtocolWithoutSupport_ThrowsButStaysReady()
+    {
+        // A revision accepted by the handshake but below the one that introduced query parameters (and at or
+        // above the one whose block format the scripted server uses). Passing parameters is a client-side error
+        // caught while encoding, before anything is flushed, so the connection must stay Ready and reusable and
+        // nothing may reach the socket.
+        var transport = new ScriptedDuplexStream(await ServerHelloBytesAsync(54458));
+        using var connection = new ClickHouseTcpConnection(transport, socket: null);
+        await connection.HandshakeAsync(Handshake, None);
+        byte[] writtenBeforeQuery = transport.Written;
+
+        var parameters = new Dictionary<string, string> { ["id"] = "42" };
+        Assert.ThrowsAsync<NotSupportedException>(async () =>
+        {
+            await foreach (Block block in connection.QueryAsync("SELECT {id:UInt64}", parameters: parameters, cancellationToken: None))
+            {
+                _ = block;
+            }
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+            Assert.That(transport.Written, Is.EqualTo(writtenBeforeQuery));
+        });
+    }
+
+    [Test]
+    public async Task QueryAsync_AfterPreFlushFailure_ConnectionRemainsUsable()
+    {
+        // After a client-side encoding failure leaves the connection Ready, a subsequent well-formed query on
+        // the same connection must run cleanly — proving the partial packet was discarded, not left buffered.
+        byte[] script = Concat(
+            await ServerHelloBytesAsync(54458),
+            await DataPacketAsync(new ulong[] { 1, 2, 3 }),
+            EndOfStreamPacket());
+        using var connection = await ConnectedAsync(script);
+
+        var parameters = new Dictionary<string, string> { ["id"] = "42" };
+        Assert.ThrowsAsync<NotSupportedException>(async () =>
+        {
+            await foreach (Block block in connection.QueryAsync("SELECT {id:UInt64}", parameters: parameters, cancellationToken: None))
+            {
+                _ = block;
+            }
+        });
+
+        var rows = await MaterializeAsync(connection);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(rows, Has.Count.EqualTo(1));
+            CollectionAssert.AreEqual(new ulong[] { 1, 2, 3 }, rows[0]);
+            Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+        });
+    }
+
+    [Test]
+    public async Task QueryAsync_PartUuidsPacket_ConsumedAndStreamStaysAligned()
+    {
+        // PartUUIDs is valid mid-query under part-level deduplication; the client has no surface for the values
+        // yet, so it must consume the body and keep reading the following Data block without desyncing.
+        byte[] script = Concat(
+            await ServerHelloBytesAsync(54476),
+            await PartUuidsPacketAsync(new UInt128[] { 1, 2 }),
+            await DataPacketAsync(new ulong[] { 9, 8, 7 }),
+            EndOfStreamPacket());
+        using var connection = await ConnectedAsync(script);
+
+        var rows = await MaterializeAsync(connection);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(rows, Has.Count.EqualTo(1));
+            CollectionAssert.AreEqual(new ulong[] { 9, 8, 7 }, rows[0]);
+            Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+        });
+    }
+
+    [Test]
+    public async Task QueryAsync_BlockColumnCountExceedsMaximum_ThrowsProtocolAndTerminates()
+    {
+        // A column count beyond the defensive ceiling must be rejected before an array is allocated from it.
+        byte[] script = Concat(
+            await ServerHelloBytesAsync(54476),
+            await BytesAsync(w =>
+            {
+                w.WriteVarUInt((ulong)ServerPacketType.Data);
+                w.WriteString(string.Empty);         // block name
+                BlockWriter.WriteBlockInfo(w, BlockInfo.Default);
+                w.WriteVarUInt((1UL << 20) + 1);     // num_columns beyond the supported maximum
+                w.WriteVarUInt(0);                   // num_rows
+            }));
+        using var connection = await ConnectedAsync(script);
+
+        Assert.ThrowsAsync<ClickHouseProtocolException>(async () => await DrainAsync(connection));
+        Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Terminated));
+    }
+
+    [Test]
+    public async Task QueryAsync_ProgressHandler_InvokedForEachProgressInWireOrder()
+    {
+        byte[] script = Concat(
+            await ServerHelloBytesAsync(54476),
+            await ProgressPacketAsync(),
+            await DataPacketAsync(new ulong[] { 5 }),
+            await ProgressPacketAsync(),
+            EndOfStreamPacket());
+        using var connection = await ConnectedAsync(script);
+
+        var progresses = new List<Progress>();
+        await DrainAsync(connection, new MetadataHandlers { OnProgress = progresses.Add });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(progresses, Has.Count.EqualTo(2));
+            Assert.That(progresses[0].Rows, Is.EqualTo(1UL));
+            Assert.That(progresses[0].Bytes, Is.EqualTo(2UL));
+            Assert.That(progresses[0].TotalRows, Is.EqualTo(3UL));
+            Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+        });
+    }
+
+    [Test]
+    public async Task QueryAsync_ProfileInfoHandler_InvokedWithDecodedSummary()
+    {
+        byte[] script = Concat(
+            await ServerHelloBytesAsync(54476),
+            await ProfileInfoPacketAsync(),
+            await DataPacketAsync(new ulong[] { 5 }),
+            EndOfStreamPacket());
+        using var connection = await ConnectedAsync(script);
+
+        var captured = new List<ProfileInfo>();
+        await DrainAsync(connection, new MetadataHandlers { OnProfileInfo = captured.Add });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(captured, Has.Count.EqualTo(1));
+            Assert.That(captured[0].Rows, Is.EqualTo(10UL));
+            Assert.That(captured[0].RowsBeforeLimit, Is.EqualTo(50UL));
+            Assert.That(captured[0].AppliedLimit, Is.True);
+        });
+    }
+
+    [Test]
+    public async Task QueryAsync_TotalsHandler_ReceivesBlockValidDuringCall()
+    {
+        byte[] script = Concat(
+            await ServerHelloBytesAsync(54476),
+            await DataPacketAsync(new ulong[] { 1, 2 }),
+            await TotalsPacketAsync(new ulong[] { 99 }),
+            EndOfStreamPacket());
+        using var connection = await ConnectedAsync(script);
+
+        var totals = new List<ulong[]>();
+        // Copy out inside the call, since the block is released as soon as the handler returns.
+        await DrainAsync(connection, new MetadataHandlers
+        {
+            OnTotals = block => totals.Add(((IColumn<ulong>)block[0]).Values.ToArray()),
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(totals, Has.Count.EqualTo(1));
+            CollectionAssert.AreEqual(new ulong[] { 99 }, totals[0]);
+            Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+        });
+    }
+
+    [Test]
+    public async Task QueryAsync_AllMetadataHandlers_EachInvokedForItsPacket()
+    {
+        byte[] script = Concat(
+            await ServerHelloBytesAsync(54476),
+            await TableColumnsPacketAsync("ext", "a UInt64"),
+            await ExtremesPacketAsync(new ulong[] { 0, 100 }),
+            await LogPacketAsync(new ulong[] { 7 }),
+            await ProfileEventsPacketAsync(),
+            await DataPacketAsync(new ulong[] { 42 }),
+            EndOfStreamPacket());
+        using var connection = await ConnectedAsync(script);
+
+        int extremes = 0;
+        int log = 0;
+        int profileEvents = 0;
+        await DrainAsync(connection, new MetadataHandlers
+        {
+            OnExtremes = _ => extremes++,
+            OnLog = _ => log++,
+            OnProfileEvents = _ => profileEvents++,
+        });
+
+        // The TableColumns packet in the script has no handler; it must be decoded and discarded without
+        // desyncing the stream, so the other handlers still fire and the query completes cleanly.
+        Assert.Multiple(() =>
+        {
+            Assert.That(extremes, Is.EqualTo(1));
+            Assert.That(log, Is.EqualTo(1));
+            Assert.That(profileEvents, Is.EqualTo(1));
+            Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+        });
+    }
+
+    [Test]
+    public async Task QueryAsync_MetadataHandlerThrows_PropagatesAndTerminates()
+    {
+        byte[] script = Concat(
+            await ServerHelloBytesAsync(54476),
+            await ProgressPacketAsync(),
+            await DataPacketAsync(new ulong[] { 1 }),
+            EndOfStreamPacket());
+        using var connection = await ConnectedAsync(script);
+
+        var boom = new InvalidOperationException("handler failed");
+        var thrown = Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await DrainAsync(connection, new MetadataHandlers { OnProgress = _ => throw boom }));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(thrown, Is.SameAs(boom));
+            Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Terminated));
+        });
+    }
+
+    [Test]
+    public async Task QueryAsync_BeforeHandshake_ThrowsInvalidOperation()
+    {
+        using var connection = new ClickHouseTcpConnection(new ScriptedDuplexStream(Array.Empty<byte>()), socket: null);
+
+        Assert.ThrowsAsync<InvalidOperationException>(async () => await DrainAsync(connection));
+    }
+
+    [Test]
+    public async Task QueryAsync_AfterTerminate_ThrowsObjectDisposed()
+    {
+        using var connection = await ConnectedAsync(await ServerHelloBytesAsync(54476));
+        connection.Terminate();
+
+        Assert.ThrowsAsync<ObjectDisposedException>(async () => await DrainAsync(connection));
+    }
+
+    private static async Task<ClickHouseTcpConnection> ConnectedAsync(byte[] script)
+    {
+        var connection = new ClickHouseTcpConnection(new ScriptedDuplexStream(script), socket: null);
+        await connection.HandshakeAsync(Handshake, None);
+        return connection;
+    }
+
+    // Materializes each yielded block's first UInt64 column into an owned array during iteration, since a block
+    // is only valid for its iteration (its buffers are released when the enumerator advances).
+    private static async Task<List<ulong[]>> MaterializeAsync(ClickHouseTcpConnection connection)
+    {
+        var rows = new List<ulong[]>();
+        await foreach (Block block in connection.QueryAsync("SELECT 1", cancellationToken: None))
+        {
+            rows.Add(((IColumn<ulong>)block[0]).Values.ToArray());
+        }
+
+        return rows;
+    }
+
+    // Enumerates the response without reading block contents (for tests that assert an exception or state).
+    private static async Task DrainAsync(ClickHouseTcpConnection connection)
+    {
+        await foreach (Block block in connection.QueryAsync("SELECT 1", cancellationToken: None))
+        {
+            _ = block;
+        }
+    }
+
+    // Enumerates the response with metadata handlers attached, ignoring the row-bearing blocks themselves.
+    private static async Task DrainAsync(ClickHouseTcpConnection connection, MetadataHandlers handlers)
+    {
+        await foreach (Block block in connection.QueryAsync("SELECT 1", handlers: handlers, cancellationToken: None))
+        {
+            _ = block;
+        }
+    }
+
+    private static Task<byte[]> DataPacketAsync(ulong[] values)
+        => BytesAsync(w =>
+        {
+            w.WriteVarUInt((ulong)ServerPacketType.Data);
+            WriteUInt64Block(w, values);
+        });
+
+    private static Task<byte[]> PartUuidsPacketAsync(UInt128[] uuids)
+        => BytesAsync(w =>
+        {
+            w.WriteVarUInt((ulong)ServerPacketType.PartUUIDs);
+            w.WriteVarUInt((ulong)uuids.Length);
+            foreach (UInt128 uuid in uuids)
+            {
+                w.WriteUInt128(uuid);
+            }
+        });
+
+    private static Task<byte[]> ProfileEventsPacketAsync()
+        => BytesAsync(w =>
+        {
+            w.WriteVarUInt((ulong)ServerPacketType.ProfileEvents);
+            WriteUInt64Block(w, new ulong[] { 42 });
+        });
+
+    private static Task<byte[]> TotalsPacketAsync(ulong[] values)
+        => BytesAsync(w =>
+        {
+            w.WriteVarUInt((ulong)ServerPacketType.Totals);
+            WriteUInt64Block(w, values);
+        });
+
+    private static Task<byte[]> ExtremesPacketAsync(ulong[] values)
+        => BytesAsync(w =>
+        {
+            w.WriteVarUInt((ulong)ServerPacketType.Extremes);
+            WriteUInt64Block(w, values);
+        });
+
+    private static Task<byte[]> LogPacketAsync(ulong[] values)
+        => BytesAsync(w =>
+        {
+            w.WriteVarUInt((ulong)ServerPacketType.Log);
+            WriteUInt64Block(w, values);
+        });
+
+    private static Task<byte[]> TableColumnsPacketAsync(string externalTableName, string columnsDescription)
+        => BytesAsync(w =>
+        {
+            w.WriteVarUInt((ulong)ServerPacketType.TableColumns);
+            w.WriteString(externalTableName);
+            w.WriteString(columnsDescription);
+        });
+
+    private static Task<byte[]> ProfileInfoPacketAsync()
+        => BytesAsync(w =>
+        {
+            w.WriteVarUInt((ulong)ServerPacketType.ProfileInfo);
+            w.WriteVarUInt(10);   // rows
+            w.WriteVarUInt(2);    // blocks
+            w.WriteVarUInt(320);  // bytes
+            w.WriteBool(true);    // applied_limit
+            w.WriteVarUInt(50);   // rows_before_limit
+            w.WriteBool(true);    // calculated_rows_before_limit
+        });
+
+    private static Task<byte[]> ProgressPacketAsync()
+        => BytesAsync(w =>
+        {
+            w.WriteVarUInt((ulong)ServerPacketType.Progress);
+            w.WriteVarUInt(1); // rows
+            w.WriteVarUInt(2); // bytes
+            w.WriteVarUInt(3); // total_rows
+            w.WriteVarUInt(0); // wrote_rows
+            w.WriteVarUInt(0); // wrote_bytes
+            w.WriteVarUInt(0); // elapsed_ns
+        });
+
+    private static Task<byte[]> ExceptionPacketAsync(int code, string message)
+        => BytesAsync(w =>
+        {
+            w.WriteVarUInt((ulong)ServerPacketType.Exception);
+            w.WriteInt32(code);
+            w.WriteString("DB::Exception");
+            w.WriteString(message);
+            w.WriteString("stack trace");
+            w.WriteBool(false); // has_nested
+        });
+
+    private static byte[] EndOfStreamPacket()
+        => BytesAsync(w => w.WriteVarUInt((ulong)ServerPacketType.EndOfStream)).GetAwaiter().GetResult();
+
+    private static byte[] PacketBytes(ServerPacketType type)
+        => BytesAsync(w => w.WriteVarUInt((ulong)type)).GetAwaiter().GetResult();
+
+    // A block with a single UInt64 column named "x": name, block info, counts, column header, then the values.
+    private static void WriteUInt64Block(ClickHouseBinaryWriter writer, ulong[] values)
+    {
+        writer.WriteString(string.Empty);
+        BlockWriter.WriteBlockInfo(writer, BlockInfo.Default);
+        writer.WriteVarUInt(1);                    // num_columns
+        writer.WriteVarUInt((ulong)values.Length); // num_rows
+        writer.WriteString("x");
+        writer.WriteString("UInt64");
+        writer.WriteBool(false);                   // has_custom_serialization
+        foreach (ulong value in values)
+        {
+            writer.WriteUInt64(value);
+        }
+    }
+
+    private static Task<byte[]> ServerHelloBytesAsync(int revision) => BytesAsync(w =>
+    {
+        w.WriteVarUInt((ulong)ServerPacketType.Hello);
+        w.WriteString("ClickHouse");
+        w.WriteVarUInt(25);
+        w.WriteVarUInt(8);
+        w.WriteVarUInt((ulong)revision);
+        w.WriteString("UTC");
+        w.WriteString("clickhouse-server");
+        w.WriteVarUInt(0);
+    });
+
+    private static async Task<byte[]> BytesAsync(Action<ClickHouseBinaryWriter> write)
+    {
+        using var ms = new MemoryStream();
+        using (var writer = new ClickHouseBinaryWriter(ms))
+        {
+            write(writer);
+            await writer.FlushAsync(None);
+        }
+
+        return ms.ToArray();
+    }
+
+    private static byte[] Concat(params byte[][] arrays)
+    {
+        int length = 0;
+        foreach (byte[] array in arrays)
+        {
+            length += array.Length;
+        }
+
+        byte[] result = new byte[length];
+        int offset = 0;
+        foreach (byte[] array in arrays)
+        {
+            Buffer.BlockCopy(array, 0, result, offset, array.Length);
+            offset += array.Length;
+        }
+
+        return result;
+    }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Protocol/ClickHouseTcpConnectionTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Protocol/ClickHouseTcpConnectionTests.cs
@@ -18,7 +18,6 @@ public class ClickHouseTcpConnectionTests
 
     private static readonly ClientHandshakeParameters Handshake = new()
     {
-        ClientName = "test-client",
         Username = "default",
     };
 
@@ -107,6 +106,29 @@ public class ClickHouseTcpConnectionTests
         connection.Terminate();
 
         Assert.ThrowsAsync<ObjectDisposedException>(async () => await connection.HandshakeAsync(Handshake, None));
+    }
+
+    [Test]
+    public async Task HandshakeAsync_ServerBelowMinimumProtocol_ThrowsNotSupportedAndTerminates()
+    {
+        // A revision below the floor the write path assumes: the settings triples we always send would desync
+        // it, so the handshake must refuse rather than proceed. The revision still sits above the timezone,
+        // display_name and version_patch gates, so those fields are present and must be written.
+        byte[] script = await BytesAsync(w =>
+        {
+            w.WriteVarUInt((ulong)ServerPacketType.Hello);
+            w.WriteString("ClickHouse");
+            w.WriteVarUInt(21);
+            w.WriteVarUInt(3);
+            w.WriteVarUInt(NegotiatedProtocol.MinimumTcpProtocolVersion - 1);
+            w.WriteString("UTC");                // timezone
+            w.WriteString("clickhouse-server");  // display_name
+            w.WriteVarUInt(0);                   // version_patch
+        });
+        using var connection = new ClickHouseTcpConnection(new ScriptedDuplexStream(script), socket: null);
+
+        Assert.ThrowsAsync<NotSupportedException>(async () => await connection.HandshakeAsync(Handshake, None));
+        Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Terminated));
     }
 
     [Test]

--- a/ClickHouse.Driver.Tcp.Tests/Protocol/HandshakeTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Protocol/HandshakeTests.cs
@@ -36,7 +36,6 @@ public class HandshakeTests
         const string quotaKey = "distinctive-secret-quota-key";
         var parameters = new ClientHandshakeParameters
         {
-            ClientName = "test-client",
             VersionMajor = 12,
             VersionMinor = 34,
             Database = "test-database",
@@ -49,7 +48,7 @@ public class HandshakeTests
         Assert.Multiple(() =>
         {
             Assert.That(description, Does.Contain(nameof(ClientHandshakeParameters)));
-            Assert.That(description, Does.Contain("test-client"));
+            Assert.That(description, Does.Contain(ClientHandshakeParameters.DefaultClientName));
             Assert.That(description, Does.Contain("12.34"));
             Assert.That(description, Does.Contain("test-database"));
             Assert.That(description, Does.Contain("test-user"));

--- a/ClickHouse.Driver.Tcp.Tests/Protocol/QueryPacketTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Protocol/QueryPacketTests.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Protocol;
+
+namespace ClickHouse.Driver.Tcp.Tests.Protocol;
+
+// Exercises the Query packet writer directly, where the serialized bytes are easiest to compare.
+[TestFixture]
+public class QueryPacketTests
+{
+    private const string NativeBinaryTypesSetting = "output_format_native_encode_types_in_binary_format";
+
+    private static readonly CancellationToken None = CancellationToken.None;
+
+    private static readonly ClientMetadata Client = new()
+    {
+        Username = "default",
+    };
+
+    [Test]
+    public async Task Write_NativeBinaryTypesSettingEnabled_ForcedToTextualForm()
+    {
+        // The block reader only decodes textual type headers, so a caller enabling binary type headers must be
+        // neutralized. Forcing the value from "1" to "0" makes the two packets byte-for-byte identical.
+        byte[] enabled = await WriteQueryAsync(new Dictionary<string, string> { [NativeBinaryTypesSetting] = "1" });
+        byte[] disabled = await WriteQueryAsync(new Dictionary<string, string> { [NativeBinaryTypesSetting] = "0" });
+
+        CollectionAssert.AreEqual(disabled, enabled);
+    }
+
+    [Test]
+    public async Task Write_UnrelatedSettingValue_PassedThroughUnchanged()
+    {
+        // A guard that the override is scoped to the one setting: unrelated values still reach the wire verbatim.
+        byte[] four = await WriteQueryAsync(new Dictionary<string, string> { ["max_threads"] = "4" });
+        byte[] eight = await WriteQueryAsync(new Dictionary<string, string> { ["max_threads"] = "8" });
+
+        CollectionAssert.AreNotEqual(eight, four);
+    }
+
+    [Test]
+    public void Write_ParametersOnProtocolBelowParametersFeature_Throws()
+    {
+        // Servers negotiating below the parameters feature (but at or above the handshake floor) have no wire
+        // slot for the parameters list; dropping the caller's parameters silently would run a different query.
+        var parameters = new Dictionary<string, string> { ["id"] = "42" };
+        using var ms = new MemoryStream();
+        using var writer = new ClickHouseBinaryWriter(ms);
+
+        Assert.Throws<System.NotSupportedException>(() =>
+            Query.Write(writer, new NegotiatedProtocol((int)ProtocolFeature.Parameters - 1), Client, "qid", "SELECT {id:UInt8}", settings: null, parameters));
+    }
+
+    [Test]
+    public async Task Write_EmptyParametersOnProtocolBelowParametersFeature_DoesNotThrow()
+    {
+        // Only a non-empty parameter set is unsatisfiable below the feature; none-to-send is always fine.
+        using var ms = new MemoryStream();
+        using (var writer = new ClickHouseBinaryWriter(ms))
+        {
+            Query.Write(writer, new NegotiatedProtocol((int)ProtocolFeature.Parameters - 1), Client, "qid", "SELECT 1", settings: null, new Dictionary<string, string>());
+            await writer.FlushAsync(None);
+        }
+
+        Assert.That(ms.Length, Is.GreaterThan(0));
+    }
+
+    private static async Task<byte[]> WriteQueryAsync(IReadOnlyDictionary<string, string> settings)
+    {
+        using var ms = new MemoryStream();
+        using (var writer = new ClickHouseBinaryWriter(ms))
+        {
+            Query.Write(writer, new NegotiatedProtocol(54460), Client, "qid", "SELECT 1", settings, queryParameters: null);
+            await writer.FlushAsync(None);
+        }
+
+        return ms.ToArray();
+    }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Protocol/ServerPacketDecoderTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Protocol/ServerPacketDecoderTests.cs
@@ -1,0 +1,122 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Protocol;
+
+namespace ClickHouse.Driver.Tcp.Tests.Protocol;
+
+[TestFixture]
+public class ServerPacketDecoderTests
+{
+    private static readonly CancellationToken None = CancellationToken.None;
+
+    [Test]
+    public async Task Progress_AtCurrentTarget_ReadsAllGatedCounters()
+    {
+        byte[] bytes = await WriteAsync(w =>
+        {
+            w.WriteVarUInt(10);   // rows
+            w.WriteVarUInt(20);   // bytes
+            w.WriteVarUInt(30);   // total_rows
+            w.WriteVarUInt(40);   // wrote_rows (>= 54420)
+            w.WriteVarUInt(50);   // wrote_bytes (>= 54420)
+            w.WriteVarUInt(60);   // elapsed_ns (>= 54460)
+        });
+        using var reader = ReaderOver(bytes);
+
+        Progress progress = await Progress.ReadAsync(reader, new NegotiatedProtocol(NegotiatedProtocol.ClientTcpProtocolVersion), None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(progress.Rows, Is.EqualTo(10UL));
+            Assert.That(progress.Bytes, Is.EqualTo(20UL));
+            Assert.That(progress.TotalRows, Is.EqualTo(30UL));
+            Assert.That(progress.WroteRows, Is.EqualTo(40UL));
+            Assert.That(progress.WroteBytes, Is.EqualTo(50UL));
+            Assert.That(progress.ElapsedNs, Is.EqualTo(60UL));
+        });
+    }
+
+    [Test]
+    public async Task Progress_BelowWriteInfoGate_ReadsOnlyBaseCounters()
+    {
+        byte[] bytes = await WriteAsync(w =>
+        {
+            w.WriteVarUInt(10);   // rows
+            w.WriteVarUInt(20);   // bytes
+            w.WriteVarUInt(30);   // total_rows
+        });
+        using var reader = ReaderOver(bytes);
+
+        // A server negotiating below 54420 sends no wrote_rows/wrote_bytes/elapsed_ns.
+        Progress progress = await Progress.ReadAsync(reader, new NegotiatedProtocol(54419), None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(progress.TotalRows, Is.EqualTo(30UL));
+            Assert.That(progress.WroteRows, Is.EqualTo(0UL));
+            Assert.That(progress.ElapsedNs, Is.EqualTo(0UL));
+        });
+    }
+
+    [Test]
+    public async Task ProfileInfo_RoundTrips()
+    {
+        byte[] bytes = await WriteAsync(w =>
+        {
+            w.WriteVarUInt(5);    // rows
+            w.WriteVarUInt(1);    // blocks
+            w.WriteVarUInt(400);  // bytes
+            w.WriteBool(true);    // applied_limit
+            w.WriteVarUInt(9);    // rows_before_limit
+            w.WriteBool(true);    // calculated_rows_before_limit
+        });
+        using var reader = ReaderOver(bytes);
+
+        ProfileInfo info = await ProfileInfo.ReadAsync(reader, None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(info.Rows, Is.EqualTo(5UL));
+            Assert.That(info.Blocks, Is.EqualTo(1UL));
+            Assert.That(info.Bytes, Is.EqualTo(400UL));
+            Assert.That(info.AppliedLimit, Is.True);
+            Assert.That(info.RowsBeforeLimit, Is.EqualTo(9UL));
+            Assert.That(info.CalculatedRowsBeforeLimit, Is.True);
+        });
+    }
+
+    [Test]
+    public async Task TableColumns_RoundTrips()
+    {
+        byte[] bytes = await WriteAsync(w =>
+        {
+            w.WriteString("ext");
+            w.WriteString("a UInt64, b String");
+        });
+        using var reader = ReaderOver(bytes);
+
+        TableColumns columns = await TableColumns.ReadAsync(reader, None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(columns.ExternalTableName, Is.EqualTo("ext"));
+            Assert.That(columns.ColumnsDescription, Is.EqualTo("a UInt64, b String"));
+        });
+    }
+
+    private static async Task<byte[]> WriteAsync(Action<ClickHouseBinaryWriter> write)
+    {
+        using var ms = new MemoryStream();
+        using (var writer = new ClickHouseBinaryWriter(ms))
+        {
+            write(writer);
+            await writer.FlushAsync(None);
+        }
+
+        return ms.ToArray();
+    }
+
+    private static ClickHouseBinaryReader ReaderOver(byte[] bytes) => new(new MemoryStream(bytes));
+}

--- a/ClickHouse.Driver.Tcp.Tests/Types/ColumnCodecRegistryTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/ColumnCodecRegistryTests.cs
@@ -1,0 +1,42 @@
+using System;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Tests.Types;
+
+[TestFixture]
+public class ColumnCodecRegistryTests
+{
+    [TestCase("UInt8")]
+    [TestCase("Int8")]
+    [TestCase("UInt16")]
+    [TestCase("Int16")]
+    [TestCase("UInt32")]
+    [TestCase("Int32")]
+    [TestCase("UInt64")]
+    [TestCase("Int64")]
+    [TestCase("UInt128")]
+    [TestCase("Int128")]
+    [TestCase("UInt256")]
+    [TestCase("Int256")]
+    [TestCase("String")]
+    public void Resolve_SupportedType_ReturnsCodecWithMatchingTypeName(string type)
+    {
+        IColumnCodec codec = ColumnCodecRegistry.Default.Resolve(type);
+        Assert.That(codec.TypeName, Is.EqualTo(type));
+    }
+
+    [Test]
+    public void Resolve_DateTimeWithTimezone_ResolvesToDateTimeCodec()
+    {
+        IColumnCodec codec = ColumnCodecRegistry.Default.Resolve("DateTime('UTC')");
+        Assert.That(codec.TypeName, Is.EqualTo("DateTime"));
+    }
+
+    [Test]
+    public void Resolve_UnsupportedButWellFormedType_ThrowsNotSupported()
+        => Assert.Throws<NotSupportedException>(() => ColumnCodecRegistry.Default.Resolve("Array(String)"));
+
+    [Test]
+    public void Resolve_MalformedType_ThrowsFormat()
+        => Assert.Throws<FormatException>(() => ColumnCodecRegistry.Default.Resolve(string.Empty));
+}

--- a/ClickHouse.Driver.Tcp.Tests/Types/DateTimeColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/DateTimeColumnCodecTests.cs
@@ -1,0 +1,65 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Protocol;
+using ClickHouse.Driver.Tcp.Types;
+using ClickHouse.Driver.Tcp.Types.Codecs;
+
+namespace ClickHouse.Driver.Tcp.Tests.Types;
+
+[TestFixture]
+public class DateTimeColumnCodecTests
+{
+    private static readonly CancellationToken None = CancellationToken.None;
+
+    [Test]
+    public async Task RoundTrip_UtcWholeSeconds_Preserved()
+    {
+        var values = new[] { DateTime.UnixEpoch, DateTime.UnixEpoch.AddSeconds(1_700_000_000) };
+
+        byte[] bytes = await WriteAsync(w => DateTimeColumnCodec.Instance.WriteColumn(w, new ArrayColumn<DateTime>("c", "DateTime", values)));
+        using var reader = ReaderOver(bytes);
+        using var column = (IColumn<DateTime>)await DateTimeColumnCodec.Instance.ReadColumnAsync(reader, "c", "DateTime('UTC')", values.Length, None);
+
+        Assert.Multiple(() =>
+        {
+            CollectionAssert.AreEqual(values, column.Values.ToArray());
+            Assert.That(column.TypeName, Is.EqualTo("DateTime('UTC')"));
+        });
+    }
+
+    [Test]
+    public async Task ReadColumn_SingleValue_DecodesUnixSecondsAsUtc()
+    {
+        // 1 row: the little-endian UInt32 1000 = 1970-01-01T00:16:40Z.
+        byte[] bytes = await WriteAsync(w => w.WriteUInt32(1000));
+        using var reader = ReaderOver(bytes);
+
+        using var column = (IColumn<DateTime>)await DateTimeColumnCodec.Instance.ReadColumnAsync(reader, "c", "DateTime", 1, None);
+
+        Assert.That(column[0], Is.EqualTo(DateTime.UnixEpoch.AddSeconds(1000)));
+    }
+
+    [Test]
+    public async Task ReadColumn_ZeroRows_ReturnsEmptyColumn()
+    {
+        using var reader = ReaderOver(Array.Empty<byte>());
+        using var column = (IColumn<DateTime>)await DateTimeColumnCodec.Instance.ReadColumnAsync(reader, "c", "DateTime", 0, None);
+        Assert.That(column.RowCount, Is.EqualTo(0));
+    }
+
+    private static async Task<byte[]> WriteAsync(Action<ClickHouseBinaryWriter> write)
+    {
+        using var ms = new MemoryStream();
+        using (var writer = new ClickHouseBinaryWriter(ms))
+        {
+            write(writer);
+            await writer.FlushAsync(None);
+        }
+
+        return ms.ToArray();
+    }
+
+    private static ClickHouseBinaryReader ReaderOver(byte[] bytes) => new(new MemoryStream(bytes));
+}

--- a/ClickHouse.Driver.Tcp.Tests/Types/IntegerColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/IntegerColumnCodecTests.cs
@@ -1,0 +1,127 @@
+using System;
+using System.IO;
+using System.Numerics;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Numerics;
+using ClickHouse.Driver.Tcp.Protocol;
+using ClickHouse.Driver.Tcp.Types;
+using ClickHouse.Driver.Tcp.Types.Codecs;
+
+namespace ClickHouse.Driver.Tcp.Tests.Types;
+
+[TestFixture]
+public class IntegerColumnCodecTests
+{
+    private static readonly CancellationToken None = CancellationToken.None;
+
+    [Test]
+    public async Task WriteColumn_Int32_IsLittleEndianAndContiguous()
+    {
+        var codec = new IntegerColumnCodec<int>("Int32");
+        IColumn column = PrimitiveColumn<int>.FromValues("c", "Int32", new[] { 1, -1 });
+
+        byte[] bytes = await WriteAsync(w => codec.WriteColumn(w, column));
+
+        CollectionAssert.AreEqual(new byte[] { 0x01, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF }, bytes);
+    }
+
+    [Test]
+    public async Task RoundTrip_UInt8() => await AssertRoundTripAsync(new IntegerColumnCodec<byte>("UInt8"), "UInt8", new byte[] { 0, 1, 128, 255 });
+
+    [Test]
+    public async Task RoundTrip_Int8() => await AssertRoundTripAsync(new IntegerColumnCodec<sbyte>("Int8"), "Int8", new sbyte[] { -128, -1, 0, 127 });
+
+    [Test]
+    public async Task RoundTrip_UInt16() => await AssertRoundTripAsync(new IntegerColumnCodec<ushort>("UInt16"), "UInt16", new ushort[] { 0, 258, ushort.MaxValue });
+
+    [Test]
+    public async Task RoundTrip_Int16() => await AssertRoundTripAsync(new IntegerColumnCodec<short>("Int16"), "Int16", new short[] { short.MinValue, -1, 0, short.MaxValue });
+
+    [Test]
+    public async Task RoundTrip_UInt32() => await AssertRoundTripAsync(new IntegerColumnCodec<uint>("UInt32"), "UInt32", new uint[] { 0, 1, uint.MaxValue });
+
+    [Test]
+    public async Task RoundTrip_Int32() => await AssertRoundTripAsync(new IntegerColumnCodec<int>("Int32"), "Int32", new[] { int.MinValue, -1, 0, int.MaxValue });
+
+    [Test]
+    public async Task RoundTrip_UInt64() => await AssertRoundTripAsync(new IntegerColumnCodec<ulong>("UInt64"), "UInt64", new ulong[] { 0, 1, ulong.MaxValue });
+
+    [Test]
+    public async Task RoundTrip_Int64() => await AssertRoundTripAsync(new IntegerColumnCodec<long>("Int64"), "Int64", new[] { long.MinValue, -1, 0, long.MaxValue });
+
+    [Test]
+    public async Task RoundTrip_UInt128() => await AssertRoundTripAsync(new IntegerColumnCodec<UInt128>("UInt128"), "UInt128", new[] { UInt128.Zero, UInt128.One, UInt128.MaxValue });
+
+    [Test]
+    public async Task RoundTrip_Int128() => await AssertRoundTripAsync(new IntegerColumnCodec<Int128>("Int128"), "Int128", new[] { Int128.MinValue, -Int128.One, Int128.Zero, Int128.MaxValue });
+
+    [Test]
+    public async Task RoundTrip_UInt256() => await AssertRoundTripAsync(
+        new IntegerColumnCodec<UInt256>("UInt256"),
+        "UInt256",
+        new[] { UInt256.Zero, UInt256.FromBigInteger(BigInteger.One), UInt256.FromBigInteger(BigInteger.Pow(2, 200)) });
+
+    [Test]
+    public async Task RoundTrip_Int256() => await AssertRoundTripAsync(
+        new IntegerColumnCodec<Int256>("Int256"),
+        "Int256",
+        new[] { Int256.Zero, Int256.FromBigInteger(-1), Int256.FromBigInteger(BigInteger.Pow(2, 200)), Int256.FromBigInteger(-BigInteger.Pow(2, 200)) });
+
+    [Test]
+    public async Task ReadColumn_ZeroRows_ReturnsEmptyColumnReadingNoBytes()
+    {
+        var codec = new IntegerColumnCodec<int>("Int32");
+        using var reader = ReaderOver(Array.Empty<byte>());
+
+        using var column = (IColumn<int>)await codec.ReadColumnAsync(reader, "c", "Int32", 0, None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(column.RowCount, Is.EqualTo(0));
+            Assert.That(column.Values.Length, Is.EqualTo(0));
+        });
+    }
+
+    [Test]
+    public async Task ReadColumn_StampsNameAndType()
+    {
+        var codec = new IntegerColumnCodec<int>("Int32");
+        byte[] bytes = await WriteAsync(w => codec.WriteColumn(w, PrimitiveColumn<int>.FromValues("ignored", "Int32", new[] { 7 })));
+        using var reader = ReaderOver(bytes);
+
+        using IColumn column = await codec.ReadColumnAsync(reader, "the_name", "Int32", 1, None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(column.Name, Is.EqualTo("the_name"));
+            Assert.That(column.TypeName, Is.EqualTo("Int32"));
+            Assert.That(column.GetValue(0), Is.EqualTo(7));
+        });
+    }
+
+    private static async Task AssertRoundTripAsync<T>(IColumnCodec codec, string type, T[] values)
+        where T : unmanaged
+    {
+        byte[] bytes = await WriteAsync(w => codec.WriteColumn(w, PrimitiveColumn<T>.FromValues("c", type, values)));
+        using var reader = ReaderOver(bytes);
+
+        using var column = (IColumn<T>)await codec.ReadColumnAsync(reader, "c", type, values.Length, None);
+
+        CollectionAssert.AreEqual(values, column.Values.ToArray());
+    }
+
+    private static async Task<byte[]> WriteAsync(Action<ClickHouseBinaryWriter> write)
+    {
+        using var ms = new MemoryStream();
+        using (var writer = new ClickHouseBinaryWriter(ms))
+        {
+            write(writer);
+            await writer.FlushAsync(None);
+        }
+
+        return ms.ToArray();
+    }
+
+    private static ClickHouseBinaryReader ReaderOver(byte[] bytes) => new(new MemoryStream(bytes));
+}

--- a/ClickHouse.Driver.Tcp.Tests/Types/StringColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/StringColumnCodecTests.cs
@@ -1,0 +1,56 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Protocol;
+using ClickHouse.Driver.Tcp.Types;
+using ClickHouse.Driver.Tcp.Types.Codecs;
+
+namespace ClickHouse.Driver.Tcp.Tests.Types;
+
+[TestFixture]
+public class StringColumnCodecTests
+{
+    private static readonly CancellationToken None = CancellationToken.None;
+
+    [Test]
+    public async Task WriteColumn_SingleValue_IsVarUIntLengthThenBytes()
+    {
+        byte[] bytes = await WriteAsync(w => StringColumnCodec.Instance.WriteColumn(w, new ArrayColumn<string>("c", "String", new[] { "hello" })));
+        CollectionAssert.AreEqual(new byte[] { 0x05, 0x68, 0x65, 0x6C, 0x6C, 0x6F }, bytes);
+    }
+
+    [Test]
+    public async Task RoundTrip_EmptyUnicodeAndEmbeddedNul_Preserved()
+    {
+        var values = new[] { string.Empty, "hello", "héllo✓", "a\0b", new string('x', 500) };
+
+        byte[] bytes = await WriteAsync(w => StringColumnCodec.Instance.WriteColumn(w, new ArrayColumn<string>("c", "String", values)));
+        using var reader = ReaderOver(bytes);
+        using var column = (IColumn<string>)await StringColumnCodec.Instance.ReadColumnAsync(reader, "c", "String", values.Length, None);
+
+        CollectionAssert.AreEqual(values, column.Values.ToArray());
+    }
+
+    [Test]
+    public async Task ReadColumn_ZeroRows_ReturnsEmptyColumn()
+    {
+        using var reader = ReaderOver(Array.Empty<byte>());
+        using var column = (IColumn<string>)await StringColumnCodec.Instance.ReadColumnAsync(reader, "c", "String", 0, None);
+        Assert.That(column.RowCount, Is.EqualTo(0));
+    }
+
+    private static async Task<byte[]> WriteAsync(Action<ClickHouseBinaryWriter> write)
+    {
+        using var ms = new MemoryStream();
+        using (var writer = new ClickHouseBinaryWriter(ms))
+        {
+            write(writer);
+            await writer.FlushAsync(None);
+        }
+
+        return ms.ToArray();
+    }
+
+    private static ClickHouseBinaryReader ReaderOver(byte[] bytes) => new(new MemoryStream(bytes));
+}

--- a/ClickHouse.Driver.Tcp.Tests/Types/TypeParserTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/TypeParserTests.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Linq;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Tests.Types;
+
+[TestFixture]
+public class TypeParserTests
+{
+    [Test]
+    public void Parse_PlainType_HasNameAndNoArguments()
+    {
+        TypeNode node = TypeParser.Parse("UInt64");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(node.Name, Is.EqualTo("UInt64"));
+            Assert.That(node.Arguments, Is.Empty);
+        });
+    }
+
+    [Test]
+    public void Parse_SurroundingWhitespace_IsTrimmed()
+    {
+        TypeNode node = TypeParser.Parse("  String  ");
+        Assert.That(node.Name, Is.EqualTo("String"));
+    }
+
+    [Test]
+    public void Parse_SingleIntegerArgument_IsALeafNode()
+    {
+        TypeNode node = TypeParser.Parse("FixedString(16)");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(node.Name, Is.EqualTo("FixedString"));
+            Assert.That(node.Arguments.Select(a => a.Name), Is.EqualTo(new[] { "16" }));
+        });
+    }
+
+    [Test]
+    public void Parse_MultipleArguments_SplitOnTopLevelCommasAndTrimmed()
+    {
+        TypeNode node = TypeParser.Parse("Decimal(10, 2)");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(node.Name, Is.EqualTo("Decimal"));
+            Assert.That(node.Arguments.Select(a => a.Name), Is.EqualTo(new[] { "10", "2" }));
+        });
+    }
+
+    [Test]
+    public void Parse_QuotedArgumentWithComma_DoesNotSplitInsideQuotes()
+    {
+        TypeNode node = TypeParser.Parse("Enum8('a,b' = 1)");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(node.Name, Is.EqualTo("Enum8"));
+            Assert.That(node.Arguments.Select(a => a.Name), Is.EqualTo(new[] { "'a,b' = 1" }));
+        });
+    }
+
+    [Test]
+    public void Parse_NestedType_DoesNotSplitInsideNestedParens()
+    {
+        TypeNode node = TypeParser.Parse("Map(String, UInt64)");
+        Assert.That(node.Arguments.Select(a => a.Name), Is.EqualTo(new[] { "String", "UInt64" }));
+    }
+
+    [Test]
+    public void Parse_NestedType_ArgumentIsAFullyParsedChildNode()
+    {
+        TypeNode node = TypeParser.Parse("Array(Nullable(String))");
+        Assert.That(node.Name, Is.EqualTo("Array"));
+
+        TypeNode inner = node.Arguments.Single();
+        Assert.Multiple(() =>
+        {
+            Assert.That(inner.Name, Is.EqualTo("Nullable"));
+            Assert.That(inner.Arguments.Single().Name, Is.EqualTo("String"));
+            Assert.That(inner.Arguments.Single().Arguments, Is.Empty);
+        });
+    }
+
+    [Test]
+    public void Parse_DeeplyNested_RoundTripsThroughToString()
+    {
+        TypeNode node = TypeParser.Parse("Map(String, Array(Nullable(UInt64)))");
+        Assert.That(node.ToString(), Is.EqualTo("Map(String, Array(Nullable(UInt64)))"));
+    }
+
+    [Test]
+    public void Parse_DateTimeWithTimezone_NameIsBaseTypeAndArgIsQuoted()
+    {
+        TypeNode node = TypeParser.Parse("DateTime('UTC')");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(node.Name, Is.EqualTo("DateTime"));
+            Assert.That(node.Arguments.Single().Name, Is.EqualTo("'UTC'"));
+        });
+    }
+
+    [Test]
+    public void Parse_Null_ThrowsArgumentNull()
+        => Assert.Throws<ArgumentNullException>(() => TypeParser.Parse(null));
+
+    [TestCase("")]
+    [TestCase("   ")]
+    [TestCase("(UInt8)")]
+    [TestCase("Array(String")]
+    [TestCase("Array(String))")]
+    [TestCase("Tuple(,)")]
+    [TestCase("Array(String)junk")]
+    [TestCase("Enum8('a")]
+    [TestCase("DateTime('UTC")]
+    public void Parse_Malformed_ThrowsFormat(string type)
+        => Assert.Throws<FormatException>(() => TypeParser.Parse(type));
+}

--- a/ClickHouse.Driver.Tcp/Format/Block.cs
+++ b/ClickHouse.Driver.Tcp/Format/Block.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Format;
+
+/// <summary>
+/// A decoded block: the columnar unit exchanged for Data, Totals, Extremes, Log, and ProfileEvents. Carries an
+/// optional name, the block info, and the columns (each holding <see cref="RowCount"/> values).
+///
+/// <para>
+/// A block <b>borrows</b> its columns' storage, which may be pooled. It is disposed by the reader that produced
+/// it — for a streamed query, when the consumer advances to the next block or stops enumerating. A consumer
+/// must not read a block's columns after that point; to retain values beyond the block, copy them (for example
+/// <c>Values.ToArray()</c>) while iterating.
+/// </para>
+/// </summary>
+internal sealed class Block : IDisposable
+{
+    /// <summary>Initializes a new instance of the <see cref="Block"/> class.</summary>
+    /// <param name="name">The block name (usually empty for result blocks).</param>
+    /// <param name="info">The block info prefix.</param>
+    /// <param name="rowCount">The number of rows every column holds.</param>
+    /// <param name="columns">The decoded columns, in header order.</param>
+    public Block(string name, BlockInfo info, int rowCount, IReadOnlyList<IColumn> columns)
+    {
+        Name = name;
+        Info = info;
+        RowCount = rowCount;
+        Columns = columns;
+    }
+
+    /// <summary>The block name.</summary>
+    public string Name { get; }
+
+    /// <summary>The block info prefix.</summary>
+    public BlockInfo Info { get; }
+
+    /// <summary>The number of rows in the block.</summary>
+    public int RowCount { get; }
+
+    /// <summary>The number of columns in the block.</summary>
+    public int ColumnCount => Columns.Count;
+
+    /// <summary>The decoded columns, in header order.</summary>
+    public IReadOnlyList<IColumn> Columns { get; }
+
+    /// <summary>The column at <paramref name="index"/>.</summary>
+    /// <param name="index">The zero-based column index.</param>
+    /// <returns>The column at that position.</returns>
+    public IColumn this[int index] => Columns[index];
+
+    /// <summary>Releases the columns' storage (returning any pooled buffers). Idempotent.</summary>
+    public void Dispose()
+    {
+        foreach (IColumn column in Columns)
+        {
+            column.Dispose();
+        }
+    }
+}

--- a/ClickHouse.Driver.Tcp/Format/BlockInfo.cs
+++ b/ClickHouse.Driver.Tcp/Format/BlockInfo.cs
@@ -1,0 +1,37 @@
+namespace ClickHouse.Driver.Tcp.Format;
+
+/// <summary>
+/// The block-info values that precede a block's columns: whether the block holds overflow rows and its
+/// two-level aggregation bucket number. This is a plain data holder — its field-id-tagged wire form is read
+/// and written by <see cref="BlockReader"/> and <see cref="BlockWriter"/>, keeping all block serialization in
+/// one place.
+/// </summary>
+internal readonly struct BlockInfo
+{
+    /// <summary>Field id for <c>is_overflows</c> in the tagged wire layout.</summary>
+    public const ulong IsOverflowsFieldId = 1;
+
+    /// <summary>Field id for <c>bucket_number</c> in the tagged wire layout.</summary>
+    public const ulong BucketNumberFieldId = 2;
+
+    /// <summary>Field id that terminates the tagged field list.</summary>
+    public const ulong TerminatorFieldId = 0;
+
+    /// <summary>The standard info for an outgoing block: not an overflow block, no aggregation bucket.</summary>
+    public static readonly BlockInfo Default = new(isOverflows: false, bucketNumber: -1);
+
+    /// <summary>Initializes a new instance of the <see cref="BlockInfo"/> struct.</summary>
+    /// <param name="isOverflows">Whether the block holds overflow rows from a GROUP BY with limit.</param>
+    /// <param name="bucketNumber">The two-level aggregation bucket number, or -1 for none.</param>
+    public BlockInfo(bool isOverflows, int bucketNumber)
+    {
+        IsOverflows = isOverflows;
+        BucketNumber = bucketNumber;
+    }
+
+    /// <summary>Whether the block holds overflow rows.</summary>
+    public bool IsOverflows { get; }
+
+    /// <summary>The two-level aggregation bucket number, or -1 when not bucketed.</summary>
+    public int BucketNumber { get; }
+}

--- a/ClickHouse.Driver.Tcp/Format/BlockReader.cs
+++ b/ClickHouse.Driver.Tcp/Format/BlockReader.cs
@@ -1,0 +1,145 @@
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Protocol;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Format;
+
+/// <summary>
+/// Reads a full block from the wire: the leading block name, the block info, the column/row counts, and each
+/// column (header plus body via its codec). This one reader serves every block-bearing packet — Data, Totals,
+/// Extremes, Log, and ProfileEvents — so they share an identical entry point.
+/// </summary>
+internal static class BlockReader
+{
+    /// <summary>Reads one block using the given codec registry, at the negotiated protocol version.</summary>
+    /// <param name="reader">The reader positioned at the block name.</param>
+    /// <param name="negotiated">The negotiated protocol, for version-gated header fields.</param>
+    /// <param name="registry">The registry that resolves each column's type string to a codec.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>The decoded block.</returns>
+    /// <exception cref="ClickHouseProtocolException">A column uses unsupported custom serialization, or a count is implausible.</exception>
+    public static async ValueTask<Block> ReadBlockAsync(
+        ClickHouseBinaryReader reader,
+        NegotiatedProtocol negotiated,
+        ColumnCodecRegistry registry,
+        CancellationToken cancellationToken)
+    {
+        string name = await reader.ReadStringAsync(cancellationToken).ConfigureAwait(false);
+        BlockInfo info = await ReadBlockInfoAsync(reader, cancellationToken).ConfigureAwait(false);
+
+        int columnCount = ToColumnCount(await reader.ReadVarUIntAsync(cancellationToken).ConfigureAwait(false));
+        int rowCount = ToCount(await reader.ReadVarUIntAsync(cancellationToken).ConfigureAwait(false), "rows");
+
+        var columns = new IColumn[columnCount];
+        try
+        {
+            for (int i = 0; i < columnCount; i++)
+            {
+                string columnName = await reader.ReadStringAsync(cancellationToken).ConfigureAwait(false);
+                string columnType = await reader.ReadStringAsync(cancellationToken).ConfigureAwait(false);
+
+                if (negotiated.Supports(ProtocolFeature.CustomSerialization))
+                {
+                    bool hasCustomSerialization = await reader.ReadBoolAsync(cancellationToken).ConfigureAwait(false);
+                    if (hasCustomSerialization)
+                    {
+                        throw new ClickHouseProtocolException(
+                            $"Column '{columnName}' ({columnType}) uses custom serialization, which this client does not support.");
+                    }
+                }
+
+                IColumnCodec codec = registry.Resolve(columnType);
+
+                // A zero-row block (a schema header, or an end-of-input marker) carries no state prefix and no body.
+                // TODO: this holds for every type with default serialization, but dictionary-bearing types
+                // (e.g. LowCardinality) write a serialization-state prefix even when empty. When such types are
+                // added, the reader and writer must emit their prefix regardless of row count or the stream desyncs.
+                if (rowCount != 0)
+                {
+                    await codec.ReadStatePrefixAsync(reader, cancellationToken).ConfigureAwait(false);
+                }
+
+                columns[i] = await codec.ReadColumnAsync(reader, columnName, columnType, rowCount, cancellationToken).ConfigureAwait(false);
+            }
+        }
+        catch
+        {
+            // Return any pooled buffers from columns read before the failure; the block is never handed out.
+            foreach (IColumn column in columns)
+            {
+                column?.Dispose();
+            }
+
+            throw;
+        }
+
+        return new Block(name, info, rowCount, columns);
+    }
+
+    /// <summary>
+    /// Reads the field-id-tagged block info, stopping at the terminator. Each field is a VarUInt id followed
+    /// by its value: id 1 is <c>is_overflows</c> (a byte), id 2 is <c>bucket_number</c> (Int32), id 0
+    /// terminates. Any other id is a protocol violation.
+    /// </summary>
+    /// <param name="reader">The reader positioned at the start of the block info.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>The decoded block info.</returns>
+    /// <exception cref="ClickHouseProtocolException">An unknown field id was encountered.</exception>
+    internal static async ValueTask<BlockInfo> ReadBlockInfoAsync(ClickHouseBinaryReader reader, CancellationToken cancellationToken)
+    {
+        bool isOverflows = false;
+        int bucketNumber = -1;
+
+        while (true)
+        {
+            ulong fieldId = await reader.ReadVarUIntAsync(cancellationToken).ConfigureAwait(false);
+            switch (fieldId)
+            {
+                case BlockInfo.TerminatorFieldId:
+                    return new BlockInfo(isOverflows, bucketNumber);
+                case BlockInfo.IsOverflowsFieldId:
+                    isOverflows = await reader.ReadBoolAsync(cancellationToken).ConfigureAwait(false);
+                    break;
+                case BlockInfo.BucketNumberFieldId:
+                    bucketNumber = await reader.ReadInt32Async(cancellationToken).ConfigureAwait(false);
+                    break;
+                default:
+                    throw new ClickHouseProtocolException($"Unknown BlockInfo field id {fieldId} (corrupt stream or unsupported protocol feature).");
+            }
+        }
+    }
+
+    // A defensive ceiling on the column count read from the wire.
+    private const int MaxColumnsPerBlock = 1_000_000;
+
+    /// <summary>Narrows the column count to int and rejects a value beyond the defensive ceiling.</summary>
+    /// <param name="value">The raw count.</param>
+    /// <returns>The count as an int.</returns>
+    /// <exception cref="ClickHouseProtocolException">The count exceeds <see cref="MaxColumnsPerBlock"/>.</exception>
+    private static int ToColumnCount(ulong value)
+    {
+        if (value > MaxColumnsPerBlock)
+        {
+            throw new ClickHouseProtocolException(
+                $"Block declares {value} columns, exceeding the supported maximum of {MaxColumnsPerBlock} (corrupt stream).");
+        }
+
+        return (int)value;
+    }
+
+    /// <summary>Narrows a VarUInt count to int, rejecting an implausibly large value.</summary>
+    /// <param name="value">The raw count.</param>
+    /// <param name="what">The count's name, for error messages.</param>
+    /// <returns>The count as an int.</returns>
+    /// <exception cref="ClickHouseProtocolException">The count exceeds <see cref="int.MaxValue"/>.</exception>
+    private static int ToCount(ulong value, string what)
+    {
+        if (value > int.MaxValue)
+        {
+            throw new ClickHouseProtocolException($"Block declares {value} {what}, exceeding the supported maximum (corrupt stream).");
+        }
+
+        return (int)value;
+    }
+}

--- a/ClickHouse.Driver.Tcp/Format/BlockWriter.cs
+++ b/ClickHouse.Driver.Tcp/Format/BlockWriter.cs
@@ -1,0 +1,36 @@
+using ClickHouse.Driver.Tcp.Protocol;
+
+namespace ClickHouse.Driver.Tcp.Format;
+
+/// <summary>
+/// Writes outgoing blocks. This slice needs only the empty block — the client sends one, with no columns and no
+/// rows, as the end-of-input "go" marker after a Query so the server begins executing. Writing populated blocks
+/// (for INSERT) is added later.
+/// </summary>
+internal static class BlockWriter
+{
+    /// <summary>
+    /// Writes the empty end-of-input block: an empty name, the standard block info, and zero column/row counts.
+    /// Does not flush.
+    /// </summary>
+    /// <param name="writer">The writer to encode into.</param>
+    public static void WriteEmptyBlock(ClickHouseBinaryWriter writer)
+    {
+        writer.WriteString(string.Empty);
+        WriteBlockInfo(writer, BlockInfo.Default);
+        writer.WriteVarUInt(0); // num_columns
+        writer.WriteVarUInt(0); // num_rows
+    }
+
+    /// <summary>Writes the field-id-tagged block info: <c>is_overflows</c>, <c>bucket_number</c>, then the terminator.</summary>
+    /// <param name="writer">The writer to encode into.</param>
+    /// <param name="info">The block info to write.</param>
+    internal static void WriteBlockInfo(ClickHouseBinaryWriter writer, BlockInfo info)
+    {
+        writer.WriteVarUInt(BlockInfo.IsOverflowsFieldId);
+        writer.WriteBool(info.IsOverflows);
+        writer.WriteVarUInt(BlockInfo.BucketNumberFieldId);
+        writer.WriteInt32(info.BucketNumber);
+        writer.WriteVarUInt(BlockInfo.TerminatorFieldId);
+    }
+}

--- a/ClickHouse.Driver.Tcp/Numerics/Int256.cs
+++ b/ClickHouse.Driver.Tcp/Numerics/Int256.cs
@@ -2,6 +2,7 @@ using System;
 using System.Buffers.Binary;
 using System.Globalization;
 using System.Numerics;
+using System.Runtime.InteropServices;
 
 namespace ClickHouse.Driver.Tcp.Numerics;
 
@@ -9,6 +10,7 @@ namespace ClickHouse.Driver.Tcp.Numerics;
 /// A signed 256-bit integer (two's complement), the CLR representation of ClickHouse <c>Int256</c>.
 /// Stored as four little-endian 64-bit limbs.
 /// </summary>
+[StructLayout(LayoutKind.Sequential)] // Necessary to match byte order on the wire
 public readonly struct Int256 : IEquatable<Int256>, IComparable<Int256>
 {
     /// <summary>The number of bytes in the little-endian wire representation.</summary>

--- a/ClickHouse.Driver.Tcp/Numerics/UInt256.cs
+++ b/ClickHouse.Driver.Tcp/Numerics/UInt256.cs
@@ -2,6 +2,7 @@ using System;
 using System.Buffers.Binary;
 using System.Globalization;
 using System.Numerics;
+using System.Runtime.InteropServices;
 
 namespace ClickHouse.Driver.Tcp.Numerics;
 
@@ -10,6 +11,7 @@ namespace ClickHouse.Driver.Tcp.Numerics;
 /// Stored as four little-endian 64-bit limbs. The BCL has no native 256-bit type, so this
 /// fills the gap (128-bit uses <see cref="UInt128"/>).
 /// </summary>
+[StructLayout(LayoutKind.Sequential)]  // Necessary to match byte order on the wire
 public readonly struct UInt256 : IEquatable<UInt256>, IComparable<UInt256>
 {
     /// <summary>The number of bytes in the little-endian wire representation.</summary>

--- a/ClickHouse.Driver.Tcp/Protocol/ClickHouseBinaryWriter.cs
+++ b/ClickHouse.Driver.Tcp/Protocol/ClickHouseBinaryWriter.cs
@@ -240,6 +240,12 @@ internal sealed class ClickHouseBinaryWriter : IDisposable
         position += 8;
     }
 
+    /// <summary>
+    /// Discards any buffered bytes that have not yet been flushed, returning the writer to an empty state. Used
+    /// to drop a partially-encoded packet after an encoding failure so nothing stale is prepended to the next one.
+    /// </summary>
+    public void Reset() => position = 0;
+
     /// <summary>Flushes buffered bytes to the underlying stream and flushes the stream.</summary>
     /// <param name="cancellationToken">A token to observe for cancellation.</param>
     /// <exception cref="ObjectDisposedException">The writer has been disposed.</exception>

--- a/ClickHouse.Driver.Tcp/Protocol/ClickHouseTcpConnection.cs
+++ b/ClickHouse.Driver.Tcp/Protocol/ClickHouseTcpConnection.cs
@@ -1,8 +1,12 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Net.Sockets;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Format;
+using ClickHouse.Driver.Tcp.Types;
 
 namespace ClickHouse.Driver.Tcp.Protocol;
 
@@ -27,6 +31,7 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
     private readonly ClickHouseBinaryReader reader;
     private readonly ClickHouseBinaryWriter writer;
     private ServerHandshake server;
+    private ClientMetadata clientMetadata;
     private TcpConnectionState state;
 
     /// <summary>
@@ -167,6 +172,223 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
     }
 
     /// <summary>
+    /// Runs a query and streams its result as a sequence of <see cref="Block"/>s. Sends the Query and the
+    /// empty end-of-input marker, then drains the response, yielding each row-bearing Data block. The
+    /// interleaved metadata packets (Progress, ProfileInfo, ProfileEvents, Log, TableColumns, Totals,
+    /// Extremes) are always consumed to keep the stream aligned; supply <paramref name="handlers"/> to
+    /// observe them, otherwise their contents are discarded.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Blocks are borrowed.</b> Each yielded <see cref="Block"/> is valid only for the current iteration of
+    /// the enumeration. The enumerator owns the block's storage and
+    /// releases it automatically when you advance to the next block, stop enumerating, or dispose the
+    /// enumerator. So do <b>not</b> dispose a yielded block yourself, and do <b>not</b> retain a block, any of
+    /// its columns, or an <see cref="IColumn{T}.Values"/> span past the current iteration. To keep data beyond
+    /// the loop body, copy it out while iterating (for example <c>((IColumn&lt;ulong&gt;)block[0]).Values.ToArray()</c>).
+    /// </para>
+    /// <example>
+    /// <code>
+    /// await foreach (Block block in connection.QueryAsync("SELECT number FROM system.numbers LIMIT 10"))
+    /// {
+    ///     // Read or copy within the loop body; the block is released once the loop advances.
+    ///     foreach (ulong value in ((IColumn&lt;ulong&gt;)block[0]).Values)
+    ///     {
+    ///         // ...
+    ///     }
+    /// }
+    /// </code>
+    /// </example>
+    /// </remarks>
+    /// <param name="sql">The SQL text.</param>
+    /// <param name="settings">Per-query settings as textual values, or null for none.</param>
+    /// <param name="parameters">Query parameter values in SQL representation, or null for none.</param>
+    /// <param name="queryId">The query id, or null to let the server assign one.</param>
+    /// <param name="handlers">Optional callbacks for the interleaved metadata packets, or null to discard them.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>An async stream of the result's row-bearing blocks, each valid only for its own iteration.</returns>
+    /// <exception cref="InvalidOperationException">The connection is busy with another operation.</exception>
+    /// <exception cref="ObjectDisposedException">The connection has been terminated.</exception>
+    /// <exception cref="ClickHouseServerException">The server reported an error while executing the query.</exception>
+    /// <exception cref="ClickHouseProtocolException">The server sent an unexpected packet.</exception>
+    /// <exception cref="OperationCanceledException"><paramref name="cancellationToken"/> was cancelled.</exception>
+    internal async IAsyncEnumerable<Block> QueryAsync(
+        string sql,
+        IReadOnlyDictionary<string, string> settings = null,
+        IReadOnlyDictionary<string, string> parameters = null,
+        string queryId = null,
+        MetadataHandlers handlers = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(sql);
+
+        // A pre-cancelled query must not transition the connection out of Ready or write anything, leaving it reusable for the next operation.
+        cancellationToken.ThrowIfCancellationRequested();
+        BeginOperation();
+
+        NegotiatedProtocol negotiated = server.Negotiated;
+        ClickHouseServerException pending = null;
+        Block current = null;
+        bool completed = false;
+
+        // Encode the request into the write buffer before any of it reaches the socket. A failure here is a
+        // client-side error (e.g. parameters on a protocol revision that predates them): nothing has been sent,
+        // so discard the partial packet and leave the connection Ready and reusable rather than terminating it.
+        try
+        {
+            Query.Write(writer, negotiated, clientMetadata, queryId, sql, settings, parameters);
+            writer.WriteClientPacketType(ClientPacketType.Data);
+            BlockWriter.WriteEmptyBlock(writer);
+        }
+        catch
+        {
+            writer.Reset();
+            state = TcpConnectionState.Ready;
+            throw;
+        }
+
+        try
+        {
+            await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
+
+            while (true)
+            {
+                // Resuming here means the consumer has advanced past the previously yielded block, so its
+                // borrowed (possibly pooled) buffers can be released before we read the next packet.
+                if (current is not null)
+                {
+                    current.Dispose();
+                    current = null;
+                }
+
+                ServerPacketType packet = await reader.ReadServerPacketTypeAsync(cancellationToken).ConfigureAwait(false);
+
+                if (packet == ServerPacketType.EndOfStream)
+                {
+                    completed = true;
+                    break;
+                }
+
+                if (packet == ServerPacketType.Exception)
+                {
+                    pending = await ClickHouseServerException.ReadAsync(reader, cancellationToken).ConfigureAwait(false);
+                    completed = true;
+                    break;
+                }
+
+                switch (packet)
+                {
+                    case ServerPacketType.Data:
+                    {
+                        Block block = await BlockReader.ReadBlockAsync(reader, negotiated, ColumnCodecRegistry.Default, cancellationToken).ConfigureAwait(false);
+                        if (block.RowCount != 0)
+                        {
+                            // Held as the current block so it is released when the consumer advances or stops.
+                            current = block;
+                            yield return block;
+                        }
+                        else
+                        {
+                            block.Dispose();
+                        }
+
+                        break;
+                    }
+                    // The remaining metadata packets are always decoded to stay stream-aligned; each is handed
+                    // to its handler when one is set, otherwise discarded. The block-bearing ones lend the block
+                    // to the handler for the duration of the call and release it immediately after.
+                    case ServerPacketType.Totals:
+                        await ReadMetadataBlockAsync(reader, negotiated, handlers?.OnTotals, cancellationToken).ConfigureAwait(false);
+                        break;
+
+                    case ServerPacketType.Extremes:
+                        await ReadMetadataBlockAsync(reader, negotiated, handlers?.OnExtremes, cancellationToken).ConfigureAwait(false);
+                        break;
+
+                    case ServerPacketType.ProfileEvents:
+                        await ReadMetadataBlockAsync(reader, negotiated, handlers?.OnProfileEvents, cancellationToken).ConfigureAwait(false);
+                        break;
+
+                    case ServerPacketType.Log:
+                        await ReadMetadataBlockAsync(reader, negotiated, handlers?.OnLog, cancellationToken).ConfigureAwait(false);
+                        break;
+
+                    case ServerPacketType.Progress:
+                    {
+                        Progress progress = await Progress.ReadAsync(reader, negotiated, cancellationToken).ConfigureAwait(false);
+                        handlers?.OnProgress?.Invoke(progress);
+                        break;
+                    }
+
+                    case ServerPacketType.ProfileInfo:
+                    {
+                        ProfileInfo profileInfo = await ProfileInfo.ReadAsync(reader, cancellationToken).ConfigureAwait(false);
+                        handlers?.OnProfileInfo?.Invoke(profileInfo);
+                        break;
+                    }
+
+                    case ServerPacketType.TableColumns:
+                        // A column-defaults description the server may send; the client has no use for it yet, so
+                        // it is decoded to stay stream-aligned and discarded (an internal concern, not surfaced).
+                        await TableColumns.ReadAsync(reader, cancellationToken).ConfigureAwait(false);
+                        break;
+
+                    case ServerPacketType.PartUUIDs:
+                        // Valid mid-query when part-level deduplication is active. Consumed to stay stream-aligned;
+                        // the decoded UUIDs have no result surface yet. TODO: surface.
+                        await PartUUIDs.ConsumeAsync(reader, cancellationToken).ConfigureAwait(false);
+                        break;
+
+                    default:
+                        // Only the packets above are valid in a query response at this protocol target; anything
+                        // else (e.g. a read-task request) is a violation here.
+                        throw new ClickHouseProtocolException($"Unexpected packet type {packet} ({(ulong)packet}) in query response.");
+                }
+            }
+        }
+        finally
+        {
+            // Release the last yielded block (still current) on end-of-stream, early disposal, or error.
+            current?.Dispose();
+
+            if (completed)
+            {
+                state = TcpConnectionState.Ready;
+            }
+            else
+            {
+                Terminate();
+            }
+        }
+
+        if (pending is not null)
+        {
+            throw pending;
+        }
+    }
+
+    /// <summary>
+    /// Reads a metadata block, lends it to the handler if one is set (borrowed only for the duration of the
+    /// call), then releases its storage. A throwing handler propagates after the block has been released.
+    /// </summary>
+    private static async ValueTask ReadMetadataBlockAsync(
+        ClickHouseBinaryReader reader,
+        NegotiatedProtocol negotiated,
+        Action<Block> handler,
+        CancellationToken cancellationToken)
+    {
+        Block block = await BlockReader.ReadBlockAsync(reader, negotiated, ColumnCodecRegistry.Default, cancellationToken).ConfigureAwait(false);
+        try
+        {
+            handler?.Invoke(block);
+        }
+        finally
+        {
+            block.Dispose();
+        }
+    }
+
+    /// <summary>
     /// Terminates the connection after any active I/O has unwound: marks the state final, closes the transport,
     /// then releases the reader and writer's pooled buffers. Idempotent, but not safe to call concurrently with
     /// another operation. Once terminated a connection is never reused.
@@ -239,6 +461,10 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
         try
         {
             server = await Handshake.PerformAsync(reader, writer, handshake, cancellationToken).ConfigureAwait(false);
+
+            // Retain only the non-secret query metadata; the full parameters (and the plaintext password they
+            // carry) go out of scope with this method rather than living for the connection's lifetime.
+            clientMetadata = ClientMetadata.FromHandshake(handshake);
         }
         catch
         {

--- a/ClickHouse.Driver.Tcp/Protocol/ClientHandshakeParameters.cs
+++ b/ClickHouse.Driver.Tcp/Protocol/ClientHandshakeParameters.cs
@@ -8,8 +8,13 @@ namespace ClickHouse.Driver.Tcp.Protocol;
 /// </summary>
 internal sealed class ClientHandshakeParameters
 {
-    /// <summary>Informational client identifier (ClientHello field 1). Does not affect negotiation.</summary>
-    required public string ClientName { get; init; }
+    /// <summary>The product identifier this driver reports on the wire, for both the handshake and every query.</summary>
+    public const string DefaultClientName = "clickhouse-cs-tcp";
+
+    /// <summary>Informational client identifier (ClientHello field 1). Pinned to <see cref="DefaultClientName"/>
+    /// and not caller-configurable, so the handshake and every query's ClientInfo report the same name. Does not
+    /// affect negotiation.</summary>
+    public string ClientName => DefaultClientName;
 
     /// <summary>Informational client major version (ClientHello field 2).</summary>
     public int VersionMajor { get; init; }

--- a/ClickHouse.Driver.Tcp/Protocol/ClientInfo.cs
+++ b/ClickHouse.Driver.Tcp/Protocol/ClientInfo.cs
@@ -1,0 +1,82 @@
+using System;
+
+namespace ClickHouse.Driver.Tcp.Protocol;
+
+/// <summary>
+/// Writes the ClientInfo block embedded in a Query packet (the TCP-interface branch). Identifies the query's
+/// origin and the client. Fields gate on the negotiated version; at the current ceiling every gate is active.
+/// The client sends a plain initial query with no distributed context, no OpenTelemetry span, and no
+/// parallel-replica coordination, so those fields are their zero/absent forms.
+/// </summary>
+internal static class ClientInfo
+{
+    // A free-form address string used only for server-side logging of the initiating client.
+    private const string InitialAddress = "0.0.0.0:0";
+
+    private static readonly string OsUser = TryGet(() => Environment.UserName);
+    private static readonly string Hostname = TryGet(() => Environment.MachineName);
+
+    /// <summary>Writes the ClientInfo fields in wire order. Does not flush.</summary>
+    /// <param name="writer">The writer to encode into.</param>
+    /// <param name="negotiated">The negotiated protocol, gating version-conditional fields.</param>
+    /// <param name="client">The client identity retained after authentication.</param>
+    public static void Write(ClickHouseBinaryWriter writer, NegotiatedProtocol negotiated, ClientMetadata client)
+    {
+        writer.WriteByte(1);                        // query_kind = InitialQuery
+        writer.WriteString(client.Username);        // initial_user
+        writer.WriteString(string.Empty);           // initial_query_id (always empty for an initial query)
+        writer.WriteString(InitialAddress);         // initial_address
+
+        if (negotiated.Supports(ProtocolFeature.InitialQueryStartTime))
+        {
+            writer.WriteInt64(0);                   // initial_query_start_time_microseconds
+        }
+
+        writer.WriteByte(1);                        // interface = TCP
+        writer.WriteString(OsUser);                 // os_user
+        writer.WriteString(Hostname);               // client_hostname
+        writer.WriteString(client.ClientName);      // client_name
+        writer.WriteVarUInt((ulong)client.VersionMajor);
+        writer.WriteVarUInt((ulong)client.VersionMinor);
+        writer.WriteVarUInt(NegotiatedProtocol.ClientTcpProtocolVersion);
+
+        if (negotiated.Supports(ProtocolFeature.QuotaKeyInClientInfo))
+        {
+            writer.WriteString(client.QuotaKey);
+        }
+
+        if (negotiated.Supports(ProtocolFeature.DistributedDepth))
+        {
+            writer.WriteVarUInt(0);                 // distributed_depth
+        }
+
+        if (negotiated.Supports(ProtocolFeature.VersionPatch))
+        {
+            writer.WriteVarUInt(0);                 // client_version_patch
+        }
+
+        if (negotiated.Supports(ProtocolFeature.OpenTelemetry))
+        {
+            writer.WriteByte(0);                    // has_trace = 0 (no OpenTelemetry span)
+        }
+
+        if (negotiated.Supports(ProtocolFeature.ParallelReplicasClientInfo))
+        {
+            writer.WriteVarUInt(0);                 // collaborate_with_initiator
+            writer.WriteVarUInt(0);                 // count_participating_replicas
+            writer.WriteVarUInt(0);                 // number_of_current_replica
+        }
+    }
+
+    private static string TryGet(Func<string> get)
+    {
+        try
+        {
+            return get() ?? string.Empty;
+        }
+        catch (Exception)
+        {
+            return string.Empty;
+        }
+    }
+}

--- a/ClickHouse.Driver.Tcp/Protocol/ClientMetadata.cs
+++ b/ClickHouse.Driver.Tcp/Protocol/ClientMetadata.cs
@@ -1,0 +1,37 @@
+namespace ClickHouse.Driver.Tcp.Protocol;
+
+/// <summary>
+/// The subset of client identity that a connection retains after authentication to populate the ClientInfo
+/// block of every Query packet. Deliberately excludes the password (and default database): those are needed
+/// only during the handshake, so keeping them alive for the connection's lifetime would widen the window in
+/// which the plaintext password sits in memory for no benefit. The quota key is kept because every query
+/// carries it.
+/// </summary>
+internal sealed class ClientMetadata
+{
+    /// <summary>Informational client identifier, pinned to the same value the handshake reports.</summary>
+    public string ClientName => ClientHandshakeParameters.DefaultClientName;
+
+    /// <summary>Informational client major version.</summary>
+    public int VersionMajor { get; init; }
+
+    /// <summary>Informational client minor version.</summary>
+    public int VersionMinor { get; init; }
+
+    /// <summary>Username, echoed as the initiating user in ClientInfo.</summary>
+    required public string Username { get; init; }
+
+    /// <summary>Keyed-quota resource key, sent with every query. Empty when the client uses no keyed quota.</summary>
+    public string QuotaKey { get; init; } = string.Empty;
+
+    /// <summary>Copies the query-time fields out of the handshake input, leaving its secrets behind.</summary>
+    /// <param name="parameters">The full handshake parameters supplied at connect time.</param>
+    /// <returns>The non-secret query metadata.</returns>
+    public static ClientMetadata FromHandshake(ClientHandshakeParameters parameters) => new()
+    {
+        VersionMajor = parameters.VersionMajor,
+        VersionMinor = parameters.VersionMinor,
+        Username = parameters.Username,
+        QuotaKey = parameters.QuotaKey,
+    };
+}

--- a/ClickHouse.Driver.Tcp/Protocol/Handshake.cs
+++ b/ClickHouse.Driver.Tcp/Protocol/Handshake.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -100,6 +101,7 @@ internal static class Handshake
     /// <returns>The decoded server handshake, including the negotiated version.</returns>
     /// <exception cref="ClickHouseServerException">The server rejected the handshake (e.g. authentication failure).</exception>
     /// <exception cref="ClickHouseProtocolException">The server sent neither Hello nor Exception.</exception>
+    /// <exception cref="NotSupportedException">The server negotiated below the minimum protocol version this client supports.</exception>
     public static async ValueTask<ServerHandshake> PerformAsync(
         ClickHouseBinaryReader reader,
         ClickHouseBinaryWriter writer,
@@ -121,6 +123,16 @@ internal static class Handshake
         }
 
         ServerHandshake server = await ReadServerHelloAsync(reader, cancellationToken).ConfigureAwait(false);
+
+        // The write path assumes string-serialized settings (the form introduced at the floor). A server that
+        // negotiates below it would desync rather than merely lose features, so refuse it with a clear error
+        // instead of corrupting the connection.
+        if (server.Negotiated.Version < NegotiatedProtocol.MinimumTcpProtocolVersion)
+        {
+            throw new NotSupportedException(
+                $"The ClickHouse server's protocol revision {server.Revision} is older than the minimum " +
+                $"{NegotiatedProtocol.MinimumTcpProtocolVersion} this client supports.");
+        }
 
         if (server.Negotiated.Supports(ProtocolFeature.Addendum))
         {

--- a/ClickHouse.Driver.Tcp/Protocol/MetadataHandlers.cs
+++ b/ClickHouse.Driver.Tcp/Protocol/MetadataHandlers.cs
@@ -1,0 +1,44 @@
+using System;
+using ClickHouse.Driver.Tcp.Format;
+
+namespace ClickHouse.Driver.Tcp.Protocol;
+
+/// <summary>
+/// Optional per-query callbacks for the metadata packets the server interleaves with a query's Data blocks.
+/// Each handler is optional; where one is null the corresponding packet is still consumed to keep the stream
+/// aligned, but its contents are discarded.
+///
+/// <para>
+/// Handlers run synchronously on the thread draining the response, in the order the packets arrive on the
+/// wire. Keep them fast: they sit on the read path between blocks. A handler that throws propagates out of the
+/// enumeration and terminates the connection, so a handler must not throw for control flow.
+/// </para>
+///
+/// <para>
+/// <b>Block-bearing handlers borrow.</b> Blocks are valid only for the duration of the call;
+/// the object is disposed and its storage is released as soon as the handler returns.
+/// Copy out anything you need to keep, and do not retain the block, its columns, or their value spans.
+/// The scalar handlers (<see cref="OnProgress"/>, <see cref="OnProfileInfo"/>)
+/// receive owned, immutable values that are safe to retain.
+/// </para>
+/// </summary>
+internal sealed class MetadataHandlers
+{
+    /// <summary>Invoked for each Progress packet, which the server sends repeatedly as the query advances.</summary>
+    public Action<Progress> OnProgress { get; init; }
+
+    /// <summary>Invoked for the ProfileInfo summary (rows/blocks/bytes read, limit application).</summary>
+    public Action<ProfileInfo> OnProfileInfo { get; init; }
+
+    /// <summary>Invoked with the borrowed Totals block (the WITH TOTALS row). Valid only for the call.</summary>
+    public Action<Block> OnTotals { get; init; }
+
+    /// <summary>Invoked with the borrowed Extremes block (min/max rows). Valid only for the call.</summary>
+    public Action<Block> OnExtremes { get; init; }
+
+    /// <summary>Invoked with a borrowed block of server log rows. Valid only for the call.</summary>
+    public Action<Block> OnLog { get; init; }
+
+    /// <summary>Invoked with a borrowed block of profile-event metric rows. Valid only for the call.</summary>
+    public Action<Block> OnProfileEvents { get; init; }
+}

--- a/ClickHouse.Driver.Tcp/Protocol/NegotiatedProtocol.cs
+++ b/ClickHouse.Driver.Tcp/Protocol/NegotiatedProtocol.cs
@@ -13,6 +13,14 @@ internal readonly struct NegotiatedProtocol
     /// </summary>
     public const int ClientTcpProtocolVersion = 54460;
 
+    /// <summary>
+    /// The lowest negotiated version this client can talk to. The Query packet always serializes settings as
+    /// string triples (the form introduced at this version); below it the server expects the legacy binary
+    /// encoding, which this client does not emit — so a lower negotiation would silently desync the stream.
+    /// Negotiating below this floor is rejected at the handshake rather than left to corrupt the connection.
+    /// </summary>
+    public const int MinimumTcpProtocolVersion = 54429;
+
     /// <summary>Computes the negotiated version from the revision the server reported in ServerHello.</summary>
     /// <param name="serverRevision">The server's protocol revision (ServerHello field 4).</param>
     public NegotiatedProtocol(int serverRevision) => Version = Math.Min(ClientTcpProtocolVersion, serverRevision);

--- a/ClickHouse.Driver.Tcp/Protocol/PartUUIDs.cs
+++ b/ClickHouse.Driver.Tcp/Protocol/PartUUIDs.cs
@@ -1,0 +1,27 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ClickHouse.Driver.Tcp.Protocol;
+
+/// <summary>
+/// The PartUUIDs packet: a VarUInt count followed by that many 16-byte part UUIDs. The server sends it during
+/// query execution when part-level query deduplication is active. The client has no result surface for these
+/// values yet, so the body is read purely to keep the stream aligned and the UUIDs are discarded.
+/// </summary>
+internal static class PartUUIDs
+{
+    /// <summary>
+    /// Reads and discards the PartUUIDs body, leaving the reader positioned at the next packet boundary.
+    /// </summary>
+    /// <param name="reader">The reader positioned at the start of the packet body.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    public static async ValueTask ConsumeAsync(ClickHouseBinaryReader reader, CancellationToken cancellationToken)
+    {
+        ulong count = await reader.ReadVarUIntAsync(cancellationToken).ConfigureAwait(false);
+        for (ulong i = 0; i < count; i++)
+        {
+            // Each UUID is a fixed 16-byte value; read and drop it via the zero-allocation fixed-width path.
+            await reader.ReadUInt128Async(cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/ClickHouse.Driver.Tcp/Protocol/ProfileInfo.cs
+++ b/ClickHouse.Driver.Tcp/Protocol/ProfileInfo.cs
@@ -1,0 +1,61 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ClickHouse.Driver.Tcp.Protocol;
+
+/// <summary>
+/// A decoded ProfileInfo packet: the once-per-query execution summary.
+/// </summary>
+internal readonly struct ProfileInfo
+{
+    /// <summary>Initializes a new instance of the <see cref="ProfileInfo"/> struct.</summary>
+    /// <param name="rows">Rows in the result.</param>
+    /// <param name="blocks">Blocks in the result.</param>
+    /// <param name="bytes">Bytes in the result.</param>
+    /// <param name="appliedLimit">Whether a LIMIT was applied.</param>
+    /// <param name="rowsBeforeLimit">Rows before the LIMIT.</param>
+    /// <param name="calculatedRowsBeforeLimit">Whether <paramref name="rowsBeforeLimit"/> is meaningful.</param>
+    public ProfileInfo(ulong rows, ulong blocks, ulong bytes, bool appliedLimit, ulong rowsBeforeLimit, bool calculatedRowsBeforeLimit)
+    {
+        Rows = rows;
+        Blocks = blocks;
+        Bytes = bytes;
+        AppliedLimit = appliedLimit;
+        RowsBeforeLimit = rowsBeforeLimit;
+        CalculatedRowsBeforeLimit = calculatedRowsBeforeLimit;
+    }
+
+    /// <summary>Rows in the result.</summary>
+    public ulong Rows { get; }
+
+    /// <summary>Blocks in the result.</summary>
+    public ulong Blocks { get; }
+
+    /// <summary>Bytes in the result.</summary>
+    public ulong Bytes { get; }
+
+    /// <summary>Whether a LIMIT was applied.</summary>
+    public bool AppliedLimit { get; }
+
+    /// <summary>Rows before the LIMIT was applied.</summary>
+    public ulong RowsBeforeLimit { get; }
+
+    /// <summary>Whether <see cref="RowsBeforeLimit"/> was calculated (otherwise it is not meaningful).</summary>
+    public bool CalculatedRowsBeforeLimit { get; }
+
+    /// <summary>Reads a ProfileInfo packet body.</summary>
+    /// <param name="reader">The reader positioned at the packet body.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>The decoded profile info.</returns>
+    public static async ValueTask<ProfileInfo> ReadAsync(ClickHouseBinaryReader reader, CancellationToken cancellationToken)
+    {
+        ulong rows = await reader.ReadVarUIntAsync(cancellationToken).ConfigureAwait(false);
+        ulong blocks = await reader.ReadVarUIntAsync(cancellationToken).ConfigureAwait(false);
+        ulong bytes = await reader.ReadVarUIntAsync(cancellationToken).ConfigureAwait(false);
+        bool appliedLimit = await reader.ReadBoolAsync(cancellationToken).ConfigureAwait(false);
+        ulong rowsBeforeLimit = await reader.ReadVarUIntAsync(cancellationToken).ConfigureAwait(false);
+        bool calculatedRowsBeforeLimit = await reader.ReadBoolAsync(cancellationToken).ConfigureAwait(false);
+
+        return new ProfileInfo(rows, blocks, bytes, appliedLimit, rowsBeforeLimit, calculatedRowsBeforeLimit);
+    }
+}

--- a/ClickHouse.Driver.Tcp/Protocol/Progress.cs
+++ b/ClickHouse.Driver.Tcp/Protocol/Progress.cs
@@ -1,0 +1,74 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ClickHouse.Driver.Tcp.Protocol;
+
+/// <summary>
+/// A decoded Progress packet: cumulative counters the server emits as a query runs. Each packet is a delta;
+/// callers accumulate.
+/// </summary>
+internal readonly struct Progress
+{
+    /// <summary>Initializes a new instance of the <see cref="Progress"/> struct.</summary>
+    /// <param name="rows">Rows read so far (delta).</param>
+    /// <param name="bytes">Bytes read so far (delta).</param>
+    /// <param name="totalRows">Total rows to read, if known.</param>
+    /// <param name="wroteRows">Rows written (INSERT), if applicable.</param>
+    /// <param name="wroteBytes">Bytes written (INSERT), if applicable.</param>
+    /// <param name="elapsedNs">Server-side elapsed time in nanoseconds.</param>
+    public Progress(ulong rows, ulong bytes, ulong totalRows, ulong wroteRows, ulong wroteBytes, ulong elapsedNs)
+    {
+        Rows = rows;
+        Bytes = bytes;
+        TotalRows = totalRows;
+        WroteRows = wroteRows;
+        WroteBytes = wroteBytes;
+        ElapsedNs = elapsedNs;
+    }
+
+    /// <summary>Rows read (delta).</summary>
+    public ulong Rows { get; }
+
+    /// <summary>Bytes read (delta).</summary>
+    public ulong Bytes { get; }
+
+    /// <summary>Total rows to read, if known.</summary>
+    public ulong TotalRows { get; }
+
+    /// <summary>Rows written (delta), for INSERT.</summary>
+    public ulong WroteRows { get; }
+
+    /// <summary>Bytes written (delta), for INSERT.</summary>
+    public ulong WroteBytes { get; }
+
+    /// <summary>Server-side elapsed time in nanoseconds.</summary>
+    public ulong ElapsedNs { get; }
+
+    /// <summary>Reads a Progress packet body at the negotiated version.</summary>
+    /// <param name="reader">The reader positioned at the packet body.</param>
+    /// <param name="negotiated">The negotiated protocol, gating the trailing counters.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>The decoded progress.</returns>
+    public static async ValueTask<Progress> ReadAsync(ClickHouseBinaryReader reader, NegotiatedProtocol negotiated, CancellationToken cancellationToken)
+    {
+        ulong rows = await reader.ReadVarUIntAsync(cancellationToken).ConfigureAwait(false);
+        ulong bytes = await reader.ReadVarUIntAsync(cancellationToken).ConfigureAwait(false);
+        ulong totalRows = await reader.ReadVarUIntAsync(cancellationToken).ConfigureAwait(false);
+
+        ulong wroteRows = 0;
+        ulong wroteBytes = 0;
+        if (negotiated.Supports(ProtocolFeature.ProgressWriteInfo))
+        {
+            wroteRows = await reader.ReadVarUIntAsync(cancellationToken).ConfigureAwait(false);
+            wroteBytes = await reader.ReadVarUIntAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        ulong elapsedNs = 0;
+        if (negotiated.Supports(ProtocolFeature.ProgressElapsedNs))
+        {
+            elapsedNs = await reader.ReadVarUIntAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        return new Progress(rows, bytes, totalRows, wroteRows, wroteBytes, elapsedNs);
+    }
+}

--- a/ClickHouse.Driver.Tcp/Protocol/ProtocolFeature.cs
+++ b/ClickHouse.Driver.Tcp/Protocol/ProtocolFeature.cs
@@ -11,14 +11,47 @@ internal enum ProtocolFeature
     /// <summary>ServerHello carries a <c>timezone</c> string.</summary>
     Timezone = 54058,
 
+    /// <summary>ClientInfo carries a <c>quota_key</c> string (distinct from the Addendum quota key).</summary>
+    QuotaKeyInClientInfo = 54060,
+
     /// <summary>ServerHello carries a <c>display_name</c> string.</summary>
     DisplayName = 54372,
 
-    /// <summary>ServerHello carries a <c>version_patch</c> VarUInt.</summary>
+    /// <summary>ServerHello carries a <c>version_patch</c> VarUInt; ClientInfo carries <c>client_version_patch</c>.</summary>
     VersionPatch = 54401,
+
+    /// <summary>Progress carries <c>wrote_rows</c> and <c>wrote_bytes</c> VarUInts.</summary>
+    ProgressWriteInfo = 54420,
+
+    /// <summary>Query settings are serialized as (key, flags, string-value) triples rather than the legacy binary form.</summary>
+    SettingsAsStrings = 54429,
+
+    /// <summary>The Query packet carries an <c>interserver_secret</c> string (empty for external clients).</summary>
+    InterserverSecret = 54441,
+
+    /// <summary>ClientInfo carries an OpenTelemetry trace block (a presence byte, plus trace context when present).</summary>
+    OpenTelemetry = 54442,
+
+    /// <summary>ClientInfo carries a <c>distributed_depth</c> VarUInt.</summary>
+    DistributedDepth = 54448,
+
+    /// <summary>ClientInfo carries an <c>initial_query_start_time_microseconds</c> Int64.</summary>
+    InitialQueryStartTime = 54449,
+
+    /// <summary>ClientInfo carries the parallel-replicas collaboration fields (collaborate flag, replica counts).</summary>
+    ParallelReplicasClientInfo = 54453,
+
+    /// <summary>Each block column carries a <c>has_custom_serialization</c> byte.</summary>
+    CustomSerialization = 54454,
 
     /// <summary>The client sends an Addendum after the handshake exchange.</summary>
     Addendum = 54458,
+
+    /// <summary>The Query packet carries a query-parameters list (name, flags, value) terminated by an empty key.</summary>
+    Parameters = 54459,
+
+    /// <summary>Progress carries an <c>elapsed_ns</c> VarUInt.</summary>
+    ProgressElapsedNs = 54460,
 
     /// <summary>Per-packet chunk framing wraps every packet body; preferences are exchanged in ServerHello and Addendum.</summary>
     ChunkedProtocol = 54470,

--- a/ClickHouse.Driver.Tcp/Protocol/Query.cs
+++ b/ClickHouse.Driver.Tcp/Protocol/Query.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+
+namespace ClickHouse.Driver.Tcp.Protocol;
+
+/// <summary>
+/// Writes the Query packet: query id, the ClientInfo block, per-query settings, the SQL text, and query
+/// parameters. Settings and parameters are (key, flags, value) string triples terminated by an empty key.
+/// This string-serialized form is unconditional; the handshake rejects any server that negotiates below the
+/// version where it became the wire format, so it is always the form the peer expects.
+/// </summary>
+internal static class Query
+{
+    private const byte StageComplete = 2;      // process the query to completion (not just parse/plan)
+    private const ulong ParameterFlagCustom = 0x02;
+
+    // The block reader decodes textual column type headers. Enabling binary type headers would change the
+    // Native block layout and desync the reader, so if the caller sets this we force it back to the textual
+    // form. We only override a value the caller supplied: servers that predate the setting reject unknown
+    // settings, and its default is already the textual form we rely on, so injecting it unprompted would be
+    // both unnecessary and unsafe against older servers.
+    private const string NativeBinaryTypesSetting = "output_format_native_encode_types_in_binary_format";
+    private const string NativeBinaryTypesDisabled = "0";
+
+    /// <summary>Writes the Query packet body. Does not flush and does not write the following data marker.</summary>
+    /// <param name="writer">The writer to encode into.</param>
+    /// <param name="negotiated">The negotiated protocol, gating version-conditional fields.</param>
+    /// <param name="client">The client identity for the embedded ClientInfo.</param>
+    /// <param name="queryId">The query id (empty to let the server assign one).</param>
+    /// <param name="sql">The SQL text.</param>
+    /// <param name="settings">Per-query settings as textual values, or null for none.</param>
+    /// <param name="queryParameters">Query parameter values (already in SQL representation), or null for none.</param>
+    public static void Write(
+        ClickHouseBinaryWriter writer,
+        NegotiatedProtocol negotiated,
+        ClientMetadata client,
+        string queryId,
+        string sql,
+        IReadOnlyDictionary<string, string> settings,
+        IReadOnlyDictionary<string, string> queryParameters)
+    {
+        writer.WriteClientPacketType(ClientPacketType.Query);
+        writer.WriteString(queryId ?? string.Empty);
+
+        ClientInfo.Write(writer, negotiated, client);
+
+        WriteSettings(writer, settings);
+
+        if (negotiated.Supports(ProtocolFeature.InterserverSecret))
+        {
+            writer.WriteString(string.Empty);      // interserver_secret: empty for external clients
+        }
+
+        writer.WriteByte(StageComplete);
+        writer.WriteBool(false);                   // compression disabled
+
+        writer.WriteString(sql);
+
+        if (negotiated.Supports(ProtocolFeature.Parameters))
+        {
+            WriteParameters(writer, queryParameters);
+        }
+        else if (queryParameters is { Count: > 0 })
+        {
+            // The parameters list is not part of the wire format below this version, so it cannot be sent.
+            // Fail loudly rather than dropping the parameters and running a query that silently means something
+            // different (or errors on the server with an opaque "unknown parameter" message).
+            throw new NotSupportedException(
+                $"The server's negotiated protocol revision {negotiated.Version} does not support query parameters " +
+                $"(introduced in revision {(int)ProtocolFeature.Parameters}); pass none or use a newer server.");
+        }
+    }
+
+    private static void WriteSettings(ClickHouseBinaryWriter writer, IReadOnlyDictionary<string, string> settings)
+    {
+        if (settings is not null)
+        {
+            foreach (KeyValuePair<string, string> setting in settings)
+            {
+                writer.WriteString(setting.Key);
+                writer.WriteVarUInt(0);            // flags: neither important nor custom
+
+                // Force the reader-desyncing binary-type-header setting back off if the caller enabled it.
+                string value = string.Equals(setting.Key, NativeBinaryTypesSetting, StringComparison.Ordinal)
+                    ? NativeBinaryTypesDisabled
+                    : setting.Value;
+                writer.WriteString(value);
+            }
+        }
+
+        writer.WriteString(string.Empty);          // empty key terminates the list
+    }
+
+    private static void WriteParameters(ClickHouseBinaryWriter writer, IReadOnlyDictionary<string, string> queryParameters)
+    {
+        if (queryParameters is not null)
+        {
+            foreach (KeyValuePair<string, string> parameter in queryParameters)
+            {
+                writer.WriteString(parameter.Key);
+                writer.WriteVarUInt(ParameterFlagCustom);
+                writer.WriteString(parameter.Value);
+            }
+        }
+
+        writer.WriteString(string.Empty);          // empty key terminates the list
+    }
+}

--- a/ClickHouse.Driver.Tcp/Protocol/TableColumns.cs
+++ b/ClickHouse.Driver.Tcp/Protocol/TableColumns.cs
@@ -1,0 +1,38 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ClickHouse.Driver.Tcp.Protocol;
+
+/// <summary>
+/// A decoded TableColumns packet: an optional column-defaults description the server may send before an INSERT
+/// schema block. The client does not use defaults yet, so the body is decoded (to stay stream-synced) and kept
+/// opaque.
+/// </summary>
+internal readonly struct TableColumns
+{
+    /// <summary>Initializes a new instance of the <see cref="TableColumns"/> struct.</summary>
+    /// <param name="externalTableName">The external table name.</param>
+    /// <param name="columnsDescription">The free-form columns description string.</param>
+    public TableColumns(string externalTableName, string columnsDescription)
+    {
+        ExternalTableName = externalTableName;
+        ColumnsDescription = columnsDescription;
+    }
+
+    /// <summary>The external table name.</summary>
+    public string ExternalTableName { get; }
+
+    /// <summary>The free-form columns-description string.</summary>
+    public string ColumnsDescription { get; }
+
+    /// <summary>Reads a TableColumns packet body.</summary>
+    /// <param name="reader">The reader positioned at the packet body.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>The decoded table columns.</returns>
+    public static async ValueTask<TableColumns> ReadAsync(ClickHouseBinaryReader reader, CancellationToken cancellationToken)
+    {
+        string externalTableName = await reader.ReadStringAsync(cancellationToken).ConfigureAwait(false);
+        string columnsDescription = await reader.ReadStringAsync(cancellationToken).ConfigureAwait(false);
+        return new TableColumns(externalTableName, columnsDescription);
+    }
+}

--- a/ClickHouse.Driver.Tcp/Types/ArrayColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/ArrayColumn.cs
@@ -1,0 +1,50 @@
+using System;
+
+namespace ClickHouse.Driver.Tcp.Types;
+
+/// <summary>
+/// A column backed by a typed array, for element types that are not a direct reinterpret of the wire bytes —
+/// <c>String</c> (variable-length) and converted types such as <c>DateTime</c>. <see cref="Values"/> is a
+/// borrowed view over the array.
+/// </summary>
+/// <typeparam name="T">The CLR element type.</typeparam>
+internal sealed class ArrayColumn<T> : IColumn<T>
+{
+    private readonly T[] values;
+
+    /// <summary>Initializes a column that takes ownership of the values array.</summary>
+    /// <param name="name">The column name.</param>
+    /// <param name="typeName">The ClickHouse type string.</param>
+    /// <param name="values">The decoded values.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="values"/> is null.</exception>
+    public ArrayColumn(string name, string typeName, T[] values)
+    {
+        Name = name;
+        TypeName = typeName;
+        this.values = values ?? throw new ArgumentNullException(nameof(values));
+    }
+
+    /// <inheritdoc/>
+    public string Name { get; }
+
+    /// <inheritdoc/>
+    public string TypeName { get; }
+
+    /// <inheritdoc/>
+    public int RowCount => values.Length;
+
+    /// <inheritdoc/>
+    public ReadOnlySpan<T> Values => values;
+
+    /// <inheritdoc/>
+    public T this[int row] => values[row];
+
+    /// <inheritdoc/>
+    public object GetValue(int row) => values[row];
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        // The values array is GC-managed, not pooled; nothing to release.
+    }
+}

--- a/ClickHouse.Driver.Tcp/Types/Codecs/DateTimeColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/DateTimeColumnCodec.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Buffers;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Protocol;
+
+namespace ClickHouse.Driver.Tcp.Types.Codecs;
+
+/// <summary>
+/// A minimal codec for the ClickHouse <c>DateTime</c> column: a little-endian <c>UInt32</c> of seconds since
+/// the Unix epoch per row, surfaced as a UTC <see cref="DateTime"/>. The type's timezone argument (part of the
+/// type string, not the body) affects only display, not the instant, so it is ignored here. This exists so the
+/// server's always-present ProfileEvents block, which carries a <c>DateTime</c> column, can be consumed; full
+/// timezone-aware DateTime handling is a later TODO.
+/// </summary>
+internal sealed class DateTimeColumnCodec : IColumnCodec
+{
+    /// <summary>The shared, stateless instance.</summary>
+    public static readonly DateTimeColumnCodec Instance = new();
+
+    private DateTimeColumnCodec()
+    {
+    }
+
+    /// <inheritdoc/>
+    public string TypeName => "DateTime";
+
+    /// <inheritdoc/>
+    public async ValueTask<IColumn> ReadColumnAsync(ClickHouseBinaryReader reader, string columnName, string columnType, int rowCount, CancellationToken cancellationToken)
+    {
+        var values = new DateTime[rowCount];
+        if (rowCount == 0)
+        {
+            return new ArrayColumn<DateTime>(columnName, columnType, values);
+        }
+
+        // Read the whole fixed-size column body in one transfer, reinterpret it as the epoch-second UInt32s,
+        // then convert. The scratch buffer is pooled since it's discarded once the DateTimes are built.
+        int byteCount = checked(rowCount * sizeof(uint));
+        byte[] rented = ArrayPool<byte>.Shared.Rent(byteCount);
+        try
+        {
+            await reader.ReadBytesAsync(rented.AsMemory(0, byteCount), cancellationToken).ConfigureAwait(false);
+            ReadOnlySpan<uint> seconds = MemoryMarshal.Cast<byte, uint>(rented.AsSpan(0, byteCount));
+            for (int i = 0; i < rowCount; i++)
+            {
+                values[i] = DateTime.UnixEpoch.AddSeconds(seconds[i]);
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(rented);
+        }
+
+        return new ArrayColumn<DateTime>(columnName, columnType, values);
+    }
+
+    /// <inheritdoc/>
+    public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column)
+    {
+        foreach (DateTime value in ((IColumn<DateTime>)column).Values)
+        {
+            long seconds = (long)(value.ToUniversalTime() - DateTime.UnixEpoch).TotalSeconds;
+            writer.WriteUInt32((uint)seconds);
+        }
+    }
+}

--- a/ClickHouse.Driver.Tcp/Types/Codecs/IntegerColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/IntegerColumnCodec.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Buffers;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Protocol;
+
+namespace ClickHouse.Driver.Tcp.Types.Codecs;
+
+/// <summary>
+/// A codec for a fixed-width integer column. ClickHouse writes these values little-endian and contiguously, so
+/// the whole column is read in one bulk transfer into a byte buffer that becomes the column's storage — no
+/// per-element decoding, and the values are reinterpreted from those bytes on access. Covers the 8- through
+/// 256-bit signed and unsigned widths.
+///
+/// <para>
+/// Little-endian only: the buffer's bytes are the wire bytes, reinterpreted as <typeparamref name="T"/>. Every
+/// runtime .NET targets is little-endian; that invariant is assumed here (not re-checked per column). TODO: a
+/// single big-endian guard at the client entry point is not yet in place — until it lands, running on a
+/// big-endian host would silently mis-decode rather than fail fast.
+/// </para>
+/// </summary>
+/// <typeparam name="T">The CLR type the ClickHouse integer maps to.</typeparam>
+internal sealed class IntegerColumnCodec<T> : IColumnCodec
+    where T : unmanaged
+{
+    /// <summary>Initializes a new instance of the <see cref="IntegerColumnCodec{T}"/> class.</summary>
+    /// <param name="typeName">The canonical ClickHouse type name (e.g. <c>Int32</c>).</param>
+    public IntegerColumnCodec(string typeName) => TypeName = typeName;
+
+    /// <inheritdoc/>
+    public string TypeName { get; }
+
+    /// <inheritdoc/>
+    public async ValueTask<IColumn> ReadColumnAsync(ClickHouseBinaryReader reader, string columnName, string columnType, int rowCount, CancellationToken cancellationToken)
+    {
+        if (rowCount == 0)
+        {
+            return new PrimitiveColumn<T>(columnName, columnType, Array.Empty<byte>(), length: 0, pooled: false);
+        }
+
+        int byteCount = checked(rowCount * Unsafe.SizeOf<T>());
+        byte[] rented = ArrayPool<byte>.Shared.Rent(byteCount);
+        try
+        {
+            await reader.ReadBytesAsync(rented.AsMemory(0, byteCount), cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            // The column never took ownership of the rent, so return it rather than leak it on a read failure.
+            ArrayPool<byte>.Shared.Return(rented);
+            throw;
+        }
+
+        return new PrimitiveColumn<T>(columnName, columnType, rented, byteCount, pooled: true);
+    }
+
+    /// <inheritdoc/>
+    public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column)
+    {
+        writer.WriteBytes(MemoryMarshal.AsBytes(((IColumn<T>)column).Values));
+    }
+}

--- a/ClickHouse.Driver.Tcp/Types/Codecs/StringColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/StringColumnCodec.cs
@@ -1,0 +1,43 @@
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Protocol;
+
+namespace ClickHouse.Driver.Tcp.Types.Codecs;
+
+/// <summary>
+/// A codec for the ClickHouse <c>String</c> column: each row is a VarUInt byte-length prefix followed by that
+/// many bytes, decoded as UTF-8. Values are read row-by-row (each carries its own length).
+/// </summary>
+internal sealed class StringColumnCodec : IColumnCodec
+{
+    /// <summary>The shared, stateless instance.</summary>
+    public static readonly StringColumnCodec Instance = new();
+
+    private StringColumnCodec()
+    {
+    }
+
+    /// <inheritdoc/>
+    public string TypeName => "String";
+
+    /// <inheritdoc/>
+    public async ValueTask<IColumn> ReadColumnAsync(ClickHouseBinaryReader reader, string columnName, string columnType, int rowCount, CancellationToken cancellationToken)
+    {
+        var values = new string[rowCount];
+        for (int i = 0; i < rowCount; i++)
+        {
+            values[i] = await reader.ReadStringAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        return new ArrayColumn<string>(columnName, columnType, values);
+    }
+
+    /// <inheritdoc/>
+    public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column)
+    {
+        foreach (string value in ((IColumn<string>)column).Values)
+        {
+            writer.WriteString(value);
+        }
+    }
+}

--- a/ClickHouse.Driver.Tcp/Types/ColumnCodecRegistry.cs
+++ b/ClickHouse.Driver.Tcp/Types/ColumnCodecRegistry.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using ClickHouse.Driver.Tcp.Numerics;
+using ClickHouse.Driver.Tcp.Types.Codecs;
+
+namespace ClickHouse.Driver.Tcp.Types;
+
+/// <summary>
+/// Resolves a ClickHouse type string to the codec that reads/writes it. The type string is parsed into a
+/// <see cref="TypeNode"/> and dispatched on its base name. This slice registers the fixed-width integers,
+/// <c>String</c>, and minimal <c>DateTime</c> / <c>Enum8</c> / <c>Enum16</c> aliases — the latter three are
+/// needed to consume the server's always-present ProfileEvents block, whose columns include a <c>DateTime</c>
+/// and an <c>Enum8</c>. The enum aliases surface the raw underlying integer; label mapping is a later type.
+/// Parameterized dispatch that consumes <see cref="TypeNode.Arguments"/> is added with composite types.
+/// </summary>
+internal sealed class ColumnCodecRegistry
+{
+    /// <summary>The default registry with the built-in codecs.</summary>
+    public static readonly ColumnCodecRegistry Default = CreateDefault();
+
+    private readonly Dictionary<string, IColumnCodec> byName;
+
+    private ColumnCodecRegistry(Dictionary<string, IColumnCodec> byName) => this.byName = byName;
+
+    /// <summary>Resolves the codec for a ClickHouse type string.</summary>
+    /// <param name="typeString">The type string from a column header (e.g. <c>UInt64</c>, <c>DateTime('UTC')</c>).</param>
+    /// <returns>The codec for that type.</returns>
+    /// <exception cref="FormatException"><paramref name="typeString"/> is malformed.</exception>
+    /// <exception cref="NotSupportedException">The type is well-formed but not yet supported by this client.</exception>
+    public IColumnCodec Resolve(string typeString)
+    {
+        TypeNode node = TypeParser.Parse(typeString);
+        if (byName.TryGetValue(node.Name, out IColumnCodec codec))
+        {
+            return codec;
+        }
+
+        throw new NotSupportedException($"ClickHouse type '{typeString}' is not supported by this client yet.");
+    }
+
+    private static ColumnCodecRegistry CreateDefault()
+    {
+        var byName = new Dictionary<string, IColumnCodec>(StringComparer.Ordinal);
+
+        void Add(IColumnCodec codec) => byName[codec.TypeName] = codec;
+
+        Add(new IntegerColumnCodec<byte>("UInt8"));
+        Add(new IntegerColumnCodec<sbyte>("Int8"));
+        Add(new IntegerColumnCodec<ushort>("UInt16"));
+        Add(new IntegerColumnCodec<short>("Int16"));
+        Add(new IntegerColumnCodec<uint>("UInt32"));
+        Add(new IntegerColumnCodec<int>("Int32"));
+        Add(new IntegerColumnCodec<ulong>("UInt64"));
+        Add(new IntegerColumnCodec<long>("Int64"));
+        Add(new IntegerColumnCodec<UInt128>("UInt128"));
+        Add(new IntegerColumnCodec<Int128>("Int128"));
+        Add(new IntegerColumnCodec<UInt256>("UInt256"));
+        Add(new IntegerColumnCodec<Int256>("Int256"));
+        Add(new IntegerColumnCodec<sbyte>("Enum8"));   // underlying Int8; raw ordinal, label mapping deferred
+        Add(new IntegerColumnCodec<short>("Enum16"));  // underlying Int16; raw ordinal, label mapping deferred
+        Add(StringColumnCodec.Instance);
+        Add(DateTimeColumnCodec.Instance);
+
+        return new ColumnCodecRegistry(byName);
+    }
+}

--- a/ClickHouse.Driver.Tcp/Types/IColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/IColumn.cs
@@ -1,0 +1,51 @@
+using System;
+
+namespace ClickHouse.Driver.Tcp.Types;
+
+/// <summary>
+/// A decoded column: a named, typed sequence of values read from one block. The generic <see cref="IColumn{T}"/>
+/// exposes the values; this non-generic view lets a block hold columns of mixed element types and read a value
+/// without knowing its static type.
+///
+/// <para>
+/// A column's storage may be a pooled buffer, so it is disposable and its values are borrowed for the block's
+/// lifetime. The owning <see cref="Format.Block"/> disposes its columns; a consumer must not read a column
+/// after the block is released (see <see cref="Format.Block"/> for the borrowing contract).
+/// </para>
+/// </summary>
+public interface IColumn : IDisposable
+{
+    /// <summary>The column name from the block header.</summary>
+    string Name { get; }
+
+    /// <summary>The ClickHouse type string from the block header (e.g. <c>UInt64</c>, <c>String</c>).</summary>
+    string TypeName { get; }
+
+    /// <summary>The number of values in the column.</summary>
+    int RowCount { get; }
+
+    /// <summary>Returns the value at <paramref name="row"/>, boxed. Prefer the typed <see cref="IColumn{T}.Values"/> on the fast path.</summary>
+    /// <param name="row">The zero-based row index.</param>
+    /// <returns>The value at that row.</returns>
+    object GetValue(int row);
+}
+
+/// <summary>
+/// A decoded column with typed access. <see cref="Values"/> is a borrowed view valid for the lifetime of the
+/// block: process it in place, or copy it (e.g. <c>ToArray()</c>) to retain the data beyond the block.
+/// </summary>
+/// <typeparam name="T">The CLR element type the column's ClickHouse type maps to.</typeparam>
+public interface IColumn<T> : IColumn
+{
+    /// <summary>
+    /// The values, in row order — a borrowed span, not owned by the caller. The span is recomputed on each
+    /// access (it cannot be cached in a field, being a ref struct); in a hot loop, read it into a local once
+    /// and iterate that rather than re-reading this property per element.
+    /// </summary>
+    ReadOnlySpan<T> Values { get; }
+
+    /// <summary>The value at <paramref name="row"/>.</summary>
+    /// <param name="row">The zero-based row index.</param>
+    /// <returns>The value at that row.</returns>
+    T this[int row] { get; }
+}

--- a/ClickHouse.Driver.Tcp/Types/IColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/IColumnCodec.cs
@@ -1,0 +1,48 @@
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Protocol;
+
+namespace ClickHouse.Driver.Tcp.Types;
+
+/// <summary>
+/// Reads and writes one ClickHouse column type over the wire. A codec is resolved from a type string by the
+/// registry and knows how to turn <c>num_rows</c> wire values into an <see cref="IColumn"/> and back.
+///
+/// <para>
+/// A column may carry a serialization state prefix before its values (used by dictionary-bearing types such
+/// as LowCardinality). Most types have none, so the prefix hooks default to no-ops; composite codecs that own
+/// child codecs recurse into them. The block layer always calls the prefix hook before the value read/write,
+/// so a codec that needs a prefix can rely on the ordering without the block layer knowing which types do.
+/// </para>
+/// </summary>
+internal interface IColumnCodec
+{
+    /// <summary>The canonical base type name this codec handles (e.g. <c>UInt64</c>, <c>String</c>).</summary>
+    string TypeName { get; }
+
+    /// <summary>Reads the column's serialization state prefix, if any. Default: none.</summary>
+    /// <param name="reader">The reader positioned at the prefix.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>A task that completes when the prefix has been consumed.</returns>
+    ValueTask ReadStatePrefixAsync(ClickHouseBinaryReader reader, CancellationToken cancellationToken) => default;
+
+    /// <summary>Reads exactly <paramref name="rowCount"/> values into a column.</summary>
+    /// <param name="reader">The reader positioned at the column body.</param>
+    /// <param name="columnName">The column name from the block header.</param>
+    /// <param name="columnType">The full ClickHouse type string from the block header (stamped onto the column).</param>
+    /// <param name="rowCount">The number of values to read.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>The decoded column.</returns>
+    ValueTask<IColumn> ReadColumnAsync(ClickHouseBinaryReader reader, string columnName, string columnType, int rowCount, CancellationToken cancellationToken);
+
+    /// <summary>Writes the column's serialization state prefix, if any. Default: none.</summary>
+    /// <param name="writer">The writer to encode into.</param>
+    void WriteStatePrefix(ClickHouseBinaryWriter writer)
+    {
+    }
+
+    /// <summary>Writes all of the column's values.</summary>
+    /// <param name="writer">The writer to encode into.</param>
+    /// <param name="column">The column whose values to write; must match this codec's element type.</param>
+    void WriteColumn(ClickHouseBinaryWriter writer, IColumn column);
+}

--- a/ClickHouse.Driver.Tcp/Types/PrimitiveColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/PrimitiveColumn.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Buffers;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace ClickHouse.Driver.Tcp.Types;
+
+/// <summary>
+/// A fixed-width column backed by the raw little-endian wire bytes, reinterpreted as <typeparamref name="T"/>
+/// on access with no copy. ClickHouse writes these values contiguously little-endian — the exact in-memory
+/// layout of a <typeparamref name="T"/> span on a little-endian host — so the decoded bytes need no
+/// transformation. <see cref="Values"/> is a borrowed view over those bytes.
+///
+/// <para>
+/// The backing buffer is normally rented from the array pool and returned on <see cref="Dispose"/>; the buffer
+/// may be larger than the data, so the logical length is tracked separately and <see cref="Values"/> slices to
+/// it. Once disposed the buffer must not be read.
+/// </para>
+/// </summary>
+/// <typeparam name="T">The CLR type the ClickHouse integer maps to.</typeparam>
+internal sealed class PrimitiveColumn<T> : IColumn<T>
+    where T : unmanaged
+{
+    private readonly int length;
+    private readonly bool pooled;
+    private byte[] buffer;
+
+    /// <summary>Initializes a column over a backing buffer.</summary>
+    /// <param name="name">The column name.</param>
+    /// <param name="typeName">The ClickHouse type string.</param>
+    /// <param name="buffer">The little-endian column bytes (may be longer than <paramref name="length"/>).</param>
+    /// <param name="length">The logical byte length; must be a whole multiple of <c>sizeof(T)</c>.</param>
+    /// <param name="pooled">Whether <paramref name="buffer"/> was rented and should be returned on dispose.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
+    public PrimitiveColumn(string name, string typeName, byte[] buffer, int length, bool pooled)
+    {
+        Name = name;
+        TypeName = typeName;
+        this.buffer = buffer ?? throw new ArgumentNullException(nameof(buffer));
+        this.length = length;
+        this.pooled = pooled;
+    }
+
+    /// <inheritdoc/>
+    public string Name { get; }
+
+    /// <inheritdoc/>
+    public string TypeName { get; }
+
+    /// <inheritdoc/>
+    public int RowCount => length / Unsafe.SizeOf<T>();
+
+    /// <inheritdoc/>
+    public ReadOnlySpan<T> Values => MemoryMarshal.Cast<byte, T>(buffer.AsSpan(0, length));
+
+    /// <inheritdoc/>
+    public T this[int row] => Values[row];
+
+    /// <inheritdoc/>
+    public object GetValue(int row) => Values[row];
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        if (pooled && buffer.Length != 0)
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+
+        buffer = Array.Empty<byte>();
+    }
+
+    /// <summary>Builds a self-owned (unpooled) column by copying <paramref name="values"/> into a backing buffer.</summary>
+    /// <param name="name">The column name.</param>
+    /// <param name="typeName">The ClickHouse type string.</param>
+    /// <param name="values">The values to store.</param>
+    /// <returns>The column.</returns>
+    public static PrimitiveColumn<T> FromValues(string name, string typeName, ReadOnlySpan<T> values)
+    {
+        byte[] bytes = MemoryMarshal.AsBytes(values).ToArray();
+        return new PrimitiveColumn<T>(name, typeName, bytes, bytes.Length, pooled: false);
+    }
+}

--- a/ClickHouse.Driver.Tcp/Types/TypeNode.cs
+++ b/ClickHouse.Driver.Tcp/Types/TypeNode.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+using System.Text;
+
+namespace ClickHouse.Driver.Tcp.Types;
+
+/// <summary>
+/// A node in a parsed ClickHouse type: a base <see cref="Name"/> plus zero or more argument nodes. The tree is
+/// fully recursive — a nested type argument (<c>Array(String)</c>) is itself a <see cref="TypeNode"/> with its
+/// own arguments, while a non-type argument (an integer like <c>16</c>, a quoted enum label like
+/// <c>'a' = 1</c>, or a <c>name Type</c> tuple element) is a childless node whose <see cref="Name"/> is the
+/// raw token text for the caller to interpret.
+/// </summary>
+internal sealed class TypeNode
+{
+    /// <summary>Initializes a new instance of the <see cref="TypeNode"/> class.</summary>
+    /// <param name="name">The base type name, or the raw token for a non-type argument.</param>
+    /// <param name="arguments">The argument nodes; empty for a plain type or a leaf token.</param>
+    public TypeNode(string name, IReadOnlyList<TypeNode> arguments)
+    {
+        Name = name;
+        Arguments = arguments;
+    }
+
+    /// <summary>The base type name (e.g. <c>UInt64</c>, <c>Array</c>), or the raw token of a non-type argument.</summary>
+    public string Name { get; }
+
+    /// <summary>The argument nodes, in source order; empty when the type takes none.</summary>
+    public IReadOnlyList<TypeNode> Arguments { get; }
+
+    /// <summary>Reconstructs a canonical type string (arguments comma-separated), useful for diagnostics.</summary>
+    /// <returns>The type string.</returns>
+    public override string ToString()
+    {
+        if (Arguments.Count == 0)
+        {
+            return Name;
+        }
+
+        var builder = new StringBuilder(Name);
+        builder.Append('(');
+        for (int i = 0; i < Arguments.Count; i++)
+        {
+            if (i > 0)
+            {
+                builder.Append(", ");
+            }
+
+            builder.Append(Arguments[i]);
+        }
+
+        builder.Append(')');
+        return builder.ToString();
+    }
+}

--- a/ClickHouse.Driver.Tcp/Types/TypeParser.cs
+++ b/ClickHouse.Driver.Tcp/Types/TypeParser.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ClickHouse.Driver.Tcp.Types;
+
+/// <summary>
+/// Parses ClickHouse type strings into a fully recursive <see cref="TypeNode"/> tree. Tokenizing is delegated
+/// to <see cref="TypeTokenizer"/> (so quotes and nesting are handled once); this builds the tree by recursive
+/// descent and validates structure — an empty input, a missing base name, unbalanced parentheses, or trailing
+/// characters are rejected rather than silently mis-parsed.
+/// </summary>
+internal static class TypeParser
+{
+    /// <summary>Parses a type string into its recursive node tree.</summary>
+    /// <param name="type">The ClickHouse type string (e.g. <c>UInt64</c>, <c>Array(Nullable(String))</c>, <c>Decimal(10, 2)</c>).</param>
+    /// <returns>The parsed type.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="type"/> is null.</exception>
+    /// <exception cref="FormatException"><paramref name="type"/> is empty or malformed.</exception>
+    public static TypeNode Parse(string type)
+    {
+        ArgumentNullException.ThrowIfNull(type);
+
+        List<string> tokens = TypeTokenizer.Tokenize(type).ToList();
+        int position = 0;
+        TypeNode node = ParseNode(tokens, ref position, type);
+
+        if (position != tokens.Count)
+        {
+            throw new FormatException($"Malformed type string '{type}': unexpected trailing input after the type.");
+        }
+
+        return node;
+    }
+
+    /// <summary>Parses one node (a type name plus its optional parenthesized arguments) starting at <paramref name="position"/>.</summary>
+    /// <param name="tokens">The full token list.</param>
+    /// <param name="position">The cursor into <paramref name="tokens"/>; advanced past the consumed tokens.</param>
+    /// <param name="original">The original type string, for error messages.</param>
+    /// <returns>The parsed node.</returns>
+    /// <exception cref="FormatException">A structural token was found where a name was expected, or the parentheses are unbalanced.</exception>
+    private static TypeNode ParseNode(List<string> tokens, ref int position, string original)
+    {
+        if (position >= tokens.Count)
+        {
+            throw new FormatException($"Malformed type string '{original}': expected a type name.");
+        }
+
+        string name = tokens[position++];
+        if (name.Length == 0 || name is "(" or ")" or ",")
+        {
+            throw new FormatException($"Malformed type string '{original}': expected a type name, found '{name}'.");
+        }
+
+        // A name not followed by '(' is a plain type or a leaf argument (integer, quoted label, name/type pair).
+        if (position >= tokens.Count || tokens[position] != "(")
+        {
+            return new TypeNode(name, Array.Empty<TypeNode>());
+        }
+
+        position++; // consume '('
+        var arguments = new List<TypeNode>();
+        while (true)
+        {
+            arguments.Add(ParseNode(tokens, ref position, original));
+
+            if (position >= tokens.Count)
+            {
+                throw new FormatException($"Malformed type string '{original}': unbalanced '(' — missing ')'.");
+            }
+
+            string separator = tokens[position++];
+            if (separator == ")")
+            {
+                break;
+            }
+
+            if (separator != ",")
+            {
+                throw new FormatException($"Malformed type string '{original}': expected ',' or ')', found '{separator}'.");
+            }
+        }
+
+        return new TypeNode(name, arguments);
+    }
+}

--- a/ClickHouse.Driver.Tcp/Types/TypeTokenizer.cs
+++ b/ClickHouse.Driver.Tcp/Types/TypeTokenizer.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+
+namespace ClickHouse.Driver.Tcp.Types;
+
+/// <summary>
+/// Splits a ClickHouse type string into tokens for <see cref="TypeParser"/>: the structural characters
+/// <c>(</c>, <c>)</c>, <c>,</c> each as their own token, and the (trimmed) runs between them as identifier
+/// tokens. Single-quoted spans (enum labels) are treated opaquely — commas and parentheses inside them, and
+/// backslash escapes, do not split — so <c>Enum8('a,b' = 1)</c> tokenizes as one argument, not two.
+/// </summary>
+internal static class TypeTokenizer
+{
+    private static readonly char[] Breaks = [',', '(', ')'];
+
+    /// <summary>Tokenizes a type string.</summary>
+    /// <param name="input">The type string.</param>
+    /// <returns>The token sequence, in source order.</returns>
+    public static IEnumerable<string> Tokenize(string input)
+    {
+        int start = 0;
+        bool inQuotes = false;
+        bool escaped = false;
+
+        for (int i = 0; i < input.Length; i++)
+        {
+            char c = input[i];
+            if (inQuotes)
+            {
+                if (escaped)
+                {
+                    escaped = false;
+                }
+                else if (c == '\\')
+                {
+                    escaped = true;
+                }
+                else if (c == '\'')
+                {
+                    inQuotes = false;
+                }
+
+                continue;
+            }
+
+            if (c == '\'')
+            {
+                inQuotes = true;
+                continue;
+            }
+
+            if (Array.IndexOf(Breaks, c) >= 0)
+            {
+                if (i > start)
+                {
+                    yield return input.Substring(start, i - start).Trim();
+                }
+
+                yield return input.Substring(i, 1);
+                start = i + 1;
+            }
+        }
+
+        if (inQuotes)
+        {
+            throw new FormatException(
+                $"Malformed type string '{input}': unterminated quoted span (a single quote was never closed).");
+        }
+
+        if (start < input.Length)
+        {
+            yield return input.Substring(start).Trim();
+        }
+    }
+}


### PR DESCRIPTION
## TCP E — Blocks, packet bodies, type parsing, and the first columnar `SELECT`

Stacked on #423. This is the first slice of the native-protocol client that can actually **run a `SELECT` end-to-end and decode results** — integer, `String`, and (stopgap) `DateTime` columns — at protocol version `54460`. It builds the load-bearing columnar machinery that every future type will sit on, kept deliberately thin to the types this slice needs.

### What's here

- **Type system** — a streaming `TypeTokenizer` + recursive-descent `TypeParser` producing a fully recursive `TypeNode` tree (ported from the HTTP client's `Types/Grammar` design, with stricter validation), and a `ColumnCodecRegistry` that dispatches a type string to an `IColumnCodec`.
- **Columns & codecs** — `IColumn` / `IColumn<T>`, backed by `PrimitiveColumn<T>` (fixed-width) or `ArrayColumn<T>` (String/DateTime). Codecs for the 8- to 256-bit signed/unsigned integers, `String`, and minimal `DateTime` / `Enum8` / `Enum16` aliases.
- **Block format** — `BlockInfo`, `Block`, and `BlockReader`/`BlockWriter` (all block wire logic lives in the reader/writer; `BlockInfo`/`Block` are plain data). Reads the BlockInfo/header/columns; asserts `has_custom_serialization = 0`.
- **Packet bodies** — `Query` + `ClientInfo` writers, and decoders for `Progress`, `ProfileInfo`, `TableColumns` (plus `EndOfStream`/`Exception` handling).
- **Query phase** — `ClickHouseTcpConnection.QueryAsync`, an `IAsyncEnumerable<Block>` read loop that sends the Query + empty go-marker and drains the response, tolerating interleaved Progress/ProfileInfo/ProfileEvents/Log/TableColumns/Totals/Extremes packets until `EndOfStream` or a server `Exception`. Those interleaved packets can be surfaced through an optional `QueryHandlers` callback bag (see below).
- **`ProtocolFeature`** gates for the version-conditional Query/ClientInfo/Progress fields.

### Metadata handlers

`QueryAsync` takes an optional `QueryHandlers` — a bag of nullable callbacks for the metadata packets the server interleaves with the Data blocks. Where a handler is null the packet is still decoded to keep the stream aligned and then discarded (unchanged from before); where one is set it receives the decoded packet:

- **Scalar, owned:** `OnProgress`, `OnProfileInfo`, `OnTableColumns` — safe to retain.
- **Block-bearing, borrowed:** `OnTotals`, `OnExtremes`, `OnLog`, `OnProfileEvents` — the `Block` is valid only for the duration of the call and released the moment the handler returns, so copy out anything you want to keep.

Handlers run synchronously on the draining thread in wire order, so their ordering relative to Data blocks is preserved and back-pressure is natural — no out-params on the enumerator, and nothing pushed behind the consumer's back. A handler that throws propagates out of the enumeration and terminates the connection. `PartUUIDs` is currently consumed and discarded (no handler yet). Callbacks are the raw surface here; richer bridges (`IProgress`, `ILogger`, a result envelope) can layer on top later.

### Memory management model

The read path is built around a single principle: **the wire bytes land in the column's own buffer, and are reinterpreted in place — not decoded element-by-element or copied through intermediates.**

**Column storage.** A fixed-width column *is* its raw little-endian wire bytes. `PrimitiveColumn<T>` holds a `byte[]` and exposes values via `ReadOnlySpan<T> Values => MemoryMarshal.Cast<byte, T>(buffer)` — a zero-copy reinterpret, no per-element decode, **no `unsafe`**. ClickHouse writes these values contiguously little-endian, which is exactly the in-memory layout of a `T[]` span on a little-endian host, so the cast is the whole "decode." (`Int256`/`UInt256` carry `[StructLayout(LayoutKind.Sequential)]` to make that reinterpret contract load-bearing.) `String`/`DateTime`, which aren't a direct byte reinterpret, use `ArrayColumn<T>` over a `T[]`. The client is little-endian only (every runtime .NET targets is), guarded with a clear `PlatformNotSupportedException`.

**Reads land close to the metal.** Each connection has one pooled 16 KB `ReadBuffer`, reused for its whole life, that serves the small scalar reads (varints, packet types, counts, header strings) as zero-copy spans. A bulk column body **bypasses** it: `ReadIntoAsync` drains whatever small prefix is already buffered, then reads the remainder **straight from the socket into the column's buffer**. So a large column is mostly a direct socket→buffer transfer with one bounded prefix copy; there's no intermediate userspace buffer.

**Pooling + borrowed blocks.** Column buffers are rented from `ArrayPool`, and `IColumn`/`Block` are `IDisposable`. **`QueryAsync` owns block lifetime entirely** — the consumer never disposes anything. There are exactly three disposal sites:
1. **Release-on-advance** — when the consumer calls `MoveNextAsync` for the next block, the loop resumes past the `yield return` and disposes the previous block (returning its pooled buffers) before reading the next packet.
2. **Discard-immediately** — a 0-row header block, and each metadata block (Totals/Extremes/ProfileEvents/Log) once its handler (if any) has returned, are disposed the instant they're decoded.
3. **Release-on-terminal** — a `finally` disposes the last outstanding block on `EndOfStream`, a server `Exception`, a transport failure, a protocol violation, cancellation, or the consumer abandoning the `await foreach` early.

Each block is disposed exactly once, and `Dispose` is idempotent as a backstop. Separately, the `finally` returns the connection to **Ready** (reusable) on a clean terminal — `EndOfStream`, or a fully-decoded server `Exception`, which is then rethrown *after* Ready is set — and **Terminates** it otherwise (the stream was left partway read and can't be trusted).

**The borrowing contract.** A yielded `Block` is **valid only for its `await foreach` iteration**. Read or copy inside the loop body; to keep data, copy it out (`Values.ToArray()`). Don't retain a block, a column, or a `Values` span past the iteration, and don't dispose it yourself.

**Why the contract can't lean on span semantics.** It's tempting to think "a `ReadOnlySpan<T>` can't escape, so the pooled buffer can't escape either." That's wrong: span-escape rules confine the *span value* (it can't be a field, cross an `await`/`yield`, or be boxed), but the *column object* holds the buffer and escapes freely (`list.Add(block)`). Under GC-owned buffers this is harmless — reachable ⟺ valid, so you can never mint a dangling span. **Pooling breaks that equivalence** (`ArrayPool.Return` ends the buffer's validity while the object still references it), so safety has to come from the reader disposing at a controlled boundary, not from the span type. That's precisely why lifetime is reader-owned.

**Allocation profile.** Per row-bearing block: one pooled `byte[]` per fixed-width column (rented, returned on release), plus the small block/column objects. `String` columns allocate a `string[]` and one `string` per value (intrinsic); the per-row decode scratch is pooled. The server's always-present **ProfileEvents** block is fully decoded each query to stay stream-aligned — handed to `OnProfileEvents` if a handler is set, otherwise discarded — with its buffers pooled and returned immediately either way.

This is the low-level, block-at-a-time tier; a future row-materialization tier (copies into owned objects, no lifetime rules for the typical user) will sit on top. It mirrors the ch-go / clickhouse-go split — though notably Go allocates-per-block + GC for reads and doesn't pool, so this is a step further on the performance/complexity trade.

### Wire-correctness notes

- The server sends a **ProfileEvents** block for essentially every query, and it can't be skipped (no length framing at 54460). Its schema is richer than the Go reference implied — the `type` column is `Enum8('increment'=1,'gauge'=2)` and it carries a `DateTime` — so minimal `DateTime` (UInt32→UTC) and `Enum8`/`Enum16` (raw ordinal) codecs exist purely to consume it. Real timezone-aware DateTime and enum-label mapping are later types.
- `Progress` decode consumes all version-gated tails at 54460 (`wrote_rows`/`wrote_bytes` @54420, `elapsed_ns` @54460); missing one silently desyncs the stream.
- `Query`/`ClientInfo` field order and version gates were cross-checked against the Go client byte-for-byte.

### Testing

- **Unit** (net8.0/9.0/10.0): type parser (incl. malformed/nested/quoted), codec round-trips per width, registry dispatch, `BlockInfo`, byte-exact `Query` writer (decoded field-by-field), scalar decoders, and a scripted-stream `QueryAsync` suite covering the state machine (row-bearing yields, server-Exception-then-reusable, unexpected packet → terminate, transport-truncation → terminate, early-abandon → terminate).
- **Metadata handlers**: `OnProgress` fires once per Progress packet in wire order, `OnProfileInfo`/`OnTableColumns` carry the decoded values, each block-bearing handler (`OnTotals`/`OnExtremes`/`OnLog`/`OnProfileEvents`) receives a borrowed block that's copied out during the call, and a throwing handler propagates and terminates the connection.
- **Integration** (real ClickHouse via Testcontainers): `SELECT 1`, string literals, `number` + `toString`, all 12 integer widths round-tripped, a 100k-row / multi-block stream (which recycles pooled buffers mid-stream), an empty result, and error-then-reuse on the same connection.
- The block reader/writer and the pooled/borrowed lifecycle are covered via the integration `SELECT`s rather than unit tests, by choice.

### Scope / deferred

Out of scope here and tracked in `docs/TODO.md`: INSERT (the full column-writing block writer), the row-materialization tier, composite/versioned types, real DateTime/Enum semantics, and the public client API. Not thread-safe; one in-flight operation per connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

