### PR TITLE
TCP I1: Nullable(T) support

### DIFF
--- a/ClickHouse.Driver.Tcp.Tests/Integration/ColumnarReadSurfaceIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ColumnarReadSurfaceIntegrationTests.cs
@@ -1,0 +1,127 @@
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Format;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Tests.Integration;
+
+/// <summary>
+/// Covers the public columnar read surface of the composite column types against a real server. Every concrete
+/// column class is internal, so these interfaces — obtained by pattern-matching an <see cref="IColumn"/> — are the
+/// only way a consumer reaches the wire layout underneath a composite. These tests assert the shape a real decoded
+/// block presents: that the view is reachable at all, that its spans are sliced to the column's row count rather
+/// than to a pooled buffer's length, and that the raw columnar data it exposes agrees with the materialized rows.
+///
+/// <para>
+/// A yielded <see cref="Block"/> is borrowed — valid only for its iteration — so every test reads or copies what it
+/// needs inside the <c>await foreach</c>, never retaining the block or a span taken from it.
+/// </para>
+/// </summary>
+[TestFixture]
+[Category("Integration")]
+public class ColumnarReadSurfaceIntegrationTests
+{
+    private static readonly CancellationToken None = CancellationToken.None;
+
+    [Test]
+    public async Task QueryAsync_NullableColumn_ExposesInnerAndNullMapThroughINullableColumn()
+    {
+        // A Nullable(T) column's wire layout is a dense inner column (a decoded value at *every* row, placeholder
+        // included where the row is null) plus the per-row null-map that says which rows are really null. The
+        // materialized IColumn<int?> surface folds those two together and discards the distinction, so reaching the
+        // pair is the whole point of INullableColumn<T>.
+        //
+        // Note the type argument is the *inner* type: a Nullable(Int32) column is an INullableColumn<int>, not an
+        // INullableColumn<int?>, even though its IColumn<T> surface is IColumn<int?>.
+        await using var connection = await TcpServerFixture.ConnectAsync(None);
+
+        bool matchedInner = false;
+        bool matchedNullable = false;
+        byte[] nullMap = null;
+        int nullMapLength = 0;
+        int rowCount = 0;
+        int innerRowCount = 0;
+        int?[] materialized = null;
+        var innerAtNonNullRows = new int[3];
+
+        await foreach (Block block in connection.QueryAsync(
+            "SELECT CAST(number = 1 ? NULL : toInt32(number * 10 - 10), 'Nullable(Int32)') FROM system.numbers LIMIT 4",
+            cancellationToken: None))
+        {
+            IColumn column = block[0];
+            matchedInner = column is INullableColumn<int>;
+            matchedNullable = column is INullableColumn<int?>;
+
+            var nullable = (INullableColumn<int>)column;
+            nullMap = nullable.NullMap.ToArray();
+            nullMapLength = nullable.NullMap.Length;
+            rowCount = nullable.RowCount;
+            innerRowCount = nullable.Inner.RowCount;
+            materialized = ((IColumn<int?>)column).Values.ToArray();
+
+            // Read the non-null rows straight out of the inner column, skipping the nulls via the map — the
+            // allocation-free access pattern the interface exists to enable.
+            int next = 0;
+            for (int row = 0; row < nullable.RowCount; row++)
+            {
+                if (nullable.NullMap[row] == 0)
+                {
+                    innerAtNonNullRows[next++] = nullable.Inner[row];
+                }
+            }
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(matchedInner, Is.True, "the view is parameterized by the inner type");
+            Assert.That(matchedNullable, Is.False, "and not by the nullable type");
+            Assert.That(rowCount, Is.EqualTo(4));
+            Assert.That(nullMap, Is.EqualTo(new byte[] { 0, 1, 0, 0 }), "one entry per row, non-zero marking null");
+            Assert.That(nullMapLength, Is.EqualTo(rowCount), "the map is sliced to the row count, not the pooled buffer length");
+            Assert.That(innerRowCount, Is.EqualTo(rowCount), "the inner column is dense: one decoded value per row");
+            Assert.That(materialized, Is.EqualTo(new int?[] { -10, null, 10, 20 }));
+            Assert.That(innerAtNonNullRows, Is.EqualTo(new[] { -10, 10, 20 }), "the null-marked row is skipped, the rest read from the inner column");
+        });
+    }
+
+    [Test]
+    public async Task QueryAsync_NullableReferenceColumn_ExposesInnerAndNullMapThroughINullableColumn()
+    {
+        // Nullable(String) decodes to a separate reference-typed column class with its own copy of the pair, whose
+        // IColumn<T> surface is IColumn<string> (a reference is already nullable) rather than IColumn<T?>. Its view
+        // is still parameterized by the inner type, so the pattern-match spelling stays uniform with the value case.
+        await using var connection = await TcpServerFixture.ConnectAsync(None);
+
+        bool matched = false;
+        byte[] nullMap = null;
+        int nullMapLength = 0;
+        int rowCount = 0;
+        int innerRowCount = 0;
+        string[] materialized = null;
+
+        await foreach (Block block in connection.QueryAsync(
+            "SELECT CAST(number = 1 ? NULL : concat('v', toString(number)), 'Nullable(String)') FROM system.numbers LIMIT 3",
+            cancellationToken: None))
+        {
+            IColumn column = block[0];
+            matched = column is INullableColumn<string>;
+
+            var nullable = (INullableColumn<string>)column;
+            nullMap = nullable.NullMap.ToArray();
+            nullMapLength = nullable.NullMap.Length;
+            rowCount = nullable.RowCount;
+            innerRowCount = nullable.Inner.RowCount;
+            materialized = ((IColumn<string>)column).Values.ToArray();
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(matched, Is.True);
+            Assert.That(rowCount, Is.EqualTo(3));
+            Assert.That(nullMap, Is.EqualTo(new byte[] { 0, 1, 0 }));
+            Assert.That(nullMapLength, Is.EqualTo(rowCount));
+            Assert.That(innerRowCount, Is.EqualTo(rowCount));
+            Assert.That(materialized, Is.EqualTo(new[] { "v0", null, "v2" }));
+        });
+    }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Types/DateTime64ColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/DateTime64ColumnCodecTests.cs
@@ -272,4 +272,23 @@ public class DateTime64ColumnCodecTests
     [Test]
     public void Create_ScaleOutOfRange_Throws()
         => Assert.Throws<FormatException>(() => Codec("DateTime64(10)"));
+
+    [Test]
+    public void WritableElementTypes_ListsNativeThenOffsetThenDateTime()
+        => Assert.That(
+            Codec("DateTime64(3)").WritableElementTypes,
+            Is.EqualTo(new[] { typeof(ClickHouseDateTime64), typeof(DateTimeOffset), typeof(DateTime) }));
+
+    [Test]
+    public void NullPlaceholderAs_ReturnsEpochInRequestedSpelling_ThrowsForOthers()
+    {
+        DateTime64ColumnCodec codec = Codec("DateTime64(3)");
+        Assert.Multiple(() =>
+        {
+            Assert.That(((ClickHouseDateTime64)codec.NullPlaceholderAs(typeof(ClickHouseDateTime64))).Count, Is.EqualTo(0));
+            Assert.That(codec.NullPlaceholderAs(typeof(DateTimeOffset)), Is.EqualTo(DateTimeOffset.UnixEpoch));
+            Assert.That(codec.NullPlaceholderAs(typeof(DateTime)), Is.EqualTo(DateTime.UnixEpoch));
+            Assert.Throws<NotSupportedException>(() => codec.NullPlaceholderAs(typeof(string)));
+        });
+    }
 }

--- a/ClickHouse.Driver.Tcp.Tests/Types/DateTime64ColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/DateTime64ColumnCodecTests.cs
@@ -274,10 +274,10 @@ public class DateTime64ColumnCodecTests
         => Assert.Throws<FormatException>(() => Codec("DateTime64(10)"));
 
     [Test]
-    public void WritableElementTypes_ListsNativeThenOffsetThenDateTime()
+    public void WritableElementTypes_ListsLongThenOffsetThenDateTime()
         => Assert.That(
             Codec("DateTime64(3)").WritableElementTypes,
-            Is.EqualTo(new[] { typeof(ClickHouseDateTime64), typeof(DateTimeOffset), typeof(DateTime) }));
+            Is.EqualTo(new[] { typeof(long), typeof(DateTimeOffset), typeof(DateTime) }));
 
     [Test]
     public void NullPlaceholderAs_ReturnsEpochInRequestedSpelling_ThrowsForOthers()
@@ -285,7 +285,7 @@ public class DateTime64ColumnCodecTests
         DateTime64ColumnCodec codec = Codec("DateTime64(3)");
         Assert.Multiple(() =>
         {
-            Assert.That(((ClickHouseDateTime64)codec.NullPlaceholderAs(typeof(ClickHouseDateTime64))).Count, Is.EqualTo(0));
+            Assert.That(codec.NullPlaceholderAs(typeof(long)), Is.EqualTo(0L));
             Assert.That(codec.NullPlaceholderAs(typeof(DateTimeOffset)), Is.EqualTo(DateTimeOffset.UnixEpoch));
             Assert.That(codec.NullPlaceholderAs(typeof(DateTime)), Is.EqualTo(DateTime.UnixEpoch));
             Assert.Throws<NotSupportedException>(() => codec.NullPlaceholderAs(typeof(string)));

--- a/ClickHouse.Driver.Tcp.Tests/Types/DateTimeColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/DateTimeColumnCodecTests.cs
@@ -313,8 +313,8 @@ public class DateTimeColumnCodecTests
     }
 
     [Test]
-    public void WritableElementTypes_ListsOffsetThenDateTime()
-        => Assert.That(Codec("DateTime").WritableElementTypes, Is.EqualTo(new[] { typeof(DateTimeOffset), typeof(DateTime) }));
+    public void WritableElementTypes_ListsUIntThenOffsetThenDateTime()
+        => Assert.That(Codec("DateTime").WritableElementTypes, Is.EqualTo(new[] { typeof(uint), typeof(DateTimeOffset), typeof(DateTime) }));
 
     [Test]
     public void NullPlaceholderAs_ReturnsEpochInRequestedSpelling_ThrowsForOthers()
@@ -322,9 +322,10 @@ public class DateTimeColumnCodecTests
         DateTimeColumnCodec codec = Codec("DateTime");
         Assert.Multiple(() =>
         {
+            Assert.That(codec.NullPlaceholderAs(typeof(uint)), Is.EqualTo(0u));
             Assert.That(codec.NullPlaceholderAs(typeof(DateTimeOffset)), Is.EqualTo(DateTimeOffset.UnixEpoch));
             Assert.That(codec.NullPlaceholderAs(typeof(DateTime)), Is.EqualTo(DateTime.UnixEpoch));
-            Assert.Throws<NotSupportedException>(() => codec.NullPlaceholderAs(typeof(int)));
+            Assert.Throws<NotSupportedException>(() => codec.NullPlaceholderAs(typeof(string)));
         });
     }
 

--- a/ClickHouse.Driver.Tcp.Tests/Types/DateTimeColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/DateTimeColumnCodecTests.cs
@@ -312,6 +312,22 @@ public class DateTimeColumnCodecTests
         });
     }
 
+    [Test]
+    public void WritableElementTypes_ListsOffsetThenDateTime()
+        => Assert.That(Codec("DateTime").WritableElementTypes, Is.EqualTo(new[] { typeof(DateTimeOffset), typeof(DateTime) }));
+
+    [Test]
+    public void NullPlaceholderAs_ReturnsEpochInRequestedSpelling_ThrowsForOthers()
+    {
+        DateTimeColumnCodec codec = Codec("DateTime");
+        Assert.Multiple(() =>
+        {
+            Assert.That(codec.NullPlaceholderAs(typeof(DateTimeOffset)), Is.EqualTo(DateTimeOffset.UnixEpoch));
+            Assert.That(codec.NullPlaceholderAs(typeof(DateTime)), Is.EqualTo(DateTime.UnixEpoch));
+            Assert.Throws<NotSupportedException>(() => codec.NullPlaceholderAs(typeof(int)));
+        });
+    }
+
     private static async Task<byte[]> WriteAsync(Action<ClickHouseBinaryWriter> write)
     {
         using var ms = new MemoryStream();

--- a/ClickHouse.Driver.Tcp.Tests/Types/EnumColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/EnumColumnCodecTests.cs
@@ -25,6 +25,10 @@ public class EnumColumnCodecTests
         => Assert.Throws<FormatException>(() => Enum8ColumnCodec.Create(TypeParser.Parse("Enum8('a' = 128)")));
 
     [Test]
+    public void Create_Enum8_NoMembers_Throws()
+        => Assert.Throws<FormatException>(() => Enum8ColumnCodec.Create(TypeParser.Parse("Enum8()")));
+
+    [Test]
     public void Create_MalformedMember_Throws()
         => Assert.Throws<FormatException>(() => Enum8ColumnCodec.Create(TypeParser.Parse("Enum8('a')")));
 

--- a/ClickHouse.Driver.Tcp.Tests/Types/NothingColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/NothingColumnCodecTests.cs
@@ -35,18 +35,6 @@ public class NothingColumnCodecTests
     }
 
     [Test]
-    public void FixedRowByteSize_IsOneByte_AndComposesUnderNullable()
-    {
-        IColumnCodec nullableOfNothing = ColumnCodecRegistry.Default.Resolve("Nullable(Nothing)", default);
-        Assert.Multiple(() =>
-        {
-            // One placeholder byte per row for the bare type; the null-map byte adds one more under Nullable.
-            Assert.That(NothingColumnCodec.Instance.FixedRowByteSize, Is.EqualTo(1));
-            Assert.That(nullableOfNothing.FixedRowByteSize, Is.EqualTo(2));
-        });
-    }
-
-    [Test]
     public void CanWrite_IsFalse_AndWriteThrows()
     {
         var column = new ArrayColumn<object>("c", "Nothing", new object[1]);

--- a/ClickHouse.Driver.Tcp.Tests/Types/NothingColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/NothingColumnCodecTests.cs
@@ -35,6 +35,18 @@ public class NothingColumnCodecTests
     }
 
     [Test]
+    public void FixedRowByteSize_IsOneByte_AndComposesUnderNullable()
+    {
+        IColumnCodec nullableOfNothing = ColumnCodecRegistry.Default.Resolve("Nullable(Nothing)", default);
+        Assert.Multiple(() =>
+        {
+            // One placeholder byte per row for the bare type; the null-map byte adds one more under Nullable.
+            Assert.That(NothingColumnCodec.Instance.FixedRowByteSize, Is.EqualTo(1));
+            Assert.That(nullableOfNothing.FixedRowByteSize, Is.EqualTo(2));
+        });
+    }
+
+    [Test]
     public void CanWrite_IsFalse_AndWriteThrows()
     {
         var column = new ArrayColumn<object>("c", "Nothing", new object[1]);

--- a/ClickHouse.Driver.Tcp.Tests/Types/NullableColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/NullableColumnCodecTests.cs
@@ -138,29 +138,6 @@ public class NullableColumnCodecTests
     }
 
     [Test]
-    public void FixedRowByteSize_IsNullMapBytePlusInner_OrNullForVariableInner()
-    {
-        Assert.Multiple(() =>
-        {
-            Assert.That(Resolve("Nullable(Int32)").FixedRowByteSize, Is.EqualTo(5));
-            Assert.That(Resolve("Nullable(String)").FixedRowByteSize, Is.Null);
-        });
-    }
-
-    [Test]
-    public void MeasureRowBytes_VariableInner_CountsNullMapBytePlusInnerValue()
-    {
-        IColumnCodec codec = Resolve("Nullable(String)");
-        var column = new ArrayColumn<string>("c", "Nullable(String)", new[] { "hi", null });
-
-        Assert.Multiple(() =>
-        {
-            Assert.That(codec.MeasureRowBytes(column, 0), Is.EqualTo(4)); // 1 null-map + 1 length prefix + 2 bytes
-            Assert.That(codec.MeasureRowBytes(column, 1), Is.EqualTo(2)); // 1 null-map + empty-string placeholder
-        });
-    }
-
-    [Test]
     public void CanWrite_AcceptsOnlyMatchingNullableColumn()
     {
         IColumnCodec value = Resolve("Nullable(Int32)");
@@ -298,102 +275,6 @@ public class NullableColumnCodecTests
     }
 
     [Test]
-    public async Task TryDensify_ErgonomicValueColumn_ProducesDenseColumnThatRoundTrips()
-    {
-        // TryDensify splits the ergonomic T? column into a dense (inner column + null-map) NullableValueColumn: the
-        // inner holds a real value at every row (the codec's placeholder at the null rows) and the null-map marks
-        // the nulls. It must surface the same T? values and round-trip identically to the ergonomic form.
-        IColumnCodec codec = Resolve("Nullable(Int32)");
-        var expected = new int?[] { 7, null, -3, null, 0 };
-        var ergonomic = new ArrayColumn<int?>("c", "Nullable(Int32)", expected);
-
-        using IColumn densified = codec.TryDensify(ergonomic, out _);
-
-        Assert.That(densified, Is.InstanceOf<NullableValueColumn<int>>());
-        var dense = (NullableValueColumn<int>)densified;
-        Assert.Multiple(() =>
-        {
-            Assert.That(dense.NullMap.ToArray(), Is.EqualTo(new byte[] { 0, 1, 0, 1, 0 }));
-            Assert.That(dense.Inner.Values.ToArray(), Is.EqualTo(new[] { 7, 0, -3, 0, 0 })); // placeholder 0 at nulls
-            Assert.That(((IColumn<int?>)densified).Values.ToArray(), Is.EqualTo(expected));
-        });
-
-        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, densified, "Nullable(Int32)", densified.RowCount);
-        Assert.That(((IColumn<int?>)read).Values.ToArray(), Is.EqualTo(expected));
-    }
-
-    [Test]
-    public async Task TryDensify_ErgonomicReferenceColumn_ProducesDenseColumnThatRoundTrips()
-    {
-        IColumnCodec codec = Resolve("Nullable(String)");
-        var expected = new[] { "hi", null, string.Empty, "world" };
-        var ergonomic = new ArrayColumn<string>("c", "Nullable(String)", expected);
-
-        using IColumn densified = codec.TryDensify(ergonomic, out _);
-
-        Assert.That(densified, Is.InstanceOf<NullableReferenceColumn<string>>());
-        var dense = (NullableReferenceColumn<string>)densified;
-        Assert.Multiple(() =>
-        {
-            Assert.That(dense.NullMap.ToArray(), Is.EqualTo(new byte[] { 0, 1, 0, 0 }));
-            Assert.That(((IColumn<string>)densified).Values.ToArray(), Is.EqualTo(expected));
-        });
-
-        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, densified, "Nullable(String)", densified.RowCount);
-        Assert.That(((IColumn<string>)read).Values.ToArray(), Is.EqualTo(expected));
-    }
-
-    [Test]
-    public void TryDensify_NullRows_UseInnerPlaceholderNotClrDefault()
-    {
-        // default(DateOnly) (0001-01-01) is out of the Date codec's range; densify must fill the null rows with
-        // the codec's own placeholder (the epoch) so the dense inner column is writable.
-        IColumnCodec codec = Resolve("Nullable(Date)");
-        var expected = new DateOnly?[] { new DateOnly(2000, 1, 1), null };
-        var ergonomic = new ArrayColumn<DateOnly?>("c", "Nullable(Date)", expected);
-
-        using var dense = (NullableValueColumn<DateOnly>)codec.TryDensify(ergonomic, out _);
-
-        Assert.Multiple(() =>
-        {
-            Assert.That(dense.Inner[1], Is.EqualTo(new DateOnly(1970, 1, 1)));
-            Assert.That(((IColumn<DateOnly?>)dense).Values.ToArray(), Is.EqualTo(expected));
-        });
-    }
-
-    [Test]
-    public void TryDensify_AlreadyDenseColumn_ReturnsSameInstanceNotBuilt()
-    {
-        // TryDensify is idempotent: a column already in dense form is returned by reference with built = false, so a
-        // caller knows it is borrowed (not to be disposed) rather than freshly built.
-        IColumnCodec codec = Resolve("Nullable(Int32)");
-        var inner = PrimitiveColumn<int>.FromValues("c", "Int32", new[] { 7, 0, 9 });
-        var dense = new NullableValueColumn<int>("c", "Nullable(Int32)", inner, new byte[] { 0, 1, 0 }, rowCount: 3, pooledMap: false);
-
-        IColumn result = codec.TryDensify(dense, out bool built);
-        Assert.Multiple(() =>
-        {
-            Assert.That(result, Is.SameAs(dense));
-            Assert.That(built, Is.False, "an already-dense column is borrowed, not rebuilt");
-        });
-    }
-
-    [Test]
-    public void TryDensify_LeafCodec_ReturnsColumnUnchangedNotBuilt()
-    {
-        // A leaf codec has no denser form, so the default hook returns the column by reference with built = false.
-        IColumnCodec codec = Resolve("Int32");
-        var column = new ArrayColumn<int>("c", "Int32", new[] { 1, 2, 3 });
-
-        IColumn result = codec.TryDensify(column, out bool built);
-        Assert.Multiple(() =>
-        {
-            Assert.That(result, Is.SameAs(column));
-            Assert.That(built, Is.False, "a leaf codec never builds a new column");
-        });
-    }
-
-    [Test]
     public void Resolve_NestedNullable_ThrowsFormat()
         => Assert.Throws<FormatException>(() => Resolve("Nullable(Nullable(Int32))"));
 
@@ -404,7 +285,7 @@ public class NullableColumnCodecTests
 
     [Test]
     public void Resolve_UnsupportedInner_ThrowsNotSupported()
-        => Assert.Throws<NotSupportedException>(() => Resolve("Nullable(Array(Int32))"));
+        => Assert.Throws<NotSupportedException>(() => Resolve("Nullable(Point)"));
 
     [Test]
     public void Resolve_Nullable_StampsFullTypeName()

--- a/ClickHouse.Driver.Tcp.Tests/Types/NullableColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/NullableColumnCodecTests.cs
@@ -1,0 +1,402 @@
+using System;
+using System.Net;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Numerics;
+using ClickHouse.Driver.Tcp.Protocol;
+using ClickHouse.Driver.Tcp.Tests.Utilities;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Tests.Types;
+
+[TestFixture]
+public class NullableColumnCodecTests
+{
+    private static IColumnCodec Resolve(string type) => ColumnCodecRegistry.Default.Resolve(type, default);
+
+    [Test]
+    public async Task ReadColumn_WriteThenRead_ValueInnerRoundTripsWithNulls()
+    {
+        IColumnCodec codec = Resolve("Nullable(Int32)");
+        var expected = new int?[] { 7, null, -3, null, 0 };
+        var column = new ArrayColumn<int?>("c", "Nullable(Int32)", expected);
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Nullable(Int32)", column.RowCount);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(read.TypeName, Is.EqualTo("Nullable(Int32)"));
+            Assert.That(read.RowCount, Is.EqualTo(5));
+            Assert.That(((IColumn<int?>)read).Values.ToArray(), Is.EqualTo(expected));
+            Assert.That(read.GetValue(0), Is.EqualTo(7));
+            Assert.That(read.GetValue(1), Is.Null);
+        });
+    }
+
+    [Test]
+    public async Task ReadColumn_WriteThenRead_ReferenceInnerRoundTripsWithNulls()
+    {
+        IColumnCodec codec = Resolve("Nullable(String)");
+        var expected = new[] { "hi", null, string.Empty, "world" };
+        var column = new ArrayColumn<string>("c", "Nullable(String)", expected);
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Nullable(String)", column.RowCount);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(read.RowCount, Is.EqualTo(4));
+            Assert.That(((IColumn<string>)read).Values.ToArray(), Is.EqualTo(expected));
+            Assert.That(read.GetValue(1), Is.Null);
+        });
+    }
+
+    [Test]
+    public async Task WriteColumn_DenseNullableColumn_RoundTripsWithoutRebuildingValues()
+    {
+        // A dense NullableValueColumn<T> (inner column + null-map, the wire's own layout) is the zero-copy write
+        // path — the same shape a read produces and the row-materialization tier will build. Writing one and
+        // reading it back must preserve the values and nulls.
+        IColumnCodec codec = Resolve("Nullable(Int32)");
+        var inner = PrimitiveColumn<int>.FromValues("c", "Int32", new[] { 7, 0, 9 });
+        var dense = new NullableValueColumn<int>("c", "Nullable(Int32)", inner, new byte[] { 0, 1, 0 }, rowCount: 3, pooledMap: false);
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, dense, "Nullable(Int32)", dense.RowCount);
+
+        Assert.That(((IColumn<int?>)read).Values.ToArray(), Is.EqualTo(new int?[] { 7, null, 9 }));
+    }
+
+    [Test]
+    public async Task ReadColumn_EveryRowNull_RoundTripsAsAllNull()
+    {
+        IColumnCodec codec = Resolve("Nullable(Int32)");
+        var column = new ArrayColumn<int?>("c", "Nullable(Int32)", new int?[] { null, null, null });
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Nullable(Int32)", column.RowCount);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(read.RowCount, Is.EqualTo(3));
+            Assert.That(read.GetValue(0), Is.Null);
+            Assert.That(read.GetValue(2), Is.Null);
+        });
+    }
+
+    [Test]
+    public async Task ReadColumn_ValueInnerWhoseDefaultIsOutOfRange_WritesPlaceholderTheCodecAccepts()
+    {
+        // default(DateOnly) is 0001-01-01, which the Date codec rejects; the null rows must borrow a present
+        // value as the placeholder instead, so writing does not throw.
+        IColumnCodec codec = Resolve("Nullable(Date)");
+        var expected = new DateOnly?[] { new DateOnly(2000, 1, 1), null, new DateOnly(1970, 1, 1) };
+        var column = new ArrayColumn<DateOnly?>("c", "Nullable(Date)", expected);
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Nullable(Date)", column.RowCount);
+
+        Assert.That(((IColumn<DateOnly?>)read).Values.ToArray(), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public async Task ReadColumn_FixedWidthReferenceInnerWithNulls_WritesPlaceholderNotDereferenced()
+    {
+        // IPv4 is reference-typed (IPAddress) but fixed-width; the IP codec dereferences each value, so a null
+        // row must be written as a placeholder rather than passed through. This would NRE if it were.
+        IColumnCodec codec = Resolve("Nullable(IPv4)");
+        var expected = new[] { IPAddress.Parse("127.0.0.1"), null, IPAddress.Parse("10.0.0.1") };
+        var column = new ArrayColumn<IPAddress>("c", "Nullable(IPv4)", expected);
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Nullable(IPv4)", column.RowCount);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(((IColumn<IPAddress>)read).Values.ToArray(), Is.EqualTo(expected));
+            Assert.That(read.GetValue(1), Is.Null);
+        });
+    }
+
+    [Test]
+    public async Task ReadColumn_FixedWidthReferenceInnerAllNull_RoundTripsAsAllNull()
+    {
+        IColumnCodec codec = Resolve("Nullable(IPv6)");
+        var column = new ArrayColumn<IPAddress>("c", "Nullable(IPv6)", new IPAddress[] { null, null });
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Nullable(IPv6)", column.RowCount);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(read.GetValue(0), Is.Null);
+            Assert.That(read.GetValue(1), Is.Null);
+        });
+    }
+
+    [Test]
+    public void ElementType_ReflectsInnerNullability()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(Resolve("Nullable(Int32)").ElementType, Is.EqualTo(typeof(int?)));
+            Assert.That(Resolve("Nullable(String)").ElementType, Is.EqualTo(typeof(string)));
+        });
+    }
+
+    [Test]
+    public void FixedRowByteSize_IsNullMapBytePlusInner_OrNullForVariableInner()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(Resolve("Nullable(Int32)").FixedRowByteSize, Is.EqualTo(5));
+            Assert.That(Resolve("Nullable(String)").FixedRowByteSize, Is.Null);
+        });
+    }
+
+    [Test]
+    public void MeasureRowBytes_VariableInner_CountsNullMapBytePlusInnerValue()
+    {
+        IColumnCodec codec = Resolve("Nullable(String)");
+        var column = new ArrayColumn<string>("c", "Nullable(String)", new[] { "hi", null });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(codec.MeasureRowBytes(column, 0), Is.EqualTo(4)); // 1 null-map + 1 length prefix + 2 bytes
+            Assert.That(codec.MeasureRowBytes(column, 1), Is.EqualTo(2)); // 1 null-map + empty-string placeholder
+        });
+    }
+
+    [Test]
+    public void CanWrite_AcceptsOnlyMatchingNullableColumn()
+    {
+        IColumnCodec value = Resolve("Nullable(Int32)");
+        IColumnCodec reference = Resolve("Nullable(String)");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(value.CanWrite(new ArrayColumn<int?>("c", "Nullable(Int32)", new int?[] { 1 })), Is.True);
+            Assert.That(value.CanWrite(new ArrayColumn<int>("c", "Int32", new[] { 1 })), Is.False);
+            Assert.That(value.CanWrite(new ArrayColumn<long?>("c", "Nullable(Int64)", new long?[] { 1 })), Is.False);
+            Assert.That(reference.CanWrite(new ArrayColumn<string>("c", "Nullable(String)", new[] { "x" })), Is.True);
+        });
+    }
+
+    [Test]
+    public async Task WriteColumn_NullableDateTimeAsDateTimeSpelling_RoundTripsAsCanonicalOffset()
+    {
+        // The bare DateTime codec accepts both DateTimeOffset and DateTime; Nullable(DateTime) re-offers both.
+        // A DateTime? column (the inner's alternate spelling made nullable) must write, with the null row taking
+        // a DateTime placeholder — not the canonical DateTimeOffset one — and read back as the canonical offset.
+        IColumnCodec codec = Resolve("Nullable(DateTime('UTC'))");
+        var input = new DateTime?[] { DateTime.UnixEpoch.AddSeconds(1_700_000_000), null, DateTime.UnixEpoch };
+        var column = new ArrayColumn<DateTime?>("c", "Nullable(DateTime('UTC'))", input);
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Nullable(DateTime('UTC'))", column.RowCount);
+
+        var expected = new DateTimeOffset?[]
+        {
+            DateTimeOffset.FromUnixTimeSeconds(1_700_000_000),
+            null,
+            DateTimeOffset.FromUnixTimeSeconds(0),
+        };
+        Assert.Multiple(() =>
+        {
+            Assert.That(codec.ElementType, Is.EqualTo(typeof(DateTimeOffset?)));
+            Assert.That(((IColumn<DateTimeOffset?>)read).Values.ToArray(), Is.EqualTo(expected));
+            Assert.That(read.GetValue(1), Is.Null);
+        });
+    }
+
+    [Test]
+    public void CanWrite_NullableDateTime_AcceptsBothOffsetAndDateTimeSpellings()
+    {
+        IColumnCodec codec = Resolve("Nullable(DateTime('UTC'))");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(codec.CanWrite(new ArrayColumn<DateTimeOffset?>("c", "Nullable(DateTime('UTC'))", new DateTimeOffset?[] { DateTimeOffset.UnixEpoch })), Is.True);
+            Assert.That(codec.CanWrite(new ArrayColumn<DateTime?>("c", "Nullable(DateTime('UTC'))", new DateTime?[] { DateTime.UnixEpoch })), Is.True);
+            Assert.That(codec.CanWrite(new ArrayColumn<int?>("c", "Nullable(Int32)", new int?[] { 1 })), Is.False);
+        });
+    }
+
+    [Test]
+    public async Task WriteColumn_NullableDateTime64AsOffsetAndDateTimeSpellings_RoundTripsAsCanonicalNative()
+    {
+        // DateTime64's canonical read type is ClickHouseDateTime64, but it accepts DateTimeOffset and DateTime on
+        // write; Nullable(DateTime64) re-offers all three. Both alternate spellings must round-trip through the
+        // native read type, each with its own-typed placeholder at the null row.
+        IColumnCodec codec = Resolve("Nullable(DateTime64(3, 'UTC'))");
+        DateTimeOffset present = DateTimeOffset.FromUnixTimeMilliseconds(1_700_000_000_123);
+
+        var asOffset = new ArrayColumn<DateTimeOffset?>("c", "Nullable(DateTime64(3, 'UTC'))", new DateTimeOffset?[] { present, null });
+        var asDateTime = new ArrayColumn<DateTime?>("c", "Nullable(DateTime64(3, 'UTC'))", new DateTime?[] { present.UtcDateTime, null });
+
+        using IColumn fromOffset = await CodecTestHarness.RoundTripAsync(codec, asOffset, "Nullable(DateTime64(3, 'UTC'))", 2);
+        using IColumn fromDateTime = await CodecTestHarness.RoundTripAsync(codec, asDateTime, "Nullable(DateTime64(3, 'UTC'))", 2);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(codec.ElementType, Is.EqualTo(typeof(ClickHouseDateTime64?)));
+
+            var offsetRead = (IColumn<ClickHouseDateTime64?>)fromOffset;
+            Assert.That(offsetRead[0].Value.ToDateTimeOffset(), Is.EqualTo(present));
+            Assert.That(fromOffset.GetValue(1), Is.Null);
+
+            var dateTimeRead = (IColumn<ClickHouseDateTime64?>)fromDateTime;
+            Assert.That(dateTimeRead[0].Value.ToDateTimeOffset(), Is.EqualTo(present));
+            Assert.That(fromDateTime.GetValue(1), Is.Null);
+        });
+    }
+
+    [Test]
+    public void CanWrite_NullableDateTime64_AcceptsNativeOffsetAndDateTimeSpellings()
+    {
+        IColumnCodec codec = Resolve("Nullable(DateTime64(3, 'UTC'))");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(codec.CanWrite(new ArrayColumn<ClickHouseDateTime64?>("c", "Nullable(DateTime64(3, 'UTC'))", new ClickHouseDateTime64?[] { new ClickHouseDateTime64(0, 3, TimeSpan.Zero) })), Is.True);
+            Assert.That(codec.CanWrite(new ArrayColumn<DateTimeOffset?>("c", "Nullable(DateTime64(3, 'UTC'))", new DateTimeOffset?[] { DateTimeOffset.UnixEpoch })), Is.True);
+            Assert.That(codec.CanWrite(new ArrayColumn<DateTime?>("c", "Nullable(DateTime64(3, 'UTC'))", new DateTime?[] { DateTime.UnixEpoch })), Is.True);
+        });
+    }
+
+    [Test]
+    public void WriteColumn_ColumnOfUnacceptedSpelling_ThrowsArgument()
+    {
+        // WriteColumn is normally guarded by CanWrite, but a direct call with a column whose CLR spelling none of
+        // the inner's writable spellings match must fail with a clear error rather than a nested cast failure.
+        IColumnCodec codec = Resolve("Nullable(DateTime('UTC'))");
+        using var writer = new ClickHouseBinaryWriter(new System.IO.MemoryStream());
+        var wrong = new ArrayColumn<long?>("c", "Nullable(Int64)", new long?[] { 1 });
+
+        Assert.Throws<ArgumentException>(() => codec.WriteColumn(writer, wrong, 0, 1));
+    }
+
+    [Test]
+    public async Task ReadColumn_NullableNothing_SurfacesEveryRowAsNull()
+    {
+        // Nullable(Nothing) is how a bare NULL literal is typed. Wire: null-map (all null) then one Nothing
+        // placeholder byte per row. This is the read-only completion of the Nothing/Nullable(Nothing) pairing.
+        IColumnCodec codec = Resolve("Nullable(Nothing)");
+        byte[] wire = { 1, 1, 1, 0, 0, 0 };
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(wire);
+
+        using IColumn read = await codec.ReadColumnAsync(reader, "c", "Nullable(Nothing)", 3, CodecTestHarness.None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(read.RowCount, Is.EqualTo(3));
+            Assert.That(read.GetValue(0), Is.Null);
+            Assert.That(read.GetValue(2), Is.Null);
+            Assert.That(codec.ElementType, Is.EqualTo(typeof(object)));
+        });
+    }
+
+    [Test]
+    public void CanWrite_NullableNothing_ReturnsFalse()
+    {
+        // The inner Nothing codec cannot write, so Nullable(Nothing) must report not-writable up front rather
+        // than accept the column and fail mid-write. (Reading Nullable(Nothing) still works — see above.)
+        IColumnCodec codec = Resolve("Nullable(Nothing)");
+        Assert.That(codec.CanWrite(new ArrayColumn<object>("c", "Nullable(Nothing)", new object[] { null, null })), Is.False);
+    }
+
+    [Test]
+    public async Task Densify_ErgonomicValueColumn_ProducesDenseColumnThatRoundTrips()
+    {
+        // Densify splits the ergonomic T? column into a dense (inner column + null-map) NullableValueColumn: the
+        // inner holds a real value at every row (the codec's placeholder at the null rows) and the null-map marks
+        // the nulls. It must surface the same T? values and round-trip identically to the ergonomic form.
+        IColumnCodec codec = Resolve("Nullable(Int32)");
+        var expected = new int?[] { 7, null, -3, null, 0 };
+        var ergonomic = new ArrayColumn<int?>("c", "Nullable(Int32)", expected);
+
+        IColumn densified = codec.Densify(ergonomic);
+
+        Assert.That(densified, Is.InstanceOf<NullableValueColumn<int>>());
+        var dense = (NullableValueColumn<int>)densified;
+        Assert.Multiple(() =>
+        {
+            Assert.That(dense.NullMap.ToArray(), Is.EqualTo(new byte[] { 0, 1, 0, 1, 0 }));
+            Assert.That(dense.Inner.Values.ToArray(), Is.EqualTo(new[] { 7, 0, -3, 0, 0 })); // placeholder 0 at nulls
+            Assert.That(((IColumn<int?>)densified).Values.ToArray(), Is.EqualTo(expected));
+        });
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, densified, "Nullable(Int32)", densified.RowCount);
+        Assert.That(((IColumn<int?>)read).Values.ToArray(), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public async Task Densify_ErgonomicReferenceColumn_ProducesDenseColumnThatRoundTrips()
+    {
+        IColumnCodec codec = Resolve("Nullable(String)");
+        var expected = new[] { "hi", null, string.Empty, "world" };
+        var ergonomic = new ArrayColumn<string>("c", "Nullable(String)", expected);
+
+        IColumn densified = codec.Densify(ergonomic);
+
+        Assert.That(densified, Is.InstanceOf<NullableReferenceColumn<string>>());
+        var dense = (NullableReferenceColumn<string>)densified;
+        Assert.Multiple(() =>
+        {
+            Assert.That(dense.NullMap.ToArray(), Is.EqualTo(new byte[] { 0, 1, 0, 0 }));
+            Assert.That(((IColumn<string>)densified).Values.ToArray(), Is.EqualTo(expected));
+        });
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, densified, "Nullable(String)", densified.RowCount);
+        Assert.That(((IColumn<string>)read).Values.ToArray(), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void Densify_NullRows_UseInnerPlaceholderNotClrDefault()
+    {
+        // default(DateOnly) (0001-01-01) is out of the Date codec's range; densify must fill the null rows with
+        // the codec's own placeholder (the epoch) so the dense inner column is writable.
+        IColumnCodec codec = Resolve("Nullable(Date)");
+        var expected = new DateOnly?[] { new DateOnly(2000, 1, 1), null };
+        var ergonomic = new ArrayColumn<DateOnly?>("c", "Nullable(Date)", expected);
+
+        var dense = (NullableValueColumn<DateOnly>)codec.Densify(ergonomic);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(dense.Inner[1], Is.EqualTo(new DateOnly(1970, 1, 1)));
+            Assert.That(((IColumn<DateOnly?>)dense).Values.ToArray(), Is.EqualTo(expected));
+        });
+    }
+
+    [Test]
+    public void Densify_AlreadyDenseColumn_ReturnsSameInstance()
+    {
+        // Densify is idempotent: a column already in dense form is returned by reference, so a caller can tell a
+        // freshly built column (to dispose) from a borrowed pass-through.
+        IColumnCodec codec = Resolve("Nullable(Int32)");
+        var inner = PrimitiveColumn<int>.FromValues("c", "Int32", new[] { 7, 0, 9 });
+        var dense = new NullableValueColumn<int>("c", "Nullable(Int32)", inner, new byte[] { 0, 1, 0 }, rowCount: 3, pooledMap: false);
+
+        Assert.That(codec.Densify(dense), Is.SameAs(dense));
+    }
+
+    [Test]
+    public void Densify_LeafCodec_ReturnsColumnUnchanged()
+    {
+        // A leaf codec has no denser form, so the default hook returns the column by reference.
+        IColumnCodec codec = Resolve("Int32");
+        var column = new ArrayColumn<int>("c", "Int32", new[] { 1, 2, 3 });
+
+        Assert.That(codec.Densify(column), Is.SameAs(column));
+    }
+
+    [Test]
+    public void Resolve_NestedNullable_ThrowsFormat()
+        => Assert.Throws<FormatException>(() => Resolve("Nullable(Nullable(Int32))"));
+
+    [TestCase("Nullable(Int32, Int32)")]
+    [TestCase("Nullable()")]
+    public void Resolve_WrongArgumentCount_ThrowsFormat(string type)
+        => Assert.Throws<FormatException>(() => Resolve(type));
+
+    [Test]
+    public void Resolve_UnsupportedInner_ThrowsNotSupported()
+        => Assert.Throws<NotSupportedException>(() => Resolve("Nullable(Array(Int32))"));
+
+    [Test]
+    public void Resolve_Nullable_StampsFullTypeName()
+        => Assert.That(Resolve("Nullable(UInt8)").TypeName, Is.EqualTo("Nullable(UInt8)"));
+}

--- a/ClickHouse.Driver.Tcp.Tests/Types/NullableColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/NullableColumnCodecTests.cs
@@ -298,16 +298,16 @@ public class NullableColumnCodecTests
     }
 
     [Test]
-    public async Task Densify_ErgonomicValueColumn_ProducesDenseColumnThatRoundTrips()
+    public async Task TryDensify_ErgonomicValueColumn_ProducesDenseColumnThatRoundTrips()
     {
-        // Densify splits the ergonomic T? column into a dense (inner column + null-map) NullableValueColumn: the
+        // TryDensify splits the ergonomic T? column into a dense (inner column + null-map) NullableValueColumn: the
         // inner holds a real value at every row (the codec's placeholder at the null rows) and the null-map marks
         // the nulls. It must surface the same T? values and round-trip identically to the ergonomic form.
         IColumnCodec codec = Resolve("Nullable(Int32)");
         var expected = new int?[] { 7, null, -3, null, 0 };
         var ergonomic = new ArrayColumn<int?>("c", "Nullable(Int32)", expected);
 
-        IColumn densified = codec.Densify(ergonomic);
+        using IColumn densified = codec.TryDensify(ergonomic, out _);
 
         Assert.That(densified, Is.InstanceOf<NullableValueColumn<int>>());
         var dense = (NullableValueColumn<int>)densified;
@@ -323,13 +323,13 @@ public class NullableColumnCodecTests
     }
 
     [Test]
-    public async Task Densify_ErgonomicReferenceColumn_ProducesDenseColumnThatRoundTrips()
+    public async Task TryDensify_ErgonomicReferenceColumn_ProducesDenseColumnThatRoundTrips()
     {
         IColumnCodec codec = Resolve("Nullable(String)");
         var expected = new[] { "hi", null, string.Empty, "world" };
         var ergonomic = new ArrayColumn<string>("c", "Nullable(String)", expected);
 
-        IColumn densified = codec.Densify(ergonomic);
+        using IColumn densified = codec.TryDensify(ergonomic, out _);
 
         Assert.That(densified, Is.InstanceOf<NullableReferenceColumn<string>>());
         var dense = (NullableReferenceColumn<string>)densified;
@@ -344,7 +344,7 @@ public class NullableColumnCodecTests
     }
 
     [Test]
-    public void Densify_NullRows_UseInnerPlaceholderNotClrDefault()
+    public void TryDensify_NullRows_UseInnerPlaceholderNotClrDefault()
     {
         // default(DateOnly) (0001-01-01) is out of the Date codec's range; densify must fill the null rows with
         // the codec's own placeholder (the epoch) so the dense inner column is writable.
@@ -352,7 +352,7 @@ public class NullableColumnCodecTests
         var expected = new DateOnly?[] { new DateOnly(2000, 1, 1), null };
         var ergonomic = new ArrayColumn<DateOnly?>("c", "Nullable(Date)", expected);
 
-        var dense = (NullableValueColumn<DateOnly>)codec.Densify(ergonomic);
+        using var dense = (NullableValueColumn<DateOnly>)codec.TryDensify(ergonomic, out _);
 
         Assert.Multiple(() =>
         {
@@ -362,25 +362,35 @@ public class NullableColumnCodecTests
     }
 
     [Test]
-    public void Densify_AlreadyDenseColumn_ReturnsSameInstance()
+    public void TryDensify_AlreadyDenseColumn_ReturnsSameInstanceNotBuilt()
     {
-        // Densify is idempotent: a column already in dense form is returned by reference, so a caller can tell a
-        // freshly built column (to dispose) from a borrowed pass-through.
+        // TryDensify is idempotent: a column already in dense form is returned by reference with built = false, so a
+        // caller knows it is borrowed (not to be disposed) rather than freshly built.
         IColumnCodec codec = Resolve("Nullable(Int32)");
         var inner = PrimitiveColumn<int>.FromValues("c", "Int32", new[] { 7, 0, 9 });
         var dense = new NullableValueColumn<int>("c", "Nullable(Int32)", inner, new byte[] { 0, 1, 0 }, rowCount: 3, pooledMap: false);
 
-        Assert.That(codec.Densify(dense), Is.SameAs(dense));
+        IColumn result = codec.TryDensify(dense, out bool built);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.SameAs(dense));
+            Assert.That(built, Is.False, "an already-dense column is borrowed, not rebuilt");
+        });
     }
 
     [Test]
-    public void Densify_LeafCodec_ReturnsColumnUnchanged()
+    public void TryDensify_LeafCodec_ReturnsColumnUnchangedNotBuilt()
     {
-        // A leaf codec has no denser form, so the default hook returns the column by reference.
+        // A leaf codec has no denser form, so the default hook returns the column by reference with built = false.
         IColumnCodec codec = Resolve("Int32");
         var column = new ArrayColumn<int>("c", "Int32", new[] { 1, 2, 3 });
 
-        Assert.That(codec.Densify(column), Is.SameAs(column));
+        IColumn result = codec.TryDensify(column, out bool built);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.SameAs(column));
+            Assert.That(built, Is.False, "a leaf codec never builds a new column");
+        });
     }
 
     [Test]

--- a/ClickHouse.Driver.Tcp.Tests/Types/NullableColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/NullableColumnCodecTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Net;
 using System.Threading.Tasks;
 using ClickHouse.Driver.Tcp.Numerics;
 using ClickHouse.Driver.Tcp.Protocol;
@@ -14,38 +13,28 @@ public class NullableColumnCodecTests
     private static IColumnCodec Resolve(string type) => ColumnCodecRegistry.Default.Resolve(type, default);
 
     [Test]
-    public async Task ReadColumn_WriteThenRead_ValueInnerRoundTripsWithNulls()
+    public async Task Values_ValueAndReferenceInners_MaterializeEveryRowIncludingNulls()
     {
-        IColumnCodec codec = Resolve("Nullable(Int32)");
-        var expected = new int?[] { 7, null, -3, null, 0 };
-        var column = new ArrayColumn<int?>("c", "Nullable(Int32)", expected);
+        // Per-type value/null round-tripping is covered against a real server by the Nullable(T) cases in
+        // InsertRoundTripCase. What that cannot reach is this accessor: the integration comparison comes from
+        // AssertColumnsEqual, which only ever calls GetValue(row), so the lazily-materialized ArrayPool-rented
+        // Values cache on NullableValueColumn/NullableReferenceColumn is exercised nowhere else. Both the value
+        // and reference shapes have their own copy of it, hence both here.
+        IColumnCodec valueCodec = Resolve("Nullable(Int32)");
+        var valueExpected = new int?[] { 7, null, -3, null, 0 };
+        var valueColumn = new ArrayColumn<int?>("c", "Nullable(Int32)", valueExpected);
 
-        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Nullable(Int32)", column.RowCount);
+        IColumnCodec referenceCodec = Resolve("Nullable(String)");
+        var referenceExpected = new[] { "hi", null, string.Empty, "world" };
+        var referenceColumn = new ArrayColumn<string>("c", "Nullable(String)", referenceExpected);
+
+        using IColumn valueRead = await CodecTestHarness.RoundTripAsync(valueCodec, valueColumn, "Nullable(Int32)", valueColumn.RowCount);
+        using IColumn referenceRead = await CodecTestHarness.RoundTripAsync(referenceCodec, referenceColumn, "Nullable(String)", referenceColumn.RowCount);
 
         Assert.Multiple(() =>
         {
-            Assert.That(read.TypeName, Is.EqualTo("Nullable(Int32)"));
-            Assert.That(read.RowCount, Is.EqualTo(5));
-            Assert.That(((IColumn<int?>)read).Values.ToArray(), Is.EqualTo(expected));
-            Assert.That(read.GetValue(0), Is.EqualTo(7));
-            Assert.That(read.GetValue(1), Is.Null);
-        });
-    }
-
-    [Test]
-    public async Task ReadColumn_WriteThenRead_ReferenceInnerRoundTripsWithNulls()
-    {
-        IColumnCodec codec = Resolve("Nullable(String)");
-        var expected = new[] { "hi", null, string.Empty, "world" };
-        var column = new ArrayColumn<string>("c", "Nullable(String)", expected);
-
-        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Nullable(String)", column.RowCount);
-
-        Assert.Multiple(() =>
-        {
-            Assert.That(read.RowCount, Is.EqualTo(4));
-            Assert.That(((IColumn<string>)read).Values.ToArray(), Is.EqualTo(expected));
-            Assert.That(read.GetValue(1), Is.Null);
+            Assert.That(((IColumn<int?>)valueRead).Values.ToArray(), Is.EqualTo(valueExpected));
+            Assert.That(((IColumn<string>)referenceRead).Values.ToArray(), Is.EqualTo(referenceExpected));
         });
     }
 
@@ -62,69 +51,6 @@ public class NullableColumnCodecTests
         using IColumn read = await CodecTestHarness.RoundTripAsync(codec, dense, "Nullable(Int32)", dense.RowCount);
 
         Assert.That(((IColumn<int?>)read).Values.ToArray(), Is.EqualTo(new int?[] { 7, null, 9 }));
-    }
-
-    [Test]
-    public async Task ReadColumn_EveryRowNull_RoundTripsAsAllNull()
-    {
-        IColumnCodec codec = Resolve("Nullable(Int32)");
-        var column = new ArrayColumn<int?>("c", "Nullable(Int32)", new int?[] { null, null, null });
-
-        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Nullable(Int32)", column.RowCount);
-
-        Assert.Multiple(() =>
-        {
-            Assert.That(read.RowCount, Is.EqualTo(3));
-            Assert.That(read.GetValue(0), Is.Null);
-            Assert.That(read.GetValue(2), Is.Null);
-        });
-    }
-
-    [Test]
-    public async Task ReadColumn_ValueInnerWhoseDefaultIsOutOfRange_WritesPlaceholderTheCodecAccepts()
-    {
-        // default(DateOnly) is 0001-01-01, which the Date codec rejects; the null rows must borrow a present
-        // value as the placeholder instead, so writing does not throw.
-        IColumnCodec codec = Resolve("Nullable(Date)");
-        var expected = new DateOnly?[] { new DateOnly(2000, 1, 1), null, new DateOnly(1970, 1, 1) };
-        var column = new ArrayColumn<DateOnly?>("c", "Nullable(Date)", expected);
-
-        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Nullable(Date)", column.RowCount);
-
-        Assert.That(((IColumn<DateOnly?>)read).Values.ToArray(), Is.EqualTo(expected));
-    }
-
-    [Test]
-    public async Task ReadColumn_FixedWidthReferenceInnerWithNulls_WritesPlaceholderNotDereferenced()
-    {
-        // IPv4 is reference-typed (IPAddress) but fixed-width; the IP codec dereferences each value, so a null
-        // row must be written as a placeholder rather than passed through. This would NRE if it were.
-        IColumnCodec codec = Resolve("Nullable(IPv4)");
-        var expected = new[] { IPAddress.Parse("127.0.0.1"), null, IPAddress.Parse("10.0.0.1") };
-        var column = new ArrayColumn<IPAddress>("c", "Nullable(IPv4)", expected);
-
-        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Nullable(IPv4)", column.RowCount);
-
-        Assert.Multiple(() =>
-        {
-            Assert.That(((IColumn<IPAddress>)read).Values.ToArray(), Is.EqualTo(expected));
-            Assert.That(read.GetValue(1), Is.Null);
-        });
-    }
-
-    [Test]
-    public async Task ReadColumn_FixedWidthReferenceInnerAllNull_RoundTripsAsAllNull()
-    {
-        IColumnCodec codec = Resolve("Nullable(IPv6)");
-        var column = new ArrayColumn<IPAddress>("c", "Nullable(IPv6)", new IPAddress[] { null, null });
-
-        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Nullable(IPv6)", column.RowCount);
-
-        Assert.Multiple(() =>
-        {
-            Assert.That(read.GetValue(0), Is.Null);
-            Assert.That(read.GetValue(1), Is.Null);
-        });
     }
 
     [Test]

--- a/ClickHouse.Driver.Tcp.Tests/Types/NullableColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/NullableColumnCodecTests.cs
@@ -157,23 +157,18 @@ public class NullableColumnCodecTests
     {
         // The bare DateTime codec accepts both DateTimeOffset and DateTime; Nullable(DateTime) re-offers both.
         // A DateTime? column (the inner's alternate spelling made nullable) must write, with the null row taking
-        // a DateTime placeholder — not the canonical DateTimeOffset one — and read back as the canonical offset.
+        // a DateTime placeholder, and read back as the canonical raw epoch seconds (uint?).
         IColumnCodec codec = Resolve("Nullable(DateTime('UTC'))");
         var input = new DateTime?[] { DateTime.UnixEpoch.AddSeconds(1_700_000_000), null, DateTime.UnixEpoch };
         var column = new ArrayColumn<DateTime?>("c", "Nullable(DateTime('UTC'))", input);
 
         using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Nullable(DateTime('UTC'))", column.RowCount);
 
-        var expected = new DateTimeOffset?[]
-        {
-            DateTimeOffset.FromUnixTimeSeconds(1_700_000_000),
-            null,
-            DateTimeOffset.FromUnixTimeSeconds(0),
-        };
+        var expected = new uint?[] { 1_700_000_000u, null, 0u };
         Assert.Multiple(() =>
         {
-            Assert.That(codec.ElementType, Is.EqualTo(typeof(DateTimeOffset?)));
-            Assert.That(((IColumn<DateTimeOffset?>)read).Values.ToArray(), Is.EqualTo(expected));
+            Assert.That(codec.ElementType, Is.EqualTo(typeof(uint?)));
+            Assert.That(((IColumn<uint?>)read).Values.ToArray(), Is.EqualTo(expected));
             Assert.That(read.GetValue(1), Is.Null);
         });
     }
@@ -194,11 +189,12 @@ public class NullableColumnCodecTests
     [Test]
     public async Task WriteColumn_NullableDateTime64AsOffsetAndDateTimeSpellings_RoundTripsAsCanonicalNative()
     {
-        // DateTime64's canonical read type is ClickHouseDateTime64, but it accepts DateTimeOffset and DateTime on
+        // DateTime64's canonical read type is the raw Int64 count, but it accepts DateTimeOffset and DateTime on
         // write; Nullable(DateTime64) re-offers all three. Both alternate spellings must round-trip through the
-        // native read type, each with its own-typed placeholder at the null row.
+        // raw read type, with a null placeholder at the null row.
         IColumnCodec codec = Resolve("Nullable(DateTime64(3, 'UTC'))");
         DateTimeOffset present = DateTimeOffset.FromUnixTimeMilliseconds(1_700_000_000_123);
+        const long presentCount = 1_700_000_000_123L; // scale 3: milliseconds since the epoch
 
         var asOffset = new ArrayColumn<DateTimeOffset?>("c", "Nullable(DateTime64(3, 'UTC'))", new DateTimeOffset?[] { present, null });
         var asDateTime = new ArrayColumn<DateTime?>("c", "Nullable(DateTime64(3, 'UTC'))", new DateTime?[] { present.UtcDateTime, null });
@@ -208,14 +204,14 @@ public class NullableColumnCodecTests
 
         Assert.Multiple(() =>
         {
-            Assert.That(codec.ElementType, Is.EqualTo(typeof(ClickHouseDateTime64?)));
+            Assert.That(codec.ElementType, Is.EqualTo(typeof(long?)));
 
-            var offsetRead = (IColumn<ClickHouseDateTime64?>)fromOffset;
-            Assert.That(offsetRead[0].Value.ToDateTimeOffset(), Is.EqualTo(present));
+            var offsetRead = (IColumn<long?>)fromOffset;
+            Assert.That(offsetRead[0].Value, Is.EqualTo(presentCount));
             Assert.That(fromOffset.GetValue(1), Is.Null);
 
-            var dateTimeRead = (IColumn<ClickHouseDateTime64?>)fromDateTime;
-            Assert.That(dateTimeRead[0].Value.ToDateTimeOffset(), Is.EqualTo(present));
+            var dateTimeRead = (IColumn<long?>)fromDateTime;
+            Assert.That(dateTimeRead[0].Value, Is.EqualTo(presentCount));
             Assert.That(fromDateTime.GetValue(1), Is.Null);
         });
     }
@@ -227,7 +223,7 @@ public class NullableColumnCodecTests
 
         Assert.Multiple(() =>
         {
-            Assert.That(codec.CanWrite(new ArrayColumn<ClickHouseDateTime64?>("c", "Nullable(DateTime64(3, 'UTC'))", new ClickHouseDateTime64?[] { new ClickHouseDateTime64(0, 3, TimeSpan.Zero) })), Is.True);
+            Assert.That(codec.CanWrite(new ArrayColumn<long?>("c", "Nullable(DateTime64(3, 'UTC'))", new long?[] { 0L })), Is.True);
             Assert.That(codec.CanWrite(new ArrayColumn<DateTimeOffset?>("c", "Nullable(DateTime64(3, 'UTC'))", new DateTimeOffset?[] { DateTimeOffset.UnixEpoch })), Is.True);
             Assert.That(codec.CanWrite(new ArrayColumn<DateTime?>("c", "Nullable(DateTime64(3, 'UTC'))", new DateTime?[] { DateTime.UnixEpoch })), Is.True);
         });

--- a/ClickHouse.Driver.Tcp.Tests/Types/NullableColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/NullableColumnCodecTests.cs
@@ -46,11 +46,40 @@ public class NullableColumnCodecTests
         // reading it back must preserve the values and nulls.
         IColumnCodec codec = Resolve("Nullable(Int32)");
         var inner = PrimitiveColumn<int>.FromValues("c", "Int32", new[] { 7, 0, 9 });
-        var dense = new NullableValueColumn<int>("c", "Nullable(Int32)", inner, new byte[] { 0, 1, 0 }, rowCount: 3, pooledMap: false);
+        var dense = new NullableValueColumn<int>("c", "Nullable(Int32)", inner, new byte[] { 0, 1, 0 }, pooledMap: false);
 
         using IColumn read = await CodecTestHarness.RoundTripAsync(codec, dense, "Nullable(Int32)", dense.RowCount);
 
-        Assert.That(((IColumn<int?>)read).Values.ToArray(), Is.EqualTo(new int?[] { 7, null, 9 }));
+        Assert.Multiple(() =>
+        {
+            Assert.That(dense.RowCount, Is.EqualTo(3), "the row count comes from the inner column, not a separate argument");
+            Assert.That(((IColumn<int?>)read).Values.ToArray(), Is.EqualTo(new int?[] { 7, null, 9 }));
+        });
+    }
+
+    [Test]
+    public void Constructor_NullMapShorterThanInner_Throws()
+    {
+        // The inner column sets the row count, so those two can no longer disagree; the null-map is the one input
+        // that still can. A pooled map is routinely longer than the row count (and must stay accepted), so only a
+        // short one is rejected — unchecked it would leave NullMap's slice and the indexer reading out of bounds.
+        var inner = PrimitiveColumn<int>.FromValues("c", "Int32", new[] { 1, 2, 3 });
+        var longer = new byte[8];
+        var reference = new ArrayColumn<string>("c", "String", new[] { "a", "b", "c" });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                () => new NullableValueColumn<int>("c", "Nullable(Int32)", inner, new byte[] { 0, 1 }, pooledMap: false),
+                Throws.ArgumentException.With.Message.Contains("shorter than"));
+            Assert.That(
+                () => new NullableReferenceColumn<string>("c", "Nullable(String)", reference, new byte[] { 0, 1 }, pooledMap: false),
+                Throws.ArgumentException.With.Message.Contains("shorter than"));
+            Assert.That(
+                new NullableValueColumn<int>("c", "Nullable(Int32)", inner, longer, pooledMap: false).RowCount,
+                Is.EqualTo(3),
+                "an over-long pooled map is accepted and does not inflate the row count");
+        });
     }
 
     [Test]

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/CodecTestHarness.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/CodecTestHarness.cs
@@ -31,45 +31,21 @@ internal static class CodecTestHarness
 
     /// <summary>
     /// Writes then reads back <paramref name="column"/> through <paramref name="codec"/>, returning the decoded
-    /// column. The column is densified first, mirroring the insert pipeline, which densifies every column before
-    /// the write so the codecs only ever measure/write the dense wire shape.
+    /// column. The column is written straight from its ergonomic form (no densify step), exactly as the insert
+    /// pipeline now does — the codec projects it to the wire through lazy views with no intermediate dense buffer.
     /// </summary>
     public static async Task<IColumn> RoundTripAsync(IColumnCodec codec, IColumn column, string columnType, int rowCount)
     {
-        IColumn dense = codec.TryDensify(column, out bool built);
-        try
-        {
-            byte[] bytes = await WriteAsync(w => codec.WriteColumn(w, dense));
-            using ClickHouseBinaryReader reader = ReaderOver(bytes);
-            return await codec.ReadColumnAsync(reader, column.Name, columnType, rowCount, None);
-        }
-        finally
-        {
-            if (built)
-            {
-                dense.Dispose();
-            }
-        }
+        byte[] bytes = await WriteAsync(w => codec.WriteColumn(w, column));
+        using ClickHouseBinaryReader reader = ReaderOver(bytes);
+        return await codec.ReadColumnAsync(reader, column.Name, columnType, rowCount, None);
     }
 
     /// <summary>
-    /// Densifies <paramref name="column"/> through <paramref name="codec"/> and encodes the requested row range,
-    /// mirroring the insert pipeline. Use for the direct-<see cref="IColumnCodec.WriteColumn(ClickHouseBinaryWriter, IColumn, int, int)"/>
-    /// slice tests that bypass <see cref="RoundTripAsync"/>.
+    /// Encodes the requested row range of <paramref name="column"/> straight from its ergonomic form. Use for the
+    /// direct-<see cref="IColumnCodec.WriteColumn(ClickHouseBinaryWriter, IColumn, int, int)"/> slice tests that
+    /// bypass <see cref="RoundTripAsync"/>.
     /// </summary>
-    public static async Task<byte[]> WriteDenseAsync(IColumnCodec codec, IColumn column, int start, int length)
-    {
-        IColumn dense = codec.TryDensify(column, out bool built);
-        try
-        {
-            return await WriteAsync(w => codec.WriteColumn(w, dense, start, length));
-        }
-        finally
-        {
-            if (built)
-            {
-                dense.Dispose();
-            }
-        }
-    }
+    public static Task<byte[]> WriteSliceAsync(IColumnCodec codec, IColumn column, int start, int length)
+        => WriteAsync(w => codec.WriteColumn(w, column, start, length));
 }

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/CodecTestHarness.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/CodecTestHarness.cs
@@ -29,11 +29,47 @@ internal static class CodecTestHarness
     /// <summary>A reader over the given bytes.</summary>
     public static ClickHouseBinaryReader ReaderOver(byte[] bytes) => new(new MemoryStream(bytes));
 
-    /// <summary>Writes then reads back <paramref name="column"/> through <paramref name="codec"/>, returning the decoded column.</summary>
+    /// <summary>
+    /// Writes then reads back <paramref name="column"/> through <paramref name="codec"/>, returning the decoded
+    /// column. The column is densified first, mirroring the insert pipeline, which densifies every column before
+    /// the write so the codecs only ever measure/write the dense wire shape.
+    /// </summary>
     public static async Task<IColumn> RoundTripAsync(IColumnCodec codec, IColumn column, string columnType, int rowCount)
     {
-        byte[] bytes = await WriteAsync(w => codec.WriteColumn(w, column));
-        using ClickHouseBinaryReader reader = ReaderOver(bytes);
-        return await codec.ReadColumnAsync(reader, column.Name, columnType, rowCount, None);
+        IColumn dense = codec.TryDensify(column, out bool built);
+        try
+        {
+            byte[] bytes = await WriteAsync(w => codec.WriteColumn(w, dense));
+            using ClickHouseBinaryReader reader = ReaderOver(bytes);
+            return await codec.ReadColumnAsync(reader, column.Name, columnType, rowCount, None);
+        }
+        finally
+        {
+            if (built)
+            {
+                dense.Dispose();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Densifies <paramref name="column"/> through <paramref name="codec"/> and encodes the requested row range,
+    /// mirroring the insert pipeline. Use for the direct-<see cref="IColumnCodec.WriteColumn(ClickHouseBinaryWriter, IColumn, int, int)"/>
+    /// slice tests that bypass <see cref="RoundTripAsync"/>.
+    /// </summary>
+    public static async Task<byte[]> WriteDenseAsync(IColumnCodec codec, IColumn column, int start, int length)
+    {
+        IColumn dense = codec.TryDensify(column, out bool built);
+        try
+        {
+            return await WriteAsync(w => codec.WriteColumn(w, dense, start, length));
+        }
+        finally
+        {
+            if (built)
+            {
+                dense.Dispose();
+            }
+        }
     }
 }

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
@@ -151,7 +151,6 @@ public sealed class InsertRoundTripCase
 
         // Newer/experimental server types: enable their flag on the round-trip
         yield return BFloat16s("BFloat16", BFloat16Settings, 0f, 1f, -2f, 0.5f, 100f);
-
         // Time surfaces as the raw Int32 seconds; Time64 as the raw Int64 count at the column's scale. The
         // inserted values are the exact wire values, returned verbatim.
         yield return TimeSeconds("Time", TimeSettings, 0, (12 * 3600) + (34 * 60) + 56, -((1 * 3600) + (2 * 60) + 3));
@@ -176,6 +175,102 @@ public sealed class InsertRoundTripCase
             name => new ArrayColumn<TimeSpan>(name, "Time64(3)", time64Spans),
             name => new ArrayColumn<long>(name, "Time64(3)", Array.ConvertAll(time64Spans, t => t.Ticks / TimeSpan.TicksPerMillisecond)),
             TimeSettings);
+
+        // Nullable(T): one case per supported inner type. A value inner surfaces as T?, a reference inner as the
+        // nullable reference; each case interleaves nulls with present values, and the all-null cases exercise
+        // the placeholder-only values stream. IMPORTANT: when adding a new type to this list, add a Nullable(that
+        // type) case here too — Nullable exercises a distinct write path (null-map + per-type null placeholder)
+        // that the bare type does not.
+        yield return NullableValues<byte>("UInt8", 0, null, byte.MaxValue);
+        yield return NullableValues<sbyte>("Int8", sbyte.MinValue, null, sbyte.MaxValue);
+        yield return NullableValues<ushort>("UInt16", 0, null, ushort.MaxValue);
+        yield return NullableValues<short>("Int16", short.MinValue, null, short.MaxValue);
+        yield return NullableValues<uint>("UInt32", 0, null, uint.MaxValue);
+        yield return NullableValues<int>("Int32", int.MinValue, null, 0, int.MaxValue);
+        yield return NullableValues<int>("Int32", (int?)null, null); // every row null: the values stream is all placeholder
+        yield return NullableValues<ulong>("UInt64", 0, null, ulong.MaxValue);
+        yield return NullableValues<long>("Int64", long.MinValue, null, long.MaxValue);
+        yield return NullableValues<UInt128>("UInt128", UInt128.Zero, null, UInt128.MaxValue);
+        yield return NullableValues<Int128>("Int128", Int128.MinValue, null, Int128.MaxValue);
+        yield return NullableValues<UInt256>("UInt256", UInt256.Zero, null, UInt256.FromBigInteger(System.Numerics.BigInteger.Pow(2, 200)));
+        yield return NullableValues<Int256>("Int256", Int256.FromBigInteger(-System.Numerics.BigInteger.Pow(2, 200)), null, Int256.Zero);
+        yield return NullableValues<float>("Float32", 0f, null, -1.5f, float.MaxValue);
+        yield return NullableValues<double>("Float64", 1.5, null, -1.5e100, null);
+        yield return NullableValues<bool>("Bool", true, null, false);
+        yield return NullableValues<sbyte>("Enum8('a' = -1, 'b' = 127)", -1, null, 127);
+        yield return NullableValues<short>("Enum16('x' = -32768, 'y' = 32767)", -32768, null, 32767);
+        yield return NullableValues<DateOnly>("Date", new DateOnly(1970, 1, 1), null, new DateOnly(2149, 6, 6));
+        yield return NullableValues<DateOnly>("Date32", new DateOnly(1900, 1, 1), null, new DateOnly(2299, 12, 31));
+        yield return NullableValues<Guid>("UUID", Guid.Empty, null, new Guid("00112233-4455-6677-8899-aabbccddeeff"));
+        yield return NullableValues<decimal>("Decimal(9, 2)", 1.23m, null, -1.23m, 9999999.99m);
+        yield return NullableValues<decimal>("Decimal(18, 4)", 12345.6789m, null, -12345.6789m);
+        yield return NullableWideDecimals("Decimal(38, 10)", "12345.6789", null, "-98765.4321");
+        yield return NullableWideDecimals("Decimal(76, 20)", "1.00000000000000000001", null, "-1.00000000000000000001");
+        yield return NullableValues<long>("IntervalSecond", 0L, null, -5L);
+
+        // DateTime reads back a DateTimeOffset?; equality is by instant, so the presented offset does not matter.
+        yield return NullableDateTimes(
+            new DateTimeOffset(2024, 1, 15, 10, 30, 0, TimeSpan.Zero),
+            null,
+            new DateTimeOffset(1988, 8, 28, 11, 22, 33, TimeSpan.Zero));
+        yield return NullableDateTime64s(3, 0L, null, 1_700_000_000_123L, null);
+        yield return NullableDateTime64s(9, 1_700_000_000_123_456_789L, null, -1_000_000_001L);
+
+        // Experimental server types: enable their flag on the round-trip (same as their non-nullable cases).
+        yield return NullableValues<float>("BFloat16", BFloat16Settings, 0f, null, 1f, -2f);
+        yield return NullableValues<TimeSpan>("Time", TimeSettings, TimeSpan.Zero, null, new TimeSpan(12, 34, 56));
+        yield return NullableValues<TimeSpan>("Time64(3)", TimeSettings, TimeSpan.Zero, null, new TimeSpan(0, 1, 2, 3, 456));
+
+        yield return NullableStrings("hello", null, "world", string.Empty);
+        yield return NullableStrings(null, null); // every row null
+
+        // IPv4/IPv6 are reference-typed (IPAddress) but fixed-width; a null row must not reach the IP codec (it
+        // dereferences the address), so the nullable write substitutes a placeholder instead.
+        yield return NullableIps("IPv4", "127.0.0.1", null, "255.255.255.255");
+        yield return NullableIps("IPv6", "::1", null, "2001:db8::1");
+        yield return NullableIps("IPv4", null, null); // every row null
+    }
+
+    private static InsertRoundTripCase NullableValues<T>(string innerType, params T?[] values)
+        where T : struct
+        => NullableValues(innerType, settings: null, values);
+
+    private static InsertRoundTripCase NullableValues<T>(string innerType, IReadOnlyDictionary<string, string> settings, params T?[] values)
+        where T : struct
+    {
+        string type = $"Nullable({innerType})";
+        return new InsertRoundTripCase($"{type} [{values.Length} rows]", type, name => new ArrayColumn<T?>(name, type, values), name => new ArrayColumn<T?>(name, type, values), settings);
+    }
+
+    // Nullable(DateTime) inserts and reads back a DateTimeOffset?; DateTimeOffset equality compares the instant,
+    // so the offset the server presents on read need not match the (UTC) one supplied here.
+    private static InsertRoundTripCase NullableDateTimes(params DateTimeOffset?[] values)
+        => Same($"Nullable(DateTime) [{values.Length} rows]", "Nullable(DateTime)", name => new ArrayColumn<DateTimeOffset?>(name, "Nullable(DateTime)", values));
+
+    // Nullable(DateTime64(scale)) surfaces a ClickHouseDateTime64?; a null count maps to a null row.
+    private static InsertRoundTripCase NullableDateTime64s(int scale, params long?[] counts)
+    {
+        string type = $"Nullable(DateTime64({scale}))";
+        return Same($"{type} [{counts.Length} rows]", type, name => new ArrayColumn<ClickHouseDateTime64?>(
+            name, type, Array.ConvertAll(counts, c => c is null ? (ClickHouseDateTime64?)null : new ClickHouseDateTime64(c.Value, scale, TimeSpan.Zero))));
+    }
+
+    // Nullable of a wide decimal (Decimal128/256) surfaces a ClickHouseDecimal?; a null string maps to a null row.
+    private static InsertRoundTripCase NullableWideDecimals(string innerType, params string[] values)
+    {
+        string type = $"Nullable({innerType})";
+        return Same($"{type} [{values.Length} rows]", type, name => new ArrayColumn<ClickHouseDecimal?>(
+            name, type, values.Select(v => v is null ? (ClickHouseDecimal?)null : ParseWide(v)).ToArray()));
+    }
+
+    private static InsertRoundTripCase NullableStrings(params string[] values)
+        => Same($"Nullable(String) [{values.Length} rows]", "Nullable(String)", name => new ArrayColumn<string>(name, "Nullable(String)", values));
+
+    private static InsertRoundTripCase NullableIps(string innerType, params string[] values)
+    {
+        string type = $"Nullable({innerType})";
+        return Same($"{type} [{values.Length} rows]", type, name => new ArrayColumn<IPAddress>(
+            name, type, values.Select(v => v is null ? null : IPAddress.Parse(v)).ToArray()));
     }
 
     private static InsertRoundTripCase Primitive<T>(string clickHouseType, T[] values)

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
@@ -218,8 +218,8 @@ public sealed class InsertRoundTripCase
 
         // Experimental server types: enable their flag on the round-trip (same as their non-nullable cases).
         yield return NullableValues<float>("BFloat16", BFloat16Settings, 0f, null, 1f, -2f);
-        yield return NullableValues<TimeSpan>("Time", TimeSettings, TimeSpan.Zero, null, new TimeSpan(12, 34, 56));
-        yield return NullableValues<TimeSpan>("Time64(3)", TimeSettings, TimeSpan.Zero, null, new TimeSpan(0, 1, 2, 3, 456));
+        yield return NullableValues<int>("Time", TimeSettings, 0, null, (12 * 3600) + (34 * 60) + 56);
+        yield return NullableValues<long>("Time64(3)", TimeSettings, 0L, null, (((1 * 3600) + (2 * 60) + 3) * 1000L) + 456);
 
         yield return NullableStrings("hello", null, "world", string.Empty);
         yield return NullableStrings(null, null); // every row null
@@ -242,17 +242,21 @@ public sealed class InsertRoundTripCase
         return new InsertRoundTripCase($"{type} [{values.Length} rows]", type, name => new ArrayColumn<T?>(name, type, values), name => new ArrayColumn<T?>(name, type, values), settings);
     }
 
-    // Nullable(DateTime) inserts and reads back a DateTimeOffset?; DateTimeOffset equality compares the instant,
-    // so the offset the server presents on read need not match the (UTC) one supplied here.
+    // Nullable(DateTime) inserts a DateTimeOffset? but reads back the raw UInt32 epoch seconds (uint?); the
+    // expected column carries each present instant's epoch seconds, with nulls preserved.
     private static InsertRoundTripCase NullableDateTimes(params DateTimeOffset?[] values)
-        => Same($"Nullable(DateTime) [{values.Length} rows]", "Nullable(DateTime)", name => new ArrayColumn<DateTimeOffset?>(name, "Nullable(DateTime)", values));
+        => new(
+            $"Nullable(DateTime) [{values.Length} rows]",
+            "Nullable(DateTime)",
+            name => new ArrayColumn<DateTimeOffset?>(name, "Nullable(DateTime)", values),
+            name => new ArrayColumn<uint?>(name, "Nullable(DateTime)", Array.ConvertAll(values, v => v is null ? (uint?)null : (uint)v.Value.ToUnixTimeSeconds())),
+            settings: null);
 
-    // Nullable(DateTime64(scale)) surfaces a ClickHouseDateTime64?; a null count maps to a null row.
+    // Nullable(DateTime64(scale)) surfaces a long? raw count at the column's scale; a null count maps to a null row.
     private static InsertRoundTripCase NullableDateTime64s(int scale, params long?[] counts)
     {
         string type = $"Nullable(DateTime64({scale}))";
-        return Same($"{type} [{counts.Length} rows]", type, name => new ArrayColumn<ClickHouseDateTime64?>(
-            name, type, Array.ConvertAll(counts, c => c is null ? (ClickHouseDateTime64?)null : new ClickHouseDateTime64(c.Value, scale, TimeSpan.Zero))));
+        return Same($"{type} [{counts.Length} rows]", type, name => new ArrayColumn<long?>(name, type, counts));
     }
 
     // Nullable of a wide decimal (Decimal128/256) surfaces a ClickHouseDecimal?; a null string maps to a null row.

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
@@ -216,6 +216,34 @@ public sealed class InsertRoundTripCase
         yield return NullableDateTime64s(3, 0L, null, 1_700_000_000_123L, null);
         yield return NullableDateTime64s(9, 1_700_000_000_123_456_789L, null, -1_000_000_001L);
 
+        // Nullable re-offers every CLR write spelling the bare inner accepts, each with its own-typed null
+        // placeholder — so Nullable(DateTime) takes DateTimeOffset? or DateTime?, and Nullable(DateTime64) takes
+        // long?, DateTimeOffset? or DateTime?. The cases above only cover the first spelling of each, which left
+        // the alternates proven by unit tests alone; these send them to a server.
+        var nullableDateTimes = new DateTime?[] { DateTime.UnixEpoch.AddSeconds(1_700_000_000), null, DateTime.UnixEpoch };
+        yield return new InsertRoundTripCase(
+            "Nullable(DateTime) <- DateTime?",
+            "Nullable(DateTime)",
+            name => new ArrayColumn<DateTime?>(name, "Nullable(DateTime)", nullableDateTimes),
+            name => new ArrayColumn<uint?>(name, "Nullable(DateTime)", Array.ConvertAll(nullableDateTimes, v => v is null ? (uint?)null : (uint)new DateTimeOffset(v.Value.ToUniversalTime()).ToUnixTimeSeconds())),
+            settings: null);
+
+        var nullableOffsets = new DateTimeOffset?[] { DateTimeOffset.FromUnixTimeMilliseconds(1_700_000_000_123), null };
+        yield return new InsertRoundTripCase(
+            "Nullable(DateTime64(3)) <- DateTimeOffset?",
+            "Nullable(DateTime64(3))",
+            name => new ArrayColumn<DateTimeOffset?>(name, "Nullable(DateTime64(3))", nullableOffsets),
+            name => new ArrayColumn<long?>(name, "Nullable(DateTime64(3))", Array.ConvertAll(nullableOffsets, o => o?.ToUnixTimeMilliseconds())),
+            settings: null);
+
+        var nullable64DateTimes = new DateTime?[] { DateTime.UnixEpoch.AddMilliseconds(1_700_000_000_123), null };
+        yield return new InsertRoundTripCase(
+            "Nullable(DateTime64(3)) <- DateTime?",
+            "Nullable(DateTime64(3))",
+            name => new ArrayColumn<DateTime?>(name, "Nullable(DateTime64(3))", nullable64DateTimes),
+            name => new ArrayColumn<long?>(name, "Nullable(DateTime64(3))", Array.ConvertAll(nullable64DateTimes, v => v is null ? (long?)null : new DateTimeOffset(v.Value.ToUniversalTime()).ToUnixTimeMilliseconds())),
+            settings: null);
+
         // Experimental server types: enable their flag on the round-trip (same as their non-nullable cases).
         yield return NullableValues<float>("BFloat16", BFloat16Settings, 0f, null, 1f, -2f);
         yield return NullableValues<int>("Time", TimeSettings, 0, null, (12 * 3600) + (34 * 60) + 56);

--- a/ClickHouse.Driver.Tcp/Types/Codecs/INullableShape.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/INullableShape.cs
@@ -22,28 +22,11 @@ internal interface INullableShape
     /// <summary>Whether the inner codec can write an inner-typed column at all (e.g. <c>Nothing</c> cannot).</summary>
     bool CanInnerWrite(IColumnCodec inner);
 
-    /// <summary>Whether the value at <paramref name="row"/> of <paramref name="column"/> is null.</summary>
-    bool IsNull(IColumn column, int row);
-
     /// <summary>
     /// Writes the full nullable body for rows [<paramref name="start"/>, start + length): the null-map, then the
-    /// inner-type values with a placeholder at each null row. The column is always the dense nullable column (inner
-    /// column + null-map) — the pipeline densifies before the write — so it is written with no intermediate copy.
+    /// inner-type values with a placeholder at each null row. A dense nullable column (inner column + null-map) is
+    /// written with no intermediate copy; the ergonomic <c>T?</c> / nullable-reference form writes the null-map from
+    /// each row's nullness and hands the inner codec a substitute view (the inner placeholder at the null rows).
     /// </summary>
     void WriteBody(IColumnCodec inner, ClickHouseBinaryWriter writer, IColumn column, int start, int length);
-
-    /// <summary>
-    /// Projects an ergonomic column of this element type (the <c>T?</c> / nullable-reference form) into the dense
-    /// nullable column — an inner column holding a real value at every row (the inner codec's placeholder at the
-    /// null rows) paired with the null-map — recursing the inner codec's own <see cref="IColumnCodec.TryDensify"/>.
-    /// A column already in dense form is returned unchanged with <paramref name="built"/> = <see langword="false"/>;
-    /// a freshly built column sets <paramref name="built"/> = <see langword="true"/> and transfers ownership to the caller.
-    /// </summary>
-    IColumn TryDensify(IColumnCodec inner, IColumn column, out bool built);
-
-    /// <summary>The inner encoded byte length of a present (non-null) row's value.</summary>
-    long MeasureInnerRow(IColumnCodec inner, IColumn column, int row);
-
-    /// <summary>The inner encoded byte length of the inner codec's null placeholder (what a null row writes).</summary>
-    long MeasureNullPlaceholder(IColumnCodec inner);
 }

--- a/ClickHouse.Driver.Tcp/Types/Codecs/INullableShape.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/INullableShape.cs
@@ -27,18 +27,19 @@ internal interface INullableShape
 
     /// <summary>
     /// Writes the full nullable body for rows [<paramref name="start"/>, start + length): the null-map, then the
-    /// inner-type values with a placeholder at each null row. A dense nullable column (inner column + null-map)
-    /// is written with no intermediate copy; the ergonomic <c>T?</c> form is filled through a pooled buffer.
+    /// inner-type values with a placeholder at each null row. The column is always the dense nullable column (inner
+    /// column + null-map) — the pipeline densifies before the write — so it is written with no intermediate copy.
     /// </summary>
     void WriteBody(IColumnCodec inner, ClickHouseBinaryWriter writer, IColumn column, int start, int length);
 
     /// <summary>
     /// Projects an ergonomic column of this element type (the <c>T?</c> / nullable-reference form) into the dense
     /// nullable column — an inner column holding a real value at every row (the inner codec's placeholder at the
-    /// null rows) paired with the null-map — recursing the inner codec's own <see cref="IColumnCodec.Densify"/>. A
-    /// column already in dense form is returned unchanged.
+    /// null rows) paired with the null-map — recursing the inner codec's own <see cref="IColumnCodec.TryDensify"/>.
+    /// A column already in dense form is returned unchanged with <paramref name="built"/> = <see langword="false"/>;
+    /// a freshly built column sets <paramref name="built"/> = <see langword="true"/> and transfers ownership to the caller.
     /// </summary>
-    IColumn Densify(IColumnCodec inner, IColumn column);
+    IColumn TryDensify(IColumnCodec inner, IColumn column, out bool built);
 
     /// <summary>The inner encoded byte length of a present (non-null) row's value.</summary>
     long MeasureInnerRow(IColumnCodec inner, IColumn column, int row);

--- a/ClickHouse.Driver.Tcp/Types/Codecs/INullableShape.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/INullableShape.cs
@@ -1,0 +1,48 @@
+using System;
+using ClickHouse.Driver.Tcp.Protocol;
+
+namespace ClickHouse.Driver.Tcp.Types.Codecs;
+
+/// <summary>
+/// The generic bridge for one nullable element type: it knows how to build the typed wrapper column, test and
+/// interrogate a writable column, and feed the inner codec. One implementation covers value-type inners
+/// (surfacing <c>T?</c>), another reference-type inners; the concrete instance is chosen once per element type.
+/// </summary>
+internal interface INullableShape
+{
+    /// <summary>The CLR element type the wrapped column surfaces (<c>T?</c> for a value inner, <c>T</c> for a reference inner).</summary>
+    Type NullableElementType { get; }
+
+    /// <summary>Wraps a decoded inner column and its null-map into the typed nullable column.</summary>
+    IColumn Wrap(string name, string typeName, IColumn inner, byte[] nullMap, int rowCount, bool pooledMap);
+
+    /// <summary>Whether <paramref name="column"/> is a nullable column of this element type, writable by the codec.</summary>
+    bool CanWrite(IColumn column);
+
+    /// <summary>Whether the inner codec can write an inner-typed column at all (e.g. <c>Nothing</c> cannot).</summary>
+    bool CanInnerWrite(IColumnCodec inner);
+
+    /// <summary>Whether the value at <paramref name="row"/> of <paramref name="column"/> is null.</summary>
+    bool IsNull(IColumn column, int row);
+
+    /// <summary>
+    /// Writes the full nullable body for rows [<paramref name="start"/>, start + length): the null-map, then the
+    /// inner-type values with a placeholder at each null row. A dense nullable column (inner column + null-map)
+    /// is written with no intermediate copy; the ergonomic <c>T?</c> form is filled through a pooled buffer.
+    /// </summary>
+    void WriteBody(IColumnCodec inner, ClickHouseBinaryWriter writer, IColumn column, int start, int length);
+
+    /// <summary>
+    /// Projects an ergonomic column of this element type (the <c>T?</c> / nullable-reference form) into the dense
+    /// nullable column — an inner column holding a real value at every row (the inner codec's placeholder at the
+    /// null rows) paired with the null-map — recursing the inner codec's own <see cref="IColumnCodec.Densify"/>. A
+    /// column already in dense form is returned unchanged.
+    /// </summary>
+    IColumn Densify(IColumnCodec inner, IColumn column);
+
+    /// <summary>The inner encoded byte length of a present (non-null) row's value.</summary>
+    long MeasureInnerRow(IColumnCodec inner, IColumn column, int row);
+
+    /// <summary>The inner encoded byte length of the inner codec's null placeholder (what a null row writes).</summary>
+    long MeasureNullPlaceholder(IColumnCodec inner);
+}

--- a/ClickHouse.Driver.Tcp/Types/Codecs/INullableShape.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/INullableShape.cs
@@ -13,8 +13,12 @@ internal interface INullableShape
     /// <summary>The CLR element type the wrapped column surfaces (<c>T?</c> for a value inner, <c>T</c> for a reference inner).</summary>
     Type NullableElementType { get; }
 
-    /// <summary>Wraps a decoded inner column and its null-map into the typed nullable column.</summary>
-    IColumn Wrap(string name, string typeName, IColumn inner, byte[] nullMap, int rowCount, bool pooledMap);
+    /// <summary>
+    /// Wraps a decoded inner column and its null-map into the typed nullable column. The inner column's row count
+    /// becomes the wrapper's, so the two cannot disagree; <paramref name="nullMap"/> may be longer (a pooled buffer)
+    /// but not shorter.
+    /// </summary>
+    IColumn Wrap(string name, string typeName, IColumn inner, byte[] nullMap, bool pooledMap);
 
     /// <summary>Whether <paramref name="column"/> is a nullable column of this element type, writable by the codec.</summary>
     bool CanWrite(IColumn column);

--- a/ClickHouse.Driver.Tcp/Types/Codecs/NullableColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/NullableColumnCodec.cs
@@ -162,9 +162,19 @@ internal sealed class NullableColumnCodec : IColumnCodec
 
     /// <inheritdoc/>
     // Delegate to the shape for the supplied column's write type, which projects the ergonomic T? / nullable-
-    // reference form into the dense (inner column + null-map) column and recurses the inner codec's Densify. A
-    // column whose write type is unrecognized is left unchanged; the write path then reports it.
-    public IColumn Densify(IColumn column) => ResolveWriteShape(column)?.Densify(inner, column) ?? column;
+    // reference form into the dense (inner column + null-map) column and recurses the inner codec's TryDensify. A
+    // column whose write type is unrecognized is left unchanged (borrowed); the write path then reports it.
+    public IColumn TryDensify(IColumn column, out bool built)
+    {
+        INullableShape shape = ResolveWriteShape(column);
+        if (shape is null)
+        {
+            built = false;
+            return column;
+        }
+
+        return shape.TryDensify(inner, column, out built);
+    }
 
     /// <inheritdoc/>
     public void WriteStatePrefix(ClickHouseBinaryWriter writer) => inner.WriteStatePrefix(writer);

--- a/ClickHouse.Driver.Tcp/Types/Codecs/NullableColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/NullableColumnCodec.cs
@@ -1,0 +1,197 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Protocol;
+
+namespace ClickHouse.Driver.Tcp.Types.Codecs;
+
+/// <summary>
+/// A codec for the ClickHouse <c>Nullable(T)</c> column. It owns no bytes of its own beyond the null-map: it
+/// delegates the serialization-state prefix to the inner codec, then reads/writes a per-row null-map (one
+/// <c>UInt8</c> each: non-zero means NULL) followed by the inner type's encoding for <em>all</em> rows —
+/// placeholders included at the null positions. The decoded column surfaces each row as the inner CLR value or
+/// <see langword="null"/>: a value type as <c>T?</c> (<see cref="NullableValueColumn{T}"/>), a reference type as the
+/// nullable reference (<see cref="NullableReferenceColumn{T}"/>).
+///
+/// <para>
+/// The codec itself stays non-generic; the generic work — building the typed wrapper column, and reading and
+/// filling a caller's column — is delegated to a cached, per-element-type <see cref="INullableShape"/>.
+/// </para>
+///
+/// <para>
+/// On the write path a Nullable column may be supplied in any of the CLR write types the inner codec accepts
+/// (<see cref="IColumnCodec.WritableElementTypes"/>), each made nullable — so <c>Nullable(DateTime)</c> takes
+/// either <c>DateTimeOffset?</c> or <c>DateTime?</c>. One <see cref="INullableShape"/> is built per write type;
+/// the supplied column picks its shape, which fills the placeholder buffer in that same write type via the inner
+/// codec's <see cref="IColumnCodec.NullPlaceholderAs"/>. Reads always produce the canonical
+/// <see cref="IColumnCodec.ElementType"/> made nullable.
+/// </para>
+/// </summary>
+internal sealed class NullableColumnCodec : IColumnCodec
+{
+    private readonly IColumnCodec inner;
+    private readonly INullableShape canonicalShape;
+    private readonly (Type Spelling, INullableShape Shape)[] writeShapes;
+    private readonly bool innerCanWrite;
+    private INullableShape measureShape;  // the shape matching the measured column's write type, resolved on first use
+    private long? nullPlaceholderBytes;   // encoded size of a null row's placeholder, measured once measureShape is known
+
+    private NullableColumnCodec(string typeName, IColumnCodec inner)
+    {
+        TypeName = typeName;
+        this.inner = inner;
+
+        // The canonical shape drives reads and the read-back element type: reads always surface the inner's
+        // canonical ElementType made nullable.
+        canonicalShape = NullableShapes.For(inner.ElementType);
+
+        // One shape per CLR write type the inner codec accepts, so a Nullable column can be supplied in any form
+        // the bare inner accepts (e.g. Nullable(DateTime) as DateTimeOffset? or DateTime?). The canonical
+        // ElementType leads the list, so it wins when a column would match more than one write type.
+        IReadOnlyList<Type> writeTypes = inner.WritableElementTypes;
+        writeShapes = new (Type, INullableShape)[writeTypes.Count];
+        for (int i = 0; i < writeTypes.Count; i++)
+        {
+            writeShapes[i] = (writeTypes[i], NullableShapes.For(writeTypes[i]));
+        }
+
+        // Whether the inner codec can write at all (e.g. Nothing cannot). Computed once so CanWrite can reject a
+        // Nullable(non-writable) column up front rather than letting the write fail mid-stream.
+        innerCanWrite = canonicalShape.CanInnerWrite(inner);
+    }
+
+    /// <inheritdoc/>
+    public string TypeName { get; }
+
+    /// <inheritdoc/>
+    public Type ElementType => canonicalShape.NullableElementType;
+
+    /// <summary>
+    /// The placeholder for an absent <c>Nullable(T)</c> value is <see langword="null"/> itself — a null-marked
+    /// row. Relevant only if a future composite nests a <c>Nullable</c> and asks for its placeholder.
+    /// </summary>
+    public object NullPlaceholder => null;
+
+    /// <inheritdoc/>
+    public int? FixedRowByteSize => inner.FixedRowByteSize is int width ? 1 + width : null;
+
+    /// <summary>Builds a <c>Nullable(T)</c> codec, resolving the inner type <c>T</c> through the registry.</summary>
+    /// <param name="node">The parsed <c>Nullable</c> type node; its single argument is the inner type.</param>
+    /// <param name="context">The resolution context, forwarded to the inner codec's factory.</param>
+    /// <param name="registry">The registry used to resolve the inner type's codec.</param>
+    /// <returns>The codec.</returns>
+    /// <exception cref="FormatException">The type has other than one argument, or the inner is itself <c>Nullable</c>.</exception>
+    public static NullableColumnCodec Create(TypeNode node, in ResolveContext context, ColumnCodecRegistry registry)
+    {
+        if (node.Arguments.Count != 1)
+        {
+            throw new FormatException($"Nullable type '{node}' must have exactly one inner type argument.");
+        }
+
+        TypeNode innerNode = node.Arguments[0];
+        if (innerNode.Name == "Nullable")
+        {
+            throw new FormatException($"Nullable cannot be nested: '{node}'.");
+        }
+
+        IColumnCodec inner = registry.ResolveNode(innerNode, in context);
+        return new NullableColumnCodec(node.ToString(), inner);
+    }
+
+    /// <inheritdoc/>
+    public long MeasureRowBytes(IColumn column, int row)
+    {
+        // Measure through the shape matching the supplied column's CLR write type — the same resolution the write
+        // path uses — because IsNull and MeasureInnerRow read the column in its own write type. Resolved once and
+        // reused: the splitter measures a single column across all its rows, and a Nullable codec instance is
+        // never shared across columns. (The fixed-width inners — the only ones with alternate write types today —
+        // are priced in O(1) via FixedRowByteSize and never reach this walk, but the resolution keeps this
+        // correct for a variable-width inner that grows alternate write types, e.g. String also taking byte[].)
+        measureShape ??= ResolveWriteShape(column) ?? canonicalShape;
+
+        // One null-map byte, then the inner size: a present row measures its value; a null row measures the
+        // inner's placeholder (never the null value itself, which the inner codec would reject). The placeholder
+        // size is the same for every null row, so measure it once and cache.
+        if (measureShape.IsNull(column, row))
+        {
+            nullPlaceholderBytes ??= measureShape.MeasureNullPlaceholder(inner);
+            return 1 + nullPlaceholderBytes.Value;
+        }
+
+        return 1 + measureShape.MeasureInnerRow(inner, column, row);
+    }
+
+    /// <inheritdoc/>
+    public ValueTask ReadStatePrefixAsync(ClickHouseBinaryReader reader, CancellationToken cancellationToken)
+        => inner.ReadStatePrefixAsync(reader, cancellationToken);
+
+    /// <inheritdoc/>
+    public async ValueTask<IColumn> ReadColumnAsync(ClickHouseBinaryReader reader, string columnName, string columnType, int rowCount, CancellationToken cancellationToken)
+    {
+        if (rowCount == 0)
+        {
+            IColumn emptyInner = await inner.ReadColumnAsync(reader, columnName, inner.TypeName, 0, cancellationToken).ConfigureAwait(false);
+            return canonicalShape.Wrap(columnName, columnType, emptyInner, Array.Empty<byte>(), rowCount: 0, pooledMap: false);
+        }
+
+        byte[] nullMap = ArrayPool<byte>.Shared.Rent(rowCount);
+        IColumn innerColumn = null;
+        try
+        {
+            await reader.ReadBytesAsync(nullMap.AsMemory(0, rowCount), cancellationToken).ConfigureAwait(false);
+            innerColumn = await inner.ReadColumnAsync(reader, columnName, inner.TypeName, rowCount, cancellationToken).ConfigureAwait(false);
+
+            // Wrap pairs the null-map with the inner column (which holds a real inner value at every row — a
+            // placeholder at the null positions) into the typed nullable column that surfaces each null row as
+            // null. Wrap inside the try: only a successful Wrap takes ownership of the rented map and the inner
+            // column, so if it throws (e.g. an element-type mismatch surfacing as a cast failure) neither is leaked.
+            return canonicalShape.Wrap(columnName, columnType, innerColumn, nullMap, rowCount, pooledMap: true);
+        }
+        catch
+        {
+            ArrayPool<byte>.Shared.Return(nullMap);
+            innerColumn?.Dispose();
+            throw;
+        }
+    }
+
+    /// <inheritdoc/>
+    public bool CanWrite(IColumn column) => innerCanWrite && ResolveWriteShape(column) is not null;
+
+    /// <inheritdoc/>
+    // Delegate to the shape for the supplied column's write type, which projects the ergonomic T? / nullable-
+    // reference form into the dense (inner column + null-map) column and recurses the inner codec's Densify. A
+    // column whose write type is unrecognized is left unchanged; the write path then reports it.
+    public IColumn Densify(IColumn column) => ResolveWriteShape(column)?.Densify(inner, column) ?? column;
+
+    /// <inheritdoc/>
+    public void WriteStatePrefix(ClickHouseBinaryWriter writer) => inner.WriteStatePrefix(writer);
+
+    /// <inheritdoc/>
+    public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
+    {
+        INullableShape shape = ResolveWriteShape(column)
+            ?? throw new ArgumentException(
+                $"A {TypeName} column must hold one of [{string.Join(", ", Array.ConvertAll(writeShapes, w => w.Spelling.Name))}] made nullable, not {column.GetType()}.",
+                nameof(column));
+
+        shape.WriteBody(inner, writer, column, start, length);
+    }
+
+    // The shape for the CLR write type the supplied column uses, or null if none of the inner's writable types
+    // match. The canonical write type leads writeShapes, so it is preferred when a column matches more than one.
+    private INullableShape ResolveWriteShape(IColumn column)
+    {
+        foreach ((Type _, INullableShape shape) in writeShapes)
+        {
+            if (shape.CanWrite(column))
+            {
+                return shape;
+            }
+        }
+
+        return null;
+    }
+}

--- a/ClickHouse.Driver.Tcp/Types/Codecs/NullableColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/NullableColumnCodec.cs
@@ -35,8 +35,6 @@ internal sealed class NullableColumnCodec : IColumnCodec
     private readonly INullableShape canonicalShape;
     private readonly (Type Spelling, INullableShape Shape)[] writeShapes;
     private readonly bool innerCanWrite;
-    private INullableShape measureShape;  // the shape matching the measured column's write type, resolved on first use
-    private long? nullPlaceholderBytes;   // encoded size of a null row's placeholder, measured once measureShape is known
 
     private NullableColumnCodec(string typeName, IColumnCodec inner)
     {
@@ -74,9 +72,6 @@ internal sealed class NullableColumnCodec : IColumnCodec
     /// </summary>
     public object NullPlaceholder => null;
 
-    /// <inheritdoc/>
-    public int? FixedRowByteSize => inner.FixedRowByteSize is int width ? 1 + width : null;
-
     /// <summary>Builds a <c>Nullable(T)</c> codec, resolving the inner type <c>T</c> through the registry.</summary>
     /// <param name="node">The parsed <c>Nullable</c> type node; its single argument is the inner type.</param>
     /// <param name="context">The resolution context, forwarded to the inner codec's factory.</param>
@@ -98,29 +93,6 @@ internal sealed class NullableColumnCodec : IColumnCodec
 
         IColumnCodec inner = registry.ResolveNode(innerNode, in context);
         return new NullableColumnCodec(node.ToString(), inner);
-    }
-
-    /// <inheritdoc/>
-    public long MeasureRowBytes(IColumn column, int row)
-    {
-        // Measure through the shape matching the supplied column's CLR write type — the same resolution the write
-        // path uses — because IsNull and MeasureInnerRow read the column in its own write type. Resolved once and
-        // reused: the splitter measures a single column across all its rows, and a Nullable codec instance is
-        // never shared across columns. (The fixed-width inners — the only ones with alternate write types today —
-        // are priced in O(1) via FixedRowByteSize and never reach this walk, but the resolution keeps this
-        // correct for a variable-width inner that grows alternate write types, e.g. String also taking byte[].)
-        measureShape ??= ResolveWriteShape(column) ?? canonicalShape;
-
-        // One null-map byte, then the inner size: a present row measures its value; a null row measures the
-        // inner's placeholder (never the null value itself, which the inner codec would reject). The placeholder
-        // size is the same for every null row, so measure it once and cache.
-        if (measureShape.IsNull(column, row))
-        {
-            nullPlaceholderBytes ??= measureShape.MeasureNullPlaceholder(inner);
-            return 1 + nullPlaceholderBytes.Value;
-        }
-
-        return 1 + measureShape.MeasureInnerRow(inner, column, row);
     }
 
     /// <inheritdoc/>
@@ -159,22 +131,6 @@ internal sealed class NullableColumnCodec : IColumnCodec
 
     /// <inheritdoc/>
     public bool CanWrite(IColumn column) => innerCanWrite && ResolveWriteShape(column) is not null;
-
-    /// <inheritdoc/>
-    // Delegate to the shape for the supplied column's write type, which projects the ergonomic T? / nullable-
-    // reference form into the dense (inner column + null-map) column and recurses the inner codec's TryDensify. A
-    // column whose write type is unrecognized is left unchanged (borrowed); the write path then reports it.
-    public IColumn TryDensify(IColumn column, out bool built)
-    {
-        INullableShape shape = ResolveWriteShape(column);
-        if (shape is null)
-        {
-            built = false;
-            return column;
-        }
-
-        return shape.TryDensify(inner, column, out built);
-    }
 
     /// <inheritdoc/>
     public void WriteStatePrefix(ClickHouseBinaryWriter writer) => inner.WriteStatePrefix(writer);

--- a/ClickHouse.Driver.Tcp/Types/Codecs/NullableColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/NullableColumnCodec.cs
@@ -105,7 +105,7 @@ internal sealed class NullableColumnCodec : IColumnCodec
         if (rowCount == 0)
         {
             IColumn emptyInner = await inner.ReadColumnAsync(reader, columnName, inner.TypeName, 0, cancellationToken).ConfigureAwait(false);
-            return canonicalShape.Wrap(columnName, columnType, emptyInner, Array.Empty<byte>(), rowCount: 0, pooledMap: false);
+            return canonicalShape.Wrap(columnName, columnType, emptyInner, Array.Empty<byte>(), pooledMap: false);
         }
 
         byte[] nullMap = ArrayPool<byte>.Shared.Rent(rowCount);
@@ -117,9 +117,10 @@ internal sealed class NullableColumnCodec : IColumnCodec
 
             // Wrap pairs the null-map with the inner column (which holds a real inner value at every row — a
             // placeholder at the null positions) into the typed nullable column that surfaces each null row as
-            // null. Wrap inside the try: only a successful Wrap takes ownership of the rented map and the inner
-            // column, so if it throws (e.g. an element-type mismatch surfacing as a cast failure) neither is leaked.
-            return canonicalShape.Wrap(columnName, columnType, innerColumn, nullMap, rowCount, pooledMap: true);
+            // null; the inner column's row count becomes the wrapper's. Wrap inside the try: only a successful Wrap
+            // takes ownership of the rented map and the inner column, so if it throws (e.g. an element-type mismatch
+            // surfacing as a cast failure) neither is leaked.
+            return canonicalShape.Wrap(columnName, columnType, innerColumn, nullMap, pooledMap: true);
         }
         catch
         {

--- a/ClickHouse.Driver.Tcp/Types/Codecs/NullableShapes.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/NullableShapes.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Concurrent;
+
+namespace ClickHouse.Driver.Tcp.Types.Codecs;
+
+/// <summary>Resolves and caches the <see cref="INullableShape"/> for a given inner element type.</summary>
+internal static class NullableShapes
+{
+    private static readonly ConcurrentDictionary<Type, INullableShape> Cache = new();
+
+    /// <summary>Returns the shape for <paramref name="elementType"/>, building it once and caching it.</summary>
+    /// <param name="elementType">The inner codec's CLR element type.</param>
+    /// <returns>The shape.</returns>
+    public static INullableShape For(Type elementType) => Cache.GetOrAdd(elementType, Build);
+
+    private static INullableShape Build(Type elementType)
+    {
+        Type shapeType = elementType.IsValueType
+            ? typeof(ValueNullableShape<>).MakeGenericType(elementType)
+            : typeof(ReferenceNullableShape<>).MakeGenericType(elementType);
+
+        // nonPublic: true so the shape's (implicit, but internal-assembly) constructor is always reachable here.
+        return (INullableShape)Activator.CreateInstance(shapeType, nonPublic: true);
+    }
+}

--- a/ClickHouse.Driver.Tcp/Types/Codecs/ReferenceNullableShape.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/ReferenceNullableShape.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Buffers;
-using System.Runtime.CompilerServices;
 using ClickHouse.Driver.Tcp.Protocol;
 
 namespace ClickHouse.Driver.Tcp.Types.Codecs;
@@ -31,62 +29,27 @@ internal sealed class ReferenceNullableShape<T> : INullableShape
     public bool IsNull(IColumn column, int row) => ((IColumn<T>)column)[row] is null;
 
     /// <inheritdoc/>
+    // Every column is densified before the write, so the body is always the dense (inner column + null-map) shape:
+    // the inner column already holds a value at every row (a placeholder at the null rows), so the null-map bytes
+    // and the inner column are written directly with no copy. The ergonomic nullable-reference form was projected
+    // into this shape by TryDensify.
     public void WriteBody(IColumnCodec inner, ClickHouseBinaryWriter writer, IColumn column, int start, int length)
     {
-        if (column is NullableReferenceColumn<T> dense)
-        {
-            WriteDense(inner, writer, dense, start, length);
-        }
-        else
-        {
-            WriteErgonomic(inner, writer, (IColumn<T>)column, start, length);
-        }
-    }
-
-    // Dense form (the wire's own layout): the inner column already holds a value at every row (a placeholder at
-    // the null rows), so write the null-map bytes and the inner column with no copy.
-    private static void WriteDense(IColumnCodec inner, ClickHouseBinaryWriter writer, NullableReferenceColumn<T> dense, int start, int length)
-    {
+        var dense = (NullableReferenceColumn<T>)column;
         writer.WriteBytes(dense.NullMap.Slice(start, length));
         inner.WriteColumn(writer, dense.Inner, start, length);
-    }
-
-    // Ergonomic form (an inner-typed column with null entries): emit the null-map per row, then materialize the
-    // values into a pooled buffer with the inner codec's own null placeholder at the null rows, so a null never
-    // reaches the inner codec — a genuinely non-nullable inner column with a stray null still fails fast.
-    private static void WriteErgonomic(IColumnCodec inner, ClickHouseBinaryWriter writer, IColumn<T> typed, int start, int length)
-    {
-        for (int i = 0; i < length; i++)
-        {
-            writer.WriteBool(typed[start + i] is null);
-        }
-
-        var placeholder = (T)inner.NullPlaceholderAs(typeof(T));
-        T[] rented = ArrayPool<T>.Shared.Rent(length);
-        try
-        {
-            for (int i = 0; i < length; i++)
-            {
-                rented[i] = typed[start + i] ?? placeholder;
-            }
-
-            inner.WriteColumn(writer, ArrayColumn<T>.OverBuffer(typed.Name, inner.TypeName, rented, length), 0, length);
-        }
-        finally
-        {
-            ArrayPool<T>.Shared.Return(rented, clearArray: RuntimeHelpers.IsReferenceOrContainsReferences<T>());
-        }
     }
 
     /// <inheritdoc/>
     // Same projection as WriteErgonomic, but materialized once into the dense column instead of written: split the
     // nullable-reference values into an inner T column (the inner codec's placeholder at the null rows) plus the
-    // null-map, recurse the inner codec's own Densify (a no-op for a leaf inner), and wrap. An already-dense column
-    // is returned as-is.
-    public IColumn Densify(IColumnCodec inner, IColumn column)
+    // null-map, recurse the inner codec's own TryDensify (a no-op for a leaf inner), and wrap. An already-dense
+    // column is returned as-is (built = false).
+    public IColumn TryDensify(IColumnCodec inner, IColumn column, out bool built)
     {
         if (column is NullableReferenceColumn<T>)
         {
+            built = false;
             return column;
         }
 
@@ -102,7 +65,8 @@ internal sealed class ReferenceNullableShape<T> : INullableShape
             values[i] = value ?? placeholder;
         }
 
-        IColumn innerColumn = inner.Densify(new ArrayColumn<T>(source.Name, inner.TypeName, values));
+        IColumn innerColumn = inner.TryDensify(new ArrayColumn<T>(source.Name, inner.TypeName, values), out _);
+        built = true;
         return new NullableReferenceColumn<T>(source.Name, source.TypeName, (IColumn<T>)innerColumn, nullMap, rowCount, pooledMap: false);
     }
 

--- a/ClickHouse.Driver.Tcp/Types/Codecs/ReferenceNullableShape.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/ReferenceNullableShape.cs
@@ -22,56 +22,26 @@ internal sealed class ReferenceNullableShape<T> : INullableShape
     public bool CanInnerWrite(IColumnCodec inner) => inner.CanWrite(new ArrayColumn<T>(string.Empty, inner.TypeName, Array.Empty<T>()));
 
     /// <inheritdoc/>
-    public long MeasureNullPlaceholder(IColumnCodec inner)
-        => inner.MeasureRowBytes(new ArrayColumn<T>(string.Empty, inner.TypeName, new[] { (T)inner.NullPlaceholderAs(typeof(T)) }), 0);
-
-    /// <inheritdoc/>
-    public bool IsNull(IColumn column, int row) => ((IColumn<T>)column)[row] is null;
-
-    /// <inheritdoc/>
-    // Every column is densified before the write, so the body is always the dense (inner column + null-map) shape:
-    // the inner column already holds a value at every row (a placeholder at the null rows), so the null-map bytes
-    // and the inner column are written directly with no copy. The ergonomic nullable-reference form was projected
-    // into this shape by TryDensify.
+    // A dense column (inner column + null-map) writes both directly with no copy. The ergonomic nullable-reference
+    // column writes the null-map from each row's nullness, then hands the inner codec a substitute view that reads
+    // the present reference or the inner placeholder per row — no flat placeholder buffer is built; the null
+    // positions the wire ignores are still written from the placeholder so the inner codec never sees a null.
     public void WriteBody(IColumnCodec inner, ClickHouseBinaryWriter writer, IColumn column, int start, int length)
     {
-        var dense = (NullableReferenceColumn<T>)column;
-        writer.WriteBytes(dense.NullMap.Slice(start, length));
-        inner.WriteColumn(writer, dense.Inner, start, length);
-    }
-
-    /// <inheritdoc/>
-    // Same projection as WriteErgonomic, but materialized once into the dense column instead of written: split the
-    // nullable-reference values into an inner T column (the inner codec's placeholder at the null rows) plus the
-    // null-map, recurse the inner codec's own TryDensify (a no-op for a leaf inner), and wrap. An already-dense
-    // column is returned as-is (built = false).
-    public IColumn TryDensify(IColumnCodec inner, IColumn column, out bool built)
-    {
-        if (column is NullableReferenceColumn<T>)
+        if (column is NullableReferenceColumn<T> dense)
         {
-            built = false;
-            return column;
+            writer.WriteBytes(dense.NullMap.Slice(start, length));
+            inner.WriteColumn(writer, dense.Inner, start, length);
+            return;
         }
 
         var source = (IColumn<T>)column;
-        int rowCount = source.RowCount;
-        var placeholder = (T)inner.NullPlaceholderAs(typeof(T));
-        var nullMap = new byte[rowCount];
-        var values = new T[rowCount];
-        for (int i = 0; i < rowCount; i++)
+        for (int i = 0; i < length; i++)
         {
-            T value = source[i];
-            nullMap[i] = value is null ? (byte)1 : (byte)0;
-            values[i] = value ?? placeholder;
+            writer.WriteBool(source[start + i] is null);
         }
 
-        IColumn innerColumn = inner.TryDensify(new ArrayColumn<T>(source.Name, inner.TypeName, values), out _);
-        built = true;
-        return new NullableReferenceColumn<T>(source.Name, source.TypeName, (IColumn<T>)innerColumn, nullMap, rowCount, pooledMap: false);
+        var placeholder = (T)inner.NullPlaceholderAs(typeof(T));
+        inner.WriteColumn(writer, new SubstituteReferenceColumn<T>(inner.TypeName, source, placeholder), start, length);
     }
-
-    /// <inheritdoc/>
-    // Reached only for a present (non-null) row of a variable-width inner (String); null rows are priced by the
-    // codec via MeasureNullPlaceholder, so the inner codec never measures a null value.
-    public long MeasureInnerRow(IColumnCodec inner, IColumn column, int row) => inner.MeasureRowBytes(column, row);
 }

--- a/ClickHouse.Driver.Tcp/Types/Codecs/ReferenceNullableShape.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/ReferenceNullableShape.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Buffers;
+using System.Runtime.CompilerServices;
+using ClickHouse.Driver.Tcp.Protocol;
+
+namespace ClickHouse.Driver.Tcp.Types.Codecs;
+
+/// <summary>The shape for a reference-type inner: the nullable column surfaces the nullable reference.</summary>
+/// <typeparam name="T">The inner reference type.</typeparam>
+internal sealed class ReferenceNullableShape<T> : INullableShape
+    where T : class
+{
+    /// <inheritdoc/>
+    public Type NullableElementType => typeof(T);
+
+    /// <inheritdoc/>
+    public IColumn Wrap(string name, string typeName, IColumn inner, byte[] nullMap, int rowCount, bool pooledMap)
+        => new NullableReferenceColumn<T>(name, typeName, (IColumn<T>)inner, nullMap, rowCount, pooledMap);
+
+    /// <inheritdoc/>
+    public bool CanWrite(IColumn column) => column is IColumn<T>;
+
+    /// <inheritdoc/>
+    public bool CanInnerWrite(IColumnCodec inner) => inner.CanWrite(new ArrayColumn<T>(string.Empty, inner.TypeName, Array.Empty<T>()));
+
+    /// <inheritdoc/>
+    public long MeasureNullPlaceholder(IColumnCodec inner)
+        => inner.MeasureRowBytes(new ArrayColumn<T>(string.Empty, inner.TypeName, new[] { (T)inner.NullPlaceholderAs(typeof(T)) }), 0);
+
+    /// <inheritdoc/>
+    public bool IsNull(IColumn column, int row) => ((IColumn<T>)column)[row] is null;
+
+    /// <inheritdoc/>
+    public void WriteBody(IColumnCodec inner, ClickHouseBinaryWriter writer, IColumn column, int start, int length)
+    {
+        if (column is NullableReferenceColumn<T> dense)
+        {
+            WriteDense(inner, writer, dense, start, length);
+        }
+        else
+        {
+            WriteErgonomic(inner, writer, (IColumn<T>)column, start, length);
+        }
+    }
+
+    // Dense form (the wire's own layout): the inner column already holds a value at every row (a placeholder at
+    // the null rows), so write the null-map bytes and the inner column with no copy.
+    private static void WriteDense(IColumnCodec inner, ClickHouseBinaryWriter writer, NullableReferenceColumn<T> dense, int start, int length)
+    {
+        writer.WriteBytes(dense.NullMap.Slice(start, length));
+        inner.WriteColumn(writer, dense.Inner, start, length);
+    }
+
+    // Ergonomic form (an inner-typed column with null entries): emit the null-map per row, then materialize the
+    // values into a pooled buffer with the inner codec's own null placeholder at the null rows, so a null never
+    // reaches the inner codec — a genuinely non-nullable inner column with a stray null still fails fast.
+    private static void WriteErgonomic(IColumnCodec inner, ClickHouseBinaryWriter writer, IColumn<T> typed, int start, int length)
+    {
+        for (int i = 0; i < length; i++)
+        {
+            writer.WriteBool(typed[start + i] is null);
+        }
+
+        var placeholder = (T)inner.NullPlaceholderAs(typeof(T));
+        T[] rented = ArrayPool<T>.Shared.Rent(length);
+        try
+        {
+            for (int i = 0; i < length; i++)
+            {
+                rented[i] = typed[start + i] ?? placeholder;
+            }
+
+            inner.WriteColumn(writer, ArrayColumn<T>.OverBuffer(typed.Name, inner.TypeName, rented, length), 0, length);
+        }
+        finally
+        {
+            ArrayPool<T>.Shared.Return(rented, clearArray: RuntimeHelpers.IsReferenceOrContainsReferences<T>());
+        }
+    }
+
+    /// <inheritdoc/>
+    // Same projection as WriteErgonomic, but materialized once into the dense column instead of written: split the
+    // nullable-reference values into an inner T column (the inner codec's placeholder at the null rows) plus the
+    // null-map, recurse the inner codec's own Densify (a no-op for a leaf inner), and wrap. An already-dense column
+    // is returned as-is.
+    public IColumn Densify(IColumnCodec inner, IColumn column)
+    {
+        if (column is NullableReferenceColumn<T>)
+        {
+            return column;
+        }
+
+        var source = (IColumn<T>)column;
+        int rowCount = source.RowCount;
+        var placeholder = (T)inner.NullPlaceholderAs(typeof(T));
+        var nullMap = new byte[rowCount];
+        var values = new T[rowCount];
+        for (int i = 0; i < rowCount; i++)
+        {
+            T value = source[i];
+            nullMap[i] = value is null ? (byte)1 : (byte)0;
+            values[i] = value ?? placeholder;
+        }
+
+        IColumn innerColumn = inner.Densify(new ArrayColumn<T>(source.Name, inner.TypeName, values));
+        return new NullableReferenceColumn<T>(source.Name, source.TypeName, (IColumn<T>)innerColumn, nullMap, rowCount, pooledMap: false);
+    }
+
+    /// <inheritdoc/>
+    // Reached only for a present (non-null) row of a variable-width inner (String); null rows are priced by the
+    // codec via MeasureNullPlaceholder, so the inner codec never measures a null value.
+    public long MeasureInnerRow(IColumnCodec inner, IColumn column, int row) => inner.MeasureRowBytes(column, row);
+}

--- a/ClickHouse.Driver.Tcp/Types/Codecs/ReferenceNullableShape.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/ReferenceNullableShape.cs
@@ -12,8 +12,8 @@ internal sealed class ReferenceNullableShape<T> : INullableShape
     public Type NullableElementType => typeof(T);
 
     /// <inheritdoc/>
-    public IColumn Wrap(string name, string typeName, IColumn inner, byte[] nullMap, int rowCount, bool pooledMap)
-        => new NullableReferenceColumn<T>(name, typeName, (IColumn<T>)inner, nullMap, rowCount, pooledMap);
+    public IColumn Wrap(string name, string typeName, IColumn inner, byte[] nullMap, bool pooledMap)
+        => new NullableReferenceColumn<T>(name, typeName, (IColumn<T>)inner, nullMap, pooledMap);
 
     /// <inheritdoc/>
     public bool CanWrite(IColumn column) => column is IColumn<T>;

--- a/ClickHouse.Driver.Tcp/Types/Codecs/ValueNullableShape.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/ValueNullableShape.cs
@@ -22,56 +22,26 @@ internal sealed class ValueNullableShape<T> : INullableShape
     public bool CanInnerWrite(IColumnCodec inner) => inner.CanWrite(new ArrayColumn<T>(string.Empty, inner.TypeName, Array.Empty<T>()));
 
     /// <inheritdoc/>
-    public long MeasureNullPlaceholder(IColumnCodec inner)
-        => inner.MeasureRowBytes(new ArrayColumn<T>(string.Empty, inner.TypeName, new[] { (T)inner.NullPlaceholderAs(typeof(T)) }), 0);
-
-    /// <inheritdoc/>
-    public bool IsNull(IColumn column, int row) => !((IColumn<T?>)column)[row].HasValue;
-
-    /// <inheritdoc/>
-    // Every column is densified before the write, so the body is always the dense (inner column + null-map) shape:
-    // the null-map is already bytes and the inner column already holds a value at every row (a placeholder at the
-    // null rows), so both are written directly with no intermediate copy. The ergonomic T? form was projected into
-    // this shape by TryDensify.
+    // A dense column (inner column + null-map) writes both directly with no copy. The ergonomic T? column writes
+    // the null-map from each row's HasValue, then hands the inner codec a substitute view that reads the present
+    // value or the inner placeholder per row — no flat placeholder buffer is built; the null positions the wire
+    // ignores are still written from the placeholder so the inner codec never sees a null.
     public void WriteBody(IColumnCodec inner, ClickHouseBinaryWriter writer, IColumn column, int start, int length)
     {
-        var dense = (NullableValueColumn<T>)column;
-        writer.WriteBytes(dense.NullMap.Slice(start, length));
-        inner.WriteColumn(writer, dense.Inner, start, length);
-    }
-
-    /// <inheritdoc/>
-    // Same projection as WriteErgonomic, but materialized once into the dense column instead of written: split the
-    // T? values into an inner T column (the inner codec's placeholder at the null rows) plus the null-map, recurse
-    // the inner codec's own TryDensify (a no-op for a leaf inner), and wrap. An already-dense column is returned
-    // as-is (built = false).
-    public IColumn TryDensify(IColumnCodec inner, IColumn column, out bool built)
-    {
-        if (column is NullableValueColumn<T>)
+        if (column is NullableValueColumn<T> dense)
         {
-            built = false;
-            return column;
+            writer.WriteBytes(dense.NullMap.Slice(start, length));
+            inner.WriteColumn(writer, dense.Inner, start, length);
+            return;
         }
 
         var source = (IColumn<T?>)column;
-        int rowCount = source.RowCount;
-        var placeholder = (T)inner.NullPlaceholderAs(typeof(T));
-        var nullMap = new byte[rowCount];
-        var values = new T[rowCount];
-        for (int i = 0; i < rowCount; i++)
+        for (int i = 0; i < length; i++)
         {
-            T? value = source[i];
-            nullMap[i] = value.HasValue ? (byte)0 : (byte)1;
-            values[i] = value.GetValueOrDefault(placeholder);
+            writer.WriteBool(!source[start + i].HasValue);
         }
 
-        IColumn innerColumn = inner.TryDensify(new ArrayColumn<T>(source.Name, inner.TypeName, values), out _);
-        built = true;
-        return new NullableValueColumn<T>(source.Name, source.TypeName, (IColumn<T>)innerColumn, nullMap, rowCount, pooledMap: false);
+        var placeholder = (T)inner.NullPlaceholderAs(typeof(T));
+        inner.WriteColumn(writer, new SubstituteValueColumn<T>(inner.TypeName, source, placeholder), start, length);
     }
-
-    /// <inheritdoc/>
-    // A value-type inner is fixed-width, so its per-row size is column-independent — read it straight off the
-    // inner codec rather than passing the T? column through (the inner's IColumn<T> view could not accept it).
-    public long MeasureInnerRow(IColumnCodec inner, IColumn column, int row) => inner.FixedRowByteSize ?? inner.MeasureRowBytes(column, row);
 }

--- a/ClickHouse.Driver.Tcp/Types/Codecs/ValueNullableShape.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/ValueNullableShape.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Buffers;
+using System.Runtime.CompilerServices;
+using ClickHouse.Driver.Tcp.Protocol;
+
+namespace ClickHouse.Driver.Tcp.Types.Codecs;
+
+/// <summary>The shape for a value-type inner: the nullable column surfaces <c>T?</c>.</summary>
+/// <typeparam name="T">The inner value type.</typeparam>
+internal sealed class ValueNullableShape<T> : INullableShape
+    where T : struct
+{
+    /// <inheritdoc/>
+    public Type NullableElementType => typeof(T?);
+
+    /// <inheritdoc/>
+    public IColumn Wrap(string name, string typeName, IColumn inner, byte[] nullMap, int rowCount, bool pooledMap)
+        => new NullableValueColumn<T>(name, typeName, (IColumn<T>)inner, nullMap, rowCount, pooledMap);
+
+    /// <inheritdoc/>
+    public bool CanWrite(IColumn column) => column is IColumn<T?>;
+
+    /// <inheritdoc/>
+    public bool CanInnerWrite(IColumnCodec inner) => inner.CanWrite(new ArrayColumn<T>(string.Empty, inner.TypeName, Array.Empty<T>()));
+
+    /// <inheritdoc/>
+    public long MeasureNullPlaceholder(IColumnCodec inner)
+        => inner.MeasureRowBytes(new ArrayColumn<T>(string.Empty, inner.TypeName, new[] { (T)inner.NullPlaceholderAs(typeof(T)) }), 0);
+
+    /// <inheritdoc/>
+    public bool IsNull(IColumn column, int row) => !((IColumn<T?>)column)[row].HasValue;
+
+    /// <inheritdoc/>
+    public void WriteBody(IColumnCodec inner, ClickHouseBinaryWriter writer, IColumn column, int start, int length)
+    {
+        if (column is NullableValueColumn<T> dense)
+        {
+            WriteDense(inner, writer, dense, start, length);
+        }
+        else
+        {
+            WriteErgonomic(inner, writer, (IColumn<T?>)column, start, length);
+        }
+    }
+
+    // Dense form (the wire's own layout): the null-map is already bytes and the inner column already holds a
+    // value at every row, so write both directly with no intermediate copy.
+    private static void WriteDense(IColumnCodec inner, ClickHouseBinaryWriter writer, NullableValueColumn<T> dense, int start, int length)
+    {
+        writer.WriteBytes(dense.NullMap.Slice(start, length));
+        inner.WriteColumn(writer, dense.Inner, start, length);
+    }
+
+    // Ergonomic T? form: emit the null-map per row, then materialize the values into a pooled inner-typed buffer
+    // (T? cannot be reinterpreted as a contiguous T, so this copy is unavoidable), substituting the inner codec's
+    // own null placeholder — in this write type T — at the null rows.
+    private static void WriteErgonomic(IColumnCodec inner, ClickHouseBinaryWriter writer, IColumn<T?> source, int start, int length)
+    {
+        for (int i = 0; i < length; i++)
+        {
+            writer.WriteBool(!source[start + i].HasValue);
+        }
+
+        var placeholder = (T)inner.NullPlaceholderAs(typeof(T));
+        T[] rented = ArrayPool<T>.Shared.Rent(length);
+        try
+        {
+            for (int i = 0; i < length; i++)
+            {
+                rented[i] = source[start + i].GetValueOrDefault(placeholder);
+            }
+
+            inner.WriteColumn(writer, ArrayColumn<T>.OverBuffer(source.Name, inner.TypeName, rented, length), 0, length);
+        }
+        finally
+        {
+            ArrayPool<T>.Shared.Return(rented, clearArray: RuntimeHelpers.IsReferenceOrContainsReferences<T>());
+        }
+    }
+
+    /// <inheritdoc/>
+    // Same projection as WriteErgonomic, but materialized once into the dense column instead of written: split the
+    // T? values into an inner T column (the inner codec's placeholder at the null rows) plus the null-map, recurse
+    // the inner codec's own Densify (a no-op for a leaf inner), and wrap. An already-dense column is returned as-is.
+    public IColumn Densify(IColumnCodec inner, IColumn column)
+    {
+        if (column is NullableValueColumn<T>)
+        {
+            return column;
+        }
+
+        var source = (IColumn<T?>)column;
+        int rowCount = source.RowCount;
+        var placeholder = (T)inner.NullPlaceholderAs(typeof(T));
+        var nullMap = new byte[rowCount];
+        var values = new T[rowCount];
+        for (int i = 0; i < rowCount; i++)
+        {
+            T? value = source[i];
+            nullMap[i] = value.HasValue ? (byte)0 : (byte)1;
+            values[i] = value.GetValueOrDefault(placeholder);
+        }
+
+        IColumn innerColumn = inner.Densify(new ArrayColumn<T>(source.Name, inner.TypeName, values));
+        return new NullableValueColumn<T>(source.Name, source.TypeName, (IColumn<T>)innerColumn, nullMap, rowCount, pooledMap: false);
+    }
+
+    /// <inheritdoc/>
+    // A value-type inner is fixed-width, so its per-row size is column-independent — read it straight off the
+    // inner codec rather than passing the T? column through (the inner's IColumn<T> view could not accept it).
+    public long MeasureInnerRow(IColumnCodec inner, IColumn column, int row) => inner.FixedRowByteSize ?? inner.MeasureRowBytes(column, row);
+}

--- a/ClickHouse.Driver.Tcp/Types/Codecs/ValueNullableShape.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/ValueNullableShape.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Buffers;
-using System.Runtime.CompilerServices;
 using ClickHouse.Driver.Tcp.Protocol;
 
 namespace ClickHouse.Driver.Tcp.Types.Codecs;
@@ -31,61 +29,27 @@ internal sealed class ValueNullableShape<T> : INullableShape
     public bool IsNull(IColumn column, int row) => !((IColumn<T?>)column)[row].HasValue;
 
     /// <inheritdoc/>
+    // Every column is densified before the write, so the body is always the dense (inner column + null-map) shape:
+    // the null-map is already bytes and the inner column already holds a value at every row (a placeholder at the
+    // null rows), so both are written directly with no intermediate copy. The ergonomic T? form was projected into
+    // this shape by TryDensify.
     public void WriteBody(IColumnCodec inner, ClickHouseBinaryWriter writer, IColumn column, int start, int length)
     {
-        if (column is NullableValueColumn<T> dense)
-        {
-            WriteDense(inner, writer, dense, start, length);
-        }
-        else
-        {
-            WriteErgonomic(inner, writer, (IColumn<T?>)column, start, length);
-        }
-    }
-
-    // Dense form (the wire's own layout): the null-map is already bytes and the inner column already holds a
-    // value at every row, so write both directly with no intermediate copy.
-    private static void WriteDense(IColumnCodec inner, ClickHouseBinaryWriter writer, NullableValueColumn<T> dense, int start, int length)
-    {
+        var dense = (NullableValueColumn<T>)column;
         writer.WriteBytes(dense.NullMap.Slice(start, length));
         inner.WriteColumn(writer, dense.Inner, start, length);
-    }
-
-    // Ergonomic T? form: emit the null-map per row, then materialize the values into a pooled inner-typed buffer
-    // (T? cannot be reinterpreted as a contiguous T, so this copy is unavoidable), substituting the inner codec's
-    // own null placeholder — in this write type T — at the null rows.
-    private static void WriteErgonomic(IColumnCodec inner, ClickHouseBinaryWriter writer, IColumn<T?> source, int start, int length)
-    {
-        for (int i = 0; i < length; i++)
-        {
-            writer.WriteBool(!source[start + i].HasValue);
-        }
-
-        var placeholder = (T)inner.NullPlaceholderAs(typeof(T));
-        T[] rented = ArrayPool<T>.Shared.Rent(length);
-        try
-        {
-            for (int i = 0; i < length; i++)
-            {
-                rented[i] = source[start + i].GetValueOrDefault(placeholder);
-            }
-
-            inner.WriteColumn(writer, ArrayColumn<T>.OverBuffer(source.Name, inner.TypeName, rented, length), 0, length);
-        }
-        finally
-        {
-            ArrayPool<T>.Shared.Return(rented, clearArray: RuntimeHelpers.IsReferenceOrContainsReferences<T>());
-        }
     }
 
     /// <inheritdoc/>
     // Same projection as WriteErgonomic, but materialized once into the dense column instead of written: split the
     // T? values into an inner T column (the inner codec's placeholder at the null rows) plus the null-map, recurse
-    // the inner codec's own Densify (a no-op for a leaf inner), and wrap. An already-dense column is returned as-is.
-    public IColumn Densify(IColumnCodec inner, IColumn column)
+    // the inner codec's own TryDensify (a no-op for a leaf inner), and wrap. An already-dense column is returned
+    // as-is (built = false).
+    public IColumn TryDensify(IColumnCodec inner, IColumn column, out bool built)
     {
         if (column is NullableValueColumn<T>)
         {
+            built = false;
             return column;
         }
 
@@ -101,7 +65,8 @@ internal sealed class ValueNullableShape<T> : INullableShape
             values[i] = value.GetValueOrDefault(placeholder);
         }
 
-        IColumn innerColumn = inner.Densify(new ArrayColumn<T>(source.Name, inner.TypeName, values));
+        IColumn innerColumn = inner.TryDensify(new ArrayColumn<T>(source.Name, inner.TypeName, values), out _);
+        built = true;
         return new NullableValueColumn<T>(source.Name, source.TypeName, (IColumn<T>)innerColumn, nullMap, rowCount, pooledMap: false);
     }
 

--- a/ClickHouse.Driver.Tcp/Types/Codecs/ValueNullableShape.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/ValueNullableShape.cs
@@ -12,8 +12,8 @@ internal sealed class ValueNullableShape<T> : INullableShape
     public Type NullableElementType => typeof(T?);
 
     /// <inheritdoc/>
-    public IColumn Wrap(string name, string typeName, IColumn inner, byte[] nullMap, int rowCount, bool pooledMap)
-        => new NullableValueColumn<T>(name, typeName, (IColumn<T>)inner, nullMap, rowCount, pooledMap);
+    public IColumn Wrap(string name, string typeName, IColumn inner, byte[] nullMap, bool pooledMap)
+        => new NullableValueColumn<T>(name, typeName, (IColumn<T>)inner, nullMap, pooledMap);
 
     /// <inheritdoc/>
     public bool CanWrite(IColumn column) => column is IColumn<T?>;

--- a/ClickHouse.Driver.Tcp/Types/ColumnCodecRegistry.cs
+++ b/ClickHouse.Driver.Tcp/Types/ColumnCodecRegistry.cs
@@ -12,8 +12,9 @@ namespace ClickHouse.Driver.Tcp.Types;
 /// </summary>
 /// <param name="node">The parsed type, whose <see cref="TypeNode.Arguments"/> carry any type parameters.</param>
 /// <param name="context">The resolution context (e.g. the server timezone).</param>
+/// <param name="registry">The registry itself, so a composite type can resolve its child type arguments.</param>
 /// <returns>The codec for the type.</returns>
-internal delegate IColumnCodec CodecFactory(TypeNode node, in ResolveContext context);
+internal delegate IColumnCodec CodecFactory(TypeNode node, in ResolveContext context, ColumnCodecRegistry registry);
 
 /// <summary>
 /// Resolves a ClickHouse type string to the codec that reads/writes it. The type string is parsed into a
@@ -39,12 +40,25 @@ internal sealed class ColumnCodecRegistry
     public IColumnCodec Resolve(string typeString, in ResolveContext context)
     {
         TypeNode node = TypeParser.Parse(typeString);
+        return ResolveNode(node, in context);
+    }
+
+    /// <summary>
+    /// Resolves the codec for an already-parsed type node. Composite codecs (e.g. <c>Nullable(T)</c>) call this
+    /// to build the codecs for their child type arguments without re-serializing and re-parsing a type string.
+    /// </summary>
+    /// <param name="node">The parsed type node.</param>
+    /// <param name="context">The resolution context (server timezone, etc.).</param>
+    /// <returns>The codec for that type.</returns>
+    /// <exception cref="NotSupportedException">The type is well-formed but not yet supported by this client.</exception>
+    public IColumnCodec ResolveNode(TypeNode node, in ResolveContext context)
+    {
         if (byName.TryGetValue(node.Name, out CodecFactory factory))
         {
-            return factory(node, in context);
+            return factory(node, in context, this);
         }
 
-        throw new NotSupportedException($"ClickHouse type '{typeString}' is not supported by this client yet.");
+        throw new NotSupportedException($"ClickHouse type '{node}' is not supported by this client yet.");
     }
 
     private static ColumnCodecRegistry CreateDefault()
@@ -53,7 +67,7 @@ internal sealed class ColumnCodecRegistry
 
         // A type whose codec ignores both the parsed arguments and the resolution context registers a single
         // shared instance, wrapped in a factory that returns it unconditionally.
-        void AddConstant(IColumnCodec codec) => byName[codec.TypeName] = (TypeNode _, in ResolveContext _) => codec;
+        void AddConstant(IColumnCodec codec) => byName[codec.TypeName] = (TypeNode _, in ResolveContext _, ColumnCodecRegistry _) => codec;
 
         void AddFactory(string name, CodecFactory factory) => byName[name] = factory;
 
@@ -94,19 +108,22 @@ internal sealed class ColumnCodecRegistry
         }
 
         // Timezone-bearing types resolve their offset from the type string or, failing that, the session timezone.
-        AddFactory("DateTime", static (TypeNode node, in ResolveContext context) => DateTimeColumnCodec.Create(node, context.ServerTimezone));
-        AddFactory("DateTime64", static (TypeNode node, in ResolveContext context) => DateTime64ColumnCodec.Create(node, context.ServerTimezone));
-        AddFactory("Time64", static (TypeNode node, in ResolveContext _) => Time64ColumnCodec.Create(node));
+        AddFactory("DateTime", static (TypeNode node, in ResolveContext context, ColumnCodecRegistry _) => DateTimeColumnCodec.Create(node, context.ServerTimezone));
+        AddFactory("DateTime64", static (TypeNode node, in ResolveContext context, ColumnCodecRegistry _) => DateTime64ColumnCodec.Create(node, context.ServerTimezone));
+        AddFactory("Time64", static (TypeNode node, in ResolveContext _, ColumnCodecRegistry _) => Time64ColumnCodec.Create(node));
 
         // Enum aliases: raw underlying Int8/Int16 ordinal; the label map is parsed and retained by the codec.
-        AddFactory("Enum8", static (TypeNode node, in ResolveContext _) => Enum8ColumnCodec.Create(node));
-        AddFactory("Enum16", static (TypeNode node, in ResolveContext _) => Enum16ColumnCodec.Create(node));
+        AddFactory("Enum8", static (TypeNode node, in ResolveContext _, ColumnCodecRegistry _) => Enum8ColumnCodec.Create(node));
+        AddFactory("Enum16", static (TypeNode node, in ResolveContext _, ColumnCodecRegistry _) => Enum16ColumnCodec.Create(node));
 
         // Decimal(P, S) and the fixed-width aliases share the width-by-precision codec factory.
         foreach (string name in new[] { "Decimal", "Decimal32", "Decimal64", "Decimal128", "Decimal256" })
         {
-            AddFactory(name, static (TypeNode node, in ResolveContext _) => DecimalColumnCodec.Create(node));
+            AddFactory(name, static (TypeNode node, in ResolveContext _, ColumnCodecRegistry _) => DecimalColumnCodec.Create(node));
         }
+
+        // Nullable(T) wraps a child codec, resolved recursively through the registry.
+        AddFactory("Nullable", static (TypeNode node, in ResolveContext context, ColumnCodecRegistry registry) => NullableColumnCodec.Create(node, context, registry));
 
         return new ColumnCodecRegistry(byName);
     }

--- a/ClickHouse.Driver.Tcp/Types/IColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/IColumnCodec.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using ClickHouse.Driver.Tcp.Protocol;
@@ -19,6 +21,52 @@ internal interface IColumnCodec
 {
     /// <summary>The canonical base type name this codec handles (e.g. <c>UInt64</c>, <c>String</c>).</summary>
     string TypeName { get; }
+
+    /// <summary>
+    /// The CLR element type the decoded column surfaces — the <c>T</c> of the <see cref="IColumn{T}"/> that
+    /// <see cref="ReadColumnAsync"/> produces (e.g. <see cref="ulong"/> for <c>UInt64</c>, <see cref="string"/>
+    /// for <c>String</c>, <see cref="System.DateTimeOffset"/> for <c>DateTime</c>). Composite codecs consult a
+    /// child codec's element type to build the right typed wrapper column (e.g. <c>Nullable(T)</c> surfaces
+    /// <c>T?</c> for a value-type inner and the nullable reference for a reference-type inner). A codec may still
+    /// <see cref="CanWrite"/> more CLR types than this on the write path (see <see cref="WritableElementTypes"/>);
+    /// this is the one it reads back.
+    /// </summary>
+    Type ElementType { get; }
+
+    /// <summary>
+    /// The CLR element types <see cref="WriteColumn"/> accepts, in preference order (the canonical
+    /// <see cref="ElementType"/> first). Defaults to just <see cref="ElementType"/>; a codec that also takes
+    /// convenience write types (e.g. a date-time codec accepting <see cref="System.DateTime"/> as well as
+    /// <see cref="System.DateTimeOffset"/>) lists them all here, so a composite such as <c>Nullable(T)</c> can
+    /// re-offer the same write types through its own write path. Every type listed must be answerable by both
+    /// <see cref="CanWrite"/> and <see cref="NullPlaceholderAs"/>.
+    /// </summary>
+    IReadOnlyList<Type> WritableElementTypes => new[] { ElementType };
+
+    /// <summary>
+    /// A value of <see cref="ElementType"/> to encode where a row has no value of its own — the placeholder
+    /// written at the null positions of a <c>Nullable(T)</c> column's values stream. The server ignores those
+    /// bytes, but the codec must still be handed a value it accepts, so this is the type's canonical zero/epoch
+    /// (e.g. <c>0</c>, <c>1970-01-01</c>, <c>0.0.0.0</c>, the empty string) rather than the CLR default, which a
+    /// range-checked type would reject. A codec whose values cannot be written throws when this is read.
+    /// </summary>
+    object NullPlaceholder { get; }
+
+    /// <summary>
+    /// <see cref="NullPlaceholder"/> expressed in <paramref name="writeType"/> — one of
+    /// <see cref="WritableElementTypes"/>. A composite filling a placeholder buffer needs the placeholder in the
+    /// same CLR write type as the buffer it materializes (e.g. a <c>Nullable(DateTime)</c> written as
+    /// <see cref="System.DateTime"/> needs a <see cref="System.DateTime"/> placeholder, not the canonical
+    /// <see cref="System.DateTimeOffset"/> one). Defaults to <see cref="NullPlaceholder"/> for the canonical
+    /// <see cref="ElementType"/> and throws for any other write type; a codec advertising extra
+    /// <see cref="WritableElementTypes"/> overrides this to answer each of them.
+    /// </summary>
+    /// <param name="writeType">The CLR write type to express the placeholder in.</param>
+    /// <returns>The placeholder value, assignable to <paramref name="writeType"/>.</returns>
+    /// <exception cref="NotSupportedException"><paramref name="writeType"/> is not a writable element type.</exception>
+    object NullPlaceholderAs(Type writeType) => writeType == ElementType
+        ? NullPlaceholder
+        : throw new NotSupportedException($"The '{TypeName}' codec has no null placeholder for {writeType}.");
 
     /// <summary>Reads the column's serialization state prefix, if any. Default: none.</summary>
     /// <param name="reader">The reader positioned at the prefix.</param>

--- a/ClickHouse.Driver.Tcp/Types/INullableColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/INullableColumn.cs
@@ -1,0 +1,42 @@
+using System;
+
+namespace ClickHouse.Driver.Tcp.Types;
+
+/// <summary>
+/// The zero-copy read surface of a decoded <c>Nullable(T)</c> column. A nullable column materializes each row as
+/// the inner value or <see langword="null"/> (see the column's <c>Values</c>/indexer), which is the convenient
+/// form; this interface exposes the underlying wire layout instead — the dense inner column, which holds a
+/// decoded value at <em>every</em> row (a placeholder where the row is null), plus the per-row null-map that says
+/// which of those rows are actually null.
+///
+/// <para>
+/// Row <c>i</c> is null when <c>NullMap[i] != 0</c>, and otherwise holds <c>Inner[i]</c>. Reading the two
+/// directly avoids the per-row null check and, for a value-type inner, the <see cref="Nullable{T}"/> wrapper: a
+/// caller that only needs the non-null rows can scan the map and index the inner column's own
+/// <see cref="IColumn{T}.Values"/> span. Both the map and the inner column's storage are borrowed views over the
+/// owning block: read them in place, and copy out only what must outlive the block.
+/// </para>
+///
+/// <para>
+/// The type parameter is the <em>inner</em> element type, not the nullable one — a <c>Nullable(Int32)</c> column
+/// is an <c>INullableColumn&lt;int&gt;</c> (whose <see cref="IColumn{T}"/> surface is <c>IColumn&lt;int?&gt;</c>),
+/// and a <c>Nullable(String)</c> column is an <c>INullableColumn&lt;string&gt;</c>. Obtain this view by
+/// pattern-matching a column, e.g. <c>if (column is INullableColumn&lt;int&gt; nullable)</c>.
+/// </para>
+/// </summary>
+/// <typeparam name="T">The inner (non-nullable) element type; <see cref="Inner"/> is a column of these.</typeparam>
+public interface INullableColumn<T> : IColumn
+{
+    /// <summary>
+    /// The dense inner column: one decoded value per row, with an arbitrary placeholder at the rows the null-map
+    /// marks null (the wire carries a value there too, so its content is meaningless — always consult
+    /// <see cref="NullMap"/> before reading a row). A borrowed view valid only while the owning block is alive.
+    /// </summary>
+    IColumn<T> Inner { get; }
+
+    /// <summary>
+    /// The per-row null-map: a non-zero byte marks the row null. One entry per row, aligned with
+    /// <see cref="Inner"/>. A borrowed span valid only while the owning block is alive.
+    /// </summary>
+    ReadOnlySpan<byte> NullMap { get; }
+}

--- a/ClickHouse.Driver.Tcp/Types/INullableColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/INullableColumn.cs
@@ -3,7 +3,7 @@ using System;
 namespace ClickHouse.Driver.Tcp.Types;
 
 /// <summary>
-/// The zero-copy read surface of a decoded <c>Nullable(T)</c> column. A nullable column materializes each row as
+/// The columnar read surface of a decoded <c>Nullable(T)</c> column. A nullable column materializes each row as
 /// the inner value or <see langword="null"/> (see the column's <c>Values</c>/indexer), which is the convenient
 /// form; this interface exposes the underlying wire layout instead — the dense inner column, which holds a
 /// decoded value at <em>every</em> row (a placeholder where the row is null), plus the per-row null-map that says
@@ -23,6 +23,12 @@ namespace ClickHouse.Driver.Tcp.Types;
 /// and a <c>Nullable(String)</c> column is an <c>INullableColumn&lt;string&gt;</c>. Obtain this view by
 /// pattern-matching a column, e.g. <c>if (column is INullableColumn&lt;int&gt; nullable)</c>.
 /// </para>
+///
+/// <para>
+/// This is not a general "is this column nullable?" test. Only a type spelled <c>Nullable(T)</c> on the wire has a
+/// null-map to expose; a type that encodes absence some other way will not implement it even though its values can
+/// be null.
+/// </para>
 /// </summary>
 /// <typeparam name="T">The inner (non-nullable) element type; <see cref="Inner"/> is a column of these.</typeparam>
 public interface INullableColumn<T> : IColumn
@@ -30,7 +36,8 @@ public interface INullableColumn<T> : IColumn
     /// <summary>
     /// The dense inner column: one decoded value per row, with an arbitrary placeholder at the rows the null-map
     /// marks null (the wire carries a value there too, so its content is meaningless — always consult
-    /// <see cref="NullMap"/> before reading a row). A borrowed view valid only while the owning block is alive.
+    /// <see cref="NullMap"/> before reading a row). A borrowed view valid only while the owning block is alive —
+    /// it is the block's to dispose, never the caller's.
     /// </summary>
     IColumn<T> Inner { get; }
 

--- a/ClickHouse.Driver.Tcp/Types/NullableReferenceColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/NullableReferenceColumn.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Buffers;
+using System.Runtime.CompilerServices;
+
+namespace ClickHouse.Driver.Tcp.Types;
+
+/// <summary>
+/// A <c>Nullable(T)</c> column for a reference-type inner (e.g. <c>Nullable(String)</c>): it pairs the inner
+/// column with the wire null-map and surfaces each row as the inner value, or <see langword="null"/> where the
+/// map marks the row null. The inner column's storage is borrowed for this column's lifetime and released on
+/// <see cref="Dispose"/>.
+/// </summary>
+/// <typeparam name="T">The inner reference type (e.g. <see cref="string"/> for <c>Nullable(String)</c>).</typeparam>
+internal sealed class NullableReferenceColumn<T> : IColumn<T>
+    where T : class
+{
+    private readonly IColumn<T> inner;
+    private readonly int rowCount;
+    private readonly bool pooledMap;
+    private byte[] nullMap;
+    private T[] cache;
+
+    /// <summary>Initializes a nullable column over an inner reference column and its null-map.</summary>
+    /// <param name="name">The column name.</param>
+    /// <param name="typeName">The full <c>Nullable(...)</c> type string.</param>
+    /// <param name="inner">The inner column holding one decoded value (or placeholder) per row.</param>
+    /// <param name="nullMap">The per-row null-map: a non-zero byte marks the row null. May be longer than <paramref name="rowCount"/>.</param>
+    /// <param name="rowCount">The number of rows.</param>
+    /// <param name="pooledMap">Whether <paramref name="nullMap"/> was rented and should be returned on dispose.</param>
+    public NullableReferenceColumn(string name, string typeName, IColumn<T> inner, byte[] nullMap, int rowCount, bool pooledMap)
+    {
+        Name = name;
+        TypeName = typeName;
+        this.inner = inner ?? throw new ArgumentNullException(nameof(inner));
+        this.nullMap = nullMap ?? throw new ArgumentNullException(nameof(nullMap));
+        this.rowCount = rowCount;
+        this.pooledMap = pooledMap;
+    }
+
+    /// <inheritdoc/>
+    public string Name { get; }
+
+    /// <inheritdoc/>
+    public string TypeName { get; }
+
+    /// <inheritdoc/>
+    public int RowCount => rowCount;
+
+    /// <summary>The dense inner column (one decoded value or placeholder per row) — the zero-copy write source.</summary>
+    internal IColumn<T> Inner => inner;
+
+    /// <summary>The per-row null-map (non-zero byte = null), sliced to <see cref="RowCount"/> — the zero-copy write source.</summary>
+    internal ReadOnlySpan<byte> NullMap => nullMap.AsSpan(0, rowCount);
+
+    /// <summary>The rows, materialized once and cached, with <see langword="null"/> at the null-marked rows.</summary>
+    public ReadOnlySpan<T> Values
+    {
+        get
+        {
+            if (cache is null)
+            {
+                // Rent rather than allocate: this is a convenience view consumers copy out of, so it only needs
+                // to live until Dispose returns it to the pool. Single-consumer per connection, so the lazy fill
+                // needs no synchronization. The rented buffer may be longer than rowCount; Values slices to it.
+                T[] decoded = ArrayPool<T>.Shared.Rent(rowCount);
+                for (int i = 0; i < rowCount; i++)
+                {
+                    decoded[i] = this[i];
+                }
+
+                cache = decoded;
+            }
+
+            return cache.AsSpan(0, rowCount);
+        }
+    }
+
+    /// <inheritdoc/>
+    public T this[int row] => nullMap[row] != 0 ? null : inner[row];
+
+    /// <inheritdoc/>
+    public object GetValue(int row) => this[row];
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        inner.Dispose();
+        if (pooledMap && nullMap.Length != 0)
+        {
+            ArrayPool<byte>.Shared.Return(nullMap);
+        }
+
+        nullMap = Array.Empty<byte>();
+
+        if (cache is not null)
+        {
+            ArrayPool<T>.Shared.Return(cache, clearArray: RuntimeHelpers.IsReferenceOrContainsReferences<T>());
+            cache = null;
+        }
+    }
+}

--- a/ClickHouse.Driver.Tcp/Types/NullableReferenceColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/NullableReferenceColumn.cs
@@ -23,18 +23,30 @@ internal sealed class NullableReferenceColumn<T> : IColumn<T>
     /// <summary>Initializes a nullable column over an inner reference column and its null-map.</summary>
     /// <param name="name">The column name.</param>
     /// <param name="typeName">The full <c>Nullable(...)</c> type string.</param>
-    /// <param name="inner">The inner column holding one decoded value (or placeholder) per row.</param>
-    /// <param name="nullMap">The per-row null-map: a non-zero byte marks the row null. May be longer than <paramref name="rowCount"/>.</param>
-    /// <param name="rowCount">The number of rows.</param>
+    /// <param name="inner">The inner column holding one decoded value (or placeholder) per row; it sets this column's <see cref="RowCount"/>.</param>
+    /// <param name="nullMap">The per-row null-map: a non-zero byte marks the row null. May be longer than the row count.</param>
     /// <param name="pooledMap">Whether <paramref name="nullMap"/> was rented and should be returned on dispose.</param>
-    public NullableReferenceColumn(string name, string typeName, IColumn<T> inner, byte[] nullMap, int rowCount, bool pooledMap)
+    /// <exception cref="ArgumentNullException"><paramref name="inner"/> or <paramref name="nullMap"/> is null.</exception>
+    /// <exception cref="ArgumentException"><paramref name="nullMap"/> is shorter than the inner column's row count.</exception>
+    public NullableReferenceColumn(string name, string typeName, IColumn<T> inner, byte[] nullMap, bool pooledMap)
     {
         Name = name;
         TypeName = typeName;
         this.inner = inner ?? throw new ArgumentNullException(nameof(inner));
         this.nullMap = nullMap ?? throw new ArgumentNullException(nameof(nullMap));
-        this.rowCount = rowCount;
         this.pooledMap = pooledMap;
+
+        // The inner column holds one value per row, so it is the single source of truth for the height and no
+        // separate count is accepted — the two cannot disagree. The null-map is the one input that still can: it is
+        // typically a pooled buffer longer than the row count, so only a short map is an error, and rejecting it
+        // here is what keeps NullMap's slice and the indexer in bounds.
+        rowCount = inner.RowCount;
+        if (nullMap.Length < rowCount)
+        {
+            throw new ArgumentException(
+                $"The null-map for column '{name}' ({typeName}) is {nullMap.Length} bytes, shorter than the inner column's {rowCount} rows.",
+                nameof(nullMap));
+        }
     }
 
     /// <inheritdoc/>

--- a/ClickHouse.Driver.Tcp/Types/NullableReferenceColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/NullableReferenceColumn.cs
@@ -76,7 +76,9 @@ internal sealed class NullableReferenceColumn<T> : IColumn<T>
     }
 
     /// <inheritdoc/>
-    public T this[int row] => nullMap[row] != 0 ? null : inner[row];
+    // Index through the RowCount-sliced null-map so an out-of-range row throws rather than reading a stale slot
+    // of the pooled buffer, which can be longer than RowCount.
+    public T this[int row] => NullMap[row] != 0 ? null : inner[row];
 
     /// <inheritdoc/>
     public object GetValue(int row) => this[row];

--- a/ClickHouse.Driver.Tcp/Types/NullableReferenceColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/NullableReferenceColumn.cs
@@ -11,7 +11,7 @@ namespace ClickHouse.Driver.Tcp.Types;
 /// <see cref="Dispose"/>.
 /// </summary>
 /// <typeparam name="T">The inner reference type (e.g. <see cref="string"/> for <c>Nullable(String)</c>).</typeparam>
-internal sealed class NullableReferenceColumn<T> : IColumn<T>
+internal sealed class NullableReferenceColumn<T> : IColumn<T>, INullableColumn<T>
     where T : class
 {
     private readonly IColumn<T> inner;
@@ -58,11 +58,11 @@ internal sealed class NullableReferenceColumn<T> : IColumn<T>
     /// <inheritdoc/>
     public int RowCount => rowCount;
 
-    /// <summary>The dense inner column (one decoded value or placeholder per row) — the zero-copy write source.</summary>
-    internal IColumn<T> Inner => inner;
+    /// <inheritdoc/>
+    public IColumn<T> Inner => inner;
 
-    /// <summary>The per-row null-map (non-zero byte = null), sliced to <see cref="RowCount"/> — the zero-copy write source.</summary>
-    internal ReadOnlySpan<byte> NullMap => nullMap.AsSpan(0, rowCount);
+    /// <inheritdoc/>
+    public ReadOnlySpan<byte> NullMap => nullMap.AsSpan(0, rowCount);
 
     /// <summary>The rows, materialized once and cached, with <see langword="null"/> at the null-marked rows.</summary>
     public ReadOnlySpan<T> Values

--- a/ClickHouse.Driver.Tcp/Types/NullableValueColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/NullableValueColumn.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Buffers;
+using System.Runtime.CompilerServices;
+
+namespace ClickHouse.Driver.Tcp.Types;
+
+/// <summary>
+/// A <c>Nullable(T)</c> column for a value-type inner: it pairs the inner column (which holds a decoded value —
+/// possibly a placeholder — for every row) with the wire null-map, and surfaces each row as a
+/// <see cref="Nullable{T}"/> that is <see langword="null"/> where the map marks the row null. The inner column's
+/// storage is borrowed for this column's lifetime and released on <see cref="Dispose"/>.
+///
+/// <para>
+/// This dense shape (a full inner column plus a null-map) is the wire's own layout, so it is also the zero-copy
+/// input for writing: handed back to the <c>Nullable(T)</c> codec it is serialized without rebuilding a values
+/// array (see <see cref="Inner"/> / <see cref="NullMap"/>). A row-materialization tier can construct it directly
+/// to insert without going through the boxed <c>T?</c> form.
+/// </para>
+/// </summary>
+/// <typeparam name="T">The inner value type (e.g. <see cref="int"/> for <c>Nullable(Int32)</c>).</typeparam>
+internal sealed class NullableValueColumn<T> : IColumn<T?>
+    where T : struct
+{
+    private readonly IColumn<T> inner;
+    private readonly int rowCount;
+    private readonly bool pooledMap;
+    private byte[] nullMap;
+    private T?[] cache;
+
+    /// <summary>Initializes a nullable column over an inner value column and its null-map.</summary>
+    /// <param name="name">The column name.</param>
+    /// <param name="typeName">The full <c>Nullable(...)</c> type string.</param>
+    /// <param name="inner">The inner column holding one decoded value (or placeholder) per row.</param>
+    /// <param name="nullMap">The per-row null-map: a non-zero byte marks the row null. May be longer than <paramref name="rowCount"/>.</param>
+    /// <param name="rowCount">The number of rows.</param>
+    /// <param name="pooledMap">Whether <paramref name="nullMap"/> was rented and should be returned on dispose.</param>
+    public NullableValueColumn(string name, string typeName, IColumn<T> inner, byte[] nullMap, int rowCount, bool pooledMap)
+    {
+        Name = name;
+        TypeName = typeName;
+        this.inner = inner ?? throw new ArgumentNullException(nameof(inner));
+        this.nullMap = nullMap ?? throw new ArgumentNullException(nameof(nullMap));
+        this.rowCount = rowCount;
+        this.pooledMap = pooledMap;
+    }
+
+    /// <inheritdoc/>
+    public string Name { get; }
+
+    /// <inheritdoc/>
+    public string TypeName { get; }
+
+    /// <inheritdoc/>
+    public int RowCount => rowCount;
+
+    /// <summary>The dense inner column (one decoded value or placeholder per row) — the zero-copy write source.</summary>
+    internal IColumn<T> Inner => inner;
+
+    /// <summary>The per-row null-map (non-zero byte = null), sliced to <see cref="RowCount"/> — the zero-copy write source.</summary>
+    internal ReadOnlySpan<byte> NullMap => nullMap.AsSpan(0, rowCount);
+
+    /// <summary>
+    /// The rows as <see cref="Nullable{T}"/>, materialized once and cached. Prefer the indexer when only some
+    /// rows are needed, to avoid building this array.
+    /// </summary>
+    public ReadOnlySpan<T?> Values
+    {
+        get
+        {
+            if (cache is null)
+            {
+                // Rent rather than allocate: this is a convenience view consumers copy out of, so it only needs
+                // to live until Dispose returns it to the pool. Single-consumer per connection, so the lazy fill
+                // needs no synchronization. The rented buffer may be longer than rowCount; Values slices to it.
+                T?[] decoded = ArrayPool<T?>.Shared.Rent(rowCount);
+                for (int i = 0; i < rowCount; i++)
+                {
+                    decoded[i] = this[i];
+                }
+
+                cache = decoded;
+            }
+
+            return cache.AsSpan(0, rowCount);
+        }
+    }
+
+    /// <inheritdoc/>
+    public T? this[int row] => nullMap[row] != 0 ? null : inner[row];
+
+    /// <inheritdoc/>
+    public object GetValue(int row) => nullMap[row] != 0 ? null : inner[row];
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        inner.Dispose();
+        if (pooledMap && nullMap.Length != 0)
+        {
+            ArrayPool<byte>.Shared.Return(nullMap);
+        }
+
+        nullMap = Array.Empty<byte>();
+
+        if (cache is not null)
+        {
+            ArrayPool<T?>.Shared.Return(cache, clearArray: RuntimeHelpers.IsReferenceOrContainsReferences<T?>());
+            cache = null;
+        }
+    }
+}

--- a/ClickHouse.Driver.Tcp/Types/NullableValueColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/NullableValueColumn.cs
@@ -30,18 +30,30 @@ internal sealed class NullableValueColumn<T> : IColumn<T?>
     /// <summary>Initializes a nullable column over an inner value column and its null-map.</summary>
     /// <param name="name">The column name.</param>
     /// <param name="typeName">The full <c>Nullable(...)</c> type string.</param>
-    /// <param name="inner">The inner column holding one decoded value (or placeholder) per row.</param>
-    /// <param name="nullMap">The per-row null-map: a non-zero byte marks the row null. May be longer than <paramref name="rowCount"/>.</param>
-    /// <param name="rowCount">The number of rows.</param>
+    /// <param name="inner">The inner column holding one decoded value (or placeholder) per row; it sets this column's <see cref="RowCount"/>.</param>
+    /// <param name="nullMap">The per-row null-map: a non-zero byte marks the row null. May be longer than the row count.</param>
     /// <param name="pooledMap">Whether <paramref name="nullMap"/> was rented and should be returned on dispose.</param>
-    public NullableValueColumn(string name, string typeName, IColumn<T> inner, byte[] nullMap, int rowCount, bool pooledMap)
+    /// <exception cref="ArgumentNullException"><paramref name="inner"/> or <paramref name="nullMap"/> is null.</exception>
+    /// <exception cref="ArgumentException"><paramref name="nullMap"/> is shorter than the inner column's row count.</exception>
+    public NullableValueColumn(string name, string typeName, IColumn<T> inner, byte[] nullMap, bool pooledMap)
     {
         Name = name;
         TypeName = typeName;
         this.inner = inner ?? throw new ArgumentNullException(nameof(inner));
         this.nullMap = nullMap ?? throw new ArgumentNullException(nameof(nullMap));
-        this.rowCount = rowCount;
         this.pooledMap = pooledMap;
+
+        // The inner column holds one value per row, so it is the single source of truth for the height and no
+        // separate count is accepted — the two cannot disagree. The null-map is the one input that still can: it is
+        // typically a pooled buffer longer than the row count, so only a short map is an error, and rejecting it
+        // here is what keeps NullMap's slice and the indexer in bounds.
+        rowCount = inner.RowCount;
+        if (nullMap.Length < rowCount)
+        {
+            throw new ArgumentException(
+                $"The null-map for column '{name}' ({typeName}) is {nullMap.Length} bytes, shorter than the inner column's {rowCount} rows.",
+                nameof(nullMap));
+        }
     }
 
     /// <inheritdoc/>

--- a/ClickHouse.Driver.Tcp/Types/NullableValueColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/NullableValueColumn.cs
@@ -18,7 +18,7 @@ namespace ClickHouse.Driver.Tcp.Types;
 /// </para>
 /// </summary>
 /// <typeparam name="T">The inner value type (e.g. <see cref="int"/> for <c>Nullable(Int32)</c>).</typeparam>
-internal sealed class NullableValueColumn<T> : IColumn<T?>
+internal sealed class NullableValueColumn<T> : IColumn<T?>, INullableColumn<T>
     where T : struct
 {
     private readonly IColumn<T> inner;
@@ -65,11 +65,11 @@ internal sealed class NullableValueColumn<T> : IColumn<T?>
     /// <inheritdoc/>
     public int RowCount => rowCount;
 
-    /// <summary>The dense inner column (one decoded value or placeholder per row) — the zero-copy write source.</summary>
-    internal IColumn<T> Inner => inner;
+    /// <inheritdoc/>
+    public IColumn<T> Inner => inner;
 
-    /// <summary>The per-row null-map (non-zero byte = null), sliced to <see cref="RowCount"/> — the zero-copy write source.</summary>
-    internal ReadOnlySpan<byte> NullMap => nullMap.AsSpan(0, rowCount);
+    /// <inheritdoc/>
+    public ReadOnlySpan<byte> NullMap => nullMap.AsSpan(0, rowCount);
 
     /// <summary>
     /// The rows as <see cref="Nullable{T}"/>, materialized once and cached. Prefer the indexer when only some

--- a/ClickHouse.Driver.Tcp/Types/NullableValueColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/NullableValueColumn.cs
@@ -86,10 +86,12 @@ internal sealed class NullableValueColumn<T> : IColumn<T?>
     }
 
     /// <inheritdoc/>
-    public T? this[int row] => nullMap[row] != 0 ? null : inner[row];
+    // Index through the RowCount-sliced null-map so an out-of-range row throws rather than reading a stale slot
+    // of the pooled buffer, which can be longer than RowCount.
+    public T? this[int row] => NullMap[row] != 0 ? null : inner[row];
 
     /// <inheritdoc/>
-    public object GetValue(int row) => nullMap[row] != 0 ? null : inner[row];
+    public object GetValue(int row) => NullMap[row] != 0 ? null : inner[row];
 
     /// <inheritdoc/>
     public void Dispose()

--- a/ClickHouse.Driver.Tcp/Types/SubstituteColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/SubstituteColumn.cs
@@ -1,0 +1,102 @@
+using System;
+
+namespace ClickHouse.Driver.Tcp.Types;
+
+/// <summary>
+/// A lazy write-path view over a nullable value column that presents a real value at every row — the source
+/// value where present, a supplied placeholder where null — so an inner value-type codec can write the
+/// <c>Nullable(T)</c> values stream straight from the ergonomic <c>T?</c> column without a materialized copy.
+/// The view is read per element (it does not expose a contiguous span), matching the per-element write the
+/// scattered null positions force. It borrows the source: disposing it does nothing.
+/// </summary>
+/// <typeparam name="T">The inner value type.</typeparam>
+internal sealed class SubstituteValueColumn<T> : IColumn<T>
+    where T : struct
+{
+    private readonly IColumn<T?> source;
+    private readonly T placeholder;
+
+    /// <summary>Initializes a substitute view over <paramref name="source"/>, filling nulls with <paramref name="placeholder"/>.</summary>
+    /// <param name="typeName">The inner type name the view reports (the codec's own type).</param>
+    /// <param name="source">The ergonomic nullable column.</param>
+    /// <param name="placeholder">The value written where a row is null.</param>
+    public SubstituteValueColumn(string typeName, IColumn<T?> source, T placeholder)
+    {
+        TypeName = typeName;
+        this.source = source;
+        this.placeholder = placeholder;
+    }
+
+    /// <inheritdoc/>
+    public string Name => source.Name;
+
+    /// <inheritdoc/>
+    public string TypeName { get; }
+
+    /// <inheritdoc/>
+    public int RowCount => source.RowCount;
+
+    /// <inheritdoc/>
+    public T this[int row] => source[row].GetValueOrDefault(placeholder);
+
+    /// <inheritdoc/>
+    public object GetValue(int row) => this[row];
+
+    /// <summary>Not supported: the view is scattered over the source and computes each value per index.</summary>
+    /// <exception cref="NotSupportedException">Always — read the view through the indexer.</exception>
+    public ReadOnlySpan<T> Values => throw new NotSupportedException($"{nameof(SubstituteValueColumn<T>)} has no contiguous span; read it per element.");
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+    }
+}
+
+/// <summary>
+/// The reference-type counterpart of <see cref="SubstituteValueColumn{T}"/>: a lazy write-path view over a
+/// nullable-reference column that presents the source reference where non-null and a supplied placeholder where
+/// null, so an inner reference-type codec (e.g. <c>String</c>) can write the <c>Nullable(T)</c> values stream
+/// straight from the ergonomic column. Borrows the source: disposing it does nothing.
+/// </summary>
+/// <typeparam name="T">The inner reference type.</typeparam>
+internal sealed class SubstituteReferenceColumn<T> : IColumn<T>
+    where T : class
+{
+    private readonly IColumn<T> source;
+    private readonly T placeholder;
+
+    /// <summary>Initializes a substitute view over <paramref name="source"/>, filling nulls with <paramref name="placeholder"/>.</summary>
+    /// <param name="typeName">The inner type name the view reports (the codec's own type).</param>
+    /// <param name="source">The ergonomic nullable-reference column.</param>
+    /// <param name="placeholder">The value written where a row is null.</param>
+    public SubstituteReferenceColumn(string typeName, IColumn<T> source, T placeholder)
+    {
+        TypeName = typeName;
+        this.source = source;
+        this.placeholder = placeholder;
+    }
+
+    /// <inheritdoc/>
+    public string Name => source.Name;
+
+    /// <inheritdoc/>
+    public string TypeName { get; }
+
+    /// <inheritdoc/>
+    public int RowCount => source.RowCount;
+
+    /// <inheritdoc/>
+    public T this[int row] => source[row] ?? placeholder;
+
+    /// <inheritdoc/>
+    public object GetValue(int row) => this[row];
+
+    /// <summary>Not supported: the view is scattered over the source and computes each value per index.</summary>
+    /// <exception cref="NotSupportedException">Always — read the view through the indexer.</exception>
+    public ReadOnlySpan<T> Values => throw new NotSupportedException($"{nameof(SubstituteReferenceColumn<T>)} has no contiguous span; read it per element.");
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+    }
+}


### PR DESCRIPTION
Stacked on `tcp/epic-g-fixed-width-types`. Implements **I1 `Nullable(T)`** (read + write) for the native/TCP client (`ClickHouse.Driver.Tcp`), and adds the codec-contract pieces the rest of Epic I will build on.

## What it does

- `Nullable(T)` on the wire is a per-row null-map (`num_rows` × `UInt8`) followed by the inner type's encoding for **every** row — placeholders included at the null positions — with the inner state-prefix phase delegated to the inner codec first. This PR reads and writes exactly that.
- A **value** inner surfaces as `T?` (`NullableColumn<T>`), a **reference** inner as the nullable reference (`NullableReferenceColumn<T>`). Also completes the previously-partial `Nullable(Nothing)` (read-only; every row null).

## Codec-contract additions (reused by all of Epic I)

- **`IColumnCodec.ElementType`** — the CLR type a codec reads back. Lets a composite bridge from its non-generic child codec to the correct typed wrapper column via a cached, per-element-type "shape".
- **`IColumnCodec.NullPlaceholder`** — the value a codec writes where a row has no value of its own (the placeholder at a `Nullable` null position): the type's canonical zero/epoch (`0`, `1970-01-01`, `0.0.0.0`, `""`, …), **not** the CLR `default`. See the write section for why. `Enum` returns a declared member; `Nothing` throws (not writable).
- **`ColumnCodecRegistry.ResolveNode(TypeNode, …)`** — resolves a child codec so composites can recurse; the registry is threaded through the codec factory.

## The write path (the interesting part)

Writing `Nullable(T)` has to emit a valid inner value at **every** row, including the null ones (the server ignores those bytes, but the inner codec still has to be handed something it accepts). Two problems surfaced:

1. **The CLR `default` is not a safe placeholder.** `default(DateTimeOffset)`/`default(DateOnly)` is year 1, which the `Date`/`DateTime` codecs range-reject; `default(IPAddress)` is `null`, which the IP codec dereferences. So the null-row placeholder must be a *valid* value per type — hence `NullPlaceholder` (each codec owns its own, mirroring how clickhouse-go's base columns render a `nil` append).
2. **The caller's ergonomic column isn't dense.** A hand-built `ArrayColumn<int?>` stores `Nullable<int>` (`{hasValue,value}` layout), which can't be reinterpreted as a contiguous `int[]`; the fixed-width codecs write via one bulk `MemoryMarshal` copy over a dense `T` span. So to write, the values have to be materialized into a dense `T[]` — a real copy, and for **value** types an unavoidable one (it's a representation gap, not a placeholder cost). For **reference** types the array is already dense; only the null entries need substituting.

### Approaches considered

| Approach | Copy / alloc | Codec stays null-oblivious | Verdict |
|---|---|---|---|
| Fill a dense array in the Nullable layer | copy for all types | ✅ | baseline |
| **Pool the fill (`ArrayPool<T>`)** | copy, **no GC** | ✅ | **landed** |
| **Zero-copy the already-dense form** | none for dense inputs | ✅ | **landed** |
| Codec-level null tolerance (per-row) | none | ❌ nullability leaks into every codec; loses the bulk write | rejected |
| Pass a null-map into `WriteColumn` | none | ❌ couples codecs to nullability | rejected |
| Dedicated non-dense per-value codec write path | none for variable-width | ✅ | deferred — only helps variable-width, marginal over pooling; revisit with streaming inserts |
| Dense (values + null-map) as the canonical write API | none | ✅ | deferred to the row/POCO tier (N9); the only thing that removes the value-type copy |

Key realization: the dense-array copy only earns its keep for **fixed-width** inners, where it feeds a single bulk `MemoryMarshal` write. For **variable-width** (`String`) it buys nothing (String already writes per-element). And pooling makes *both* cases GC-free with no new codec API, so it captures almost all of the benefit.

### What we landed on

- **Pooled fill** for the ergonomic `T?` / nulls-in-`T[]` form: rent the inner-typed buffer from `ArrayPool<T>` (via a non-owning `ArrayColumn<T>.OverBuffer` view), substitute `NullPlaceholder` at null rows, write, return the buffer. GC-free; keeps the fixed-width bulk write.
- **Zero-copy fast path** when the column is already dense (`NullableColumn<T>` / `NullableReferenceColumn<T>` — inner column + null-map, the wire's own layout): write the null-map bytes and the inner column directly, no intermediate array.
- **Ready for the POCO/row tier (N9):** that dense form is exactly what a read produces and what N9 can construct directly, so it hits the zero-copy path with no interface change. `Inner`/`NullMap` are exposed and documented as the dense write input. Making dense the *canonical* input (removing the value-type copy entirely) is left to N9, where the API-shape decision belongs.

An aside this shook out: `StringColumnCodec` no longer silently coerces a `null` to `""`. The Nullable layer substitutes the placeholder itself, so a genuinely non-nullable `String` column with a stray `null` still fails fast in `WriteString`.

## Follow-ups (deferred)

- Pool/dense-input the value-type write end-to-end via the N9 row tier (removes the representation copy).
- A non-dense per-value codec write path if streaming inserts (N8/N9) or profiling justify it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)