### PR TITLE
TCP F: Add basic insert support

### DIFF
--- a/ClickHouse.Driver.Tcp.Tests/Format/BlockWriterTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Format/BlockWriterTests.cs
@@ -1,0 +1,163 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Format;
+using ClickHouse.Driver.Tcp.Protocol;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Tests.Format;
+
+[TestFixture]
+public class BlockWriterTests
+{
+    private static readonly CancellationToken None = CancellationToken.None;
+
+    // A revision high enough to include BlockInfo and the has_custom_serialization byte (>= 54454).
+    private static readonly NegotiatedProtocol Negotiated = new(54476);
+
+    [Test]
+    public async Task WriteEmptyBlock_ProducesNameInfoAndZeroCounts()
+    {
+        byte[] bytes = await WriteAsync(w => BlockWriter.WriteEmptyBlock(w));
+
+        // empty name, block info (field-tagged), num_columns = 0, num_rows = 0.
+        CollectionAssert.AreEqual(new byte[] { 0x00, 0x01, 0x00, 0x02, 0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00 }, bytes);
+    }
+
+    [Test]
+    public async Task WriteDataBlockAsync_MultipleColumns_RoundTripsThroughBlockReader()
+    {
+        IColumn[] columns =
+        {
+            PrimitiveColumn<int>.FromValues("id", "Int32", new[] { 1, 2, 3 }),
+            new ArrayColumn<string>("name", "String", new[] { "a", "bb", "ccc" }),
+        };
+
+        byte[] bytes = await WriteAsync(w => BlockWriter.WriteDataBlockAsync(
+            w, Negotiated, columns, rowCount: 3, ColumnCodecRegistry.Default, BlockWriter.DefaultFlushThresholdBytes, None));
+
+        using var reader = new ClickHouseBinaryReader(new MemoryStream(bytes));
+        using Block block = await BlockReader.ReadBlockAsync(reader, Negotiated, ColumnCodecRegistry.Default, None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(block.Name, Is.Empty);
+            Assert.That(block.RowCount, Is.EqualTo(3));
+            Assert.That(block.ColumnCount, Is.EqualTo(2));
+            Assert.That(block[0].Name, Is.EqualTo("id"));
+            Assert.That(block[0].TypeName, Is.EqualTo("Int32"));
+            CollectionAssert.AreEqual(new[] { 1, 2, 3 }, ((IColumn<int>)block[0]).Values.ToArray());
+            Assert.That(block[1].Name, Is.EqualTo("name"));
+            Assert.That(block[1].TypeName, Is.EqualTo("String"));
+            CollectionAssert.AreEqual(new[] { "a", "bb", "ccc" }, ((IColumn<string>)block[1]).Values.ToArray());
+        });
+    }
+
+    [Test]
+    public async Task WriteDataBlockAsync_SubRange_WritesOnlyThoseRows()
+    {
+        // Two columns of five rows; write the middle three [1, 4) straight from their spans (no slicing).
+        var id = PrimitiveColumn<int>.FromValues("id", "Int32", new[] { 10, 20, 30, 40, 50 });
+        var name = new ArrayColumn<string>("name", "String", new[] { "a", "bb", "ccc", "dddd", "eeeee" });
+        InsertColumn[] columns =
+        {
+            new("id", "Int32", ColumnCodecRegistry.Default.Resolve("Int32"), id),
+            new("name", "String", ColumnCodecRegistry.Default.Resolve("String"), name),
+        };
+
+        byte[] bytes = await WriteAsync(w => BlockWriter.WriteDataBlockAsync(
+            w, Negotiated, columns, start: 1, rowCount: 3, BlockWriter.DefaultFlushThresholdBytes, None));
+
+        using var reader = new ClickHouseBinaryReader(new MemoryStream(bytes));
+        using Block block = await BlockReader.ReadBlockAsync(reader, Negotiated, ColumnCodecRegistry.Default, None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(block.RowCount, Is.EqualTo(3));
+            CollectionAssert.AreEqual(new[] { 20, 30, 40 }, ((IColumn<int>)block[0]).Values.ToArray());
+            CollectionAssert.AreEqual(new[] { "bb", "ccc", "dddd" }, ((IColumn<string>)block[1]).Values.ToArray());
+        });
+    }
+
+    [Test]
+    public async Task WriteDataBlockAsync_WhenNegotiatedLacksCustomSerialization_OmitsTheByte()
+    {
+        var legacy = new NegotiatedProtocol(54440); // below CUSTOM_SERIALIZATION (54454)
+        IColumn[] columns = { PrimitiveColumn<byte>.FromValues("c", "UInt8", new byte[] { 7 }) };
+
+        byte[] with = await WriteAsync(w => BlockWriter.WriteDataBlockAsync(w, Negotiated, columns, 1, ColumnCodecRegistry.Default, BlockWriter.DefaultFlushThresholdBytes, None));
+        byte[] without = await WriteAsync(w => BlockWriter.WriteDataBlockAsync(w, legacy, columns, 1, ColumnCodecRegistry.Default, BlockWriter.DefaultFlushThresholdBytes, None));
+
+        // The only difference is the single has_custom_serialization byte per column.
+        Assert.That(without, Has.Length.EqualTo(with.Length - 1));
+    }
+
+    [Test]
+    public async Task WriteDataBlockAsync_SmallFlushThreshold_FlushesBetweenColumnsMidBlock()
+    {
+        IColumn[] columns =
+        {
+            PrimitiveColumn<int>.FromValues("a", "Int32", new[] { 1, 2 }),
+            PrimitiveColumn<int>.FromValues("b", "Int32", new[] { 3, 4 }),
+        };
+
+        using var stream = new MemoryStream();
+        using var writer = new ClickHouseBinaryWriter(stream);
+
+        // Threshold of 1 forces a flush after every column, so bytes reach the stream before the caller's own
+        // message-boundary flush.
+        await BlockWriter.WriteDataBlockAsync(writer, Negotiated, columns, rowCount: 2, ColumnCodecRegistry.Default, flushThresholdBytes: 1, None);
+
+        Assert.That(stream.Length, Is.GreaterThan(0), "a small threshold should flush mid-block");
+    }
+
+    [Test]
+    public async Task WriteDataBlockAsync_DefaultFlushThreshold_BuffersUntilCallerFlush()
+    {
+        IColumn[] columns = { PrimitiveColumn<int>.FromValues("a", "Int32", new[] { 1, 2 }) };
+
+        using var stream = new MemoryStream();
+        using var writer = new ClickHouseBinaryWriter(stream);
+
+        await BlockWriter.WriteDataBlockAsync(writer, Negotiated, columns, rowCount: 2, ColumnCodecRegistry.Default, BlockWriter.DefaultFlushThresholdBytes, None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(stream.Length, Is.EqualTo(0), "a small block should stay buffered until the message-boundary flush");
+            Assert.That(writer.BufferedBytes, Is.GreaterThan(0));
+        });
+    }
+
+    [Test]
+    public void WriteDataBlockAsync_ColumnRowCountDisagreesWithBlock_Throws()
+    {
+        IColumn[] columns = { PrimitiveColumn<int>.FromValues("a", "Int32", new[] { 1, 2, 3 }) };
+
+        using var stream = new MemoryStream();
+        using var writer = new ClickHouseBinaryWriter(stream);
+
+        Assert.ThrowsAsync<ArgumentException>(async () => await BlockWriter.WriteDataBlockAsync(
+            writer, Negotiated, columns, rowCount: 2, ColumnCodecRegistry.Default, BlockWriter.DefaultFlushThresholdBytes, None));
+    }
+
+    private static async Task<byte[]> WriteAsync(Func<ClickHouseBinaryWriter, ValueTask> write)
+    {
+        using var ms = new MemoryStream();
+        using (var writer = new ClickHouseBinaryWriter(ms))
+        {
+            await write(writer);
+            await writer.FlushAsync(None);
+        }
+
+        return ms.ToArray();
+    }
+
+    private static async Task<byte[]> WriteAsync(Action<ClickHouseBinaryWriter> write)
+        => await WriteAsync(w =>
+        {
+            write(w);
+            return default;
+        });
+}

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpConnectionInsertIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpConnectionInsertIntegrationTests.cs
@@ -1,0 +1,387 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Format;
+using ClickHouse.Driver.Tcp.Protocol;
+using ClickHouse.Driver.Tcp.Tests.Utilities;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Tests.Integration;
+
+// A yielded Block is borrowed — valid only for its iteration — so every read compares or copies inside the
+// await foreach, never retaining the block.
+[TestFixture]
+[Category("Integration")]
+public class ClickHouseTcpConnectionInsertIntegrationTests
+{
+    private static readonly CancellationToken None = CancellationToken.None;
+
+    [TestCaseSource(typeof(InsertRoundTripCase), nameof(InsertRoundTripCase.Cases))]
+    public async Task InsertAsync_ColumnarData_RoundTripsThroughSelect(InsertRoundTripCase testCase)
+    {
+        await using var connection = await TcpServerFixture.ConnectAsync(None);
+        string table = UniqueTableName();
+        try
+        {
+            await ExecuteAsync(connection, $"CREATE TABLE {table} (value {testCase.ClickHouseType}) ENGINE = Memory");
+
+            IColumn insert = testCase.BuildInsertColumn("value");
+            IColumn expected = testCase.BuildExpectedColumn("value");
+            await connection.InsertAsync($"INSERT INTO {table} (value) VALUES", new[] { insert }, cancellationToken: None);
+
+            int blockCount = 0;
+            await foreach (Block block in connection.QueryAsync($"SELECT value FROM {table}", cancellationToken: None))
+            {
+                blockCount++;
+                AssertColumnsEqual(expected, block[0]);
+            }
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(blockCount, Is.EqualTo(1), "the round-trip should read back exactly one row-bearing block");
+                Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+            });
+        }
+        finally
+        {
+            await ExecuteAsync(connection, $"DROP TABLE IF EXISTS {table}");
+        }
+    }
+
+    [Test]
+    public async Task InsertAsync_MultipleColumnsAndRows_RoundTripsEveryColumn()
+    {
+        await using var connection = await TcpServerFixture.ConnectAsync(None);
+        string table = UniqueTableName();
+        try
+        {
+            await ExecuteAsync(connection, $"CREATE TABLE {table} (id UInt64, name String, at DateTime) ENGINE = Memory");
+
+            const int rows = 5000;
+            var ids = new ulong[rows];
+            var names = new string[rows];
+            var timestamps = new DateTime[rows];
+            for (int i = 0; i < rows; i++)
+            {
+                ids[i] = (ulong)i;
+                names[i] = $"row-{i}";
+                timestamps[i] = DateTime.UnixEpoch.AddSeconds(i);
+            }
+
+            IColumn[] columns =
+            {
+                PrimitiveColumn<ulong>.FromValues("id", "UInt64", ids),
+                new ArrayColumn<string>("name", "String", names),
+                new ArrayColumn<DateTime>("at", "DateTime", timestamps),
+            };
+
+            await connection.InsertAsync($"INSERT INTO {table} (id, name, at) VALUES", columns, cancellationToken: None);
+
+            var readIds = new List<ulong>();
+            var readNames = new List<string>();
+            var readTimestamps = new List<DateTime>();
+            await foreach (Block block in connection.QueryAsync($"SELECT id, name, at FROM {table} ORDER BY id", cancellationToken: None))
+            {
+                readIds.AddRange(((IColumn<ulong>)block[0]).Values.ToArray());
+                readNames.AddRange(((IColumn<string>)block[1]).Values.ToArray());
+                readTimestamps.AddRange(((IColumn<DateTime>)block[2]).Values.ToArray());
+            }
+
+            Assert.Multiple(() =>
+            {
+                CollectionAssert.AreEqual(ids, readIds);
+                CollectionAssert.AreEqual(names, readNames);
+                CollectionAssert.AreEqual(timestamps, readTimestamps);
+                Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+            });
+        }
+        finally
+        {
+            await ExecuteAsync(connection, $"DROP TABLE IF EXISTS {table}");
+        }
+    }
+
+    [Test]
+    public async Task InsertAsync_ZeroRowColumns_InsertsNothingAndStaysReady()
+    {
+        await using var connection = await TcpServerFixture.ConnectAsync(None);
+        string table = UniqueTableName();
+        try
+        {
+            await ExecuteAsync(connection, $"CREATE TABLE {table} (value Int32) ENGINE = Memory");
+
+            IColumn empty = PrimitiveColumn<int>.FromValues("value", "Int32", Array.Empty<int>());
+            await connection.InsertAsync($"INSERT INTO {table} (value) VALUES", new[] { empty }, cancellationToken: None);
+
+            Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+            Assert.That(await CountAsync(connection, table), Is.EqualTo(0UL));
+        }
+        finally
+        {
+            await ExecuteAsync(connection, $"DROP TABLE IF EXISTS {table}");
+        }
+    }
+
+    [Test]
+    public async Task InsertAsync_ColumnCountDisagreesWithSchema_AbortsCleanlyAndStaysReady()
+    {
+        await using var connection = await TcpServerFixture.ConnectAsync(None);
+        string table = UniqueTableName();
+        try
+        {
+            await ExecuteAsync(connection, $"CREATE TABLE {table} (a Int32, b Int32) ENGINE = Memory");
+
+            // The table has two columns but the insert supplies one.
+            IColumn onlyOne = PrimitiveColumn<int>.FromValues("a", "Int32", new[] { 1, 2, 3 });
+
+            var thrown = Assert.ThrowsAsync<ArgumentException>(async () =>
+                await connection.InsertAsync($"INSERT INTO {table} VALUES", new[] { onlyOne }, cancellationToken: None));
+            Assert.That(thrown.Message, Does.Contain("schema"));
+
+            // The insert was aborted cleanly (empty row stream), so nothing was written and the connection is reusable.
+            Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+            Assert.That(await CountAsync(connection, table), Is.EqualTo(0UL));
+        }
+        finally
+        {
+            await ExecuteAsync(connection, $"DROP TABLE IF EXISTS {table}");
+        }
+    }
+
+    [Test]
+    public async Task InsertAsync_ZeroRowColumnCountDisagreesWithSchema_AbortsCleanlyAndStaysReady()
+    {
+        await using var connection = await TcpServerFixture.ConnectAsync(None);
+        string table = UniqueTableName();
+        try
+        {
+            await ExecuteAsync(connection, $"CREATE TABLE {table} (a Int32, b Int32) ENGINE = Memory");
+
+            // Two-column table but one (zero-row) column supplied: the count mismatch is caught even with no rows,
+            // rather than silently succeeding.
+            IColumn onlyOne = PrimitiveColumn<int>.FromValues("a", "Int32", Array.Empty<int>());
+
+            var thrown = Assert.ThrowsAsync<ArgumentException>(async () =>
+                await connection.InsertAsync($"INSERT INTO {table} VALUES", new[] { onlyOne }, cancellationToken: None));
+            Assert.That(thrown.Message, Does.Contain("schema"));
+
+            Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+            Assert.That(await CountAsync(connection, table), Is.EqualTo(0UL));
+        }
+        finally
+        {
+            await ExecuteAsync(connection, $"DROP TABLE IF EXISTS {table}");
+        }
+    }
+
+    [Test]
+    public async Task InsertAsync_ColumnClrTypeNotWritableAsTarget_ThrowsThenConnectionIsReusable()
+    {
+        await using var connection = await TcpServerFixture.ConnectAsync(None);
+        string table = UniqueTableName();
+        try
+        {
+            await ExecuteAsync(connection, $"CREATE TABLE {table} (value Int32) ENGINE = Memory");
+
+            // The target column is Int32 but the value column carries longs: the Int32 codec cannot write it.
+            // The type is resolved from the server's schema, so this is caught after the schema round-trip.
+            IColumn mismatched = PrimitiveColumn<long>.FromValues("value", "Int32", new[] { 1L, 2L });
+
+            var thrown = Assert.ThrowsAsync<ArgumentException>(async () =>
+                await connection.InsertAsync($"INSERT INTO {table} (value) VALUES", new[] { mismatched }, cancellationToken: None));
+            Assert.That(thrown.Message, Does.Contain("Int32"));
+
+            // Only the terminator went out (no data block), so the server saw an insert of no rows and the
+            // connection is left ready and usable — and nothing was actually inserted.
+            Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+            Assert.That(await CountAsync(connection, table), Is.EqualTo(0UL));
+        }
+        finally
+        {
+            await ExecuteAsync(connection, $"DROP TABLE IF EXISTS {table}");
+        }
+    }
+
+    [Test]
+    public async Task InsertAsync_SubsetOfColumns_LeavesOmittedColumnsAtTheirDefaults()
+    {
+        await using var connection = await TcpServerFixture.ConnectAsync(None);
+        string table = UniqueTableName();
+        try
+        {
+            await ExecuteAsync(connection, $"CREATE TABLE {table} (a Int32, b Int32 DEFAULT 42, c String) ENGINE = Memory");
+
+            // Name only a and c; b is not supplied, so the server fills it from its DEFAULT expression.
+            IColumn[] columns =
+            {
+                PrimitiveColumn<int>.FromValues("a", "Int32", new[] { 1, 2 }),
+                new ArrayColumn<string>("c", "String", new[] { "x", "y" }),
+            };
+            await connection.InsertAsync($"INSERT INTO {table} (a, c) VALUES", columns, cancellationToken: None);
+
+            var readA = new List<int>();
+            var readB = new List<int>();
+            var readC = new List<string>();
+            await foreach (Block block in connection.QueryAsync($"SELECT a, b, c FROM {table} ORDER BY a", cancellationToken: None))
+            {
+                readA.AddRange(((IColumn<int>)block[0]).Values.ToArray());
+                readB.AddRange(((IColumn<int>)block[1]).Values.ToArray());
+                readC.AddRange(((IColumn<string>)block[2]).Values.ToArray());
+            }
+
+            Assert.Multiple(() =>
+            {
+                CollectionAssert.AreEqual(new[] { 1, 2 }, readA);
+                CollectionAssert.AreEqual(new[] { 42, 42 }, readB); // filled from DEFAULT
+                CollectionAssert.AreEqual(new[] { "x", "y" }, readC);
+                Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+            });
+        }
+        finally
+        {
+            await ExecuteAsync(connection, $"DROP TABLE IF EXISTS {table}");
+        }
+    }
+
+    [Test]
+    public async Task InsertAsync_ColumnsSuppliedOutOfSchemaOrder_AlignsByNameAndRoundTrips()
+    {
+        await using var connection = await TcpServerFixture.ConnectAsync(None);
+        string table = UniqueTableName();
+        try
+        {
+            await ExecuteAsync(connection, $"CREATE TABLE {table} (a Int32, b String) ENGINE = Memory");
+
+            // Supply the columns in the opposite order to the statement's (a, b); alignment is by name, not order.
+            IColumn[] columns =
+            {
+                new ArrayColumn<string>("b", "String", new[] { "one", "two" }),
+                PrimitiveColumn<int>.FromValues("a", "Int32", new[] { 1, 2 }),
+            };
+            await connection.InsertAsync($"INSERT INTO {table} (a, b) VALUES", columns, cancellationToken: None);
+
+            var readA = new List<int>();
+            var readB = new List<string>();
+            await foreach (Block block in connection.QueryAsync($"SELECT a, b FROM {table} ORDER BY a", cancellationToken: None))
+            {
+                readA.AddRange(((IColumn<int>)block[0]).Values.ToArray());
+                readB.AddRange(((IColumn<string>)block[1]).Values.ToArray());
+            }
+
+            Assert.Multiple(() =>
+            {
+                CollectionAssert.AreEqual(new[] { 1, 2 }, readA);
+                CollectionAssert.AreEqual(new[] { "one", "two" }, readB);
+                Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+            });
+        }
+        finally
+        {
+            await ExecuteAsync(connection, $"DROP TABLE IF EXISTS {table}");
+        }
+    }
+
+    [Test]
+    public async Task InsertAsync_ColumnNameNotInTarget_AbortsCleanlyAndStaysReady()
+    {
+        await using var connection = await TcpServerFixture.ConnectAsync(None);
+        string table = UniqueTableName();
+        try
+        {
+            await ExecuteAsync(connection, $"CREATE TABLE {table} (a Int32) ENGINE = Memory");
+
+            // The statement names only 'a', so the schema block carries 'a'; a column named 'z' matches nothing.
+            IColumn wrongName = PrimitiveColumn<int>.FromValues("z", "Int32", new[] { 1, 2 });
+
+            var thrown = Assert.ThrowsAsync<ArgumentException>(async () =>
+                await connection.InsertAsync($"INSERT INTO {table} (a) VALUES", new[] { wrongName }, cancellationToken: None));
+            Assert.Multiple(() =>
+            {
+                Assert.That(thrown.Message, Does.Contain("z"));
+                Assert.That(thrown.Message, Does.Contain("a"));
+            });
+
+            Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+            Assert.That(await CountAsync(connection, table), Is.EqualTo(0UL));
+        }
+        finally
+        {
+            await ExecuteAsync(connection, $"DROP TABLE IF EXISTS {table}");
+        }
+    }
+
+    [Test]
+    public async Task InsertAsync_ColumnsWithDifferingRowCounts_ThrowsWithoutTouchingConnection()
+    {
+        await using var connection = await TcpServerFixture.ConnectAsync(None);
+
+        IColumn two = PrimitiveColumn<int>.FromValues("a", "Int32", new[] { 1, 2 });
+        IColumn three = PrimitiveColumn<int>.FromValues("b", "Int32", new[] { 3, 4, 5 });
+
+        Assert.ThrowsAsync<ArgumentException>(async () =>
+            await connection.InsertAsync("INSERT INTO whatever VALUES", new[] { two, three }, cancellationToken: None));
+
+        // Validation happens before the connection is claimed, so it stays ready and usable.
+        Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+        byte probe = 0;
+        await foreach (Block block in connection.QueryAsync("SELECT 1", cancellationToken: None))
+        {
+            probe = ((IColumn<byte>)block[0]).Values[0];
+        }
+
+        Assert.That(probe, Is.EqualTo((byte)1));
+    }
+
+    [Test]
+    public async Task InsertAsync_ServerRejectsStatement_ThrowsThenConnectionIsReusable()
+    {
+        await using var connection = await TcpServerFixture.ConnectAsync(None);
+
+        IColumn column = PrimitiveColumn<int>.FromValues("value", "Int32", new[] { 1 });
+
+        var thrown = Assert.ThrowsAsync<ClickHouseServerException>(async () =>
+            await connection.InsertAsync("INSERT INTO table_that_does_not_exist_xyz (value) VALUES", new[] { column }, cancellationToken: None));
+        Assert.That(thrown.Code, Is.GreaterThan(0));
+
+        // The server Exception is a complete response, so the same connection can run another statement.
+        Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+        byte probe = 0;
+        await foreach (Block block in connection.QueryAsync("SELECT 1", cancellationToken: None))
+        {
+            probe = ((IColumn<byte>)block[0]).Values[0];
+        }
+
+        Assert.That(probe, Is.EqualTo((byte)1));
+    }
+
+    private static void AssertColumnsEqual(IColumn expected, IColumn actual)
+    {
+        Assert.That(actual.RowCount, Is.EqualTo(expected.RowCount), "row count");
+        for (int row = 0; row < expected.RowCount; row++)
+        {
+            Assert.That(actual.GetValue(row), Is.EqualTo(expected.GetValue(row)), $"row {row}");
+        }
+    }
+
+    private static async Task<ulong> CountAsync(ClickHouseTcpConnection connection, string table)
+    {
+        ulong count = 0;
+        await foreach (Block block in connection.QueryAsync($"SELECT count() FROM {table}", cancellationToken: None))
+        {
+            count = ((IColumn<ulong>)block[0]).Values[0];
+        }
+
+        return count;
+    }
+
+    private static async Task ExecuteAsync(ClickHouseTcpConnection connection, string sql)
+    {
+        await foreach (Block block in connection.QueryAsync(sql, cancellationToken: None))
+        {
+            _ = block;
+        }
+    }
+
+    private static string UniqueTableName() => $"tcp_insert_test_{Guid.NewGuid():N}";
+}

--- a/ClickHouse.Driver.Tcp.Tests/Integration/InsertSlicingIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/InsertSlicingIntegrationTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Format;
+using ClickHouse.Driver.Tcp.Protocol;
+using ClickHouse.Driver.Tcp.Tests.Utilities;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Tests.Integration;
+
+/// <summary>
+/// Slice coverage for every type's write path. The per-type round-trip matrix in
+/// <see cref="ClickHouseTcpConnectionInsertIntegrationTests"/> inserts each column whole, so every codec writes its
+/// slice at start 0 — and at start 0 a codec that ignores <c>start</c> still writes correct bytes. That left the
+/// slice path, which a real insert of more than
+/// <see cref="ClickHouseTcpConnection.DefaultMaxRowsPerBlock"/> rows takes, unproven for every type.
+///
+/// <para>
+/// These tests insert the same matrix as several wire blocks, so each block after the first writes a slice with a
+/// non-zero start. That is what shows a codec rebases its own offsets, run starts, and element ranges. The tests
+/// live in their own fixture so the matrix stays one parameterized test per concern rather than a hand-written
+/// slice test per type.
+/// </para>
+/// </summary>
+[TestFixture]
+[Category("Integration")]
+public class InsertSlicingIntegrationTests
+{
+    private static readonly CancellationToken None = CancellationToken.None;
+
+    // One row per block: the strongest guarantee of a non-zero start, since it splits every case with two or more
+    // rows regardless of how many rows that case declares. Multi-row slices (a non-zero start *and* a length above
+    // one) are covered by the per-type cases in the insert fixture, which split a longer column at 2 rows a block.
+    //
+    // The id column pins the read-back order; the Memory engine does not guarantee it across blocks.
+    [TestCaseSource(typeof(InsertRoundTripCase), nameof(InsertRoundTripCase.Cases))]
+    public async Task InsertAsync_ColumnarDataOneRowPerBlock_RoundTripsEveryRow(InsertRoundTripCase testCase)
+    {
+        await using var connection = await TcpServerFixture.ConnectAsync(None);
+        string table = UniqueTableName();
+        try
+        {
+            await ExecuteAsync(connection, $"CREATE TABLE {table} (id UInt32, value {testCase.ClickHouseType}) ENGINE = Memory");
+
+            IColumn insert = testCase.BuildInsertColumn("value");
+            IColumn expected = testCase.BuildExpectedColumn("value");
+            IColumn[] columns = { RowIds(insert.RowCount), insert };
+            await connection.InsertAsync(
+                $"INSERT INTO {table} (id, value) VALUES", columns, maxRowsPerBlock: 1, cancellationToken: None);
+
+            await AssertReadsBackAsync(connection, table, expected);
+            Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+        }
+        finally
+        {
+            await ExecuteAsync(connection, $"DROP TABLE IF EXISTS {table}");
+        }
+    }
+
+    // Compares the read-back against a row cursor inside the iteration: the read-back may arrive as several blocks,
+    // and a yielded block is borrowed, so no value may be retained past its own iteration.
+    private static async Task AssertReadsBackAsync(ClickHouseTcpConnection connection, string table, IColumn expected)
+    {
+        int row = 0;
+        await foreach (Block block in connection.QueryAsync($"SELECT value FROM {table} ORDER BY id", cancellationToken: None))
+        {
+            IColumn actual = block[0];
+            for (int i = 0; i < actual.RowCount; i++, row++)
+            {
+                Assert.That(row, Is.LessThan(expected.RowCount), "the read-back returned more rows than were inserted");
+                Assert.That(actual.GetValue(i), Is.EqualTo(expected.GetValue(row)), $"row {row}");
+            }
+        }
+
+        Assert.That(row, Is.EqualTo(expected.RowCount), "every inserted row should read back");
+    }
+
+    private static IColumn RowIds(int rowCount)
+    {
+        var ids = new uint[rowCount];
+        for (int i = 0; i < ids.Length; i++)
+        {
+            ids[i] = (uint)i;
+        }
+
+        return PrimitiveColumn<uint>.FromValues("id", "UInt32", ids);
+    }
+
+    private static async Task ExecuteAsync(ClickHouseTcpConnection connection, string sql)
+    {
+        await foreach (Block block in connection.QueryAsync(sql, cancellationToken: None))
+        {
+            _ = block;
+        }
+    }
+
+    private static string UniqueTableName() => $"tcp_slice_test_{Guid.NewGuid():N}";
+}

--- a/ClickHouse.Driver.Tcp.Tests/Protocol/ClickHouseTcpConnectionInsertTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Protocol/ClickHouseTcpConnectionInsertTests.cs
@@ -234,80 +234,42 @@ public class ClickHouseTcpConnectionInsertTests
     }
 
     [Test]
-    public void PlanInsertBlocks_FixedWidthExceedingByteLimit_SplitsByByteBudget()
+    public void PlanInsertBlocks_NoRowCap_ProducesOneBlock()
     {
-        // UInt64 is 8 bytes/row; a 16-byte budget fits two rows per block.
-        IColumn[] columns = { UInt64Column(1, 2, 3, 4, 5) };
-        var plan = ClickHouseTcpConnection.PlanInsertBlocks(columns, Codecs(columns), rowCount: 5, maxRowsPerBlock: null, byteLimit: 16);
+        // With no row cap the whole insert is one block; peak memory is bounded by the flush backstop, not a split.
+        var plan = ClickHouseTcpConnection.PlanInsertBlocks(rowCount: 5, maxRowsPerBlock: null);
+
+        CollectionAssert.AreEqual(new[] { (0, 5) }, plan);
+    }
+
+    [Test]
+    public void PlanInsertBlocks_RowCapSmallerThanRowCount_SplitsByRowCap()
+    {
+        var plan = ClickHouseTcpConnection.PlanInsertBlocks(rowCount: 5, maxRowsPerBlock: 2);
 
         CollectionAssert.AreEqual(new[] { (0, 2), (2, 2), (4, 1) }, plan);
     }
 
     [Test]
-    public void PlanInsertBlocks_RowCapTighterThanByteBudget_SplitsByRowCap()
+    public void PlanInsertBlocks_RowCapExactMultiple_SplitsEvenly()
     {
-        IColumn[] columns = { UInt64Column(1, 2, 3, 4, 5) };
-        // The byte budget alone would allow one big block; the row cap of two is reached first.
-        var plan = ClickHouseTcpConnection.PlanInsertBlocks(columns, Codecs(columns), rowCount: 5, maxRowsPerBlock: 2, byteLimit: 10 * 1024 * 1024);
+        var plan = ClickHouseTcpConnection.PlanInsertBlocks(rowCount: 4, maxRowsPerBlock: 2);
 
-        CollectionAssert.AreEqual(new[] { (0, 2), (2, 2), (4, 1) }, plan);
+        CollectionAssert.AreEqual(new[] { (0, 2), (2, 2) }, plan);
     }
 
     [Test]
-    public void PlanInsertBlocks_ByteBudgetTighterThanRowCap_SplitsByBytes()
+    public void PlanInsertBlocks_RowCapAtLeastRowCount_ProducesOneBlock()
     {
-        IColumn[] columns = { UInt64Column(1, 2, 3, 4, 5) };
-        // UInt64 is 8 bytes/row; a 16-byte budget fits two rows, reached before the four-row cap.
-        var plan = ClickHouseTcpConnection.PlanInsertBlocks(columns, Codecs(columns), rowCount: 5, maxRowsPerBlock: 4, byteLimit: 16);
-
-        CollectionAssert.AreEqual(new[] { (0, 2), (2, 2), (4, 1) }, plan);
-    }
-
-    [Test]
-    public void PlanInsertBlocks_RowCapWithVariableWidthColumn_ClosesBlockAtRowCap()
-    {
-        // A variable-width column takes the measured path; the row cap must bind there too, before the byte limit.
-        IColumn[] columns = { new ArrayColumn<string>("s", "String", new[] { "a", "bb", "ccc", "dddd", "e" }) };
-        var plan = ClickHouseTcpConnection.PlanInsertBlocks(columns, Codecs(columns), rowCount: 5, maxRowsPerBlock: 2, byteLimit: 10 * 1024 * 1024);
-
-        CollectionAssert.AreEqual(new[] { (0, 2), (2, 2), (4, 1) }, plan);
-    }
-
-    [Test]
-    public void PlanInsertBlocks_SingleRowLargerThanLimit_FormsItsOwnBlock()
-    {
-        // "xxxxx" encodes as varint(5)+5 = 6 bytes, past the 3-byte budget, but a single row is never split.
-        IColumn[] columns = { new ArrayColumn<string>("s", "String", new[] { "xxxxx", "aa" }) };
-        var plan = ClickHouseTcpConnection.PlanInsertBlocks(columns, Codecs(columns), rowCount: 2, maxRowsPerBlock: null, byteLimit: 3);
-
-        CollectionAssert.AreEqual(new[] { (0, 1), (1, 1) }, plan);
-    }
-
-    [Test]
-    public void PlanInsertBlocks_DataWithinLimit_ProducesOneBlock()
-    {
-        IColumn[] columns = { UInt64Column(1, 2, 3) };
-        var plan = ClickHouseTcpConnection.PlanInsertBlocks(columns, Codecs(columns), rowCount: 3, maxRowsPerBlock: null, byteLimit: 10 * 1024 * 1024);
+        var plan = ClickHouseTcpConnection.PlanInsertBlocks(rowCount: 3, maxRowsPerBlock: 10);
 
         CollectionAssert.AreEqual(new[] { (0, 3) }, plan);
     }
 
     [Test]
-    public void PlanInsertBlocks_MultipleFixedWidthColumns_SizesByCombinedRowWidth()
+    public void PlanInsertBlocks_RowCapOfOne_EmitsOneRowPerBlock()
     {
-        // Two UInt64 columns = 16 bytes/row; a 40-byte budget fits two rows per block.
-        IColumn[] columns = { UInt64Column(1, 2, 3, 4, 5), UInt64Column(6, 7, 8, 9, 10) };
-        var plan = ClickHouseTcpConnection.PlanInsertBlocks(columns, Codecs(columns), rowCount: 5, maxRowsPerBlock: null, byteLimit: 40);
-
-        CollectionAssert.AreEqual(new[] { (0, 2), (2, 2), (4, 1) }, plan);
-    }
-
-    [Test]
-    public void PlanInsertBlocks_FixedWidthRowExceedsLimit_EmitsOneRowPerBlock()
-    {
-        // UInt64 is 8 bytes/row, past the 3-byte budget; a fixed-width row is never split, so one row per block.
-        IColumn[] columns = { UInt64Column(1, 2, 3) };
-        var plan = ClickHouseTcpConnection.PlanInsertBlocks(columns, Codecs(columns), rowCount: 3, maxRowsPerBlock: null, byteLimit: 3);
+        var plan = ClickHouseTcpConnection.PlanInsertBlocks(rowCount: 3, maxRowsPerBlock: 1);
 
         CollectionAssert.AreEqual(new[] { (0, 1), (1, 1), (2, 1) }, plan);
     }
@@ -322,17 +284,6 @@ public class ClickHouseTcpConnectionInsertTests
     private static IColumn[] Columns(params IColumn[] columns) => columns;
 
     private static IColumn UInt64Column(params ulong[] values) => PrimitiveColumn<ulong>.FromValues("x", "UInt64", values);
-
-    private static IColumnCodec[] Codecs(IReadOnlyList<IColumn> columns)
-    {
-        var codecs = new IColumnCodec[columns.Count];
-        for (int i = 0; i < columns.Count; i++)
-        {
-            codecs[i] = ColumnCodecRegistry.Default.Resolve(columns[i].TypeName);
-        }
-
-        return codecs;
-    }
 
     // A zero-row Data block carrying only column headers — the shape the server sends as the INSERT schema.
     private static Task<byte[]> SchemaBlockAsync(params (string Name, string Type)[] columns)

--- a/ClickHouse.Driver.Tcp.Tests/Protocol/ClickHouseTcpConnectionInsertTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Protocol/ClickHouseTcpConnectionInsertTests.cs
@@ -1,0 +1,422 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Format;
+using ClickHouse.Driver.Tcp.Protocol;
+using ClickHouse.Driver.Tcp.Tests.Utilities;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Tests.Protocol;
+
+// Drives InsertAsync over a scripted server stream (the client's own writes go to an inspectable sink, so the
+// scripted side only supplies the server's schema/terminal packets). A real INSERT round-trip lives in the
+// integration suite; the row-splitting maths is unit-tested against PlanInsertBlocks directly.
+[TestFixture]
+public class ClickHouseTcpConnectionInsertTests
+{
+    private static readonly CancellationToken None = CancellationToken.None;
+
+    private static readonly ClientHandshakeParameters Handshake = new()
+    {
+        Username = "default",
+    };
+
+    [Test]
+    public async Task InsertAsync_SchemaThenEndOfStream_CompletesAndStaysReady()
+    {
+        byte[] script = Concat(
+            await ServerHelloBytesAsync(54476),
+            await SchemaBlockAsync(("x", "UInt64")),
+            EndOfStreamPacket());
+        using var connection = await ConnectedAsync(script);
+
+        await connection.InsertAsync("INSERT INTO t VALUES", Columns(UInt64Column(1, 2, 3)), cancellationToken: None);
+
+        Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+    }
+
+    [Test]
+    public async Task InsertAsync_MaxRowsPerBlock_StreamsMultipleBlocksAndStaysReady()
+    {
+        // The scripted server accepts whatever the client streams; forcing a small row cap exercises the
+        // multi-block write path end-to-end without desyncing.
+        byte[] script = Concat(
+            await ServerHelloBytesAsync(54476),
+            await SchemaBlockAsync(("x", "UInt64")),
+            EndOfStreamPacket());
+        using var connection = await ConnectedAsync(script);
+
+        await connection.InsertAsync("INSERT INTO t VALUES", Columns(UInt64Column(1, 2, 3, 4, 5)), maxRowsPerBlock: 2, cancellationToken: None);
+
+        Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+    }
+
+    [Test]
+    public async Task InsertAsync_ProgressInAcknowledgement_InvokesHandlerAndStaysReady()
+    {
+        // The server interleaves a Progress packet into the acknowledgement before end-of-stream.
+        byte[] script = Concat(
+            await ServerHelloBytesAsync(54476),
+            await SchemaBlockAsync(("x", "UInt64")),
+            await ProgressPacketAsync(),
+            EndOfStreamPacket());
+        using var connection = await ConnectedAsync(script);
+
+        var progresses = new List<Progress>();
+        await connection.InsertAsync(
+            "INSERT INTO t VALUES",
+            Columns(UInt64Column(1, 2, 3)),
+            handlers: new MetadataHandlers { OnProgress = progresses.Add },
+            cancellationToken: None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(progresses, Has.Count.EqualTo(1));
+            Assert.That(progresses[0].Rows, Is.EqualTo(1UL));
+            Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+        });
+    }
+
+    [Test]
+    public async Task InsertAsync_StringColumnMaxRowsPerBlock_SlicesAndStreamsAndStaysReady()
+    {
+        // A variable-width column forced across multiple blocks exercises the array-slice + string write path.
+        byte[] script = Concat(
+            await ServerHelloBytesAsync(54476),
+            await SchemaBlockAsync(("s", "String")),
+            EndOfStreamPacket());
+        using var connection = await ConnectedAsync(script);
+
+        IColumn[] columns = { new ArrayColumn<string>("s", "String", new[] { "a", "bb", "ccc", "dddd" }) };
+        await connection.InsertAsync("INSERT INTO t VALUES", columns, maxRowsPerBlock: 2, cancellationToken: None);
+
+        Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+    }
+
+    [Test]
+    public async Task InsertAsync_ZeroRows_CompletesAsNoOpAndStaysReady()
+    {
+        byte[] script = Concat(
+            await ServerHelloBytesAsync(54476),
+            await SchemaBlockAsync(("x", "UInt64")),
+            EndOfStreamPacket());
+        using var connection = await ConnectedAsync(script);
+
+        await connection.InsertAsync("INSERT INTO t VALUES", Columns(UInt64Column()), cancellationToken: None);
+
+        Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+    }
+
+    [Test]
+    public async Task InsertAsync_CleanEndOfStreamBeforeSchema_ThrowsProtocolAndTerminates()
+    {
+        byte[] script = Concat(await ServerHelloBytesAsync(54476), EndOfStreamPacket());
+        using var connection = await ConnectedAsync(script);
+
+        Assert.ThrowsAsync<ClickHouseProtocolException>(async () =>
+            await connection.InsertAsync("INSERT INTO t VALUES", Columns(UInt64Column(1)), cancellationToken: None));
+        Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Terminated));
+    }
+
+    [Test]
+    public async Task InsertAsync_ServerExceptionInsteadOfSchema_ThrowsButStaysReusable()
+    {
+        byte[] script = Concat(
+            await ServerHelloBytesAsync(54476),
+            await ExceptionPacketAsync(60, "unknown table"));
+        using var connection = await ConnectedAsync(script);
+
+        var thrown = Assert.ThrowsAsync<ClickHouseServerException>(async () =>
+            await connection.InsertAsync("INSERT INTO t VALUES", Columns(UInt64Column(1)), cancellationToken: None));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(thrown.Code, Is.EqualTo(60));
+            Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+        });
+    }
+
+    [Test]
+    public async Task InsertAsync_ServerExceptionDuringAcknowledgement_ThrowsButStaysReusable()
+    {
+        byte[] script = Concat(
+            await ServerHelloBytesAsync(54476),
+            await SchemaBlockAsync(("x", "UInt64")),
+            await ExceptionPacketAsync(241, "memory limit exceeded"));
+        using var connection = await ConnectedAsync(script);
+
+        var thrown = Assert.ThrowsAsync<ClickHouseServerException>(async () =>
+            await connection.InsertAsync("INSERT INTO t VALUES", Columns(UInt64Column(1, 2)), cancellationToken: None));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(thrown.Code, Is.EqualTo(241));
+            Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+        });
+    }
+
+    [Test]
+    public async Task InsertAsync_TransportTruncatedDuringSchema_Terminates()
+    {
+        // A Data packet type with no block body: reading the schema hits end of stream mid-way.
+        byte[] script = Concat(
+            await ServerHelloBytesAsync(54476),
+            await BytesAsync(w => w.WriteVarUInt((ulong)ServerPacketType.Data)));
+        using var connection = await ConnectedAsync(script);
+
+        Assert.ThrowsAsync<EndOfStreamException>(async () =>
+            await connection.InsertAsync("INSERT INTO t VALUES", Columns(UInt64Column(1)), cancellationToken: None));
+        Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Terminated));
+    }
+
+    [Test]
+    public async Task InsertAsync_TokenAlreadyCancelled_ThrowsWithoutClaimingConnection()
+    {
+        var transport = new ScriptedDuplexStream(await ServerHelloBytesAsync(54476));
+        using var connection = new ClickHouseTcpConnection(transport, socket: null);
+        await connection.HandshakeAsync(Handshake, None);
+        byte[] writtenBeforeInsert = transport.Written;
+
+        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await connection.InsertAsync("INSERT INTO t VALUES", Columns(UInt64Column(1)), cancellationToken: new CancellationToken(canceled: true)));
+
+        // A pre-cancelled insert must not claim the connection or send anything, leaving it Ready and reusable.
+        Assert.Multiple(() =>
+        {
+            Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+            Assert.That(transport.Written, Is.EqualTo(writtenBeforeInsert));
+        });
+    }
+
+    [Test]
+    public async Task InsertAsync_ColumnCountDisagreesWithSchema_ThrowsArgumentButStaysReady()
+    {
+        byte[] script = Concat(
+            await ServerHelloBytesAsync(54476),
+            await SchemaBlockAsync(("a", "UInt64"), ("b", "UInt64")), // schema wants two columns
+            EndOfStreamPacket());
+        using var connection = await ConnectedAsync(script);
+
+        Assert.ThrowsAsync<ArgumentException>(async () =>
+            await connection.InsertAsync("INSERT INTO t VALUES", Columns(UInt64Column(1)), cancellationToken: None));
+        Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+    }
+
+    [Test]
+    public async Task InsertAsync_ColumnsWithDifferingRowCounts_ThrowsWithoutClaimingConnection()
+    {
+        var transport = new ScriptedDuplexStream(await ServerHelloBytesAsync(54476));
+        using var connection = new ClickHouseTcpConnection(transport, socket: null);
+        await connection.HandshakeAsync(Handshake, None);
+        byte[] writtenBeforeInsert = transport.Written;
+
+        IColumn[] columns = { UInt64Column(1, 2), UInt64Column(3) };
+        Assert.ThrowsAsync<ArgumentException>(async () =>
+            await connection.InsertAsync("INSERT INTO t VALUES", columns, cancellationToken: None));
+
+        // Validation happens before the connection is claimed, so nothing is sent and it stays Ready.
+        Assert.Multiple(() =>
+        {
+            Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+            Assert.That(transport.Written, Is.EqualTo(writtenBeforeInsert));
+        });
+    }
+
+    [Test]
+    public void InsertAsync_NonPositiveMaxRowsPerBlock_ThrowsArgumentOutOfRange()
+    {
+        using var connection = new ClickHouseTcpConnection(new ScriptedDuplexStream(Array.Empty<byte>()), socket: null);
+
+        Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
+            await connection.InsertAsync("INSERT INTO t VALUES", Columns(UInt64Column(1)), maxRowsPerBlock: 0, cancellationToken: None));
+    }
+
+    [Test]
+    public void PlanInsertBlocks_FixedWidthExceedingByteLimit_SplitsByByteBudget()
+    {
+        // UInt64 is 8 bytes/row; a 16-byte budget fits two rows per block.
+        IColumn[] columns = { UInt64Column(1, 2, 3, 4, 5) };
+        var plan = ClickHouseTcpConnection.PlanInsertBlocks(columns, Codecs(columns), rowCount: 5, maxRowsPerBlock: null, byteLimit: 16);
+
+        CollectionAssert.AreEqual(new[] { (0, 2), (2, 2), (4, 1) }, plan);
+    }
+
+    [Test]
+    public void PlanInsertBlocks_RowCapTighterThanByteBudget_SplitsByRowCap()
+    {
+        IColumn[] columns = { UInt64Column(1, 2, 3, 4, 5) };
+        // The byte budget alone would allow one big block; the row cap of two is reached first.
+        var plan = ClickHouseTcpConnection.PlanInsertBlocks(columns, Codecs(columns), rowCount: 5, maxRowsPerBlock: 2, byteLimit: 10 * 1024 * 1024);
+
+        CollectionAssert.AreEqual(new[] { (0, 2), (2, 2), (4, 1) }, plan);
+    }
+
+    [Test]
+    public void PlanInsertBlocks_ByteBudgetTighterThanRowCap_SplitsByBytes()
+    {
+        IColumn[] columns = { UInt64Column(1, 2, 3, 4, 5) };
+        // UInt64 is 8 bytes/row; a 16-byte budget fits two rows, reached before the four-row cap.
+        var plan = ClickHouseTcpConnection.PlanInsertBlocks(columns, Codecs(columns), rowCount: 5, maxRowsPerBlock: 4, byteLimit: 16);
+
+        CollectionAssert.AreEqual(new[] { (0, 2), (2, 2), (4, 1) }, plan);
+    }
+
+    [Test]
+    public void PlanInsertBlocks_RowCapWithVariableWidthColumn_ClosesBlockAtRowCap()
+    {
+        // A variable-width column takes the measured path; the row cap must bind there too, before the byte limit.
+        IColumn[] columns = { new ArrayColumn<string>("s", "String", new[] { "a", "bb", "ccc", "dddd", "e" }) };
+        var plan = ClickHouseTcpConnection.PlanInsertBlocks(columns, Codecs(columns), rowCount: 5, maxRowsPerBlock: 2, byteLimit: 10 * 1024 * 1024);
+
+        CollectionAssert.AreEqual(new[] { (0, 2), (2, 2), (4, 1) }, plan);
+    }
+
+    [Test]
+    public void PlanInsertBlocks_SingleRowLargerThanLimit_FormsItsOwnBlock()
+    {
+        // "xxxxx" encodes as varint(5)+5 = 6 bytes, past the 3-byte budget, but a single row is never split.
+        IColumn[] columns = { new ArrayColumn<string>("s", "String", new[] { "xxxxx", "aa" }) };
+        var plan = ClickHouseTcpConnection.PlanInsertBlocks(columns, Codecs(columns), rowCount: 2, maxRowsPerBlock: null, byteLimit: 3);
+
+        CollectionAssert.AreEqual(new[] { (0, 1), (1, 1) }, plan);
+    }
+
+    [Test]
+    public void PlanInsertBlocks_DataWithinLimit_ProducesOneBlock()
+    {
+        IColumn[] columns = { UInt64Column(1, 2, 3) };
+        var plan = ClickHouseTcpConnection.PlanInsertBlocks(columns, Codecs(columns), rowCount: 3, maxRowsPerBlock: null, byteLimit: 10 * 1024 * 1024);
+
+        CollectionAssert.AreEqual(new[] { (0, 3) }, plan);
+    }
+
+    [Test]
+    public void PlanInsertBlocks_MultipleFixedWidthColumns_SizesByCombinedRowWidth()
+    {
+        // Two UInt64 columns = 16 bytes/row; a 40-byte budget fits two rows per block.
+        IColumn[] columns = { UInt64Column(1, 2, 3, 4, 5), UInt64Column(6, 7, 8, 9, 10) };
+        var plan = ClickHouseTcpConnection.PlanInsertBlocks(columns, Codecs(columns), rowCount: 5, maxRowsPerBlock: null, byteLimit: 40);
+
+        CollectionAssert.AreEqual(new[] { (0, 2), (2, 2), (4, 1) }, plan);
+    }
+
+    [Test]
+    public void PlanInsertBlocks_FixedWidthRowExceedsLimit_EmitsOneRowPerBlock()
+    {
+        // UInt64 is 8 bytes/row, past the 3-byte budget; a fixed-width row is never split, so one row per block.
+        IColumn[] columns = { UInt64Column(1, 2, 3) };
+        var plan = ClickHouseTcpConnection.PlanInsertBlocks(columns, Codecs(columns), rowCount: 3, maxRowsPerBlock: null, byteLimit: 3);
+
+        CollectionAssert.AreEqual(new[] { (0, 1), (1, 1), (2, 1) }, plan);
+    }
+
+    private static async Task<ClickHouseTcpConnection> ConnectedAsync(byte[] script)
+    {
+        var connection = new ClickHouseTcpConnection(new ScriptedDuplexStream(script), socket: null);
+        await connection.HandshakeAsync(Handshake, None);
+        return connection;
+    }
+
+    private static IColumn[] Columns(params IColumn[] columns) => columns;
+
+    private static IColumn UInt64Column(params ulong[] values) => PrimitiveColumn<ulong>.FromValues("x", "UInt64", values);
+
+    private static IColumnCodec[] Codecs(IReadOnlyList<IColumn> columns)
+    {
+        var codecs = new IColumnCodec[columns.Count];
+        for (int i = 0; i < columns.Count; i++)
+        {
+            codecs[i] = ColumnCodecRegistry.Default.Resolve(columns[i].TypeName);
+        }
+
+        return codecs;
+    }
+
+    // A zero-row Data block carrying only column headers — the shape the server sends as the INSERT schema.
+    private static Task<byte[]> SchemaBlockAsync(params (string Name, string Type)[] columns)
+        => BytesAsync(w =>
+        {
+            w.WriteVarUInt((ulong)ServerPacketType.Data);
+            w.WriteString(string.Empty);
+            BlockWriter.WriteBlockInfo(w, BlockInfo.Default);
+            w.WriteVarUInt((ulong)columns.Length); // num_columns
+            w.WriteVarUInt(0);                      // num_rows
+            foreach ((string name, string type) in columns)
+            {
+                w.WriteString(name);
+                w.WriteString(type);
+                w.WriteBool(false); // has_custom_serialization (supported at 54476)
+            }
+        });
+
+    private static Task<byte[]> ExceptionPacketAsync(int code, string message)
+        => BytesAsync(w =>
+        {
+            w.WriteVarUInt((ulong)ServerPacketType.Exception);
+            w.WriteInt32(code);
+            w.WriteString("DB::Exception");
+            w.WriteString(message);
+            w.WriteString("stack trace");
+            w.WriteBool(false); // has_nested
+        });
+
+    private static byte[] EndOfStreamPacket()
+        => BytesAsync(w => w.WriteVarUInt((ulong)ServerPacketType.EndOfStream)).GetAwaiter().GetResult();
+
+    private static Task<byte[]> ProgressPacketAsync()
+        => BytesAsync(w =>
+        {
+            w.WriteVarUInt((ulong)ServerPacketType.Progress);
+            w.WriteVarUInt(1); // rows
+            w.WriteVarUInt(2); // bytes
+            w.WriteVarUInt(3); // total_rows
+            w.WriteVarUInt(0); // wrote_rows
+            w.WriteVarUInt(0); // wrote_bytes
+            w.WriteVarUInt(0); // elapsed_ns
+        });
+
+    private static Task<byte[]> ServerHelloBytesAsync(int revision) => BytesAsync(w =>
+    {
+        w.WriteVarUInt((ulong)ServerPacketType.Hello);
+        w.WriteString("ClickHouse");
+        w.WriteVarUInt(25);
+        w.WriteVarUInt(8);
+        w.WriteVarUInt((ulong)revision);
+        w.WriteString("UTC");
+        w.WriteString("clickhouse-server");
+        w.WriteVarUInt(0);
+    });
+
+    private static async Task<byte[]> BytesAsync(Action<ClickHouseBinaryWriter> write)
+    {
+        using var ms = new MemoryStream();
+        using (var writer = new ClickHouseBinaryWriter(ms))
+        {
+            write(writer);
+            await writer.FlushAsync(None);
+        }
+
+        return ms.ToArray();
+    }
+
+    private static byte[] Concat(params byte[][] arrays)
+    {
+        int length = 0;
+        foreach (byte[] array in arrays)
+        {
+            length += array.Length;
+        }
+
+        byte[] result = new byte[length];
+        int offset = 0;
+        foreach (byte[] array in arrays)
+        {
+            Buffer.BlockCopy(array, 0, result, offset, array.Length);
+            offset += array.Length;
+        }
+
+        return result;
+    }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Types/DateTimeColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/DateTimeColumnCodecTests.cs
@@ -49,6 +49,46 @@ public class DateTimeColumnCodecTests
         Assert.That(column.RowCount, Is.EqualTo(0));
     }
 
+    [Test]
+    public async Task WriteColumn_DateTimeOffset_EncodesSameUnixSecondsAsEquivalentDateTime()
+    {
+        // The same instant expressed as a DateTimeOffset (with a non-zero offset) and as a UTC DateTime must
+        // produce identical column bodies — both are epoch seconds of the UTC instant.
+        DateTime utc = DateTime.UnixEpoch.AddSeconds(1_700_000_000);
+        var offset = new DateTimeOffset(utc, TimeSpan.Zero).ToOffset(TimeSpan.FromHours(5));
+
+        byte[] fromDateTime = await WriteAsync(w => DateTimeColumnCodec.Instance.WriteColumn(w, new ArrayColumn<DateTime>("c", "DateTime", new[] { utc })));
+        byte[] fromOffset = await WriteAsync(w => DateTimeColumnCodec.Instance.WriteColumn(w, new ArrayColumn<DateTimeOffset>("c", "DateTime", new[] { offset })));
+
+        CollectionAssert.AreEqual(fromDateTime, fromOffset);
+    }
+
+    [Test]
+    public void WriteColumn_DateTimeOutsideClickHouseRange_Throws()
+    {
+        using var ms = new MemoryStream();
+        using var writer = new ClickHouseBinaryWriter(ms);
+        var beforeEpoch = new ArrayColumn<DateTime>("c", "DateTime", new[] { new DateTime(1969, 12, 31, 23, 59, 59, DateTimeKind.Utc) });
+        var pastMax = new ArrayColumn<DateTime>("c", "DateTime", new[] { new DateTime(2200, 1, 1, 0, 0, 0, DateTimeKind.Utc) });
+
+        Assert.Multiple(() =>
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => DateTimeColumnCodec.Instance.WriteColumn(writer, beforeEpoch));
+            Assert.Throws<ArgumentOutOfRangeException>(() => DateTimeColumnCodec.Instance.WriteColumn(writer, pastMax));
+        });
+    }
+
+    [Test]
+    public void CanWrite_AcceptsDateTimeAndDateTimeOffset_RejectsOthers()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(DateTimeColumnCodec.Instance.CanWrite(new ArrayColumn<DateTime>("c", "DateTime", Array.Empty<DateTime>())), Is.True);
+            Assert.That(DateTimeColumnCodec.Instance.CanWrite(new ArrayColumn<DateTimeOffset>("c", "DateTime", Array.Empty<DateTimeOffset>())), Is.True);
+            Assert.That(DateTimeColumnCodec.Instance.CanWrite(new ArrayColumn<string>("c", "DateTime", Array.Empty<string>())), Is.False);
+        });
+    }
+
     private static async Task<byte[]> WriteAsync(Action<ClickHouseBinaryWriter> write)
     {
         using var ms = new MemoryStream();

--- a/ClickHouse.Driver.Tcp.Tests/Types/IntegerColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/IntegerColumnCodecTests.cs
@@ -100,6 +100,19 @@ public class IntegerColumnCodecTests
         });
     }
 
+    [Test]
+    public void CanWrite_MatchesElementType_RejectsMismatch()
+    {
+        var codec = new IntegerColumnCodec<int>("Int32");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(codec.CanWrite(PrimitiveColumn<int>.FromValues("c", "Int32", new[] { 1 })), Is.True);
+            Assert.That(codec.CanWrite(PrimitiveColumn<long>.FromValues("c", "Int64", new[] { 1L })), Is.False);
+            Assert.That(codec.CanWrite(new ArrayColumn<string>("c", "String", new[] { "x" })), Is.False);
+        });
+    }
+
     private static async Task AssertRoundTripAsync<T>(IColumnCodec codec, string type, T[] values)
         where T : unmanaged
     {

--- a/ClickHouse.Driver.Tcp.Tests/Types/StringColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/StringColumnCodecTests.cs
@@ -40,6 +40,16 @@ public class StringColumnCodecTests
         Assert.That(column.RowCount, Is.EqualTo(0));
     }
 
+    [Test]
+    public void CanWrite_AcceptsStringColumn_RejectsOthers()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(StringColumnCodec.Instance.CanWrite(new ArrayColumn<string>("c", "String", new[] { "x" })), Is.True);
+            Assert.That(StringColumnCodec.Instance.CanWrite(PrimitiveColumn<int>.FromValues("c", "Int32", new[] { 1 })), Is.False);
+        });
+    }
+
     private static async Task<byte[]> WriteAsync(Action<ClickHouseBinaryWriter> write)
     {
         using var ms = new MemoryStream();

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using ClickHouse.Driver.Tcp.Numerics;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Tests.Utilities;
+
+/// <summary>
+/// Sample columns for the INSERT → SELECT round-trip integration tests, in the spirit of the HTTP suite's
+/// <c>TestCases</c>: one place that enumerates a representative value set per supported type, so a single
+/// parameterized test exercises every type rather than a hand-written test each. The test creates a matching
+/// one-column table, inserts the case's column, selects it back, and asserts the read-back column equals the
+/// expected column. Covers the types the native codecs support today — the fixed-width integers, the raw enum
+/// aliases, <c>String</c>, and <c>DateTime</c>.
+///
+/// <para>
+/// A case usually inserts and reads back the same CLR type, so the inserted column doubles as the expected one.
+/// Some cases differ, though — inserting a <c>DateTimeOffset</c> into a <c>DateTime</c> column reads back a
+/// <c>DateTime</c> — so a case carries both an insert-column builder and an expected-column builder; the common
+/// factories set them to the same builder.
+/// </para>
+/// </summary>
+public sealed class InsertRoundTripCase
+{
+    private readonly Func<string, IColumn> buildInsert;
+    private readonly Func<string, IColumn> buildExpected;
+
+    private InsertRoundTripCase(string label, string clickHouseType, Func<string, IColumn> buildInsert, Func<string, IColumn> buildExpected)
+    {
+        Label = label;
+        ClickHouseType = clickHouseType;
+        this.buildInsert = buildInsert;
+        this.buildExpected = buildExpected;
+    }
+
+    /// <summary>The ClickHouse type for the target column (used both to create the table and as the column header).</summary>
+    public string ClickHouseType { get; }
+
+    private string Label { get; }
+
+    /// <summary>Builds the column to insert, stamped with <paramref name="columnName"/>.</summary>
+    /// <param name="columnName">The column name, which must match the target table column.</param>
+    /// <returns>The column to insert.</returns>
+    internal IColumn BuildInsertColumn(string columnName) => buildInsert(columnName);
+
+    /// <summary>Builds the column whose values the read-back column is expected to equal.</summary>
+    /// <param name="columnName">The column name.</param>
+    /// <returns>The expected column.</returns>
+    internal IColumn BuildExpectedColumn(string columnName) => buildExpected(columnName);
+
+    public override string ToString() => Label;
+
+    /// <summary>All round-trip cases, for use as an NUnit <c>TestCaseSource</c>.</summary>
+    public static IEnumerable<InsertRoundTripCase> Cases()
+    {
+        yield return Primitive("UInt8", new byte[] { 0, 1, 128, 255 });
+        yield return Primitive("Int8", new sbyte[] { -128, -1, 0, 127 });
+        yield return Primitive("UInt16", new ushort[] { 0, 258, ushort.MaxValue });
+        yield return Primitive("Int16", new short[] { short.MinValue, -1, 0, short.MaxValue });
+        yield return Primitive("UInt32", new uint[] { 0, 1, uint.MaxValue });
+        yield return Primitive("Int32", new[] { int.MinValue, -1, 0, int.MaxValue });
+        yield return Primitive("UInt64", new ulong[] { 0, 1, ulong.MaxValue });
+        yield return Primitive("Int64", new[] { long.MinValue, -1, 0, long.MaxValue });
+        yield return Primitive("UInt128", new[] { UInt128.Zero, UInt128.One, UInt128.MaxValue });
+        yield return Primitive("Int128", new[] { Int128.MinValue, -Int128.One, Int128.Zero, Int128.MaxValue });
+        yield return Primitive("UInt256", new[] { UInt256.Zero, UInt256.FromBigInteger(1), UInt256.FromBigInteger(System.Numerics.BigInteger.Pow(2, 200)) });
+        yield return Primitive("Int256", new[] { Int256.FromBigInteger(-System.Numerics.BigInteger.Pow(2, 200)), Int256.FromBigInteger(-1), Int256.Zero, Int256.FromBigInteger(System.Numerics.BigInteger.Pow(2, 200)) });
+
+        // Enum columns are inserted and read as their raw underlying ordinals; the ordinals must be declared members.
+        yield return Primitive("Enum8('a' = -1, 'b' = 127)", new sbyte[] { -1, 127 });
+        yield return Primitive("Enum16('x' = -32768, 'y' = 32767)", new short[] { -32768, 32767 });
+
+        yield return Strings("String", string.Empty, "hello", "héllo✓", "a\0b", new string('x', 500));
+
+        yield return DateTimes(
+            "DateTime",
+            new DateTime(1988, 8, 28, 11, 22, 33, DateTimeKind.Utc),
+            new DateTime(2024, 1, 15, 10, 30, 0, DateTimeKind.Utc),
+            DateTime.UnixEpoch);
+
+        // A DateTimeOffset inserted into a DateTime column round-trips as its UTC instant (read back as DateTime).
+        yield return DateTimeOffsets(
+            "DateTime",
+            new DateTimeOffset(2024, 1, 15, 10, 30, 0, TimeSpan.FromHours(5)),
+            new DateTimeOffset(1988, 8, 28, 11, 22, 33, TimeSpan.FromHours(-8)));
+    }
+
+    private static InsertRoundTripCase Primitive<T>(string clickHouseType, T[] values)
+        where T : unmanaged
+        => Same($"{clickHouseType} [{values.Length} rows]", clickHouseType, name => PrimitiveColumn<T>.FromValues(name, clickHouseType, values));
+
+    private static InsertRoundTripCase Strings(string clickHouseType, params string[] values)
+        => Same($"{clickHouseType} [{values.Length} rows]", clickHouseType, name => new ArrayColumn<string>(name, clickHouseType, values));
+
+    private static InsertRoundTripCase DateTimes(string clickHouseType, params DateTime[] values)
+        => Same($"{clickHouseType} [{values.Length} rows]", clickHouseType, name => new ArrayColumn<DateTime>(name, clickHouseType, values));
+
+    private static InsertRoundTripCase DateTimeOffsets(string clickHouseType, params DateTimeOffset[] values)
+        => new(
+            $"{clickHouseType} <- DateTimeOffset [{values.Length} rows]",
+            clickHouseType,
+            name => new ArrayColumn<DateTimeOffset>(name, clickHouseType, values),
+            name => new ArrayColumn<DateTime>(name, clickHouseType, Array.ConvertAll(values, v => v.UtcDateTime)));
+
+    /// <summary>A case that inserts and reads back the same column — the common shape.</summary>
+    private static InsertRoundTripCase Same(string label, string clickHouseType, Func<string, IColumn> build)
+        => new(label, clickHouseType, build, build);
+}

--- a/ClickHouse.Driver.Tcp/Format/BlockWriter.cs
+++ b/ClickHouse.Driver.Tcp/Format/BlockWriter.cs
@@ -1,14 +1,24 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using ClickHouse.Driver.Tcp.Protocol;
+using ClickHouse.Driver.Tcp.Types;
 
 namespace ClickHouse.Driver.Tcp.Format;
 
 /// <summary>
-/// Writes outgoing blocks. This slice needs only the empty block — the client sends one, with no columns and no
-/// rows, as the end-of-input "go" marker after a Query so the server begins executing. Writing populated blocks
-/// (for INSERT) is added later.
+/// Writes outgoing blocks: the empty end-of-input marker sent after a Query, and the populated data blocks an
+/// INSERT streams to the server. The wire layout mirrors <see cref="BlockReader"/>.
 /// </summary>
 internal static class BlockWriter
 {
+    /// <summary>
+    /// The default per-block encoded-size target (50 MiB): the insert path sizes blocks to stay within it, and
+    /// the encoder flushes between columns once the buffer passes it as a backstop.
+    /// </summary>
+    public const int DefaultFlushThresholdBytes = 50 * 1024 * 1024;
+
     /// <summary>
     /// Writes the empty end-of-input block: an empty name, the standard block info, and zero column/row counts.
     /// Does not flush.
@@ -20,6 +30,110 @@ internal static class BlockWriter
         WriteBlockInfo(writer, BlockInfo.Default);
         writer.WriteVarUInt(0); // num_columns
         writer.WriteVarUInt(0); // num_rows
+    }
+
+    /// <summary>
+    /// Writes a populated data block from whole columns, resolving each column's codec from its own type string.
+    /// Every column must hold exactly <paramref name="rowCount"/> rows.
+    /// </summary>
+    /// <param name="writer">The writer to encode into.</param>
+    /// <param name="negotiated">The negotiated protocol, gating the <c>has_custom_serialization</c> byte.</param>
+    /// <param name="columns">The columns to write, in header order; each supplies its own name, type, and values.</param>
+    /// <param name="rowCount">The number of rows every column holds.</param>
+    /// <param name="registry">The registry that resolves each column's type string to its codec.</param>
+    /// <param name="flushThresholdBytes">The buffered-byte cap that triggers a between-column flush.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    public static ValueTask WriteDataBlockAsync(
+        ClickHouseBinaryWriter writer,
+        NegotiatedProtocol negotiated,
+        IReadOnlyList<IColumn> columns,
+        int rowCount,
+        ColumnCodecRegistry registry,
+        int flushThresholdBytes,
+        CancellationToken cancellationToken)
+    {
+        // A column whose length disagrees with the declared row count would corrupt the block. Catch it first.
+        foreach (IColumn column in columns)
+        {
+            if (column.RowCount != rowCount)
+            {
+                throw new ArgumentException(
+                    $"Column '{column.Name}' holds {column.RowCount} row(s) but the block declares {rowCount}; every column must match the block's row count.",
+                    nameof(columns));
+            }
+        }
+
+        var planned = new InsertColumn[columns.Count];
+        for (int i = 0; i < columns.Count; i++)
+        {
+            IColumn column = columns[i];
+            planned[i] = new InsertColumn(column.Name, column.TypeName, registry.Resolve(column.TypeName), column);
+        }
+
+        return WriteDataBlockAsync(writer, negotiated, planned, start: 0, rowCount, flushThresholdBytes, cancellationToken);
+    }
+
+    /// <summary>
+    /// Writes a populated data block covering rows <c>[start, start + rowCount)</c> of each column, read straight
+    /// from its borrowed span. Each column's header and codec come from the descriptor (the target schema's
+    /// authoritative name and resolved type), not the value column.
+    /// </summary>
+    /// <param name="writer">The writer to encode into.</param>
+    /// <param name="negotiated">The negotiated protocol, gating the <c>has_custom_serialization</c> byte.</param>
+    /// <param name="columns">The columns to write, in header order; each pairs a target header and codec with values.</param>
+    /// <param name="start">The zero-based first row of the range each column contributes.</param>
+    /// <param name="rowCount">The number of rows the block holds.</param>
+    /// <param name="flushThresholdBytes">The buffered-byte cap that triggers a between-column flush.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    public static async ValueTask WriteDataBlockAsync(
+        ClickHouseBinaryWriter writer,
+        NegotiatedProtocol negotiated,
+        IReadOnlyList<InsertColumn> columns,
+        int start,
+        int rowCount,
+        int flushThresholdBytes,
+        CancellationToken cancellationToken)
+    {
+        // The requested range must lie within every column, or the body would run past the values. Catch it first.
+        foreach (InsertColumn column in columns)
+        {
+            if (start < 0 || rowCount < 0 || start + (long)rowCount > column.Values.RowCount)
+            {
+                throw new ArgumentException(
+                    $"Column '{column.Name}' cannot supply rows [{start}, {start + (long)rowCount}) of its {column.Values.RowCount} row(s).",
+                    nameof(columns));
+            }
+        }
+
+        writer.WriteString(string.Empty); // table_name: empty for the INSERT row stream
+        WriteBlockInfo(writer, BlockInfo.Default);
+        writer.WriteVarUInt((ulong)columns.Count); // num_columns
+        writer.WriteVarUInt((ulong)rowCount);       // num_rows
+
+        foreach (InsertColumn column in columns)
+        {
+            writer.WriteString(column.Name);
+            writer.WriteString(column.TypeName);
+            if (negotiated.Supports(ProtocolFeature.CustomSerialization))
+            {
+                writer.WriteBool(false); // has_custom_serialization: default serialization only
+            }
+
+            // A zero-row block has no state prefix or body; skip both rather than rely on every codec treating
+            // an empty range as a no-op (the Nothing codec, for one, refuses to write at all).
+            if (rowCount != 0)
+            {
+                column.Codec.WriteStatePrefix(writer);
+                column.Codec.WriteColumn(writer, column.Values, start, rowCount);
+            }
+
+            // Backstop: flush between columns once the buffer passes the threshold, so a wide block doesn't
+            // balloon before the message-boundary flush.
+            if (writer.BufferedBytes >= flushThresholdBytes)
+            {
+                await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
     }
 
     /// <summary>Writes the field-id-tagged block info: <c>is_overflows</c>, <c>bucket_number</c>, then the terminator.</summary>

--- a/ClickHouse.Driver.Tcp/Format/InsertColumn.cs
+++ b/ClickHouse.Driver.Tcp/Format/InsertColumn.cs
@@ -1,0 +1,36 @@
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Format;
+
+/// <summary>
+/// One column of an outgoing INSERT block: the wire header (<see cref="Name"/>, <see cref="TypeName"/>), the
+/// <see cref="Codec"/> that serializes the body, and the caller's <see cref="Values"/>. Header and codec come
+/// from the server's sample block, not the value column, so the wire always carries the target's name and type.
+/// </summary>
+internal readonly struct InsertColumn
+{
+    /// <summary>Initializes a descriptor pairing a target header and codec with the caller's values.</summary>
+    /// <param name="name">The target column name, written to the block header.</param>
+    /// <param name="typeName">The target's resolved type string, written to the block header.</param>
+    /// <param name="codec">The codec that serializes <paramref name="values"/>, resolved from <paramref name="typeName"/>.</param>
+    /// <param name="values">The caller-supplied values for this column.</param>
+    public InsertColumn(string name, string typeName, IColumnCodec codec, IColumn values)
+    {
+        Name = name;
+        TypeName = typeName;
+        Codec = codec;
+        Values = values;
+    }
+
+    /// <summary>The target column name written to the block header.</summary>
+    public string Name { get; }
+
+    /// <summary>The target's resolved type string written to the block header.</summary>
+    public string TypeName { get; }
+
+    /// <summary>The codec that serializes the body.</summary>
+    public IColumnCodec Codec { get; }
+
+    /// <summary>The caller-supplied values.</summary>
+    public IColumn Values { get; }
+}

--- a/ClickHouse.Driver.Tcp/Protocol/ClickHouseBinaryWriter.cs
+++ b/ClickHouse.Driver.Tcp/Protocol/ClickHouseBinaryWriter.cs
@@ -17,6 +17,7 @@ namespace ClickHouse.Driver.Tcp.Protocol;
 internal sealed class ClickHouseBinaryWriter : IDisposable
 {
     private readonly Stream stream;
+    private readonly int initialBufferSize;
     private byte[] buffer;
     private int position;
     private bool disposed;
@@ -34,11 +35,43 @@ internal sealed class ClickHouseBinaryWriter : IDisposable
             throw new ArgumentOutOfRangeException(nameof(bufferSize), "Buffer must hold at least one 32-byte value.");
         }
 
+        initialBufferSize = bufferSize;
         buffer = ArrayPool<byte>.Shared.Rent(bufferSize);
     }
 
     /// <summary>The number of bytes buffered and not yet flushed.</summary>
     public int BufferedBytes => position;
+
+    /// <summary>The number of bytes a VarUInt encoding of <paramref name="value"/> occupies (1–10).</summary>
+    /// <param name="value">The value that would be written with <see cref="WriteVarUInt"/>.</param>
+    /// <returns>The encoded length in bytes.</returns>
+    public static int MeasureVarUInt(ulong value)
+    {
+        int bytes = 1;
+        while (value >= 0x80)
+        {
+            bytes++;
+            value >>= 7;
+        }
+
+        return bytes;
+    }
+
+    /// <summary>
+    /// Returns the working buffer to its initial size if a large write grew it, so a connection that streamed
+    /// one big block does not retain the peak-sized pooled buffer for the rest of its life. Must be called with
+    /// nothing buffered (after a flush); a no-op when the buffer is already at or below its initial size.
+    /// </summary>
+    public void TrimBuffer()
+    {
+        if (disposed || position != 0 || buffer.Length <= initialBufferSize)
+        {
+            return;
+        }
+
+        ArrayPool<byte>.Shared.Return(buffer);
+        buffer = ArrayPool<byte>.Shared.Rent(initialBufferSize);
+    }
 
     /// <summary>Writes a single byte.</summary>
     /// <param name="value">The byte to write.</param>

--- a/ClickHouse.Driver.Tcp/Protocol/ClickHouseTcpConnection.cs
+++ b/ClickHouse.Driver.Tcp/Protocol/ClickHouseTcpConnection.cs
@@ -509,9 +509,10 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
     {
         if (rowCount > 0 && plan is not null)
         {
-            var values = Array.ConvertAll(plan, p => p.Values);
-            var codecs = Array.ConvertAll(plan, p => p.Codec);
-            foreach ((int start, int length) in PlanInsertBlocks(values, codecs, rowCount, maxRowsPerBlock, BlockWriter.DefaultFlushThresholdBytes))
+            // Split into wire blocks by row count alone (each column is written straight from its ergonomic form,
+            // so there is no intermediate dense buffer to build first). The between-column flush backstop bounds
+            // peak client memory while a block streams.
+            foreach ((int start, int length) in PlanInsertBlocks(rowCount, maxRowsPerBlock))
             {
                 writer.WriteClientPacketType(ClientPacketType.Data);
                 await BlockWriter.WriteDataBlockAsync(
@@ -555,81 +556,24 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
     }
 
     /// <summary>
-    /// Splits <paramref name="rowCount"/> rows into contiguous wire-block ranges, closing a block whenever adding
-    /// the next row would push its encoded body past <paramref name="byteLimit"/> or the block already holds
-    /// <paramref name="maxRowsPerBlock"/> rows — whichever limit a block reaches first. A single row larger than
-    /// the byte limit still forms its own block. With no <paramref name="maxRowsPerBlock"/> only the byte target
-    /// bounds a block: when every column is fixed-width the rows-per-block is a single division (uniform blocks,
-    /// nothing measured), and when any column is variable-width the rows are measured through the codecs.
+    /// Splits <paramref name="rowCount"/> rows into contiguous wire-block ranges of at most
+    /// <paramref name="maxRowsPerBlock"/> rows each — the block geometry is bounded by row count alone. With no
+    /// <paramref name="maxRowsPerBlock"/> the whole insert is a single block; peak client memory while it is
+    /// written is instead bounded by the between-column flush backstop
+    /// (<see cref="BlockWriter.DefaultFlushThresholdBytes"/>), not by splitting the block.
     /// </summary>
-    /// <param name="columns">The insert's columns, all of the same length.</param>
-    /// <param name="codecs">The resolved codec for each column, positionally aligned with <paramref name="columns"/>.</param>
     /// <param name="rowCount">The number of rows to split (assumed greater than zero).</param>
-    /// <param name="maxRowsPerBlock">A cap on the rows per block, applied alongside <paramref name="byteLimit"/>, or null for no row cap.</param>
-    /// <param name="byteLimit">The per-block encoded-size target.</param>
+    /// <param name="maxRowsPerBlock">The cap on the rows per block, or null for a single block.</param>
     /// <returns>The (start, length) row range of each wire block, in order.</returns>
-    internal static List<(int Start, int Length)> PlanInsertBlocks(
-        IReadOnlyList<IColumn> columns, IColumnCodec[] codecs, int rowCount, int? maxRowsPerBlock, long byteLimit)
+    internal static List<(int Start, int Length)> PlanInsertBlocks(int rowCount, int? maxRowsPerBlock)
     {
         var blocks = new List<(int Start, int Length)>();
-        int rowCap = maxRowsPerBlock ?? int.MaxValue;
-
-        long fixedBytesPerRow = 0;
-        List<(IColumn Column, IColumnCodec Codec)> variable = null;
-        for (int i = 0; i < columns.Count; i++)
+        int step = maxRowsPerBlock is int cap && cap > 0 ? cap : rowCount;
+        for (int start = 0; start < rowCount; start += step)
         {
-            if (codecs[i].FixedRowByteSize is int size)
-            {
-                fixedBytesPerRow += size;
-            }
-            else
-            {
-                (variable ??= new List<(IColumn, IColumnCodec)>()).Add((columns[i], codecs[i]));
-            }
+            blocks.Add((start, Math.Min(step, rowCount - start)));
         }
 
-        if (variable is null)
-        {
-            // Every column is fixed-width, so every row costs the same: the rows that fill the byte budget is one
-            // division, and the block is bounded by whichever of that and the row cap is smaller. Blocks are
-            // uniform (bar the last), no per-row walk. A zero per-row size (no columns priced) can't be divided
-            // by, so bytes impose no limit and only the row cap (if any) applies.
-            long byteStep = fixedBytesPerRow == 0 ? rowCount : Math.Max(1, byteLimit / fixedBytesPerRow);
-            int step = (int)Math.Min(Math.Min((long)rowCount, byteStep), rowCap);
-            for (int start = 0; start < rowCount; start += step)
-            {
-                blocks.Add((start, Math.Min(step, rowCount - start)));
-            }
-
-            return blocks;
-        }
-
-        // At least one variable-width column, so each row must be measured. The fixed columns contribute a
-        // constant; only the variable ones are walked per row.
-        int blockStart = 0;
-        long blockBytes = 0;
-        for (int row = 0; row < rowCount; row++)
-        {
-            long rowBytes = fixedBytesPerRow;
-            foreach ((IColumn column, IColumnCodec codec) in variable)
-            {
-                rowBytes += codec.MeasureRowBytes(column, row);
-            }
-
-            // Close the current block before this row when it already holds a row and adding this one would cross
-            // the byte limit, or the block has reached the row cap — whichever comes first. A row larger than the
-            // byte limit on its own still becomes a single-row block.
-            if (row > blockStart && (blockBytes + rowBytes > byteLimit || row - blockStart >= rowCap))
-            {
-                blocks.Add((blockStart, row - blockStart));
-                blockStart = row;
-                blockBytes = 0;
-            }
-
-            blockBytes += rowBytes;
-        }
-
-        blocks.Add((blockStart, rowCount - blockStart));
         return blocks;
     }
 

--- a/ClickHouse.Driver.Tcp/Protocol/ClickHouseTcpConnection.cs
+++ b/ClickHouse.Driver.Tcp/Protocol/ClickHouseTcpConnection.cs
@@ -276,73 +276,25 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
                     break;
                 }
 
-                switch (packet)
+                if (packet == ServerPacketType.Data)
                 {
-                    case ServerPacketType.Data:
+                    Block block = await BlockReader.ReadBlockAsync(reader, negotiated, ColumnCodecRegistry.Default, cancellationToken).ConfigureAwait(false);
+                    if (block.RowCount != 0)
                     {
-                        Block block = await BlockReader.ReadBlockAsync(reader, negotiated, ColumnCodecRegistry.Default, cancellationToken).ConfigureAwait(false);
-                        if (block.RowCount != 0)
-                        {
-                            // Held as the current block so it is released when the consumer advances or stops.
-                            current = block;
-                            yield return block;
-                        }
-                        else
-                        {
-                            block.Dispose();
-                        }
-
-                        break;
+                        // Held as the current block so it is released when the consumer advances or stops.
+                        current = block;
+                        yield return block;
                     }
-                    // The remaining metadata packets are always decoded to stay stream-aligned; each is handed
-                    // to its handler when one is set, otherwise discarded. The block-bearing ones lend the block
-                    // to the handler for the duration of the call and release it immediately after.
-                    case ServerPacketType.Totals:
-                        await ReadMetadataBlockAsync(reader, negotiated, handlers?.OnTotals, cancellationToken).ConfigureAwait(false);
-                        break;
-
-                    case ServerPacketType.Extremes:
-                        await ReadMetadataBlockAsync(reader, negotiated, handlers?.OnExtremes, cancellationToken).ConfigureAwait(false);
-                        break;
-
-                    case ServerPacketType.ProfileEvents:
-                        await ReadMetadataBlockAsync(reader, negotiated, handlers?.OnProfileEvents, cancellationToken).ConfigureAwait(false);
-                        break;
-
-                    case ServerPacketType.Log:
-                        await ReadMetadataBlockAsync(reader, negotiated, handlers?.OnLog, cancellationToken).ConfigureAwait(false);
-                        break;
-
-                    case ServerPacketType.Progress:
+                    else
                     {
-                        Progress progress = await Progress.ReadAsync(reader, negotiated, cancellationToken).ConfigureAwait(false);
-                        handlers?.OnProgress?.Invoke(progress);
-                        break;
+                        block.Dispose();
                     }
-
-                    case ServerPacketType.ProfileInfo:
-                    {
-                        ProfileInfo profileInfo = await ProfileInfo.ReadAsync(reader, cancellationToken).ConfigureAwait(false);
-                        handlers?.OnProfileInfo?.Invoke(profileInfo);
-                        break;
-                    }
-
-                    case ServerPacketType.TableColumns:
-                        // A column-defaults description the server may send; the client has no use for it yet, so
-                        // it is decoded to stay stream-aligned and discarded (an internal concern, not surfaced).
-                        await TableColumns.ReadAsync(reader, cancellationToken).ConfigureAwait(false);
-                        break;
-
-                    case ServerPacketType.PartUUIDs:
-                        // Valid mid-query when part-level deduplication is active. Consumed to stay stream-aligned;
-                        // the decoded UUIDs have no result surface yet. TODO: surface.
-                        await PartUUIDs.ConsumeAsync(reader, cancellationToken).ConfigureAwait(false);
-                        break;
-
-                    default:
-                        // Only the packets above are valid in a query response at this protocol target; anything
-                        // else (e.g. a read-task request) is a violation here.
-                        throw new ClickHouseProtocolException($"Unexpected packet type {packet} ({(ulong)packet}) in query response.");
+                }
+                else
+                {
+                    // Everything else is interleaved metadata: consumed to stay stream-aligned, surfaced to the
+                    // handlers when set. An unexpected packet throws from here.
+                    await ConsumeMetadataAsync(packet, negotiated, handlers, cancellationToken).ConfigureAwait(false);
                 }
             }
         }
@@ -365,6 +317,426 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
         {
             throw pending;
         }
+    }
+
+    /// <summary>
+    /// The default cap on the rows per wire block (1,000,000), applied alongside the byte target
+    /// (<see cref="BlockWriter.DefaultFlushThresholdBytes"/>) so a block closes at whichever it reaches first.
+    /// The byte target is the primary, width-invariant bound; this row cap keeps very narrow rows from producing
+    /// an unbounded row count in a single block.
+    /// </summary>
+    public const int DefaultMaxRowsPerBlock = 1_000_000;
+
+    /// <summary>
+    /// Runs an INSERT, streaming <paramref name="columns"/> as the row data and returning once the server
+    /// acknowledges it.
+    /// </summary>
+    /// <remarks>
+    /// Columns are matched to the target's schema <b>by name</b>: order is free, and naming a subset of the
+    /// table's columns in the statement (<c>INSERT INTO t (a, c) VALUES</c>) inserts only those, with the server
+    /// filling the rest from their defaults. Values are serialized as the target's resolved type, not the type
+    /// the column declares. Zero rows is a no-op INSERT. A mismatch (wrong names, or a CLR type the target
+    /// cannot accept) writes nothing and leaves the connection usable before throwing. Large inserts are split
+    /// into wire blocks sized to an internal byte target, additionally capped at <paramref name="maxRowsPerBlock"/>
+    /// rows per block when set (a block closes at whichever limit it reaches first).
+    /// </remarks>
+    /// <param name="sql">The <c>INSERT INTO … VALUES</c> statement, with no inline <c>VALUES (...)</c> literal.</param>
+    /// <param name="columns">The row data, matched to the target columns by name.</param>
+    /// <param name="settings">Per-query settings as textual values, or null for none.</param>
+    /// <param name="parameters">Query parameter values in SQL representation, or null for none.</param>
+    /// <param name="queryId">The query id, or null to let the server assign one.</param>
+    /// <param name="maxRowsPerBlock">A cap on the rows per wire block, applied alongside the internal byte target
+    /// (a block closes at whichever it reaches first). Defaults to <see cref="DefaultMaxRowsPerBlock"/>; pass null
+    /// for no row cap (byte target only).</param>
+    /// <param name="handlers">Optional callbacks for the metadata the server interleaves into the insert
+    /// acknowledgement (notably <see cref="MetadataHandlers.OnProgress"/> for rows written and
+    /// <see cref="MetadataHandlers.OnProfileEvents"/>), or null to discard it.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>A task that completes when the server acknowledges the insert with end-of-stream.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="sql"/> or <paramref name="columns"/> is null.</exception>
+    /// <exception cref="ArgumentException">The columns hold differing row counts or duplicate names, their names
+    /// do not match the target schema, or a column's CLR type is not writable as its target type.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="maxRowsPerBlock"/> is zero or negative.</exception>
+    /// <exception cref="InvalidOperationException">The connection is busy with another operation.</exception>
+    /// <exception cref="ObjectDisposedException">The connection has been terminated.</exception>
+    /// <exception cref="ClickHouseServerException">The server reported an error while executing the insert.</exception>
+    /// <exception cref="ClickHouseProtocolException">The server sent an unexpected packet, or no schema block.</exception>
+    /// <exception cref="OperationCanceledException"><paramref name="cancellationToken"/> was cancelled.</exception>
+    internal async ValueTask InsertAsync(
+        string sql,
+        IReadOnlyList<IColumn> columns,
+        IReadOnlyDictionary<string, string> settings = null,
+        IReadOnlyDictionary<string, string> parameters = null,
+        string queryId = null,
+        int? maxRowsPerBlock = DefaultMaxRowsPerBlock,
+        MetadataHandlers handlers = null,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateInsertArguments(sql, columns, maxRowsPerBlock, out int rowCount);
+
+        // Bail on cancellation before claiming the connection, so a pre-cancelled call leaves it idle.
+        cancellationToken.ThrowIfCancellationRequested();
+        BeginOperation();
+
+        NegotiatedProtocol negotiated = server.Negotiated;
+        ClickHouseServerException pending = null;
+        bool completed = false;
+        string mismatchError = null;
+        try
+        {
+            // The empty end-of-input block must follow the Query: the server waits for it before sending the
+            // schema block, so omitting it deadlocks.
+            Query.Write(writer, negotiated, clientMetadata, queryId, sql, settings, parameters);
+            writer.WriteClientPacketType(ClientPacketType.Data);
+            BlockWriter.WriteEmptyBlock(writer);
+            await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
+
+            // Drain metadata until the schema block (the first Data packet) or a terminal packet.
+            (Block schema, ClickHouseServerException error) = await ReadToNextDataBlockAsync(negotiated, handlers, cancellationToken).ConfigureAwait(false);
+            if (schema is null)
+            {
+                if (error is null)
+                {
+                    // Clean end-of-stream with no schema: the server never opened the row-stream phase (e.g.
+                    // inline VALUES, or INSERT … SELECT). That breaks the INSERT contract, so terminate rather
+                    // than pool a spent connection.
+                    throw new ClickHouseProtocolException("The server ended the INSERT response without sending a schema block.");
+                }
+
+                // Server Exception instead of the schema: the stream is at a packet boundary, so rethrow once
+                // the state is back to Ready.
+                pending = error;
+                completed = true;
+            }
+            else
+            {
+                // Align the caller's columns to the schema by name. No columns is the explicit no-op insert; a
+                // mismatch leaves plan null (so only the terminator goes out) and defers the throw until Ready.
+                InsertColumn[] plan;
+                using (schema)
+                {
+                    plan = columns.Count == 0
+                        ? null
+                        : BuildInsertPlan(columns, schema, validateWritable: rowCount > 0, out mismatchError);
+                }
+
+                await StreamInsertRowsAsync(plan, rowCount, maxRowsPerBlock, negotiated, cancellationToken).ConfigureAwait(false);
+
+                // Rethrow any server error once the state is back to Ready.
+                pending = await DrainToEndOfStreamAsync(negotiated, handlers, cancellationToken).ConfigureAwait(false);
+                completed = true;
+            }
+        }
+        finally
+        {
+            if (completed)
+            {
+                state = TcpConnectionState.Ready;
+            }
+            else
+            {
+                Terminate();
+            }
+        }
+
+        if (pending is not null)
+        {
+            throw pending;
+        }
+
+        if (mismatchError is not null)
+        {
+            throw new ArgumentException(mismatchError, nameof(columns));
+        }
+    }
+
+    /// <summary>
+    /// Validates the arguments that need no server round-trip — non-null inputs, a positive
+    /// <paramref name="maxRowsPerBlock"/>, a consistent row count, and unique column names — and reports that row
+    /// count. Runs before the connection is claimed, so a malformed call leaves it idle. Name-to-schema
+    /// alignment and per-column writability need the sample block and are checked after the query round-trip.
+    /// </summary>
+    /// <param name="rowCount">Set to the row count every column must share (zero when there are no columns).</param>
+    private static void ValidateInsertArguments(
+        string sql,
+        IReadOnlyList<IColumn> columns,
+        int? maxRowsPerBlock,
+        out int rowCount)
+    {
+        ArgumentNullException.ThrowIfNull(sql);
+        ArgumentNullException.ThrowIfNull(columns);
+        if (maxRowsPerBlock is <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxRowsPerBlock), maxRowsPerBlock, "The rows-per-block cap must be positive.");
+        }
+
+        rowCount = columns.Count == 0 ? 0 : columns[0].RowCount;
+        for (int i = 1; i < columns.Count; i++)
+        {
+            if (columns[i].RowCount != rowCount)
+            {
+                throw new ArgumentException(
+                    $"All columns must hold the same number of rows; column 0 has {rowCount} but column {i} has {columns[i].RowCount}.",
+                    nameof(columns));
+            }
+        }
+
+        var names = new HashSet<string>(columns.Count, StringComparer.Ordinal);
+        foreach (IColumn column in columns)
+        {
+            if (!names.Add(column.Name))
+            {
+                throw new ArgumentException(
+                    $"Column '{column.Name}' is supplied more than once; column names must be unique.",
+                    nameof(columns));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Writes the INSERT row stream: the rows as bounded wire blocks (each read straight from the columns'
+    /// spans), then the empty terminator that closes it. A null <paramref name="plan"/> or zero
+    /// <paramref name="rowCount"/> writes only the terminator — a no-op insert. Trims the writer's pooled buffer
+    /// once everything is flushed.
+    /// </summary>
+    /// <param name="plan">The per-column write plan in schema order, or null to write only the terminator.</param>
+    private async ValueTask StreamInsertRowsAsync(
+        InsertColumn[] plan,
+        int rowCount,
+        int? maxRowsPerBlock,
+        NegotiatedProtocol negotiated,
+        CancellationToken cancellationToken)
+    {
+        if (rowCount > 0 && plan is not null)
+        {
+            var values = Array.ConvertAll(plan, p => p.Values);
+            var codecs = Array.ConvertAll(plan, p => p.Codec);
+            foreach ((int start, int length) in PlanInsertBlocks(values, codecs, rowCount, maxRowsPerBlock, BlockWriter.DefaultFlushThresholdBytes))
+            {
+                writer.WriteClientPacketType(ClientPacketType.Data);
+                await BlockWriter.WriteDataBlockAsync(
+                    writer, negotiated, plan, start, length, BlockWriter.DefaultFlushThresholdBytes, cancellationToken).ConfigureAwait(false);
+                await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        writer.WriteClientPacketType(ClientPacketType.Data);
+        BlockWriter.WriteEmptyBlock(writer);
+        await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
+
+        // Return the pooled buffer to baseline so an idle connection doesn't retain a large insert's peak size.
+        writer.TrimBuffer();
+    }
+
+    /// <summary>
+    /// Reads and releases blocks until the response ends, returning the server
+    /// <see cref="ClickHouseServerException"/> that terminated it, or null on a clean end-of-stream. Either way
+    /// the stream is left at a packet boundary, so the connection stays usable.
+    /// </summary>
+    /// <param name="negotiated">The negotiated protocol.</param>
+    /// <param name="handlers">Optional metadata callbacks for the interleaved packets, or null to discard them.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>The parked server exception, or null if the stream ended cleanly.</returns>
+    private async ValueTask<ClickHouseServerException> DrainToEndOfStreamAsync(
+        NegotiatedProtocol negotiated,
+        MetadataHandlers handlers,
+        CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            (Block block, ClickHouseServerException error) = await ReadToNextDataBlockAsync(negotiated, handlers, cancellationToken).ConfigureAwait(false);
+            if (block is null)
+            {
+                return error;
+            }
+
+            block.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Splits <paramref name="rowCount"/> rows into contiguous wire-block ranges, closing a block whenever adding
+    /// the next row would push its encoded body past <paramref name="byteLimit"/> or the block already holds
+    /// <paramref name="maxRowsPerBlock"/> rows — whichever limit a block reaches first. A single row larger than
+    /// the byte limit still forms its own block. With no <paramref name="maxRowsPerBlock"/> only the byte target
+    /// bounds a block: when every column is fixed-width the rows-per-block is a single division (uniform blocks,
+    /// nothing measured), and when any column is variable-width the rows are measured through the codecs.
+    /// </summary>
+    /// <param name="columns">The insert's columns, all of the same length.</param>
+    /// <param name="codecs">The resolved codec for each column, positionally aligned with <paramref name="columns"/>.</param>
+    /// <param name="rowCount">The number of rows to split (assumed greater than zero).</param>
+    /// <param name="maxRowsPerBlock">A cap on the rows per block, applied alongside <paramref name="byteLimit"/>, or null for no row cap.</param>
+    /// <param name="byteLimit">The per-block encoded-size target.</param>
+    /// <returns>The (start, length) row range of each wire block, in order.</returns>
+    internal static List<(int Start, int Length)> PlanInsertBlocks(
+        IReadOnlyList<IColumn> columns, IColumnCodec[] codecs, int rowCount, int? maxRowsPerBlock, long byteLimit)
+    {
+        var blocks = new List<(int Start, int Length)>();
+        int rowCap = maxRowsPerBlock ?? int.MaxValue;
+
+        long fixedBytesPerRow = 0;
+        List<(IColumn Column, IColumnCodec Codec)> variable = null;
+        for (int i = 0; i < columns.Count; i++)
+        {
+            if (codecs[i].FixedRowByteSize is int size)
+            {
+                fixedBytesPerRow += size;
+            }
+            else
+            {
+                (variable ??= new List<(IColumn, IColumnCodec)>()).Add((columns[i], codecs[i]));
+            }
+        }
+
+        if (variable is null)
+        {
+            // Every column is fixed-width, so every row costs the same: the rows that fill the byte budget is one
+            // division, and the block is bounded by whichever of that and the row cap is smaller. Blocks are
+            // uniform (bar the last), no per-row walk. A zero per-row size (no columns priced) can't be divided
+            // by, so bytes impose no limit and only the row cap (if any) applies.
+            long byteStep = fixedBytesPerRow == 0 ? rowCount : Math.Max(1, byteLimit / fixedBytesPerRow);
+            int step = (int)Math.Min(Math.Min((long)rowCount, byteStep), rowCap);
+            for (int start = 0; start < rowCount; start += step)
+            {
+                blocks.Add((start, Math.Min(step, rowCount - start)));
+            }
+
+            return blocks;
+        }
+
+        // At least one variable-width column, so each row must be measured. The fixed columns contribute a
+        // constant; only the variable ones are walked per row.
+        int blockStart = 0;
+        long blockBytes = 0;
+        for (int row = 0; row < rowCount; row++)
+        {
+            long rowBytes = fixedBytesPerRow;
+            foreach ((IColumn column, IColumnCodec codec) in variable)
+            {
+                rowBytes += codec.MeasureRowBytes(column, row);
+            }
+
+            // Close the current block before this row when it already holds a row and adding this one would cross
+            // the byte limit, or the block has reached the row cap — whichever comes first. A row larger than the
+            // byte limit on its own still becomes a single-row block.
+            if (row > blockStart && (blockBytes + rowBytes > byteLimit || row - blockStart >= rowCap))
+            {
+                blocks.Add((blockStart, row - blockStart));
+                blockStart = row;
+                blockBytes = 0;
+            }
+
+            blockBytes += rowBytes;
+        }
+
+        blocks.Add((blockStart, rowCount - blockStart));
+        return blocks;
+    }
+
+    /// <summary>
+    /// Aligns the caller's columns to the schema by name, returning one descriptor per schema column (in schema
+    /// order) that pairs the target's name, resolved type, and codec with the caller's values — the caller's own
+    /// type string is ignored. With <paramref name="validateWritable"/> set, a value column whose CLR type the
+    /// target cannot serialize is rejected. Returns null and sets <paramref name="error"/> on any mismatch.
+    /// </summary>
+    /// <param name="columns">The caller's value columns; names are unique (validated earlier).</param>
+    /// <param name="schema">The server's sample block describing the target columns.</param>
+    /// <param name="validateWritable">Whether to confirm each value column is writable as its target type.</param>
+    /// <param name="error">Set to a human-readable message on mismatch; null on success.</param>
+    /// <returns>The per-column write plan in schema order, or null when <paramref name="error"/> is set.</returns>
+    private static InsertColumn[] BuildInsertPlan(IReadOnlyList<IColumn> columns, Block schema, bool validateWritable, out string error)
+    {
+        error = null;
+
+        var byName = new Dictionary<string, IColumn>(columns.Count, StringComparer.Ordinal);
+        foreach (IColumn column in columns)
+        {
+            byName[column.Name] = column;
+        }
+
+        // Align by name: every schema column must be supplied and every supplied column must exist in the schema.
+        // Both directions are reported so a wrong column set is actionable, not just a count mismatch.
+        var plan = new InsertColumn[schema.ColumnCount];
+        List<string> missing = null;
+        int matched = 0;
+        for (int i = 0; i < schema.ColumnCount; i++)
+        {
+            IColumn schemaColumn = schema[i];
+            if (byName.TryGetValue(schemaColumn.Name, out IColumn value))
+            {
+                matched++;
+                plan[i] = new InsertColumn(schemaColumn.Name, schemaColumn.TypeName, codec: null, value);
+            }
+            else
+            {
+                (missing ??= new List<string>()).Add(schemaColumn.Name);
+            }
+        }
+
+        if (missing is not null || matched != columns.Count)
+        {
+            error = DescribeSchemaMismatch(columns, schema, missing);
+            return null;
+        }
+
+        // Names line up one-to-one; resolve each target type to its codec (the target type, not the caller's) and
+        // confirm the value column is writable as it.
+        for (int i = 0; i < plan.Length; i++)
+        {
+            InsertColumn slot = plan[i];
+            IColumnCodec codec;
+            try
+            {
+                codec = ColumnCodecRegistry.Default.Resolve(slot.TypeName);
+            }
+            catch (Exception ex) when (ex is NotSupportedException or FormatException)
+            {
+                error = $"The target column '{slot.Name}' has type '{slot.TypeName}', which this client cannot serialize: {ex.Message}";
+                return null;
+            }
+
+            if (validateWritable && !codec.CanWrite(slot.Values))
+            {
+                error = $"Column '{slot.Name}' was given a value column of type {slot.Values.GetType()}, whose CLR element type the target type '{slot.TypeName}' does not accept.";
+                return null;
+            }
+
+            plan[i] = new InsertColumn(slot.Name, slot.TypeName, codec, slot.Values);
+        }
+
+        return plan;
+    }
+
+    /// <summary>Composes a message naming the columns the caller failed to supply and the ones it supplied in excess.</summary>
+    private static string DescribeSchemaMismatch(IReadOnlyList<IColumn> columns, Block schema, List<string> missing)
+    {
+        var schemaNames = new HashSet<string>(StringComparer.Ordinal);
+        for (int i = 0; i < schema.ColumnCount; i++)
+        {
+            schemaNames.Add(schema[i].Name);
+        }
+
+        List<string> unexpected = null;
+        foreach (IColumn column in columns)
+        {
+            if (!schemaNames.Contains(column.Name))
+            {
+                (unexpected ??= new List<string>()).Add(column.Name);
+            }
+        }
+
+        var parts = new List<string>(2);
+        if (missing is not null)
+        {
+            parts.Add($"missing column(s) the target requires: {string.Join(", ", missing)}");
+        }
+
+        if (unexpected is not null)
+        {
+            parts.Add($"column(s) not in the target: {string.Join(", ", unexpected)}");
+        }
+
+        return $"The insert columns do not match the target schema — {string.Join("; ", parts)}. Columns are matched to the target by name.";
     }
 
     /// <summary>
@@ -473,6 +845,110 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
         }
 
         state = TcpConnectionState.Ready;
+    }
+
+    /// <summary>
+    /// Reads packets, consuming interleaved metadata, until the next Data block or a terminal packet. Returns
+    /// the decoded block (the caller owns and must dispose it), or a null block when the stream ended — with the
+    /// server Exception attached when the end was an <see cref="ServerPacketType.Exception"/>, or a null
+    /// exception on a clean <see cref="ServerPacketType.EndOfStream"/>. A read failure propagates; the caller
+    /// terminates the connection.
+    /// </summary>
+    /// <param name="negotiated">The negotiated protocol, for version-gated fields.</param>
+    /// <param name="handlers">Optional metadata callbacks for the interleaved packets, or null to discard them.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>The next Data block, or a null block plus the parked terminal exception (if any).</returns>
+    private async ValueTask<(Block block, ClickHouseServerException error)> ReadToNextDataBlockAsync(
+        NegotiatedProtocol negotiated,
+        MetadataHandlers handlers,
+        CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            ServerPacketType packet = await reader.ReadServerPacketTypeAsync(cancellationToken).ConfigureAwait(false);
+            switch (packet)
+            {
+                case ServerPacketType.EndOfStream:
+                    return (null, null);
+
+                case ServerPacketType.Exception:
+                    return (null, await ClickHouseServerException.ReadAsync(reader, cancellationToken).ConfigureAwait(false));
+
+                case ServerPacketType.Data:
+                    return (await BlockReader.ReadBlockAsync(reader, negotiated, ColumnCodecRegistry.Default, cancellationToken).ConfigureAwait(false), null);
+
+                default:
+                    await ConsumeMetadataAsync(packet, negotiated, handlers, cancellationToken).ConfigureAwait(false);
+                    break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Consumes one interleaved metadata packet to keep the stream aligned, handing it to the matching callback
+    /// in <paramref name="handlers"/> when one is set and discarding it otherwise. Shared by the query and insert
+    /// response drains. Any packet type not valid mid-response at this protocol target is a violation.
+    /// </summary>
+    /// <param name="packet">The packet type just read (never Data, Exception, or EndOfStream).</param>
+    /// <param name="negotiated">The negotiated protocol, for version-gated fields.</param>
+    /// <param name="handlers">Optional metadata callbacks, or null to discard every packet.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <exception cref="ClickHouseProtocolException"><paramref name="packet"/> is not a valid interleaved packet.</exception>
+    private async ValueTask ConsumeMetadataAsync(
+        ServerPacketType packet,
+        NegotiatedProtocol negotiated,
+        MetadataHandlers handlers,
+        CancellationToken cancellationToken)
+    {
+        switch (packet)
+        {
+            // Block-bearing packets lend the borrowed block to the handler for the call, then release it.
+            case ServerPacketType.Totals:
+                await ReadMetadataBlockAsync(reader, negotiated, handlers?.OnTotals, cancellationToken).ConfigureAwait(false);
+                break;
+
+            case ServerPacketType.Extremes:
+                await ReadMetadataBlockAsync(reader, negotiated, handlers?.OnExtremes, cancellationToken).ConfigureAwait(false);
+                break;
+
+            case ServerPacketType.ProfileEvents:
+                await ReadMetadataBlockAsync(reader, negotiated, handlers?.OnProfileEvents, cancellationToken).ConfigureAwait(false);
+                break;
+
+            case ServerPacketType.Log:
+                await ReadMetadataBlockAsync(reader, negotiated, handlers?.OnLog, cancellationToken).ConfigureAwait(false);
+                break;
+
+            case ServerPacketType.Progress:
+            {
+                Progress progress = await Progress.ReadAsync(reader, negotiated, cancellationToken).ConfigureAwait(false);
+                handlers?.OnProgress?.Invoke(progress);
+                break;
+            }
+
+            case ServerPacketType.ProfileInfo:
+            {
+                ProfileInfo profileInfo = await ProfileInfo.ReadAsync(reader, cancellationToken).ConfigureAwait(false);
+                handlers?.OnProfileInfo?.Invoke(profileInfo);
+                break;
+            }
+
+            case ServerPacketType.TableColumns:
+                // Column-defaults metadata the server may send before the schema block; decoded to stay aligned
+                // and discarded (no result surface yet).
+                await TableColumns.ReadAsync(reader, cancellationToken).ConfigureAwait(false);
+                break;
+
+            case ServerPacketType.PartUUIDs:
+                // Valid when part-level deduplication is active; consumed to stay aligned. TODO: surface.
+                await PartUUIDs.ConsumeAsync(reader, cancellationToken).ConfigureAwait(false);
+                break;
+
+            default:
+                // Anything else (e.g. TimezoneUpdate, a read-task request) is not valid interleaved in a query or
+                // insert response at this protocol target.
+                throw new ClickHouseProtocolException($"Unexpected packet type {packet} ({(ulong)packet}) in server response.");
+        }
     }
 
     /// <summary>

--- a/ClickHouse.Driver.Tcp/Protocol/ClickHouseTcpConnection.cs
+++ b/ClickHouse.Driver.Tcp/Protocol/ClickHouseTcpConnection.cs
@@ -471,13 +471,22 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
             throw new ArgumentOutOfRangeException(nameof(maxRowsPerBlock), maxRowsPerBlock, "The rows-per-block cap must be positive.");
         }
 
-        rowCount = columns.Count == 0 ? 0 : columns[0].RowCount;
-        for (int i = 1; i < columns.Count; i++)
+        rowCount = 0;
+        for (int i = 0; i < columns.Count; i++)
         {
-            if (columns[i].RowCount != rowCount)
+            // Reject a null element with a clear error before the connection is claimed, rather than NREing
+            // mid-validation on its RowCount/Name.
+            IColumn column = columns[i]
+                ?? throw new ArgumentException($"Column at index {i} is null; every supplied column must be non-null.", nameof(columns));
+
+            if (i == 0)
+            {
+                rowCount = column.RowCount;
+            }
+            else if (column.RowCount != rowCount)
             {
                 throw new ArgumentException(
-                    $"All columns must hold the same number of rows; column 0 has {rowCount} but column {i} has {columns[i].RowCount}.",
+                    $"All columns must hold the same number of rows; column 0 has {rowCount} but column {i} has {column.RowCount}.",
                     nameof(columns));
             }
         }

--- a/ClickHouse.Driver.Tcp/Protocol/ClickHouseTcpConnection.cs
+++ b/ClickHouse.Driver.Tcp/Protocol/ClickHouseTcpConnection.cs
@@ -320,10 +320,10 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
     }
 
     /// <summary>
-    /// The default cap on the rows per wire block (1,000,000), applied alongside the byte target
-    /// (<see cref="BlockWriter.DefaultFlushThresholdBytes"/>) so a block closes at whichever it reaches first.
-    /// The byte target is the primary, width-invariant bound; this row cap keeps very narrow rows from producing
-    /// an unbounded row count in a single block.
+    /// The default cap on the rows per wire block (1,000,000). Block geometry is bounded by row count alone, so
+    /// this cap is what splits a large insert into bounded blocks. Peak buffered bytes while a block is written
+    /// are bounded separately by the between-column flush backstop
+    /// (<see cref="BlockWriter.DefaultFlushThresholdBytes"/>), which flushes mid-block rather than closing it.
     /// </summary>
     public const int DefaultMaxRowsPerBlock = 1_000_000;
 
@@ -337,17 +337,18 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
     /// filling the rest from their defaults. Values are serialized as the target's resolved type, not the type
     /// the column declares. Zero rows is a no-op INSERT. A mismatch (wrong names, or a CLR type the target
     /// cannot accept) writes nothing and leaves the connection usable before throwing. Large inserts are split
-    /// into wire blocks sized to an internal byte target, additionally capped at <paramref name="maxRowsPerBlock"/>
-    /// rows per block when set (a block closes at whichever limit it reaches first).
+    /// into wire blocks of at most <paramref name="maxRowsPerBlock"/> rows each — row count is the only bound on
+    /// block geometry — or written as a single block when the cap is null.
     /// </remarks>
     /// <param name="sql">The <c>INSERT INTO … VALUES</c> statement, with no inline <c>VALUES (...)</c> literal.</param>
     /// <param name="columns">The row data, matched to the target columns by name.</param>
     /// <param name="settings">Per-query settings as textual values, or null for none.</param>
     /// <param name="parameters">Query parameter values in SQL representation, or null for none.</param>
     /// <param name="queryId">The query id, or null to let the server assign one.</param>
-    /// <param name="maxRowsPerBlock">A cap on the rows per wire block, applied alongside the internal byte target
-    /// (a block closes at whichever it reaches first). Defaults to <see cref="DefaultMaxRowsPerBlock"/>; pass null
-    /// for no row cap (byte target only).</param>
+    /// <param name="maxRowsPerBlock">A cap on the rows per wire block — the only bound on block geometry.
+    /// Defaults to <see cref="DefaultMaxRowsPerBlock"/>; pass null to write the whole insert as a single block.
+    /// Peak buffered bytes are bounded separately by the between-column flush backstop
+    /// (<see cref="BlockWriter.DefaultFlushThresholdBytes"/>).</param>
     /// <param name="handlers">Optional callbacks for the metadata the server interleaves into the insert
     /// acknowledgement (notably <see cref="MetadataHandlers.OnProgress"/> for rows written and
     /// <see cref="MetadataHandlers.OnProfileEvents"/>), or null to discard it.</param>

--- a/ClickHouse.Driver.Tcp/Protocol/MetadataHandlers.cs
+++ b/ClickHouse.Driver.Tcp/Protocol/MetadataHandlers.cs
@@ -4,14 +4,14 @@ using ClickHouse.Driver.Tcp.Format;
 namespace ClickHouse.Driver.Tcp.Protocol;
 
 /// <summary>
-/// Optional per-query callbacks for the metadata packets the server interleaves with a query's Data blocks.
-/// Each handler is optional; where one is null the corresponding packet is still consumed to keep the stream
+/// Optional callbacks for the metadata packets the server interleaves into a query or insert response. Each
+/// handler is optional; where one is null the corresponding packet is still consumed to keep the stream
 /// aligned, but its contents are discarded.
 ///
 /// <para>
 /// Handlers run synchronously on the thread draining the response, in the order the packets arrive on the
 /// wire. Keep them fast: they sit on the read path between blocks. A handler that throws propagates out of the
-/// enumeration and terminates the connection, so a handler must not throw for control flow.
+/// operation and terminates the connection, so a handler must not throw for control flow.
 /// </para>
 ///
 /// <para>
@@ -24,7 +24,7 @@ namespace ClickHouse.Driver.Tcp.Protocol;
 /// </summary>
 internal sealed class MetadataHandlers
 {
-    /// <summary>Invoked for each Progress packet, which the server sends repeatedly as the query advances.</summary>
+    /// <summary>Invoked for each Progress packet, which the server sends repeatedly as work advances.</summary>
     public Action<Progress> OnProgress { get; init; }
 
     /// <summary>Invoked for the ProfileInfo summary (rows/blocks/bytes read, limit application).</summary>

--- a/ClickHouse.Driver.Tcp/Types/ArrayColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/ArrayColumn.cs
@@ -11,6 +11,8 @@ namespace ClickHouse.Driver.Tcp.Types;
 internal sealed class ArrayColumn<T> : IColumn<T>
 {
     private readonly T[] values;
+    private readonly int offset;
+    private readonly int length;
 
     /// <summary>Initializes a column that takes ownership of the values array.</summary>
     /// <param name="name">The column name.</param>
@@ -18,10 +20,17 @@ internal sealed class ArrayColumn<T> : IColumn<T>
     /// <param name="values">The decoded values.</param>
     /// <exception cref="ArgumentNullException"><paramref name="values"/> is null.</exception>
     public ArrayColumn(string name, string typeName, T[] values)
+        : this(name, typeName, values, offset: 0, values?.Length ?? 0)
+    {
+    }
+
+    private ArrayColumn(string name, string typeName, T[] values, int offset, int length)
     {
         Name = name;
         TypeName = typeName;
         this.values = values ?? throw new ArgumentNullException(nameof(values));
+        this.offset = offset;
+        this.length = length;
     }
 
     /// <inheritdoc/>
@@ -31,16 +40,16 @@ internal sealed class ArrayColumn<T> : IColumn<T>
     public string TypeName { get; }
 
     /// <inheritdoc/>
-    public int RowCount => values.Length;
+    public int RowCount => length;
 
     /// <inheritdoc/>
-    public ReadOnlySpan<T> Values => values;
+    public ReadOnlySpan<T> Values => new ReadOnlySpan<T>(values, offset, length);
 
     /// <inheritdoc/>
-    public T this[int row] => values[row];
+    public T this[int row] => values[offset + row];
 
     /// <inheritdoc/>
-    public object GetValue(int row) => values[row];
+    public object GetValue(int row) => values[offset + row];
 
     /// <inheritdoc/>
     public void Dispose()

--- a/ClickHouse.Driver.Tcp/Types/ArrayColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/ArrayColumn.cs
@@ -8,7 +8,7 @@ namespace ClickHouse.Driver.Tcp.Types;
 /// borrowed view over the array.
 /// </summary>
 /// <typeparam name="T">The CLR element type.</typeparam>
-internal sealed class ArrayColumn<T> : IColumn<T>
+internal sealed class ArrayColumn<T> : IColumn<T>, ISpanColumn<T>
 {
     private readonly T[] values;
     private readonly int offset;
@@ -44,6 +44,9 @@ internal sealed class ArrayColumn<T> : IColumn<T>
 
     /// <inheritdoc/>
     public ReadOnlySpan<T> Values => new ReadOnlySpan<T>(values, offset, length);
+
+    /// <inheritdoc/>
+    ReadOnlySpan<T> ISpanColumn<T>.Span => Values;
 
     /// <inheritdoc/>
     public T this[int row] => values[offset + row];

--- a/ClickHouse.Driver.Tcp/Types/Codecs/DateTimeColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/DateTimeColumnCodec.cs
@@ -27,6 +27,9 @@ internal sealed class DateTimeColumnCodec : IColumnCodec
     public string TypeName => "DateTime";
 
     /// <inheritdoc/>
+    public int? FixedRowByteSize => sizeof(uint);
+
+    /// <inheritdoc/>
     public async ValueTask<IColumn> ReadColumnAsync(ClickHouseBinaryReader reader, string columnName, string columnType, int rowCount, CancellationToken cancellationToken)
     {
         var values = new DateTime[rowCount];
@@ -57,12 +60,50 @@ internal sealed class DateTimeColumnCodec : IColumnCodec
     }
 
     /// <inheritdoc/>
-    public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column)
+    public bool CanWrite(IColumn column) => column is IColumn<DateTime> or IColumn<DateTimeOffset>;
+
+    /// <inheritdoc/>
+    public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
     {
-        foreach (DateTime value in ((IColumn<DateTime>)column).Values)
+        // Both a UTC instant (DateTimeOffset) and a DateTime map to the same epoch-second column body; a
+        // DateTime is normalized to UTC first (its offset, if any, is resolved by ToUniversalTime).
+        switch (column)
         {
-            long seconds = (long)(value.ToUniversalTime() - DateTime.UnixEpoch).TotalSeconds;
-            writer.WriteUInt32((uint)seconds);
+            case IColumn<DateTime> dateTimes:
+                foreach (DateTime value in dateTimes.Values.Slice(start, length))
+                {
+                    writer.WriteUInt32(ToUnixSeconds(value.ToUniversalTime()));
+                }
+
+                break;
+
+            case IColumn<DateTimeOffset> offsets:
+                foreach (DateTimeOffset value in offsets.Values.Slice(start, length))
+                {
+                    writer.WriteUInt32(ToUnixSeconds(value.UtcDateTime));
+                }
+
+                break;
+
+            default:
+                throw new ArgumentException($"A DateTime column must hold DateTime or DateTimeOffset values, not {column.GetType()}.", nameof(column));
         }
+    }
+
+    private static uint ToUnixSeconds(DateTime utc)
+    {
+        // Seconds from ticks (not TotalSeconds, which is a double), then range-check: ClickHouse DateTime is a
+        // UInt32 second count, so anything before the epoch or past 2106-02-07 06:28:15 UTC cannot be
+        // represented and must fail loudly rather than silently wrap.
+        long seconds = (utc - DateTime.UnixEpoch).Ticks / TimeSpan.TicksPerSecond;
+        if (seconds < 0 || seconds > uint.MaxValue)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(utc),
+                utc,
+                "DateTime is outside the range ClickHouse DateTime can hold (1970-01-01 to 2106-02-07 06:28:15 UTC).");
+        }
+
+        return (uint)seconds;
     }
 }

--- a/ClickHouse.Driver.Tcp/Types/Codecs/DateTimeColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/DateTimeColumnCodec.cs
@@ -27,9 +27,6 @@ internal sealed class DateTimeColumnCodec : IColumnCodec
     public string TypeName => "DateTime";
 
     /// <inheritdoc/>
-    public int? FixedRowByteSize => sizeof(uint);
-
-    /// <inheritdoc/>
     public async ValueTask<IColumn> ReadColumnAsync(ClickHouseBinaryReader reader, string columnName, string columnType, int rowCount, CancellationToken cancellationToken)
     {
         var values = new DateTime[rowCount];
@@ -70,17 +67,17 @@ internal sealed class DateTimeColumnCodec : IColumnCodec
         switch (column)
         {
             case IColumn<DateTime> dateTimes:
-                foreach (DateTime value in dateTimes.Values.Slice(start, length))
+                for (int i = 0; i < length; i++)
                 {
-                    writer.WriteUInt32(ToUnixSeconds(value.ToUniversalTime()));
+                    writer.WriteUInt32(ToUnixSeconds(dateTimes[start + i].ToUniversalTime()));
                 }
 
                 break;
 
             case IColumn<DateTimeOffset> offsets:
-                foreach (DateTimeOffset value in offsets.Values.Slice(start, length))
+                for (int i = 0; i < length; i++)
                 {
-                    writer.WriteUInt32(ToUnixSeconds(value.UtcDateTime));
+                    writer.WriteUInt32(ToUnixSeconds(offsets[start + i].UtcDateTime));
                 }
 
                 break;

--- a/ClickHouse.Driver.Tcp/Types/Codecs/IntegerColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/IntegerColumnCodec.cs
@@ -33,6 +33,9 @@ internal sealed class IntegerColumnCodec<T> : IColumnCodec
     public string TypeName { get; }
 
     /// <inheritdoc/>
+    public int? FixedRowByteSize => Unsafe.SizeOf<T>();
+
+    /// <inheritdoc/>
     public async ValueTask<IColumn> ReadColumnAsync(ClickHouseBinaryReader reader, string columnName, string columnType, int rowCount, CancellationToken cancellationToken)
     {
         if (rowCount == 0)
@@ -57,8 +60,11 @@ internal sealed class IntegerColumnCodec<T> : IColumnCodec
     }
 
     /// <inheritdoc/>
-    public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column)
+    public bool CanWrite(IColumn column) => column is IColumn<T>;
+
+    /// <inheritdoc/>
+    public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
     {
-        writer.WriteBytes(MemoryMarshal.AsBytes(((IColumn<T>)column).Values));
+        writer.WriteBytes(MemoryMarshal.AsBytes(((IColumn<T>)column).Values.Slice(start, length)));
     }
 }

--- a/ClickHouse.Driver.Tcp/Types/Codecs/IntegerColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/IntegerColumnCodec.cs
@@ -22,7 +22,7 @@ namespace ClickHouse.Driver.Tcp.Types.Codecs;
 /// </para>
 /// </summary>
 /// <typeparam name="T">The CLR type the ClickHouse integer maps to.</typeparam>
-internal sealed class IntegerColumnCodec<T> : IColumnCodec
+internal sealed class IntegerColumnCodec<T> : IColumnCodec, ISpanWritableCodec<T>
     where T : unmanaged
 {
     /// <summary>Initializes a new instance of the <see cref="IntegerColumnCodec{T}"/> class.</summary>
@@ -31,9 +31,6 @@ internal sealed class IntegerColumnCodec<T> : IColumnCodec
 
     /// <inheritdoc/>
     public string TypeName { get; }
-
-    /// <inheritdoc/>
-    public int? FixedRowByteSize => Unsafe.SizeOf<T>();
 
     /// <inheritdoc/>
     public async ValueTask<IColumn> ReadColumnAsync(ClickHouseBinaryReader reader, string columnName, string columnType, int rowCount, CancellationToken cancellationToken)
@@ -63,8 +60,27 @@ internal sealed class IntegerColumnCodec<T> : IColumnCodec
     public bool CanWrite(IColumn column) => column is IColumn<T>;
 
     /// <inheritdoc/>
+    // A contiguous column (the dense read-back, or a caller's array-backed column) blits its whole slice in one
+    // copy; a scattered write-path view (Nullable's substitute, a Tuple field, a Variant alternative) has no span,
+    // so each value is written on its own — the per-element cost the scattered fixed-width positions accept.
     public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
     {
-        writer.WriteBytes(MemoryMarshal.AsBytes(((IColumn<T>)column).Values.Slice(start, length)));
+        var typed = (IColumn<T>)column;
+        if (typed is ISpanColumn<T> contiguous)
+        {
+            writer.WriteBytes(MemoryMarshal.AsBytes(contiguous.Span.Slice(start, length)));
+            return;
+        }
+
+        for (int i = 0; i < length; i++)
+        {
+            T value = typed[start + i];
+            writer.WriteBytes(MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref value, 1)));
+        }
     }
+
+    /// <inheritdoc/>
+    // The wire form is the raw little-endian bytes, so a run of values is one contiguous blit.
+    public void WriteValues(ClickHouseBinaryWriter writer, ReadOnlySpan<T> values)
+        => writer.WriteBytes(MemoryMarshal.AsBytes(values));
 }

--- a/ClickHouse.Driver.Tcp/Types/Codecs/StringColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/StringColumnCodec.cs
@@ -1,4 +1,4 @@
-using System.Text;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using ClickHouse.Driver.Tcp.Protocol;
@@ -9,7 +9,7 @@ namespace ClickHouse.Driver.Tcp.Types.Codecs;
 /// A codec for the ClickHouse <c>String</c> column: each row is a VarUInt byte-length prefix followed by that
 /// many bytes, decoded as UTF-8. Values are read row-by-row (each carries its own length).
 /// </summary>
-internal sealed class StringColumnCodec : IColumnCodec
+internal sealed class StringColumnCodec : IColumnCodec, ISpanWritableCodec<string>
 {
     /// <summary>The shared, stateless instance.</summary>
     public static readonly StringColumnCodec Instance = new();
@@ -34,20 +34,25 @@ internal sealed class StringColumnCodec : IColumnCodec
     }
 
     /// <inheritdoc/>
-    public long MeasureRowBytes(IColumn column, int row)
-    {
-        // Mirrors WriteString: a VarUInt byte-length prefix followed by the UTF-8 bytes.
-        int byteCount = Encoding.UTF8.GetByteCount(((IColumn<string>)column)[row]);
-        return ClickHouseBinaryWriter.MeasureVarUInt((ulong)byteCount) + byteCount;
-    }
-
-    /// <inheritdoc/>
     public bool CanWrite(IColumn column) => column is IColumn<string>;
 
     /// <inheritdoc/>
+    // Read per element through the indexer so a scattered write-path view (a substitute for a nullable string, a
+    // Tuple field) writes with no materialized copy; a contiguous column reads each row just the same.
     public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
     {
-        foreach (string value in ((IColumn<string>)column).Values.Slice(start, length))
+        var typed = (IColumn<string>)column;
+        for (int i = 0; i < length; i++)
+        {
+            writer.WriteString(typed[start + i]);
+        }
+    }
+
+    /// <inheritdoc/>
+    // Each element is its own length-prefixed byte run, so a run of values is just written in order.
+    public void WriteValues(ClickHouseBinaryWriter writer, ReadOnlySpan<string> values)
+    {
+        foreach (string value in values)
         {
             writer.WriteString(value);
         }

--- a/ClickHouse.Driver.Tcp/Types/Codecs/StringColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/StringColumnCodec.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using ClickHouse.Driver.Tcp.Protocol;
@@ -33,9 +34,20 @@ internal sealed class StringColumnCodec : IColumnCodec
     }
 
     /// <inheritdoc/>
-    public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column)
+    public long MeasureRowBytes(IColumn column, int row)
     {
-        foreach (string value in ((IColumn<string>)column).Values)
+        // Mirrors WriteString: a VarUInt byte-length prefix followed by the UTF-8 bytes.
+        int byteCount = Encoding.UTF8.GetByteCount(((IColumn<string>)column)[row]);
+        return ClickHouseBinaryWriter.MeasureVarUInt((ulong)byteCount) + byteCount;
+    }
+
+    /// <inheritdoc/>
+    public bool CanWrite(IColumn column) => column is IColumn<string>;
+
+    /// <inheritdoc/>
+    public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
+    {
+        foreach (string value in ((IColumn<string>)column).Values.Slice(start, length))
         {
             writer.WriteString(value);
         }

--- a/ClickHouse.Driver.Tcp/Types/ColumnCodecExtensions.cs
+++ b/ClickHouse.Driver.Tcp/Types/ColumnCodecExtensions.cs
@@ -1,0 +1,14 @@
+using ClickHouse.Driver.Tcp.Protocol;
+
+namespace ClickHouse.Driver.Tcp.Types;
+
+/// <summary>Convenience helpers over <see cref="IColumnCodec"/>.</summary>
+internal static class ColumnCodecExtensions
+{
+    /// <summary>Writes all of the column's values — rows [0, <see cref="IColumn.RowCount"/>).</summary>
+    /// <param name="codec">The codec to write with.</param>
+    /// <param name="writer">The writer to encode into.</param>
+    /// <param name="column">The column whose values to write; must match the codec's element type.</param>
+    public static void WriteColumn(this IColumnCodec codec, ClickHouseBinaryWriter writer, IColumn column)
+        => codec.WriteColumn(writer, column, 0, column.RowCount);
+}

--- a/ClickHouse.Driver.Tcp/Types/IColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/IColumnCodec.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using ClickHouse.Driver.Tcp.Protocol;
@@ -20,6 +21,25 @@ internal interface IColumnCodec
     /// <summary>The canonical base type name this codec handles (e.g. <c>UInt64</c>, <c>String</c>).</summary>
     string TypeName { get; }
 
+    /// <summary>
+    /// The exact number of value bytes <see cref="WriteColumn"/> emits per row when that size is identical for
+    /// every row (fixed-width types), or null when a row's size varies (e.g. <c>String</c>). The insert
+    /// splitter uses this to price fixed-width columns in O(1) and walk only the variable-width ones per row.
+    /// </summary>
+    int? FixedRowByteSize => null;
+
+    /// <summary>
+    /// The exact number of value bytes <see cref="WriteColumn"/> emits for row <paramref name="row"/> of
+    /// <paramref name="column"/> (state prefix and header excluded). Fixed-width codecs inherit this from
+    /// <see cref="FixedRowByteSize"/>; a variable-width codec overrides it to measure the value.
+    /// </summary>
+    /// <param name="column">The column being measured.</param>
+    /// <param name="row">The zero-based row index.</param>
+    /// <returns>The encoded byte length of that row's value.</returns>
+    long MeasureRowBytes(IColumn column, int row)
+        => FixedRowByteSize ?? throw new NotSupportedException(
+            $"The '{TypeName}' codec has a variable per-row size and must override {nameof(MeasureRowBytes)}.");
+
     /// <summary>Reads the column's serialization state prefix, if any. Default: none.</summary>
     /// <param name="reader">The reader positioned at the prefix.</param>
     /// <param name="cancellationToken">A token to observe for cancellation.</param>
@@ -35,14 +55,31 @@ internal interface IColumnCodec
     /// <returns>The decoded column.</returns>
     ValueTask<IColumn> ReadColumnAsync(ClickHouseBinaryReader reader, string columnName, string columnType, int rowCount, CancellationToken cancellationToken);
 
+    /// <summary>
+    /// Whether <see cref="WriteColumn"/> accepts <paramref name="column"/>'s CLR element type. A codec may
+    /// accept several (e.g. a date-time codec taking both <see cref="System.DateTime"/> and
+    /// <see cref="System.DateTimeOffset"/>), so this is a membership test. Inserts check it up front so a bad
+    /// column type is a clear error rather than a mid-write cast failure.
+    /// </summary>
+    /// <param name="column">The column to test.</param>
+    /// <returns><see langword="true"/> if <see cref="WriteColumn"/> accepts <paramref name="column"/>.</returns>
+    bool CanWrite(IColumn column);
+
     /// <summary>Writes the column's serialization state prefix, if any. Default: none.</summary>
     /// <param name="writer">The writer to encode into.</param>
     void WriteStatePrefix(ClickHouseBinaryWriter writer)
     {
     }
 
-    /// <summary>Writes all of the column's values.</summary>
+    /// <summary>
+    /// Writes rows [<paramref name="start"/>, <paramref name="start"/> + <paramref name="length"/>) of the
+    /// column, slicing <see cref="IColumn{T}.Values"/> directly so a large insert splits into bounded blocks
+    /// with no copying. To write the whole column use the
+    /// <see cref="ColumnCodecExtensions.WriteColumn(IColumnCodec, ClickHouseBinaryWriter, IColumn)"/> overload.
+    /// </summary>
     /// <param name="writer">The writer to encode into.</param>
     /// <param name="column">The column whose values to write; must match this codec's element type.</param>
-    void WriteColumn(ClickHouseBinaryWriter writer, IColumn column);
+    /// <param name="start">The zero-based first row to write.</param>
+    /// <param name="length">The number of rows to write.</param>
+    void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length);
 }

--- a/ClickHouse.Driver.Tcp/Types/IColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/IColumnCodec.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 using ClickHouse.Driver.Tcp.Protocol;
@@ -20,25 +19,6 @@ internal interface IColumnCodec
 {
     /// <summary>The canonical base type name this codec handles (e.g. <c>UInt64</c>, <c>String</c>).</summary>
     string TypeName { get; }
-
-    /// <summary>
-    /// The exact number of value bytes <see cref="WriteColumn"/> emits per row when that size is identical for
-    /// every row (fixed-width types), or null when a row's size varies (e.g. <c>String</c>). The insert
-    /// splitter uses this to price fixed-width columns in O(1) and walk only the variable-width ones per row.
-    /// </summary>
-    int? FixedRowByteSize => null;
-
-    /// <summary>
-    /// The exact number of value bytes <see cref="WriteColumn"/> emits for row <paramref name="row"/> of
-    /// <paramref name="column"/> (state prefix and header excluded). Fixed-width codecs inherit this from
-    /// <see cref="FixedRowByteSize"/>; a variable-width codec overrides it to measure the value.
-    /// </summary>
-    /// <param name="column">The column being measured.</param>
-    /// <param name="row">The zero-based row index.</param>
-    /// <returns>The encoded byte length of that row's value.</returns>
-    long MeasureRowBytes(IColumn column, int row)
-        => FixedRowByteSize ?? throw new NotSupportedException(
-            $"The '{TypeName}' codec has a variable per-row size and must override {nameof(MeasureRowBytes)}.");
 
     /// <summary>Reads the column's serialization state prefix, if any. Default: none.</summary>
     /// <param name="reader">The reader positioned at the prefix.</param>

--- a/ClickHouse.Driver.Tcp/Types/ISpanColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/ISpanColumn.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace ClickHouse.Driver.Tcp.Types;
+
+/// <summary>
+/// A column whose values live in one contiguous run of memory, so a codec can blit them in a single bulk copy
+/// rather than reading them one at a time. The dense read-back columns and a caller's own array-backed column
+/// implement this; the lazy write-path <em>views</em> (which compute a value per index over another column) do
+/// not, so a codec handed one of those falls back to its per-element write.
+/// </summary>
+/// <typeparam name="T">The CLR element type.</typeparam>
+internal interface ISpanColumn<T>
+{
+    /// <summary>The values as one contiguous span — the same sequence as the indexer, addressable in bulk.</summary>
+    ReadOnlySpan<T> Span { get; }
+}

--- a/ClickHouse.Driver.Tcp/Types/ISpanWritableCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/ISpanWritableCodec.cs
@@ -1,0 +1,26 @@
+using ClickHouse.Driver.Tcp.Protocol;
+
+namespace ClickHouse.Driver.Tcp.Types;
+
+/// <summary>
+/// A leaf codec whose values encode as one flat per-element stream with no framing sections (no null-map, no
+/// dictionary, no offsets) — the fixed-width types, <c>String</c>, and <c>FixedString</c>. Because the stream is
+/// just the elements back to back, a run of elements can be written on its own, which lets a concatenating
+/// composite (<c>Array</c>, <c>Map</c>, <c>Nested</c>) drive the wire straight from the ergonomic per-row arrays
+/// one run at a time — a contiguous bulk blit for the fixed-width codecs — with no flat buffer built first.
+///
+/// <para>
+/// This is <em>only</em> valid for a codec with no serialization sections spanning the whole run; a sectioned
+/// inner (<c>Nullable</c>, <c>LowCardinality</c>, a nested <c>Array</c>, <c>Dynamic</c>) must instead see every
+/// element as one column so its section is emitted once, so those codecs do not implement this and are fed a
+/// flattening view instead.
+/// </para>
+/// </summary>
+/// <typeparam name="T">The codec's CLR element type.</typeparam>
+internal interface ISpanWritableCodec<T>
+{
+    /// <summary>Writes <paramref name="values"/> as a run of the codec's per-element encoding, in order.</summary>
+    /// <param name="writer">The writer to encode into.</param>
+    /// <param name="values">The contiguous run of values to write.</param>
+    void WriteValues(ClickHouseBinaryWriter writer, System.ReadOnlySpan<T> values);
+}

--- a/ClickHouse.Driver.Tcp/Types/PrimitiveColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/PrimitiveColumn.cs
@@ -18,7 +18,7 @@ namespace ClickHouse.Driver.Tcp.Types;
 /// </para>
 /// </summary>
 /// <typeparam name="T">The CLR type the ClickHouse integer maps to.</typeparam>
-internal sealed class PrimitiveColumn<T> : IColumn<T>
+internal sealed class PrimitiveColumn<T> : IColumn<T>, ISpanColumn<T>
     where T : unmanaged
 {
     private readonly int byteOffset;
@@ -59,6 +59,9 @@ internal sealed class PrimitiveColumn<T> : IColumn<T>
 
     /// <inheritdoc/>
     public ReadOnlySpan<T> Values => MemoryMarshal.Cast<byte, T>(buffer.AsSpan(byteOffset, length));
+
+    /// <inheritdoc/>
+    ReadOnlySpan<T> ISpanColumn<T>.Span => Values;
 
     /// <inheritdoc/>
     public T this[int row] => Values[row];

--- a/ClickHouse.Driver.Tcp/Types/PrimitiveColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/PrimitiveColumn.cs
@@ -21,6 +21,7 @@ namespace ClickHouse.Driver.Tcp.Types;
 internal sealed class PrimitiveColumn<T> : IColumn<T>
     where T : unmanaged
 {
+    private readonly int byteOffset;
     private readonly int length;
     private readonly bool pooled;
     private byte[] buffer;
@@ -33,10 +34,16 @@ internal sealed class PrimitiveColumn<T> : IColumn<T>
     /// <param name="pooled">Whether <paramref name="buffer"/> was rented and should be returned on dispose.</param>
     /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
     public PrimitiveColumn(string name, string typeName, byte[] buffer, int length, bool pooled)
+        : this(name, typeName, buffer, byteOffset: 0, length, pooled)
+    {
+    }
+
+    private PrimitiveColumn(string name, string typeName, byte[] buffer, int byteOffset, int length, bool pooled)
     {
         Name = name;
         TypeName = typeName;
         this.buffer = buffer ?? throw new ArgumentNullException(nameof(buffer));
+        this.byteOffset = byteOffset;
         this.length = length;
         this.pooled = pooled;
     }
@@ -51,7 +58,7 @@ internal sealed class PrimitiveColumn<T> : IColumn<T>
     public int RowCount => length / Unsafe.SizeOf<T>();
 
     /// <inheritdoc/>
-    public ReadOnlySpan<T> Values => MemoryMarshal.Cast<byte, T>(buffer.AsSpan(0, length));
+    public ReadOnlySpan<T> Values => MemoryMarshal.Cast<byte, T>(buffer.AsSpan(byteOffset, length));
 
     /// <inheritdoc/>
     public T this[int row] => Values[row];


### PR DESCRIPTION
## Summary

Adds the INSERT (write) path to the native-TCP client, so a connection can stream columnar data to the server end-to-end: build data columns from `IColumn`s, hand them to `InsertAsync`, and they round-trip through a `SELECT`. Columns are aligned to the target by **name**, so a statement may name a subset of the table's columns (`INSERT INTO t (a, c) VALUES`) and the server fills the rest from their `DEFAULT`/`MATERIALIZED` expressions. Stacked on the read-side work in the base branch (`tcp/epic-e-blocks-and-queries`).

## What's included

**Populated block writer** — `BlockWriter.WriteDataBlockAsync`
- Writes a full Data block that mirrors `BlockReader` exactly: table name, block info, column/row counts, then per column the header (name, type, and the `has_custom_serialization=0` byte when the negotiated protocol carries it), the state prefix, and the codec body.
- Two overloads: one where each `IColumn` supplies its own header and the codec is resolved from its type; and one over an `InsertColumn` descriptor (header + codec + values) so the INSERT path can emit the **target schema's** authoritative name and resolved type while serializing the caller's values. Both take a `(start, length)` row range that the codec reads straight from the column's borrowed span, so a bounded block is written without materializing a narrower column. The former delegates to the latter.
- The 50 MiB `DefaultFlushThresholdBytes` is the per-block size target the insert path splits on (see below), and also a between-column flush backstop. (The backstop check is between columns, so a single column larger than the threshold still buffers in full.)

**INSERT orchestration** — `ClickHouseTcpConnection.InsertAsync` (internal)
- Sends the `Query`, drains interleaved metadata to the schema block, streams the caller's rows as one or more data blocks, sends the end-of-rows terminator, and drains to `EndOfStream`. The response's interleaved metadata is consumed via a shared helper.
- **Schema-authoritative, matched by name**: the server's sample block is the source of truth. The caller's columns are aligned to it by `IColumn.Name` (order-free); each target type's codec is resolved from the **target** type (not the caller's declared type, so a cosmetic variant still serializes correctly), and each value column is checked writable as that type. The wire header carries the target's name and resolved type.
- **Partial-column inserts**: name a subset of columns in the statement and supply only those; unlisted columns are omitted from the block and the server fills them from their `DEFAULT`/`MATERIALIZED` expressions.
- **Validation split**: what needs no server round-trip is checked **before claiming the connection** (and an already-cancelled token is honoured there too) — all columns share a row count, and column names are unique — so a malformed or pre-cancelled call leaves an idle connection untouched. Name/type validation needs the sample block and so happens after the query round-trip; on any mismatch nothing but the terminator goes out (the server reads it as an insert of no rows, keeping the connection aligned) and a clear `ArgumentException` is thrown once the state is back to Ready.
- **Mismatch reporting**: a column set that doesn't line up with the target names the columns the caller failed to supply and the ones it supplied in excess, rather than a bare count mismatch. A CLR type the target codec cannot serialize, or a target type this client doesn't support, is reported the same way (clean abort, connection reusable).
- **Multi-block streaming**: the rows are split into wire blocks so each block's *exact* encoded size (measured through the codecs — precise even for variable-width columns) stays within the byte target; pass `rowsPerBlock` to override with a fixed row count. A single row larger than the target still forms its own block. Each block writes its row range directly from the columns' spans (the codec slices `Values`) — there are no per-block column objects.
- **Missing schema**: a clean `EndOfStream` before any schema block means the statement never solicited row data (e.g. inline `VALUES`, or `INSERT … SELECT`) — treated as a protocol violation, terminating the connection. A server `Exception` instead leaves the stream aligned and the connection reusable, and is rethrown after returning to Ready.
- The writer's peak-sized pooled buffer is trimmed back to baseline after the insert, so an idle pooled connection doesn't retain a multi-MiB buffer.

**Codec write validation** — `IColumnCodec.CanWrite`
- Each codec declares which CLR element types it accepts, as a membership test rather than a single-type comparison, so a ClickHouse type can accept more than one CLR representation.
- `DateTime` columns now accept both `DateTime` and `DateTimeOffset` on write (both encode to the same epoch-second body).
- Codecs also expose `FixedRowByteSize` (fixed-width types) / `MeasureRowBytes` (variable-width) so the block splitter can price each row's encoded size — in O(1) for fixed-width columns.

## Protocol correction

An INSERT sends the empty end-of-input marker **twice**: once right after the `Query` (closing the external-data phase — the server will not send the schema block until it arrives) and once after the row blocks (ending the row stream). The prior working note claimed the first marker is skipped for INSERT; omitting it deadlocks — the server waits for the marker while the client waits for the schema. Fixed `InsertAsync` accordingly and corrected `docs/native-protocol.md` to match the real server and the clickhouse-go reference client's `sendQuery`/`batch.closeQuery`.

## Tests

- Parameterized INSERT → SELECT round-trips over every supported type (all integer widths incl. 128/256, enum aliases as raw ordinals, `String`, `DateTime`, and `DateTimeOffset` → `DateTime`), modeled on the HTTP suite's `TestCases`. Cases carry separate insert/expected columns so a case can insert one CLR type and expect another on read-back.
- Partial / by-name inserts: a subset insert that leaves an omitted column at its `DEFAULT`, columns supplied out of schema order aligned by name, and a column name absent from the target aborting cleanly.
- Negative / edge cases: multi-column 5000-row block, zero-row no-op insert, column set disagreeing with the schema, differing row counts, a CLR type not writable as its target, and server rejection (all asserting the connection is left reusable where appropriate).
- Scripted `InsertAsync` state-machine tests (no server): schema-then-`EndOfStream` success, multi-block split via `rowsPerBlock`, `String`-column slicing, missing-schema → terminate, server exception instead-of-schema / during-ack → reusable, transport truncation → terminate, pre-cancelled token → stays Ready without writing, column/row-count mismatches, and a non-positive `rowsPerBlock` guard.
- `PlanInsertBlocks` unit tests for the split maths: exact byte-budget splitting (fixed-width and `String`), the explicit `rowsPerBlock` override, a single row larger than the budget, and small data as one block.
- Unit tests: `BlockWriter` round-trip through `BlockReader`, `has_custom_serialization` gating, flush-backstop both directions; `CanWrite` per codec; `DateTimeOffset` write encoding.
- Full suite green (325 tests) on net8.0/net9.0/net10.0 against a real ClickHouse server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


