### PR TITLE
TCP I2: Add Array(T) support

### DIFF
--- a/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpConnectionInsertIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpConnectionInsertIntegrationTests.cs
@@ -351,6 +351,107 @@ public class ClickHouseTcpConnectionInsertIntegrationTests
         Assert.That(probe, Is.EqualTo((byte)1));
     }
 
+    // The values-per-row shape (varying lengths, interspersed empties) that makes the offsets stream non-trivial,
+    // shared by the two block-splitting tests below.
+    private static readonly uint[][] JaggedArrayRows =
+    {
+        new uint[] { 1 },
+        Array.Empty<uint>(),
+        new uint[] { 2, 3 },
+        new uint[] { 4, 5, 6 },
+        Array.Empty<uint>(),
+        new uint[] { 7 },
+        new uint[] { 8, 9, 10, 11 },
+    };
+
+    [Test]
+    public async Task InsertAsync_JaggedArrayColumnSplitAcrossBlocks_RoundTripsEveryRow()
+    {
+        await using var connection = await TcpServerFixture.ConnectAsync(None);
+        string table = UniqueTableName();
+        try
+        {
+            await ExecuteAsync(connection, $"CREATE TABLE {table} (id UInt32, value Array(UInt32)) ENGINE = Memory");
+
+            // maxRowsPerBlock: 2 forces the seven rows into four wire blocks. Each block re-bases its offsets at
+            // zero, so this drives the ergonomic jagged write path across block boundaries. The id column pins the
+            // read-back order (Memory does not guarantee it otherwise).
+            IColumn[] columns =
+            {
+                PrimitiveColumn<uint>.FromValues("id", "UInt32", RowIds(JaggedArrayRows.Length)),
+                new ArrayColumn<uint[]>("value", "Array(UInt32)", JaggedArrayRows),
+            };
+            await connection.InsertAsync($"INSERT INTO {table} (id, value) VALUES", columns, maxRowsPerBlock: 2, cancellationToken: None);
+
+            uint[][] readBack = await ReadArraysOrderedByIdAsync(connection, table, JaggedArrayRows.Length);
+            Assert.That(readBack, Is.EqualTo(JaggedArrayRows));
+            Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+        }
+        finally
+        {
+            await ExecuteAsync(connection, $"DROP TABLE IF EXISTS {table}");
+        }
+    }
+
+    [Test]
+    public async Task InsertAsync_DenseArrayValueColumnSplitAcrossBlocks_RoundTripsEveryRow()
+    {
+        await using var connection = await TcpServerFixture.ConnectAsync(None);
+        string table = UniqueTableName();
+        try
+        {
+            await ExecuteAsync(connection, $"CREATE TABLE {table} (id UInt32, value Array(UInt32)) ENGINE = Memory");
+
+            // The dense wire-shaped column (one flat inner column + a cumulative offsets array) is the zero-copy
+            // write source a read produces. Splitting it with maxRowsPerBlock: 2 exercises the dense write path's
+            // slice-relative offset arithmetic — subtracting each block's first element index — which only runs
+            // when a block begins at a non-zero element offset (blocks 2+ here).
+            var inner = PrimitiveColumn<uint>.FromValues("value", "UInt32", new uint[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 });
+            var dense = new ArrayValueColumn<uint>("value", "Array(UInt32)", inner, new[] { 0, 1, 1, 3, 6, 6, 7, 11 }, rowCount: JaggedArrayRows.Length, pooledOffsets: false);
+            IColumn[] columns =
+            {
+                PrimitiveColumn<uint>.FromValues("id", "UInt32", RowIds(JaggedArrayRows.Length)),
+                dense,
+            };
+            await connection.InsertAsync($"INSERT INTO {table} (id, value) VALUES", columns, maxRowsPerBlock: 2, cancellationToken: None);
+
+            uint[][] readBack = await ReadArraysOrderedByIdAsync(connection, table, JaggedArrayRows.Length);
+            Assert.That(readBack, Is.EqualTo(JaggedArrayRows));
+            Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+        }
+        finally
+        {
+            await ExecuteAsync(connection, $"DROP TABLE IF EXISTS {table}");
+        }
+    }
+
+    private static uint[] RowIds(int count)
+    {
+        var ids = new uint[count];
+        for (uint i = 0; i < count; i++)
+        {
+            ids[i] = i;
+        }
+
+        return ids;
+    }
+
+    // Reads the Array(UInt32) column back in id order, copying each row out of the borrowed block (the materialized
+    // arrays are fresh copies, so they outlive it).
+    private static async Task<uint[][]> ReadArraysOrderedByIdAsync(ClickHouseTcpConnection connection, string table, int expectedRows)
+    {
+        var rows = new List<uint[]>(expectedRows);
+        await foreach (Block block in connection.QueryAsync($"SELECT value FROM {table} ORDER BY id", cancellationToken: None))
+        {
+            foreach (uint[] row in ((IColumn<uint[]>)block[0]).Values)
+            {
+                rows.Add(row);
+            }
+        }
+
+        return rows.ToArray();
+    }
+
     private static void AssertColumnsEqual(IColumn expected, IColumn actual)
     {
         Assert.That(actual.RowCount, Is.EqualTo(expected.RowCount), "row count");

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpConnectionInsertIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpConnectionInsertIntegrationTests.cs
@@ -49,6 +49,55 @@ public class ClickHouseTcpConnectionInsertIntegrationTests
         }
     }
 
+    // The dense counterpart of the convenient-form round-trip above: seed a table with the caller-friendly column,
+    // then re-insert what a read produces — the dense wire-shaped column (ArrayValueColumn, TupleColumn, MapColumn,
+    // NestedColumn, VariantColumn, the dictionary-backed LowCardinality column, …) — into a second table and read
+    // that back. This proves every supported type also inserts correctly in its dense form, not just the ergonomic
+    // one, exercising the codecs' zero-copy dense write path end-to-end. The read-back block is re-inserted inside
+    // its own iteration (through a second connection), never retained past it.
+    [TestCaseSource(typeof(InsertRoundTripCase), nameof(InsertRoundTripCase.Cases))]
+    public async Task InsertAsync_DenseReadbackReinserted_RoundTripsThroughSelect(InsertRoundTripCase testCase)
+    {
+        await using var source = await TcpServerFixture.ConnectAsync(None);
+        await using var sink = await TcpServerFixture.ConnectAsync(None);
+        string seedTable = UniqueTableName();
+        string denseTable = UniqueTableName();
+        try
+        {
+            await ExecuteAsync(source, $"CREATE TABLE {seedTable} (value {testCase.ClickHouseType}) ENGINE = Memory", testCase.Settings);
+            await ExecuteAsync(sink, $"CREATE TABLE {denseTable} (value {testCase.ClickHouseType}) ENGINE = Memory", testCase.Settings);
+
+            await source.InsertAsync($"INSERT INTO {seedTable} (value) VALUES", new[] { testCase.BuildInsertColumn("value") }, settings: testCase.Settings, cancellationToken: None);
+
+            // Re-insert each dense read-back block into the second table while it is still valid (a second
+            // connection, since the source query is streaming on the first).
+            await foreach (Block block in source.QueryAsync($"SELECT value FROM {seedTable}", settings: testCase.Settings, cancellationToken: None))
+            {
+                await sink.InsertAsync($"INSERT INTO {denseTable} (value) VALUES", new[] { block[0] }, settings: testCase.Settings, cancellationToken: None);
+            }
+
+            IColumn expected = testCase.BuildExpectedColumn("value");
+            int blockCount = 0;
+            await foreach (Block block in sink.QueryAsync($"SELECT value FROM {denseTable}", settings: testCase.Settings, cancellationToken: None))
+            {
+                blockCount++;
+                AssertColumnsEqual(expected, block[0]);
+            }
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(blockCount, Is.EqualTo(1), "re-inserting the dense read-back should round-trip exactly one row-bearing block");
+                Assert.That(source.State, Is.EqualTo(TcpConnectionState.Ready));
+                Assert.That(sink.State, Is.EqualTo(TcpConnectionState.Ready));
+            });
+        }
+        finally
+        {
+            await ExecuteAsync(source, $"DROP TABLE IF EXISTS {seedTable}");
+            await ExecuteAsync(sink, $"DROP TABLE IF EXISTS {denseTable}");
+        }
+    }
+
     [Test]
     public async Task InsertAsync_MultipleColumnsAndRows_RoundTripsEveryColumn()
     {

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpConnectionQueryIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpConnectionQueryIntegrationTests.cs
@@ -161,6 +161,38 @@ public class ClickHouseTcpConnectionQueryIntegrationTests
     }
 
     [Test]
+    public async Task QueryAsync_ServerGeneratedArrayViaRange_ReadsBackEveryRow()
+    {
+        await using var connection = await TcpServerFixture.ConnectAsync(None);
+
+        // range(number) yields a server-authored Array(UInt64) whose offsets and values the client never wrote:
+        // row n is [0, 1, ..., n-1], so row 0 is empty and later rows grow. This validates the Array read path
+        // against offsets the server produced, independent of the client's own write path.
+        const int rowCount = 64;
+        var readBack = new List<ulong[]>(rowCount);
+        await foreach (Block block in connection.QueryAsync($"SELECT range(number) AS r FROM numbers({rowCount}) ORDER BY number", cancellationToken: None))
+        {
+            Assert.That(block[0].TypeName, Is.EqualTo("Array(UInt64)"));
+            foreach (ulong[] row in ((IColumn<ulong[]>)block[0]).Values)
+            {
+                readBack.Add(row);
+            }
+        }
+
+        Assert.That(readBack, Has.Count.EqualTo(rowCount));
+        for (int n = 0; n < rowCount; n++)
+        {
+            var expected = new ulong[n];
+            for (int i = 0; i < n; i++)
+            {
+                expected[i] = (ulong)i;
+            }
+
+            Assert.That(readBack[n], Is.EqualTo(expected), $"row {n}");
+        }
+    }
+
+    [Test]
     public async Task QueryAsync_EmptyResult_YieldsNoRowBearingBlocksAndStaysReady()
     {
         await using var connection = await TcpServerFixture.ConnectAsync(None);

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ColumnarReadSurfaceIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ColumnarReadSurfaceIntegrationTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using ClickHouse.Driver.Tcp.Format;
@@ -122,6 +123,101 @@ public class ColumnarReadSurfaceIntegrationTests
             Assert.That(nullMapLength, Is.EqualTo(rowCount));
             Assert.That(innerRowCount, Is.EqualTo(rowCount));
             Assert.That(materialized, Is.EqualTo(new[] { "v0", null, "v2" }));
+        });
+    }
+
+    [Test]
+    public async Task QueryAsync_ArrayColumn_ExposesFlatElementsAndOffsetsThroughIArrayColumn()
+    {
+        // An Array(T) column's wire layout is every row's elements concatenated into one flat run plus the per-row
+        // offsets that delimit them. The materialized IColumn<T[]> surface allocates a fresh array per row;
+        // IArrayColumn<TElement> is the allocation-free alternative, so the test walks the rows through the spans
+        // and checks they reconstruct what the materialized surface produced.
+        await using var connection = await TcpServerFixture.ConnectAsync(None);
+
+        bool matched = false;
+        int rowCount = 0;
+        int[] offsets = null;
+        int[] innerValues = null;
+        int innerRowCount = 0;
+        var slices = new List<int[]>();
+        int[][] materialized = null;
+
+        // Rows: [], [0], [0, 1], [0, 1, 2] — an empty leading row makes a zero-length slice part of the check.
+        await foreach (Block block in connection.QueryAsync(
+            "SELECT CAST(range(number), 'Array(Int32)') FROM system.numbers LIMIT 4",
+            cancellationToken: None))
+        {
+            IColumn column = block[0];
+            matched = column is IArrayColumn<int>;
+
+            var array = (IArrayColumn<int>)column;
+            rowCount = array.RowCount;
+            offsets = array.Offsets.ToArray();
+            innerValues = array.InnerValues.ToArray();
+            innerRowCount = array.Inner.RowCount;
+            materialized = ((IColumn<int[]>)column).Values.ToArray();
+
+            for (int row = 0; row < array.RowCount; row++)
+            {
+                slices.Add(array.InnerValues.Slice(array.Offsets[row], array.Offsets[row + 1] - array.Offsets[row]).ToArray());
+            }
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(matched, Is.True);
+            Assert.That(rowCount, Is.EqualTo(4));
+            Assert.That(offsets, Is.EqualTo(new[] { 0, 0, 1, 3, 6 }), "one more entry than rows; [0] is 0");
+            Assert.That(offsets.Length, Is.EqualTo(rowCount + 1), "sliced to the row count, not the pooled buffer length");
+            Assert.That(innerValues, Is.EqualTo(new[] { 0, 0, 1, 0, 1, 2 }), "every row's elements end-to-end");
+            Assert.That(innerRowCount, Is.EqualTo(6), "the inner column is flat: one entry per element, not per row");
+            Assert.That(slices, Is.EqualTo(materialized), "the zero-copy slices reconstruct the materialized rows");
+        });
+    }
+
+    [Test]
+    public async Task QueryAsync_NestedArrayColumn_ExposesInnerAsAnotherArrayColumnForRecursion()
+    {
+        // Why IArrayColumn exposes Inner as a column and not just InnerValues as a span: when the element type is
+        // itself composite, the span's element type is the *materialized* form (here int[]), so reading it defeats
+        // the point. Inner hands back the flat inner column instead, which pattern-matches to the element type's own
+        // view — so a nested composite can be walked to the bottom without materializing an intermediate level.
+        await using var connection = await TcpServerFixture.ConnectAsync(None);
+
+        bool outerMatched = false;
+        bool innerMatched = false;
+        int[] outerOffsets = null;
+        int[] innerOffsets = null;
+        int[] leafValues = null;
+        int[][][] materialized = null;
+
+        // Rows: [[0], [0, 1]] and [[1], [1, 2]].
+        await foreach (Block block in connection.QueryAsync(
+            "SELECT [[toInt32(number)], [toInt32(number), toInt32(number + 1)]] FROM system.numbers LIMIT 2",
+            cancellationToken: None))
+        {
+            IColumn column = block[0];
+            outerMatched = column is IArrayColumn<int[]>;
+
+            var outer = (IArrayColumn<int[]>)column;
+            outerOffsets = outer.Offsets.ToArray();
+            materialized = ((IColumn<int[][]>)column).Values.ToArray();
+
+            innerMatched = outer.Inner is IArrayColumn<int>;
+            var inner = (IArrayColumn<int>)outer.Inner;
+            innerOffsets = inner.Offsets.ToArray();
+            leafValues = inner.InnerValues.ToArray();
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(outerMatched, Is.True, "the outer view's element type is the materialized inner array");
+            Assert.That(innerMatched, Is.True, "and Inner re-enters the columnar surface one level down");
+            Assert.That(outerOffsets, Is.EqualTo(new[] { 0, 2, 4 }), "two inner arrays per outer row");
+            Assert.That(innerOffsets, Is.EqualTo(new[] { 0, 1, 3, 4, 6 }), "four inner arrays, of lengths 1, 2, 1, 2");
+            Assert.That(leafValues, Is.EqualTo(new[] { 0, 0, 1, 1, 1, 2 }), "the leaf run, reached without materializing a level");
+            Assert.That(materialized, Is.EqualTo(new[] { new[] { new[] { 0 }, new[] { 0, 1 } }, new[] { new[] { 1 }, new[] { 1, 2 } } }));
         });
     }
 }

--- a/ClickHouse.Driver.Tcp.Tests/Integration/NestedArrayInsertIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/NestedArrayInsertIntegrationTests.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Format;
+using ClickHouse.Driver.Tcp.Protocol;
+using ClickHouse.Driver.Tcp.Tests.Utilities;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Tests.Integration;
+
+/// <summary>
+/// Block-splitting inserts for the deeply nested <c>Array(Array(...))</c> shapes. The insert fixture splits a single
+/// <c>Array</c> level at two rows a block; these repeat that for the whole nesting ladder, where the per-block
+/// arithmetic has to hold at every level at once rather than only the outermost.
+///
+/// <para>
+/// The same shapes also reach <c>InsertRoundTripCase.Cases()</c>, so each one gets the unsplit round-trip, the dense
+/// read-back re-insert, and the one-row-per-block slice for free. What is left to this fixture is the case those
+/// cannot reach: a slice with a non-zero start <em>and</em> a length above one, at depth.
+/// </para>
+///
+/// <para>
+/// A yielded Block is borrowed — valid only for its iteration — so every read compares or copies inside the
+/// <c>await foreach</c>, never retaining the block.
+/// </para>
+/// </summary>
+[TestFixture]
+[Category("Integration")]
+public class NestedArrayInsertIntegrationTests
+{
+    private static readonly CancellationToken None = CancellationToken.None;
+
+    [TestCaseSource(typeof(NestedArrayShape), nameof(NestedArrayShape.Shapes))]
+    public async Task InsertAsync_JaggedNestedArrayColumnSplitAcrossBlocks_RoundTripsEveryRow(NestedArrayShape shape)
+    {
+        await using var connection = await TcpServerFixture.ConnectAsync(None);
+        string table = UniqueTableName();
+        try
+        {
+            await ExecuteAsync(connection, $"CREATE TABLE {table} (id UInt32, value {shape.ClickHouseType}) ENGINE = Memory");
+
+            // The ergonomic write derives each block's offsets from that block's rows alone, and hands a nested Array
+            // inner a ConcatColumn view over exactly those rows rather than driving it per row. maxRowsPerBlock: 2
+            // makes every block a strict subset, so at depth 5 this stacks four of those views over a two-row window.
+            // The id column pins the read-back order; the Memory engine does not guarantee it across blocks.
+            IColumn[] columns = { RowIds(shape.RowCount), shape.BuildColumn("value") };
+            await connection.InsertAsync($"INSERT INTO {table} (id, value) VALUES", columns, maxRowsPerBlock: 2, cancellationToken: None);
+
+            object[] readBack = await ReadValuesOrderedByIdAsync(connection, table, shape.RowCount);
+            Assert.Multiple(() =>
+            {
+                Assert.That(readBack, Is.EqualTo(ExpectedRows(shape)));
+                Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+            });
+        }
+        finally
+        {
+            await ExecuteAsync(connection, $"DROP TABLE IF EXISTS {table}");
+        }
+    }
+
+    [TestCaseSource(typeof(NestedArrayShape), nameof(NestedArrayShape.Shapes))]
+    public async Task InsertAsync_DenseNestedArrayReadbackSplitAcrossBlocks_RoundTripsEveryRow(NestedArrayShape shape)
+    {
+        await using var source = await TcpServerFixture.ConnectAsync(None);
+        await using var sink = await TcpServerFixture.ConnectAsync(None);
+        string seedTable = UniqueTableName();
+        string splitTable = UniqueTableName();
+        try
+        {
+            await ExecuteAsync(source, $"CREATE TABLE {seedTable} (id UInt32, value {shape.ClickHouseType}) ENGINE = Memory");
+            await ExecuteAsync(sink, $"CREATE TABLE {splitTable} (id UInt32, value {shape.ClickHouseType}) ENGINE = Memory");
+
+            IColumn[] seed = { RowIds(shape.RowCount), shape.BuildColumn("value") };
+            await source.InsertAsync($"INSERT INTO {seedTable} (id, value) VALUES", seed, cancellationToken: None);
+
+            // The dense counterpart: a read-back block is a stack of ArrayValueColumns whose offsets, at every level,
+            // count from the start of the whole column. Re-inserting it at two rows a block makes every block after
+            // the first begin at a non-zero element offset *at each level of the shape*, so each level has to rebase
+            // its own offsets on its own slice; a level that skipped it would emit offsets running past the elements
+            // it wrote. Building the equivalent column by hand at depth 5 is unreadable, so the server's read-back
+            // supplies it — re-inserted inside its own iteration, through a second connection, never retained.
+            await foreach (Block block in source.QueryAsync($"SELECT id, value FROM {seedTable} ORDER BY id", cancellationToken: None))
+            {
+                await sink.InsertAsync(
+                    $"INSERT INTO {splitTable} (id, value) VALUES",
+                    new[] { block[0], block[1] },
+                    maxRowsPerBlock: 2,
+                    cancellationToken: None);
+            }
+
+            object[] readBack = await ReadValuesOrderedByIdAsync(sink, splitTable, shape.RowCount);
+            Assert.Multiple(() =>
+            {
+                Assert.That(readBack, Is.EqualTo(ExpectedRows(shape)));
+                Assert.That(source.State, Is.EqualTo(TcpConnectionState.Ready));
+                Assert.That(sink.State, Is.EqualTo(TcpConnectionState.Ready));
+            });
+        }
+        finally
+        {
+            await ExecuteAsync(source, $"DROP TABLE IF EXISTS {seedTable}");
+            await ExecuteAsync(sink, $"DROP TABLE IF EXISTS {splitTable}");
+        }
+    }
+
+    // The shape's rows as the nested arrays a read-back surfaces, so NUnit's recursive collection equality compares
+    // them level by level.
+    private static object[] ExpectedRows(NestedArrayShape shape)
+    {
+        IColumn expected = shape.BuildColumn("value");
+        var rows = new object[expected.RowCount];
+        for (int row = 0; row < rows.Length; row++)
+        {
+            rows[row] = expected.GetValue(row);
+        }
+
+        return rows;
+    }
+
+    // Reads the value column back in id order. An array column materializes each row into a fresh array on access, so
+    // the collected rows outlive the borrowed block.
+    private static async Task<object[]> ReadValuesOrderedByIdAsync(ClickHouseTcpConnection connection, string table, int expectedRows)
+    {
+        var rows = new List<object>(expectedRows);
+        await foreach (Block block in connection.QueryAsync($"SELECT value FROM {table} ORDER BY id", cancellationToken: None))
+        {
+            for (int row = 0; row < block[0].RowCount; row++)
+            {
+                rows.Add(block[0].GetValue(row));
+            }
+        }
+
+        return rows.ToArray();
+    }
+
+    private static IColumn RowIds(int rowCount)
+    {
+        var ids = new uint[rowCount];
+        for (int i = 0; i < ids.Length; i++)
+        {
+            ids[i] = (uint)i;
+        }
+
+        return PrimitiveColumn<uint>.FromValues("id", "UInt32", ids);
+    }
+
+    private static async Task ExecuteAsync(ClickHouseTcpConnection connection, string sql)
+    {
+        await foreach (Block block in connection.QueryAsync(sql, cancellationToken: None))
+        {
+            _ = block;
+        }
+    }
+
+    private static string UniqueTableName() => $"tcp_nested_array_test_{Guid.NewGuid():N}";
+}

--- a/ClickHouse.Driver.Tcp.Tests/Types/ArrayColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/ArrayColumnCodecTests.cs
@@ -258,6 +258,60 @@ public class ArrayColumnCodecTests
     }
 
     [Test]
+    public async Task Densify_JaggedColumn_ProducesDenseColumnThatRoundTrips()
+    {
+        // Densify flattens the jagged T[]-per-row form into the dense wire shape: a per-row offsets array plus a
+        // single flat inner column holding every element end-to-end. It must surface the same rows and round-trip.
+        IColumnCodec codec = Resolve("Array(UInt32)");
+        var expected = new[] { new uint[] { 10, 20, 30 }, Array.Empty<uint>(), new uint[] { 40, 50 } };
+        var jagged = new ArrayColumn<uint[]>("c", "Array(UInt32)", expected);
+
+        IColumn densified = codec.Densify(jagged);
+
+        Assert.That(densified, Is.InstanceOf<ArrayValueColumn<uint>>());
+        var dense = (ArrayValueColumn<uint>)densified;
+        Assert.Multiple(() =>
+        {
+            Assert.That(dense.Offsets.ToArray(), Is.EqualTo(new[] { 0, 3, 3, 5 }));
+            Assert.That(dense.Inner.Values.ToArray(), Is.EqualTo(new uint[] { 10, 20, 30, 40, 50 }));
+            Assert.That(((IColumn<uint[]>)densified).Values.ToArray(), Is.EqualTo(expected));
+        });
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, densified, "Array(UInt32)", densified.RowCount);
+        Assert.That(((IColumn<uint[]>)read).Values.ToArray(), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void Densify_NestedNullableInner_DensifiesInnerToo()
+    {
+        // Array(Nullable(T)): densify flattens the jagged rows AND recurses the inner codec, turning the
+        // concatenated T? run into the dense (inner column + null-map) nullable column — the whole tree is dense.
+        IColumnCodec codec = Resolve("Array(Nullable(UInt32))");
+        var expected = new[] { new uint?[] { 1, null }, new uint?[] { 3 } };
+        var jagged = new ArrayColumn<uint?[]>("c", "Array(Nullable(UInt32))", expected);
+
+        var dense = (ArrayValueColumn<uint?>)codec.Densify(jagged);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(dense.Offsets.ToArray(), Is.EqualTo(new[] { 0, 2, 3 }));
+            Assert.That(dense.Inner, Is.InstanceOf<NullableValueColumn<uint>>());
+            Assert.That(((IColumn<uint?[]>)dense).Values.ToArray(), Is.EqualTo(expected));
+        });
+    }
+
+    [Test]
+    public void Densify_AlreadyDenseColumn_ReturnsSameInstance()
+    {
+        // Idempotent: a dense column whose inner is already dense is returned by reference (nothing to rebuild).
+        IColumnCodec codec = Resolve("Array(UInt32)");
+        var inner = PrimitiveColumn<uint>.FromValues("c", "UInt32", new uint[] { 10, 20, 30, 40, 50 });
+        var dense = new ArrayValueColumn<uint>("c", "Array(UInt32)", inner, new[] { 0, 3, 3, 5 }, rowCount: 3, pooledOffsets: false);
+
+        Assert.That(codec.Densify(dense), Is.SameAs(dense));
+    }
+
+    [Test]
     public void Resolve_Array_StampsFullTypeName()
         => Assert.That(Resolve("Array(Nullable(String))").TypeName, Is.EqualTo("Array(Nullable(String))"));
 

--- a/ClickHouse.Driver.Tcp.Tests/Types/ArrayColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/ArrayColumnCodecTests.cs
@@ -76,7 +76,7 @@ public class ArrayColumnCodecTests
         IColumnCodec codec = Resolve("Array(UInt32)");
         var column = new ArrayColumn<uint[]>("c", "Array(UInt32)", Array.Empty<uint[]>());
 
-        byte[] bytes = await CodecTestHarness.WriteDenseAsync(codec, column, 0, 0);
+        byte[] bytes = await CodecTestHarness.WriteSliceAsync(codec, column, 0, 0);
         Assert.That(bytes, Is.Empty, "an empty array column writes no offsets and no values");
 
         using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(bytes);
@@ -124,84 +124,11 @@ public class ArrayColumnCodecTests
             new uint[] { 4, 5, 6 },
         });
 
-        byte[] bytes = await CodecTestHarness.WriteDenseAsync(codec, full, start: 1, length: 2);
+        byte[] bytes = await CodecTestHarness.WriteSliceAsync(codec, full, start: 1, length: 2);
         using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(bytes);
         using IColumn read = await codec.ReadColumnAsync(reader, "c", "Array(UInt32)", 2, CodecTestHarness.None);
 
         Assert.That(((IColumn<uint[]>)read).Values.ToArray(), Is.EqualTo(new[] { new uint[] { 2, 3 }, Array.Empty<uint>() }));
-    }
-
-    [Test]
-    public void MeasureRowBytes_FixedWidthInner_CountsOneOffsetPlusElements()
-    {
-        IColumnCodec codec = Resolve("Array(UInt32)");
-        var column = new ArrayColumn<uint[]>("c", "Array(UInt32)", new[] { new uint[] { 10, 20, 30 }, Array.Empty<uint>() });
-        using IColumn dense = codec.TryDensify(column, out _);
-
-        Assert.Multiple(() =>
-        {
-            Assert.That(codec.MeasureRowBytes(dense, 0), Is.EqualTo(8 + (3 * 4))); // one UInt64 offset + three UInt32
-            Assert.That(codec.MeasureRowBytes(dense, 1), Is.EqualTo(8));           // one offset, no elements
-            Assert.That(codec.FixedRowByteSize, Is.Null);
-        });
-    }
-
-    [Test]
-    public void WriteColumn_NullRow_ThrowsArgumentException()
-    {
-        // Array(T) rows are non-nullable, so a null row is rejected (during densify, before the write) rather than
-        // silently written as an empty array.
-        IColumnCodec codec = Resolve("Array(UInt32)");
-        var column = new ArrayColumn<uint[]>("c", "Array(UInt32)", new[] { new uint[] { 1, 2 }, null, new uint[] { 3 } });
-
-        Assert.Throws<ArgumentException>(() => codec.TryDensify(column, out _));
-    }
-
-    [Test]
-    public void MeasureRowBytes_NullRow_ThrowsArgumentException()
-    {
-        // TryDensify (which the measure/write pipeline runs first) must reject a null row rather than treat it as empty.
-        IColumnCodec codec = Resolve("Array(UInt32)");
-        var column = new ArrayColumn<uint[]>("c", "Array(UInt32)", new[] { new uint[] { 1, 2 }, null });
-
-        Assert.Throws<ArgumentException>(() => codec.TryDensify(column, out _));
-    }
-
-    [Test]
-    public void MeasureRowBytes_VariableInner_WalksEachElement()
-    {
-        IColumnCodec codec = Resolve("Array(String)");
-        var column = new ArrayColumn<string[]>("c", "Array(String)", new[] { new[] { "a", "bb" }, Array.Empty<string>() });
-        using IColumn dense = codec.TryDensify(column, out _);
-
-        Assert.Multiple(() =>
-        {
-            Assert.That(codec.MeasureRowBytes(dense, 0), Is.EqualTo(8 + (1 + 1) + (1 + 2))); // offset + "a" + "bb"
-            Assert.That(codec.MeasureRowBytes(dense, 1), Is.EqualTo(8));
-        });
-    }
-
-    [Test]
-    public async Task MeasureRowBytes_DenseColumn_PricesFromOffsetsAndInner()
-    {
-        // A dense ArrayValueColumn (the read-back shape) re-inserted goes through the offsets-based measure path,
-        // distinct from the jagged-column path. Both a fixed-width and a variable-width inner are priced.
-        IColumnCodec fixedCodec = Resolve("Array(UInt32)");
-        var inner = PrimitiveColumn<uint>.FromValues("c", "UInt32", new uint[] { 10, 20, 30, 40, 50 });
-        var dense = new ArrayValueColumn<uint>("c", "Array(UInt32)", inner, new[] { 0, 3, 3, 5 }, rowCount: 3, pooledOffsets: false);
-
-        IColumnCodec stringCodec = Resolve("Array(String)");
-        var jagged = new ArrayColumn<string[]>("c", "Array(String)", new[] { new[] { "a", "bb" }, Array.Empty<string>() });
-        using IColumn denseStrings = await CodecTestHarness.RoundTripAsync(stringCodec, jagged, "Array(String)", 2);
-
-        Assert.Multiple(() =>
-        {
-            Assert.That(fixedCodec.MeasureRowBytes(dense, 0), Is.EqualTo(8 + (3 * 4)));
-            Assert.That(fixedCodec.MeasureRowBytes(dense, 1), Is.EqualTo(8));
-            Assert.That(fixedCodec.MeasureRowBytes(dense, 2), Is.EqualTo(8 + (2 * 4)));
-            Assert.That(stringCodec.MeasureRowBytes(denseStrings, 0), Is.EqualTo(8 + (1 + 1) + (1 + 2)));
-            Assert.That(stringCodec.MeasureRowBytes(denseStrings, 1), Is.EqualTo(8));
-        });
     }
 
     [Test]
@@ -258,66 +185,6 @@ public class ArrayColumnCodecTests
 
         Assert.ThrowsAsync<ClickHouseProtocolException>(async () =>
             await codec.ReadColumnAsync(reader, "c", "Array(UInt32)", 1, CodecTestHarness.None));
-    }
-
-    [Test]
-    public async Task TryDensify_JaggedColumn_ProducesDenseColumnThatRoundTrips()
-    {
-        // TryDensify flattens the jagged T[]-per-row form into the dense wire shape: a per-row offsets array plus a
-        // single flat inner column holding every element end-to-end. It must surface the same rows and round-trip.
-        IColumnCodec codec = Resolve("Array(UInt32)");
-        var expected = new[] { new uint[] { 10, 20, 30 }, Array.Empty<uint>(), new uint[] { 40, 50 } };
-        var jagged = new ArrayColumn<uint[]>("c", "Array(UInt32)", expected);
-
-        IColumn densified = codec.TryDensify(jagged, out _);
-
-        Assert.That(densified, Is.InstanceOf<ArrayValueColumn<uint>>());
-        var dense = (ArrayValueColumn<uint>)densified;
-        Assert.Multiple(() =>
-        {
-            Assert.That(dense.Offsets.ToArray(), Is.EqualTo(new[] { 0, 3, 3, 5 }));
-            Assert.That(dense.Inner.Values.ToArray(), Is.EqualTo(new uint[] { 10, 20, 30, 40, 50 }));
-            Assert.That(((IColumn<uint[]>)densified).Values.ToArray(), Is.EqualTo(expected));
-        });
-
-        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, densified, "Array(UInt32)", densified.RowCount);
-        Assert.That(((IColumn<uint[]>)read).Values.ToArray(), Is.EqualTo(expected));
-    }
-
-    [Test]
-    public void TryDensify_NestedNullableInner_DensifiesInnerToo()
-    {
-        // Array(Nullable(T)): densify flattens the jagged rows AND recurses the inner codec, turning the
-        // concatenated T? run into the dense (inner column + null-map) nullable column — the whole tree is dense.
-        IColumnCodec codec = Resolve("Array(Nullable(UInt32))");
-        var expected = new[] { new uint?[] { 1, null }, new uint?[] { 3 } };
-        var jagged = new ArrayColumn<uint?[]>("c", "Array(Nullable(UInt32))", expected);
-
-        var dense = (ArrayValueColumn<uint?>)codec.TryDensify(jagged, out _);
-
-        Assert.Multiple(() =>
-        {
-            Assert.That(dense.Offsets.ToArray(), Is.EqualTo(new[] { 0, 2, 3 }));
-            Assert.That(dense.Inner, Is.InstanceOf<NullableValueColumn<uint>>());
-            Assert.That(((IColumn<uint?[]>)dense).Values.ToArray(), Is.EqualTo(expected));
-        });
-    }
-
-    [Test]
-    public void TryDensify_AlreadyDenseColumn_ReturnsSameInstanceNotBuilt()
-    {
-        // Idempotent: a dense column whose inner is already dense is returned by reference with built = false
-        // (nothing to rebuild).
-        IColumnCodec codec = Resolve("Array(UInt32)");
-        var inner = PrimitiveColumn<uint>.FromValues("c", "UInt32", new uint[] { 10, 20, 30, 40, 50 });
-        var dense = new ArrayValueColumn<uint>("c", "Array(UInt32)", inner, new[] { 0, 3, 3, 5 }, rowCount: 3, pooledOffsets: false);
-
-        IColumn result = codec.TryDensify(dense, out bool built);
-        Assert.Multiple(() =>
-        {
-            Assert.That(result, Is.SameAs(dense));
-            Assert.That(built, Is.False, "an already-dense column is borrowed, not rebuilt");
-        });
     }
 
     [Test]

--- a/ClickHouse.Driver.Tcp.Tests/Types/ArrayColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/ArrayColumnCodecTests.cs
@@ -1,0 +1,272 @@
+using System;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Protocol;
+using ClickHouse.Driver.Tcp.Tests.Utilities;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Tests.Types;
+
+[TestFixture]
+public class ArrayColumnCodecTests
+{
+    private static IColumnCodec Resolve(string type) => ColumnCodecRegistry.Default.Resolve(type, default);
+
+    [Test]
+    public async Task ReadColumn_WriteThenRead_FixedWidthInnerRoundTripsWithEmptyRows()
+    {
+        IColumnCodec codec = Resolve("Array(UInt32)");
+        var expected = new[] { new uint[] { 10, 20, 30 }, Array.Empty<uint>(), new uint[] { 40, 50 } };
+        var column = new ArrayColumn<uint[]>("c", "Array(UInt32)", expected);
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Array(UInt32)", column.RowCount);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(read.TypeName, Is.EqualTo("Array(UInt32)"));
+            Assert.That(read.RowCount, Is.EqualTo(3));
+            Assert.That(((IColumn<uint[]>)read).Values.ToArray(), Is.EqualTo(expected));
+            Assert.That(read.GetValue(1), Is.EqualTo(Array.Empty<uint>()));
+        });
+    }
+
+    [Test]
+    public async Task ReadColumn_WriteThenRead_VariableInnerRoundTrips()
+    {
+        IColumnCodec codec = Resolve("Array(String)");
+        var expected = new[] { new[] { "a", "bb" }, Array.Empty<string>(), new[] { string.Empty, "héllo✓" } };
+        var column = new ArrayColumn<string[]>("c", "Array(String)", expected);
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Array(String)", column.RowCount);
+
+        Assert.That(((IColumn<string[]>)read).Values.ToArray(), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public async Task ReadColumn_WriteThenRead_NestedArrayRoundTrips()
+    {
+        IColumnCodec codec = Resolve("Array(Array(UInt32))");
+        var expected = new[]
+        {
+            new[] { new uint[] { 1, 2 } },
+            Array.Empty<uint[]>(),
+            new[] { new uint[] { 3 }, new uint[] { 4, 5 } },
+        };
+        var column = new ArrayColumn<uint[][]>("c", "Array(Array(UInt32))", expected);
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Array(Array(UInt32))", column.RowCount);
+
+        Assert.That(((IColumn<uint[][]>)read).Values.ToArray(), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public async Task ReadColumn_WriteThenRead_NullableInnerRoundTrips()
+    {
+        IColumnCodec codec = Resolve("Array(Nullable(UInt32))");
+        var expected = new[] { new uint?[] { 1, null, 3 }, Array.Empty<uint?>(), new uint?[] { null, null } };
+        var column = new ArrayColumn<uint?[]>("c", "Array(Nullable(UInt32))", expected);
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Array(Nullable(UInt32))", column.RowCount);
+
+        Assert.That(((IColumn<uint?[]>)read).Values.ToArray(), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public async Task ReadColumn_EmptyColumn_ReadsZeroRowsWithoutConsumingBytes()
+    {
+        IColumnCodec codec = Resolve("Array(UInt32)");
+        var column = new ArrayColumn<uint[]>("c", "Array(UInt32)", Array.Empty<uint[]>());
+
+        byte[] bytes = await CodecTestHarness.WriteAsync(w => codec.WriteColumn(w, column, 0, 0));
+        Assert.That(bytes, Is.Empty, "an empty array column writes no offsets and no values");
+
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(bytes);
+        using IColumn read = await codec.ReadColumnAsync(reader, "c", "Array(UInt32)", 0, CodecTestHarness.None);
+        Assert.That(read.RowCount, Is.Zero);
+    }
+
+    [Test]
+    public async Task ReadColumn_EveryRowEmpty_RoundTripsAsAllEmpty()
+    {
+        IColumnCodec codec = Resolve("Array(UInt32)");
+        var expected = new[] { Array.Empty<uint>(), Array.Empty<uint>(), Array.Empty<uint>() };
+        var column = new ArrayColumn<uint[]>("c", "Array(UInt32)", expected);
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Array(UInt32)", column.RowCount);
+
+        Assert.That(((IColumn<uint[]>)read).Values.ToArray(), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public async Task WriteColumn_DenseArrayValueColumn_RoundTripsWithoutRebuildingValues()
+    {
+        // A dense ArrayValueColumn<T> (flat inner column + offsets, the wire's own layout) is the zero-copy write
+        // path — the same shape a read produces. Writing one and reading it back must preserve the rows.
+        IColumnCodec codec = Resolve("Array(UInt32)");
+        var inner = PrimitiveColumn<uint>.FromValues("c", "UInt32", new uint[] { 10, 20, 30, 40, 50 });
+        var dense = new ArrayValueColumn<uint>("c", "Array(UInt32)", inner, new[] { 0, 3, 3, 5 }, rowCount: 3, pooledOffsets: false);
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, dense, "Array(UInt32)", dense.RowCount);
+
+        Assert.That(((IColumn<uint[]>)read).Values.ToArray(), Is.EqualTo(new[] { new uint[] { 10, 20, 30 }, Array.Empty<uint>(), new uint[] { 40, 50 } }));
+    }
+
+    [Test]
+    public async Task WriteColumn_SlicedRange_WritesOffsetsRelativeToTheSlice()
+    {
+        // Writing only rows [1, 3) of a four-row column (the insert splitter's per-block path) must emit offsets
+        // relative to that block's own values stream, not the full column.
+        IColumnCodec codec = Resolve("Array(UInt32)");
+        var full = new ArrayColumn<uint[]>("c", "Array(UInt32)", new[]
+        {
+            new uint[] { 1 },
+            new uint[] { 2, 3 },
+            Array.Empty<uint>(),
+            new uint[] { 4, 5, 6 },
+        });
+
+        byte[] bytes = await CodecTestHarness.WriteAsync(w => codec.WriteColumn(w, full, start: 1, length: 2));
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(bytes);
+        using IColumn read = await codec.ReadColumnAsync(reader, "c", "Array(UInt32)", 2, CodecTestHarness.None);
+
+        Assert.That(((IColumn<uint[]>)read).Values.ToArray(), Is.EqualTo(new[] { new uint[] { 2, 3 }, Array.Empty<uint>() }));
+    }
+
+    [Test]
+    public void MeasureRowBytes_FixedWidthInner_CountsOneOffsetPlusElements()
+    {
+        IColumnCodec codec = Resolve("Array(UInt32)");
+        var column = new ArrayColumn<uint[]>("c", "Array(UInt32)", new[] { new uint[] { 10, 20, 30 }, Array.Empty<uint>() });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(codec.MeasureRowBytes(column, 0), Is.EqualTo(8 + (3 * 4))); // one UInt64 offset + three UInt32
+            Assert.That(codec.MeasureRowBytes(column, 1), Is.EqualTo(8));           // one offset, no elements
+            Assert.That(codec.FixedRowByteSize, Is.Null);
+        });
+    }
+
+    [Test]
+    public void WriteColumn_NullRow_ThrowsArgumentException()
+    {
+        // Array(T) rows are non-nullable, so a null row is rejected rather than silently written as an empty array.
+        IColumnCodec codec = Resolve("Array(UInt32)");
+        var column = new ArrayColumn<uint[]>("c", "Array(UInt32)", new[] { new uint[] { 1, 2 }, null, new uint[] { 3 } });
+
+        Assert.ThrowsAsync<ArgumentException>(() => CodecTestHarness.WriteAsync(w => codec.WriteColumn(w, column)));
+    }
+
+    [Test]
+    public void MeasureRowBytes_NullRow_ThrowsArgumentException()
+    {
+        // Sizing must agree with the write path: a null row is invalid, not empty.
+        IColumnCodec codec = Resolve("Array(UInt32)");
+        var column = new ArrayColumn<uint[]>("c", "Array(UInt32)", new[] { new uint[] { 1, 2 }, null });
+
+        Assert.Throws<ArgumentException>(() => codec.MeasureRowBytes(column, 1));
+    }
+
+    [Test]
+    public void MeasureRowBytes_VariableInner_WalksEachElement()
+    {
+        IColumnCodec codec = Resolve("Array(String)");
+        var column = new ArrayColumn<string[]>("c", "Array(String)", new[] { new[] { "a", "bb" }, Array.Empty<string>() });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(codec.MeasureRowBytes(column, 0), Is.EqualTo(8 + (1 + 1) + (1 + 2))); // offset + "a" + "bb"
+            Assert.That(codec.MeasureRowBytes(column, 1), Is.EqualTo(8));
+        });
+    }
+
+    [Test]
+    public async Task MeasureRowBytes_DenseColumn_PricesFromOffsetsAndInner()
+    {
+        // A dense ArrayValueColumn (the read-back shape) re-inserted goes through the offsets-based measure path,
+        // distinct from the jagged-column path. Both a fixed-width and a variable-width inner are priced.
+        IColumnCodec fixedCodec = Resolve("Array(UInt32)");
+        var inner = PrimitiveColumn<uint>.FromValues("c", "UInt32", new uint[] { 10, 20, 30, 40, 50 });
+        var dense = new ArrayValueColumn<uint>("c", "Array(UInt32)", inner, new[] { 0, 3, 3, 5 }, rowCount: 3, pooledOffsets: false);
+
+        IColumnCodec stringCodec = Resolve("Array(String)");
+        var jagged = new ArrayColumn<string[]>("c", "Array(String)", new[] { new[] { "a", "bb" }, Array.Empty<string>() });
+        using IColumn denseStrings = await CodecTestHarness.RoundTripAsync(stringCodec, jagged, "Array(String)", 2);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(fixedCodec.MeasureRowBytes(dense, 0), Is.EqualTo(8 + (3 * 4)));
+            Assert.That(fixedCodec.MeasureRowBytes(dense, 1), Is.EqualTo(8));
+            Assert.That(fixedCodec.MeasureRowBytes(dense, 2), Is.EqualTo(8 + (2 * 4)));
+            Assert.That(stringCodec.MeasureRowBytes(denseStrings, 0), Is.EqualTo(8 + (1 + 1) + (1 + 2)));
+            Assert.That(stringCodec.MeasureRowBytes(denseStrings, 1), Is.EqualTo(8));
+        });
+    }
+
+    [Test]
+    public void CanWrite_AcceptsOnlyMatchingArrayColumn()
+    {
+        IColumnCodec codec = Resolve("Array(UInt32)");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(codec.CanWrite(new ArrayColumn<uint[]>("c", "Array(UInt32)", new[] { new uint[] { 1 } })), Is.True);
+            Assert.That(codec.CanWrite(new ArrayColumn<int[]>("c", "Array(Int32)", new[] { new[] { 1 } })), Is.False);
+            Assert.That(codec.CanWrite(PrimitiveColumn<uint>.FromValues("c", "UInt32", new uint[] { 1 })), Is.False);
+        });
+    }
+
+    [Test]
+    public void ElementType_IsInnerElementTypeArray()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(Resolve("Array(UInt32)").ElementType, Is.EqualTo(typeof(uint[])));
+            Assert.That(Resolve("Array(String)").ElementType, Is.EqualTo(typeof(string[])));
+            Assert.That(Resolve("Array(Nullable(UInt32))").ElementType, Is.EqualTo(typeof(uint?[])));
+            Assert.That(Resolve("Array(Array(UInt8))").ElementType, Is.EqualTo(typeof(byte[][])));
+        });
+    }
+
+    [Test]
+    public void NullPlaceholder_IsEmptyInnerArray()
+        => Assert.That(Resolve("Array(UInt32)").NullPlaceholder, Is.EqualTo(Array.Empty<uint>()));
+
+    [Test]
+    public async Task ReadColumn_NonMonotonicOffsets_ThrowsProtocol()
+    {
+        // Offsets must be non-decreasing; a decrease is corruption. Wire: two UInt64 offsets [2, 1].
+        IColumnCodec codec = Resolve("Array(UInt32)");
+        byte[] wire = new byte[16];
+        BitConverter.TryWriteBytes(wire.AsSpan(0, 8), 2UL);
+        BitConverter.TryWriteBytes(wire.AsSpan(8, 8), 1UL);
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(wire);
+
+        Assert.ThrowsAsync<ClickHouseProtocolException>(async () =>
+            await codec.ReadColumnAsync(reader, "c", "Array(UInt32)", 2, CodecTestHarness.None));
+    }
+
+    [Test]
+    public async Task ReadColumn_OffsetBeyondInt32_ThrowsProtocol()
+    {
+        // An offset larger than int.MaxValue cannot be addressed by this client and is rejected up front.
+        IColumnCodec codec = Resolve("Array(UInt32)");
+        byte[] wire = new byte[8];
+        BitConverter.TryWriteBytes(wire.AsSpan(0, 8), (ulong)int.MaxValue + 1);
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(wire);
+
+        Assert.ThrowsAsync<ClickHouseProtocolException>(async () =>
+            await codec.ReadColumnAsync(reader, "c", "Array(UInt32)", 1, CodecTestHarness.None));
+    }
+
+    [Test]
+    public void Resolve_Array_StampsFullTypeName()
+        => Assert.That(Resolve("Array(Nullable(String))").TypeName, Is.EqualTo("Array(Nullable(String))"));
+
+    [TestCase("Array(Int32, Int32)")]
+    [TestCase("Array()")]
+    public void Resolve_WrongArgumentCount_ThrowsFormat(string type)
+        => Assert.Throws<FormatException>(() => Resolve(type));
+
+    [Test]
+    public void Resolve_UnsupportedInner_ThrowsNotSupported()
+        => Assert.Throws<NotSupportedException>(() => Resolve("Array(NoSuchType)"));
+}

--- a/ClickHouse.Driver.Tcp.Tests/Types/ArrayColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/ArrayColumnCodecTests.cs
@@ -76,7 +76,7 @@ public class ArrayColumnCodecTests
         IColumnCodec codec = Resolve("Array(UInt32)");
         var column = new ArrayColumn<uint[]>("c", "Array(UInt32)", Array.Empty<uint[]>());
 
-        byte[] bytes = await CodecTestHarness.WriteAsync(w => codec.WriteColumn(w, column, 0, 0));
+        byte[] bytes = await CodecTestHarness.WriteDenseAsync(codec, column, 0, 0);
         Assert.That(bytes, Is.Empty, "an empty array column writes no offsets and no values");
 
         using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(bytes);
@@ -124,7 +124,7 @@ public class ArrayColumnCodecTests
             new uint[] { 4, 5, 6 },
         });
 
-        byte[] bytes = await CodecTestHarness.WriteAsync(w => codec.WriteColumn(w, full, start: 1, length: 2));
+        byte[] bytes = await CodecTestHarness.WriteDenseAsync(codec, full, start: 1, length: 2);
         using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(bytes);
         using IColumn read = await codec.ReadColumnAsync(reader, "c", "Array(UInt32)", 2, CodecTestHarness.None);
 
@@ -136,11 +136,12 @@ public class ArrayColumnCodecTests
     {
         IColumnCodec codec = Resolve("Array(UInt32)");
         var column = new ArrayColumn<uint[]>("c", "Array(UInt32)", new[] { new uint[] { 10, 20, 30 }, Array.Empty<uint>() });
+        using IColumn dense = codec.TryDensify(column, out _);
 
         Assert.Multiple(() =>
         {
-            Assert.That(codec.MeasureRowBytes(column, 0), Is.EqualTo(8 + (3 * 4))); // one UInt64 offset + three UInt32
-            Assert.That(codec.MeasureRowBytes(column, 1), Is.EqualTo(8));           // one offset, no elements
+            Assert.That(codec.MeasureRowBytes(dense, 0), Is.EqualTo(8 + (3 * 4))); // one UInt64 offset + three UInt32
+            Assert.That(codec.MeasureRowBytes(dense, 1), Is.EqualTo(8));           // one offset, no elements
             Assert.That(codec.FixedRowByteSize, Is.Null);
         });
     }
@@ -148,21 +149,22 @@ public class ArrayColumnCodecTests
     [Test]
     public void WriteColumn_NullRow_ThrowsArgumentException()
     {
-        // Array(T) rows are non-nullable, so a null row is rejected rather than silently written as an empty array.
+        // Array(T) rows are non-nullable, so a null row is rejected (during densify, before the write) rather than
+        // silently written as an empty array.
         IColumnCodec codec = Resolve("Array(UInt32)");
         var column = new ArrayColumn<uint[]>("c", "Array(UInt32)", new[] { new uint[] { 1, 2 }, null, new uint[] { 3 } });
 
-        Assert.ThrowsAsync<ArgumentException>(() => CodecTestHarness.WriteAsync(w => codec.WriteColumn(w, column)));
+        Assert.Throws<ArgumentException>(() => codec.TryDensify(column, out _));
     }
 
     [Test]
     public void MeasureRowBytes_NullRow_ThrowsArgumentException()
     {
-        // Sizing must agree with the write path: a null row is invalid, not empty.
+        // TryDensify (which the measure/write pipeline runs first) must reject a null row rather than treat it as empty.
         IColumnCodec codec = Resolve("Array(UInt32)");
         var column = new ArrayColumn<uint[]>("c", "Array(UInt32)", new[] { new uint[] { 1, 2 }, null });
 
-        Assert.Throws<ArgumentException>(() => codec.MeasureRowBytes(column, 1));
+        Assert.Throws<ArgumentException>(() => codec.TryDensify(column, out _));
     }
 
     [Test]
@@ -170,11 +172,12 @@ public class ArrayColumnCodecTests
     {
         IColumnCodec codec = Resolve("Array(String)");
         var column = new ArrayColumn<string[]>("c", "Array(String)", new[] { new[] { "a", "bb" }, Array.Empty<string>() });
+        using IColumn dense = codec.TryDensify(column, out _);
 
         Assert.Multiple(() =>
         {
-            Assert.That(codec.MeasureRowBytes(column, 0), Is.EqualTo(8 + (1 + 1) + (1 + 2))); // offset + "a" + "bb"
-            Assert.That(codec.MeasureRowBytes(column, 1), Is.EqualTo(8));
+            Assert.That(codec.MeasureRowBytes(dense, 0), Is.EqualTo(8 + (1 + 1) + (1 + 2))); // offset + "a" + "bb"
+            Assert.That(codec.MeasureRowBytes(dense, 1), Is.EqualTo(8));
         });
     }
 
@@ -258,15 +261,15 @@ public class ArrayColumnCodecTests
     }
 
     [Test]
-    public async Task Densify_JaggedColumn_ProducesDenseColumnThatRoundTrips()
+    public async Task TryDensify_JaggedColumn_ProducesDenseColumnThatRoundTrips()
     {
-        // Densify flattens the jagged T[]-per-row form into the dense wire shape: a per-row offsets array plus a
+        // TryDensify flattens the jagged T[]-per-row form into the dense wire shape: a per-row offsets array plus a
         // single flat inner column holding every element end-to-end. It must surface the same rows and round-trip.
         IColumnCodec codec = Resolve("Array(UInt32)");
         var expected = new[] { new uint[] { 10, 20, 30 }, Array.Empty<uint>(), new uint[] { 40, 50 } };
         var jagged = new ArrayColumn<uint[]>("c", "Array(UInt32)", expected);
 
-        IColumn densified = codec.Densify(jagged);
+        IColumn densified = codec.TryDensify(jagged, out _);
 
         Assert.That(densified, Is.InstanceOf<ArrayValueColumn<uint>>());
         var dense = (ArrayValueColumn<uint>)densified;
@@ -282,7 +285,7 @@ public class ArrayColumnCodecTests
     }
 
     [Test]
-    public void Densify_NestedNullableInner_DensifiesInnerToo()
+    public void TryDensify_NestedNullableInner_DensifiesInnerToo()
     {
         // Array(Nullable(T)): densify flattens the jagged rows AND recurses the inner codec, turning the
         // concatenated T? run into the dense (inner column + null-map) nullable column — the whole tree is dense.
@@ -290,7 +293,7 @@ public class ArrayColumnCodecTests
         var expected = new[] { new uint?[] { 1, null }, new uint?[] { 3 } };
         var jagged = new ArrayColumn<uint?[]>("c", "Array(Nullable(UInt32))", expected);
 
-        var dense = (ArrayValueColumn<uint?>)codec.Densify(jagged);
+        var dense = (ArrayValueColumn<uint?>)codec.TryDensify(jagged, out _);
 
         Assert.Multiple(() =>
         {
@@ -301,14 +304,20 @@ public class ArrayColumnCodecTests
     }
 
     [Test]
-    public void Densify_AlreadyDenseColumn_ReturnsSameInstance()
+    public void TryDensify_AlreadyDenseColumn_ReturnsSameInstanceNotBuilt()
     {
-        // Idempotent: a dense column whose inner is already dense is returned by reference (nothing to rebuild).
+        // Idempotent: a dense column whose inner is already dense is returned by reference with built = false
+        // (nothing to rebuild).
         IColumnCodec codec = Resolve("Array(UInt32)");
         var inner = PrimitiveColumn<uint>.FromValues("c", "UInt32", new uint[] { 10, 20, 30, 40, 50 });
         var dense = new ArrayValueColumn<uint>("c", "Array(UInt32)", inner, new[] { 0, 3, 3, 5 }, rowCount: 3, pooledOffsets: false);
 
-        Assert.That(codec.Densify(dense), Is.SameAs(dense));
+        IColumn result = codec.TryDensify(dense, out bool built);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.SameAs(dense));
+            Assert.That(built, Is.False, "an already-dense column is borrowed, not rebuilt");
+        });
     }
 
     [Test]

--- a/ClickHouse.Driver.Tcp.Tests/Types/ArrayColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/ArrayColumnCodecTests.cs
@@ -38,6 +38,36 @@ public class ArrayColumnCodecTests
     }
 
     [Test]
+    public void Indexer_RowPastRowCount_ThrowsRatherThanReadingStaleOffsets()
+    {
+        // The offsets buffer is normally a pooled array longer than the column, and a previous, larger read leaves
+        // monotonic offsets behind in the tail. Reading a row past RowCount through the raw buffer would therefore
+        // hand back a real-looking slice of the inner column instead of failing — silent wrong data, not a crash.
+        // Here rows 0 and 1 are the column; the 7 and 9 are the stale tail a longer read would have left.
+        var inner = PrimitiveColumn<uint>.FromValues("c", "UInt32", new uint[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 });
+        var offsets = new[] { 0, 2, 5, 7, 9 };
+        using var column = new ArrayValueColumn<uint>("c", "Array(UInt32)", inner, offsets, rowCount: 2, pooledOffsets: false);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(column[1], Is.EqualTo(new uint[] { 3, 4, 5 }), "the last real row still materializes");
+            Assert.That(() => column[2], Throws.InstanceOf<IndexOutOfRangeException>());
+        });
+    }
+
+    [Test]
+    public void Constructor_OffsetsShorterThanRowCountPlusOne_Throws()
+    {
+        // rowCount is load-bearing here — the inner column is flat and the offsets are pooled — so it is validated
+        // rather than derived. One offset per row plus the leading zero is the minimum.
+        var inner = PrimitiveColumn<uint>.FromValues("c", "UInt32", new uint[] { 1, 2, 3 });
+
+        Assert.That(
+            () => new ArrayValueColumn<uint>("c", "Array(UInt32)", inner, new[] { 0, 3 }, rowCount: 2, pooledOffsets: false),
+            Throws.ArgumentException.With.Message.Contains("fewer than"));
+    }
+
+    [Test]
     public async Task ReadColumn_EmptyColumn_ReadsZeroRowsWithoutConsumingBytes()
     {
         IColumnCodec codec = Resolve("Array(UInt32)");

--- a/ClickHouse.Driver.Tcp.Tests/Types/ArrayColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/ArrayColumnCodecTests.cs
@@ -137,6 +137,33 @@ public class ArrayColumnCodecTests
             await codec.ReadColumnAsync(reader, "c", "Array(UInt32)", 1, CodecTestHarness.None));
     }
 
+    // The state-aware overloads take the state this codec's own BeginWrite returned, and nothing else. They used to
+    // treat null as "the caller has none to share" and rebuild one, which meant a caller that lost or never opened
+    // the state still got correct bytes, so the mistake could not be seen. Only the state-free overloads build
+    // their own state now.
+    [Test]
+    public async Task WriteColumn_StateAwareOverloadGivenNoState_ThrowsArgument()
+    {
+        IColumnCodec codec = Resolve("Array(UInt32)");
+        var column = new ArrayColumn<uint[]>("c", "Array(UInt32)", new[] { new uint[] { 1, 2 } });
+
+        ArgumentException thrown = null;
+        await CodecTestHarness.WriteAsync(writer =>
+            thrown = Assert.Throws<ArgumentException>(() => codec.WriteColumn(writer, column, 0, 1, state: null)));
+
+        Assert.That(thrown.Message, Does.Contain("Array(UInt32)"));
+    }
+
+    [Test]
+    public async Task WriteStatePrefix_StateAwareOverloadGivenNoState_ThrowsArgument()
+    {
+        IColumnCodec codec = Resolve("Array(UInt32)");
+        var column = new ArrayColumn<uint[]>("c", "Array(UInt32)", new[] { new uint[] { 1, 2 } });
+
+        await CodecTestHarness.WriteAsync(writer =>
+            Assert.Throws<ArgumentException>(() => codec.WriteStatePrefix(writer, column, 0, 1, state: null)));
+    }
+
     [Test]
     public void Resolve_Array_StampsFullTypeName()
         => Assert.That(Resolve("Array(Nullable(String))").TypeName, Is.EqualTo("Array(Nullable(String))"));

--- a/ClickHouse.Driver.Tcp.Tests/Types/ArrayColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/ArrayColumnCodecTests.cs
@@ -12,8 +12,14 @@ public class ArrayColumnCodecTests
     private static IColumnCodec Resolve(string type) => ColumnCodecRegistry.Default.Resolve(type, default);
 
     [Test]
-    public async Task ReadColumn_WriteThenRead_FixedWidthInnerRoundTripsWithEmptyRows()
+    public async Task Values_AfterMaterializing_AgreesWithTheIndexer()
     {
+        // Per-type row values are covered against a real server by the Array(T) cases in InsertRoundTripCase.
+        // What those cannot reach is the warm-cache branch: ArrayValueColumn.Values materializes a cache, while
+        // the indexer reads `cache is not null ? cache[row] : Materialize(row)`, and AssertColumnsEqual only ever
+        // calls GetValue on a cold column — so the indexer's cached branch runs nowhere else. Reading Values
+        // first and then the indexer pins the two against each other. TypeName is asserted here for the same
+        // reason: the integration comparison never looks at it.
         IColumnCodec codec = Resolve("Array(UInt32)");
         var expected = new[] { new uint[] { 10, 20, 30 }, Array.Empty<uint>(), new uint[] { 40, 50 } };
         var column = new ArrayColumn<uint[]>("c", "Array(UInt32)", expected);
@@ -23,51 +29,12 @@ public class ArrayColumnCodecTests
         Assert.Multiple(() =>
         {
             Assert.That(read.TypeName, Is.EqualTo("Array(UInt32)"));
-            Assert.That(read.RowCount, Is.EqualTo(3));
             Assert.That(((IColumn<uint[]>)read).Values.ToArray(), Is.EqualTo(expected));
-            Assert.That(read.GetValue(1), Is.EqualTo(Array.Empty<uint>()));
+            for (int row = 0; row < expected.Length; row++)
+            {
+                Assert.That(read.GetValue(row), Is.EqualTo(expected[row]), $"row {row} through the warm cache");
+            }
         });
-    }
-
-    [Test]
-    public async Task ReadColumn_WriteThenRead_VariableInnerRoundTrips()
-    {
-        IColumnCodec codec = Resolve("Array(String)");
-        var expected = new[] { new[] { "a", "bb" }, Array.Empty<string>(), new[] { string.Empty, "héllo✓" } };
-        var column = new ArrayColumn<string[]>("c", "Array(String)", expected);
-
-        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Array(String)", column.RowCount);
-
-        Assert.That(((IColumn<string[]>)read).Values.ToArray(), Is.EqualTo(expected));
-    }
-
-    [Test]
-    public async Task ReadColumn_WriteThenRead_NestedArrayRoundTrips()
-    {
-        IColumnCodec codec = Resolve("Array(Array(UInt32))");
-        var expected = new[]
-        {
-            new[] { new uint[] { 1, 2 } },
-            Array.Empty<uint[]>(),
-            new[] { new uint[] { 3 }, new uint[] { 4, 5 } },
-        };
-        var column = new ArrayColumn<uint[][]>("c", "Array(Array(UInt32))", expected);
-
-        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Array(Array(UInt32))", column.RowCount);
-
-        Assert.That(((IColumn<uint[][]>)read).Values.ToArray(), Is.EqualTo(expected));
-    }
-
-    [Test]
-    public async Task ReadColumn_WriteThenRead_NullableInnerRoundTrips()
-    {
-        IColumnCodec codec = Resolve("Array(Nullable(UInt32))");
-        var expected = new[] { new uint?[] { 1, null, 3 }, Array.Empty<uint?>(), new uint?[] { null, null } };
-        var column = new ArrayColumn<uint?[]>("c", "Array(Nullable(UInt32))", expected);
-
-        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Array(Nullable(UInt32))", column.RowCount);
-
-        Assert.That(((IColumn<uint?[]>)read).Values.ToArray(), Is.EqualTo(expected));
     }
 
     [Test]
@@ -82,53 +49,6 @@ public class ArrayColumnCodecTests
         using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(bytes);
         using IColumn read = await codec.ReadColumnAsync(reader, "c", "Array(UInt32)", 0, CodecTestHarness.None);
         Assert.That(read.RowCount, Is.Zero);
-    }
-
-    [Test]
-    public async Task ReadColumn_EveryRowEmpty_RoundTripsAsAllEmpty()
-    {
-        IColumnCodec codec = Resolve("Array(UInt32)");
-        var expected = new[] { Array.Empty<uint>(), Array.Empty<uint>(), Array.Empty<uint>() };
-        var column = new ArrayColumn<uint[]>("c", "Array(UInt32)", expected);
-
-        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Array(UInt32)", column.RowCount);
-
-        Assert.That(((IColumn<uint[]>)read).Values.ToArray(), Is.EqualTo(expected));
-    }
-
-    [Test]
-    public async Task WriteColumn_DenseArrayValueColumn_RoundTripsWithoutRebuildingValues()
-    {
-        // A dense ArrayValueColumn<T> (flat inner column + offsets, the wire's own layout) is the zero-copy write
-        // path — the same shape a read produces. Writing one and reading it back must preserve the rows.
-        IColumnCodec codec = Resolve("Array(UInt32)");
-        var inner = PrimitiveColumn<uint>.FromValues("c", "UInt32", new uint[] { 10, 20, 30, 40, 50 });
-        var dense = new ArrayValueColumn<uint>("c", "Array(UInt32)", inner, new[] { 0, 3, 3, 5 }, rowCount: 3, pooledOffsets: false);
-
-        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, dense, "Array(UInt32)", dense.RowCount);
-
-        Assert.That(((IColumn<uint[]>)read).Values.ToArray(), Is.EqualTo(new[] { new uint[] { 10, 20, 30 }, Array.Empty<uint>(), new uint[] { 40, 50 } }));
-    }
-
-    [Test]
-    public async Task WriteColumn_SlicedRange_WritesOffsetsRelativeToTheSlice()
-    {
-        // Writing only rows [1, 3) of a four-row column (the insert splitter's per-block path) must emit offsets
-        // relative to that block's own values stream, not the full column.
-        IColumnCodec codec = Resolve("Array(UInt32)");
-        var full = new ArrayColumn<uint[]>("c", "Array(UInt32)", new[]
-        {
-            new uint[] { 1 },
-            new uint[] { 2, 3 },
-            Array.Empty<uint>(),
-            new uint[] { 4, 5, 6 },
-        });
-
-        byte[] bytes = await CodecTestHarness.WriteSliceAsync(codec, full, start: 1, length: 2);
-        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(bytes);
-        using IColumn read = await codec.ReadColumnAsync(reader, "c", "Array(UInt32)", 2, CodecTestHarness.None);
-
-        Assert.That(((IColumn<uint[]>)read).Values.ToArray(), Is.EqualTo(new[] { new uint[] { 2, 3 }, Array.Empty<uint>() }));
     }
 
     [Test]

--- a/ClickHouse.Driver.Tcp.Tests/Types/ColumnCodecRegistryTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/ColumnCodecRegistryTests.cs
@@ -34,7 +34,7 @@ public class ColumnCodecRegistryTests
 
     [Test]
     public void Resolve_UnsupportedButWellFormedType_ThrowsNotSupported()
-        => Assert.Throws<NotSupportedException>(() => ColumnCodecRegistry.Default.Resolve("Array(String)", default));
+        => Assert.Throws<NotSupportedException>(() => ColumnCodecRegistry.Default.Resolve("Tuple(String)", default));
 
     [Test]
     public void Resolve_MalformedType_ThrowsFormat()

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
@@ -284,11 +284,10 @@ public sealed class InsertRoundTripCase
         yield return Arrays("Date", new[] { new DateOnly(1970, 1, 1), new DateOnly(2149, 6, 6) }, Array.Empty<DateOnly>());
         yield return Arrays("Date32", new[] { new DateOnly(1900, 1, 1), new DateOnly(2299, 12, 31) });
 
-        // Array(DateTime)/Array(DateTime64) insert and read back a DateTimeOffset / ClickHouseDateTime64 element;
-        // equality is by instant, so the offset the server presents does not matter.
-        yield return Arrays<DateTimeOffset>("DateTime", new[] { new DateTimeOffset(2024, 1, 15, 10, 30, 0, TimeSpan.Zero), DateTimeOffset.UnixEpoch }, Array.Empty<DateTimeOffset>());
-        yield return Arrays<ClickHouseDateTime64>("DateTime64(3)", new[] { new ClickHouseDateTime64(0L, 3, TimeSpan.Zero), new ClickHouseDateTime64(1_700_000_000_123L, 3, TimeSpan.Zero) });
-        yield return Arrays<ClickHouseDateTime64>("DateTime64(9)", new[] { new ClickHouseDateTime64(1_700_000_000_123_456_789L, 9, TimeSpan.Zero) }, Array.Empty<ClickHouseDateTime64>());
+        // Array(DateTime) reads back raw uint epoch seconds; Array(DateTime64) raw long counts at the column scale.
+        yield return Arrays<uint>("DateTime", new uint[] { 1_700_000_000, 0 }, Array.Empty<uint>());
+        yield return Arrays<long>("DateTime64(3)", new[] { 0L, 1_700_000_000_123L });
+        yield return Arrays<long>("DateTime64(9)", new[] { 1_700_000_000_123_456_789L }, Array.Empty<long>());
 
         yield return Arrays("UUID", new[] { Guid.Empty }, new[] { new Guid("00112233-4455-6677-8899-aabbccddeeff"), new Guid("ffffffff-ffff-ffff-ffff-ffffffffffff") });
         yield return Arrays<IPAddress>("IPv4", new[] { IPAddress.Parse("0.0.0.0"), IPAddress.Parse("255.255.255.255") }, Array.Empty<IPAddress>());
@@ -304,8 +303,8 @@ public sealed class InsertRoundTripCase
 
         // Experimental server types: enable their flag on the round-trip (same as their bare cases).
         yield return Arrays("BFloat16", BFloat16Settings, new[] { 0f, 1f, -2f, 0.5f }, Array.Empty<float>());
-        yield return Arrays("Time", TimeSettings, new[] { TimeSpan.Zero, new TimeSpan(12, 34, 56) }, Array.Empty<TimeSpan>());
-        yield return Arrays("Time64(3)", TimeSettings, new[] { TimeSpan.Zero, new TimeSpan(0, 1, 2, 3, 456) });
+        yield return Arrays("Time", TimeSettings, new[] { 0, (12 * 3600) + (34 * 60) + 56 }, Array.Empty<int>());
+        yield return Arrays("Time64(3)", TimeSettings, new[] { 0L, (((1 * 3600) + (2 * 60) + 3) * 1000L) + 456 });
 
         // Array(Nullable(T)): nullability composed inside the array, for both a value inner and a reference inner.
         yield return Arrays<uint?>("Nullable(UInt32)", new uint?[] { 1, null, 3 }, Array.Empty<uint?>(), new uint?[] { null });

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
@@ -315,6 +315,18 @@ public sealed class InsertRoundTripCase
         // Nested arrays: the same offsets-plus-values shape recurses one level down.
         yield return Arrays<byte[]>("Array(UInt8)", new[] { new byte[] { 1, 2 } }, Array.Empty<byte[]>(), new[] { new byte[] { 3 }, new byte[] { 4, 5 } });
         yield return Arrays<string[]>("Array(String)", new[] { new[] { "a" }, new[] { "b", "c" } }, Array.Empty<string[]>());
+
+        // Every row empty: the offsets stream is all zeroes and the values stream is absent entirely. The cases
+        // above all have at least one non-empty row, so nothing exercised that shape end to end.
+        yield return Arrays("UInt32", Array.Empty<uint>(), Array.Empty<uint>(), Array.Empty<uint>());
+
+        // An empty *inner* array — the only shape where the inner codec's own offsets stream holds an equal
+        // consecutive pair. The nested cases above only ever have an empty outer row.
+        yield return Arrays<byte[]>("Array(UInt8)", new[] { Array.Empty<byte>(), new byte[] { 1 } }, Array.Empty<byte[]>());
+
+        // Array(Array(Nullable(T))) composes the array recursion with the nullable state prefix, which the
+        // Array(Nullable(T)) and Array(Array(T)) cases each cover only half of.
+        yield return Arrays<uint?[]>("Array(Nullable(UInt32))", new[] { new uint?[] { 1, null } }, Array.Empty<uint?[]>());
     }
 
     // Array(T) inserts and reads back the inner element arrays; the ergonomic jagged column doubles as expected.

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
@@ -327,6 +327,14 @@ public sealed class InsertRoundTripCase
         // Array(Array(Nullable(T))) composes the array recursion with the nullable state prefix, which the
         // Array(Nullable(T)) and Array(Array(T)) cases each cover only half of.
         yield return Arrays<uint?[]>("Array(Nullable(UInt32))", new[] { new uint?[] { 1, null } }, Array.Empty<uint?[]>());
+
+        // The deep-nesting ladder, Array(UInt8) wrapped 2 to 5 levels plus a String and a Nullable leaf. Every level
+        // carries an empty row and an uneven run, so no level's offsets stream is trivial. See NestedArrayShape; the
+        // block-splitting tests read the same shapes.
+        foreach (NestedArrayShape shape in NestedArrayShape.Shapes())
+        {
+            yield return Same(shape.ToString(), shape.ClickHouseType, shape.BuildColumn);
+        }
     }
 
     // Array(T) inserts and reads back the inner element arrays; the ergonomic jagged column doubles as expected.

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
@@ -257,6 +257,75 @@ public sealed class InsertRoundTripCase
         yield return NullableIps("IPv4", "127.0.0.1", null, "255.255.255.255");
         yield return NullableIps("IPv6", "::1", null, "2001:db8::1");
         yield return NullableIps("IPv4", null, null); // every row null
+
+        // Array(T): one case per supported inner element type, so every type also survives being wrapped in an
+        // Array — a distinct write path (offsets stream + a single flattened values stream). Each row surfaces as
+        // the inner element array; empty rows (equal consecutive offsets) and all-empty columns exercise the
+        // zero-length paths. Array is the one exception to the "wrap every type in Nullable" rule — the server
+        // rejects Nullable(Array(T)) — so nullability is composed the other way here, as Array(Nullable(T)).
+        yield return Arrays("UInt8", new byte[] { 0, 128, 255 }, Array.Empty<byte>(), new byte[] { 1 });
+        yield return Arrays("Int8", new sbyte[] { -128, -1, 0, 127 }, Array.Empty<sbyte>());
+        yield return Arrays("UInt16", new ushort[] { 0, 258, ushort.MaxValue }, new ushort[] { 1 });
+        yield return Arrays("Int16", new short[] { short.MinValue, -1, 0, short.MaxValue });
+        yield return Arrays("UInt32", new uint[] { 10, 20, 30 }, Array.Empty<uint>(), new uint[] { 40, 50 });
+        yield return Arrays("Int32", new[] { int.MinValue, -1, 0, int.MaxValue }, Array.Empty<int>());
+        yield return Arrays("UInt64", new ulong[] { 0, 1, ulong.MaxValue });
+        yield return Arrays("Int64", new[] { long.MinValue, 0L }, new[] { long.MaxValue });
+        yield return Arrays("UInt128", new[] { UInt128.Zero, UInt128.One, UInt128.MaxValue });
+        yield return Arrays("Int128", new[] { Int128.MinValue, Int128.Zero, Int128.MaxValue });
+        yield return Arrays("UInt256", new[] { UInt256.Zero, UInt256.FromBigInteger(System.Numerics.BigInteger.Pow(2, 200)) });
+        yield return Arrays("Int256", new[] { Int256.FromBigInteger(-System.Numerics.BigInteger.Pow(2, 200)), Int256.Zero });
+        yield return Arrays("Enum8('a' = -1, 'b' = 127)", new sbyte[] { -1, 127 }, Array.Empty<sbyte>());
+        yield return Arrays("Enum16('x' = -32768, 'y' = 32767)", new short[] { -32768, 32767 });
+        yield return Arrays("Float32", new[] { 0f, 1.5f, -1.5f, float.MaxValue }, Array.Empty<float>());
+        yield return Arrays("Float64", new[] { 0d, -1.5e100, double.MaxValue });
+        yield return Arrays("Bool", new[] { true, false, true }, Array.Empty<bool>());
+        yield return Arrays("String", new[] { "a", "bb" }, Array.Empty<string>(), new[] { string.Empty, "héllo✓" });
+        yield return Arrays("Date", new[] { new DateOnly(1970, 1, 1), new DateOnly(2149, 6, 6) }, Array.Empty<DateOnly>());
+        yield return Arrays("Date32", new[] { new DateOnly(1900, 1, 1), new DateOnly(2299, 12, 31) });
+
+        // Array(DateTime)/Array(DateTime64) insert and read back a DateTimeOffset / ClickHouseDateTime64 element;
+        // equality is by instant, so the offset the server presents does not matter.
+        yield return Arrays<DateTimeOffset>("DateTime", new[] { new DateTimeOffset(2024, 1, 15, 10, 30, 0, TimeSpan.Zero), DateTimeOffset.UnixEpoch }, Array.Empty<DateTimeOffset>());
+        yield return Arrays<ClickHouseDateTime64>("DateTime64(3)", new[] { new ClickHouseDateTime64(0L, 3, TimeSpan.Zero), new ClickHouseDateTime64(1_700_000_000_123L, 3, TimeSpan.Zero) });
+        yield return Arrays<ClickHouseDateTime64>("DateTime64(9)", new[] { new ClickHouseDateTime64(1_700_000_000_123_456_789L, 9, TimeSpan.Zero) }, Array.Empty<ClickHouseDateTime64>());
+
+        yield return Arrays("UUID", new[] { Guid.Empty }, new[] { new Guid("00112233-4455-6677-8899-aabbccddeeff"), new Guid("ffffffff-ffff-ffff-ffff-ffffffffffff") });
+        yield return Arrays<IPAddress>("IPv4", new[] { IPAddress.Parse("0.0.0.0"), IPAddress.Parse("255.255.255.255") }, Array.Empty<IPAddress>());
+        yield return Arrays<IPAddress>("IPv6", new[] { IPAddress.Parse("::1"), IPAddress.Parse("2001:db8::1") });
+
+        yield return Arrays("Decimal(9, 2)", new[] { 0m, 1.23m, -1.23m, 9999999.99m }, Array.Empty<decimal>());
+        yield return Arrays("Decimal(18, 4)", new[] { 12345.6789m, -12345.6789m });
+        yield return Arrays<ClickHouseDecimal>("Decimal(38, 10)", new[] { ParseWide("12345.6789"), ParseWide("-98765.4321") });
+        yield return Arrays<ClickHouseDecimal>("Decimal(76, 20)", new[] { ParseWide("1.00000000000000000001"), ParseWide("-1.00000000000000000001") });
+
+        yield return Arrays("IntervalSecond", new[] { 0L, 1L, -5L }, Array.Empty<long>());
+        yield return Arrays("IntervalDay", new[] { 7L, -30L });
+
+        // Experimental server types: enable their flag on the round-trip (same as their bare cases).
+        yield return Arrays("BFloat16", BFloat16Settings, new[] { 0f, 1f, -2f, 0.5f }, Array.Empty<float>());
+        yield return Arrays("Time", TimeSettings, new[] { TimeSpan.Zero, new TimeSpan(12, 34, 56) }, Array.Empty<TimeSpan>());
+        yield return Arrays("Time64(3)", TimeSettings, new[] { TimeSpan.Zero, new TimeSpan(0, 1, 2, 3, 456) });
+
+        // Array(Nullable(T)): nullability composed inside the array, for both a value inner and a reference inner.
+        yield return Arrays<uint?>("Nullable(UInt32)", new uint?[] { 1, null, 3 }, Array.Empty<uint?>(), new uint?[] { null });
+        yield return Arrays<int?>("Nullable(Int32)", new int?[] { int.MinValue, null, 0 });
+        yield return Arrays<string>("Nullable(String)", new[] { "x", null, string.Empty }, new string[] { null });
+        yield return Arrays<IPAddress>("Nullable(IPv4)", new[] { IPAddress.Parse("127.0.0.1"), null });
+
+        // Nested arrays: the same offsets-plus-values shape recurses one level down.
+        yield return Arrays<byte[]>("Array(UInt8)", new[] { new byte[] { 1, 2 } }, Array.Empty<byte[]>(), new[] { new byte[] { 3 }, new byte[] { 4, 5 } });
+        yield return Arrays<string[]>("Array(String)", new[] { new[] { "a" }, new[] { "b", "c" } }, Array.Empty<string[]>());
+    }
+
+    // Array(T) inserts and reads back the inner element arrays; the ergonomic jagged column doubles as expected.
+    private static InsertRoundTripCase Arrays<T>(string innerType, params T[][] rows)
+        => Arrays(innerType, settings: null, rows);
+
+    private static InsertRoundTripCase Arrays<T>(string innerType, IReadOnlyDictionary<string, string> settings, params T[][] rows)
+    {
+        string type = $"Array({innerType})";
+        return Same($"{type} [{rows.Length} rows]", type, name => new ArrayColumn<T[]>(name, type, rows), settings);
     }
 
     private static InsertRoundTripCase NullableValues<T>(string innerType, params T?[] values)

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/NestedArrayShape.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/NestedArrayShape.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Collections.Generic;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Tests.Utilities;
+
+/// <summary>
+/// A ladder of <c>Array(Array(...))</c> columns of increasing nesting depth, shared by the round-trip cases and the
+/// block-splitting integration tests so one set of row literals serves both.
+///
+/// <para>
+/// Depth is the number of <c>Array</c> levels. Every level of every shape carries an empty row somewhere and rows of
+/// differing lengths, so each level's offsets stream holds both an equal consecutive pair (an empty row) and an
+/// uneven run. That matters most on the write path: the ergonomic (jagged) write gives a nested <c>Array</c> inner a
+/// <c>ConcatColumn</c> flattening view rather than driving it per row, so depth <c>d</c> stacks <c>d - 1</c> of those
+/// views, each one resolving flat element indices back through the level below it.
+/// </para>
+/// </summary>
+public sealed class NestedArrayShape
+{
+    private readonly Func<string, IColumn> build;
+
+    private NestedArrayShape(int depth, string clickHouseType, int rowCount, Func<string, IColumn> build)
+    {
+        Depth = depth;
+        ClickHouseType = clickHouseType;
+        RowCount = rowCount;
+        this.build = build;
+    }
+
+    /// <summary>The number of <c>Array</c> levels the column nests.</summary>
+    public int Depth { get; }
+
+    /// <summary>The full <c>Array(...)</c> type for the target column.</summary>
+    public string ClickHouseType { get; }
+
+    /// <summary>The number of rows the shape's column holds.</summary>
+    public int RowCount { get; }
+
+    /// <summary>Builds the ergonomic (jagged) column for this shape, stamped with <paramref name="columnName"/>.</summary>
+    /// <param name="columnName">The column name, which must match the target table column.</param>
+    /// <returns>The column to insert.</returns>
+    internal IColumn BuildColumn(string columnName) => build(columnName);
+
+    public override string ToString() => $"{ClickHouseType} [{RowCount} rows]";
+
+    /// <summary>The shapes, for use as an NUnit <c>TestCaseSource</c>.</summary>
+    public static IEnumerable<NestedArrayShape> Shapes()
+    {
+        // The UInt8 ladder, depth 2 to 5: a fixed-width leaf, so the innermost write is the bulk blit reached through
+        // the whole ConcatColumn stack.
+        yield return Shape<byte[]>(2, "Array(UInt8)", Depth2Rows);
+        yield return Shape<byte[][]>(3, "Array(Array(UInt8))", Depth3Rows);
+        yield return Shape<byte[][][]>(4, "Array(Array(Array(UInt8)))", Depth4Rows);
+        yield return Shape<byte[][][][]>(5, "Array(Array(Array(Array(UInt8))))", Depth5Rows);
+
+        // Two other leaf kinds under the same skeleton, at depth 3 — enough to put more than one Array level above
+        // the leaf, which is all that distinguishes them. Deeper adds another ConcatColumn but no new branch, so the
+        // ladder above carries the depth and these carry the leaf.
+        //
+        // String: a variable-width leaf, so the innermost write is a per-element length prefix rather than a blit.
+        yield return Shape<string[][]>(3, "Array(Array(String))", StringDepth3Rows);
+
+        // Nullable(UInt32): a *sectioned* leaf. Its null-map has to be emitted once spanning every element of the
+        // whole flattened run, so a level that drove its inner per row instead of handing over one column would
+        // interleave the map into the values and corrupt the stream.
+        yield return Shape<uint?[][]>(3, "Array(Array(Nullable(UInt32)))", NullableDepth3Rows);
+    }
+
+    // Rows for the depth-2 shape. Row 1 is an empty outer row, row 2 holds a single empty leaf row, and row 3 puts an
+    // empty leaf row between two non-empty ones — so both levels see an empty and an uneven run.
+    private static readonly byte[][][] Depth2Rows =
+    {
+        new[] { new byte[] { 1, 2 }, new byte[] { 3 } },
+        Array.Empty<byte[]>(),
+        new[] { Array.Empty<byte>() },
+        new[] { new byte[] { 4 }, Array.Empty<byte>(), new byte[] { 5, 6, 7 } },
+        new[] { new byte[] { 8 } },
+    };
+
+    // Each deeper shape wraps the one above it and adds an empty at the new level, keeping the same five-row skeleton:
+    // a populated row, an empty outer row, a row holding one empty child, a second populated row, and a short row.
+    private static readonly byte[][][][] Depth3Rows =
+    {
+        new[] { Depth2Rows[0], new[] { Array.Empty<byte>() } },
+        Array.Empty<byte[][]>(),
+        new[] { Array.Empty<byte[]>() },
+        new[] { Depth2Rows[3], Array.Empty<byte[]>(), Depth2Rows[4] },
+        new[] { new[] { new byte[] { 9 } } },
+    };
+
+    private static readonly byte[][][][][] Depth4Rows =
+    {
+        new[] { Depth3Rows[0], Array.Empty<byte[][]>() },
+        Array.Empty<byte[][][]>(),
+        new[] { Array.Empty<byte[][]>() },
+        new[] { Depth3Rows[3], Depth3Rows[4] },
+        new[] { new[] { new[] { Array.Empty<byte>() } } },
+    };
+
+    private static readonly byte[][][][][][] Depth5Rows =
+    {
+        new[] { Depth4Rows[0] },
+        Array.Empty<byte[][][][]>(),
+        new[] { Array.Empty<byte[][][]>() },
+        new[] { Depth4Rows[3], Depth4Rows[4] },
+        new[] { new[] { new[] { new[] { Array.Empty<byte>() } } } },
+    };
+
+    // The depth-2 skeleton over a variable-width leaf. The empty string is a distinct value from an empty row, so
+    // both appear.
+    private static readonly string[][][] StringDepth2Rows =
+    {
+        new[] { new[] { "a", "bb" }, new[] { string.Empty } },
+        Array.Empty<string[]>(),
+        new[] { Array.Empty<string>() },
+        new[] { new[] { "héllo✓" }, Array.Empty<string>(), new[] { "c", "d", "e" } },
+        new[] { new[] { "f" } },
+    };
+
+    private static readonly string[][][][] StringDepth3Rows =
+    {
+        new[] { StringDepth2Rows[0], new[] { Array.Empty<string>() } },
+        Array.Empty<string[][]>(),
+        new[] { Array.Empty<string[]>() },
+        new[] { StringDepth2Rows[3], Array.Empty<string[]>(), StringDepth2Rows[4] },
+        new[] { new[] { new[] { "g" } } },
+    };
+
+    // The depth-2 skeleton over the sectioned leaf. A null sits next to a non-null in the same leaf row, and one leaf
+    // row is all nulls, so the null-map is neither all-set nor all-clear over the flattened run.
+    private static readonly uint?[][][] NullableDepth2Rows =
+    {
+        new[] { new uint?[] { 1, null }, new uint?[] { 0 } },
+        Array.Empty<uint?[]>(),
+        new[] { Array.Empty<uint?>() },
+        new[] { new uint?[] { null, null }, Array.Empty<uint?>(), new uint?[] { 2, uint.MaxValue, null } },
+        new[] { new uint?[] { null } },
+    };
+
+    private static readonly uint?[][][][] NullableDepth3Rows =
+    {
+        new[] { NullableDepth2Rows[0], new[] { Array.Empty<uint?>() } },
+        Array.Empty<uint?[][]>(),
+        new[] { Array.Empty<uint?[]>() },
+        new[] { NullableDepth2Rows[3], Array.Empty<uint?[]>(), NullableDepth2Rows[4] },
+        new[] { new[] { new uint?[] { 3, null } } },
+    };
+
+    // Wraps the rows in the ergonomic jagged column the callers insert. TElement is the inner codec's element type,
+    // so a row is TElement[] and the declared type is Array(innerType).
+    private static NestedArrayShape Shape<TElement>(int depth, string innerType, TElement[][] rows)
+    {
+        string type = $"Array({innerType})";
+        return new NestedArrayShape(depth, type, rows.Length, name => new ArrayColumn<TElement[]>(name, type, rows));
+    }
+}

--- a/ClickHouse.Driver.Tcp/Format/BlockWriter.cs
+++ b/ClickHouse.Driver.Tcp/Format/BlockWriter.cs
@@ -125,8 +125,18 @@ internal static class BlockWriter
             // an empty range as a no-op (the Nothing codec, for one, refuses to write at all).
             if (rowCount != 0)
             {
-                column.Codec.WriteStatePrefix(writer);
-                column.Codec.WriteColumn(writer, column.Values, start, rowCount);
+                // Compute any per-operation scratch once, share it across the prefix and body phases (a
+                // data-dependent prefix and the element-flattening composites need this), and free it after.
+                IColumnWriteState state = column.Codec.BeginWrite(column.Values, start, rowCount);
+                try
+                {
+                    column.Codec.WriteStatePrefix(writer, column.Values, start, rowCount, state);
+                    column.Codec.WriteColumn(writer, column.Values, start, rowCount, state);
+                }
+                finally
+                {
+                    state?.Dispose();
+                }
             }
 
             // Backstop: flush between columns once the buffer passes the threshold, so a wide block doesn't

--- a/ClickHouse.Driver.Tcp/Protocol/ClickHouseTcpConnection.cs
+++ b/ClickHouse.Driver.Tcp/Protocol/ClickHouseTcpConnection.cs
@@ -377,8 +377,11 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
     /// <param name="queryId">The query id, or null to let the server assign one.</param>
     /// <param name="maxRowsPerBlock">A cap on the rows per wire block — the only bound on block geometry.
     /// Defaults to <see cref="DefaultMaxRowsPerBlock"/>; pass null to write the whole insert as a single block.
-    /// Peak buffered bytes are bounded separately by the between-column flush backstop
-    /// (<see cref="BlockWriter.DefaultFlushThresholdBytes"/>).</param>
+    /// Peak buffered bytes are bounded separately by <paramref name="maxSendBufferBytes"/>.</param>
+    /// <param name="maxSendBufferBytes">The buffered-byte cap that triggers a between-column flush while a block is
+    /// written — the write memory backstop bounding peak client memory during a large insert (a single column
+    /// larger than the cap still buffers in full). Independent of the row-based block split. Defaults to
+    /// <see cref="BlockWriter.DefaultFlushThresholdBytes"/>.</param>
     /// <param name="handlers">Optional callbacks for the metadata the server interleaves into the insert
     /// acknowledgement (notably <see cref="MetadataHandlers.OnProgress"/> for rows written and
     /// <see cref="MetadataHandlers.OnProfileEvents"/>), or null to discard it.</param>
@@ -387,7 +390,7 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
     /// <exception cref="ArgumentNullException"><paramref name="sql"/> or <paramref name="columns"/> is null.</exception>
     /// <exception cref="ArgumentException">The columns hold differing row counts or duplicate names, their names
     /// do not match the target schema, or a column's CLR type is not writable as its target type.</exception>
-    /// <exception cref="ArgumentOutOfRangeException"><paramref name="maxRowsPerBlock"/> is zero or negative.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="maxRowsPerBlock"/> is zero or negative, or <paramref name="maxSendBufferBytes"/> is not positive.</exception>
     /// <exception cref="InvalidOperationException">The connection is busy with another operation.</exception>
     /// <exception cref="ObjectDisposedException">The connection has been terminated.</exception>
     /// <exception cref="ClickHouseServerException">The server reported an error while executing the insert.</exception>
@@ -400,10 +403,11 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
         IReadOnlyDictionary<string, string> parameters = null,
         string queryId = null,
         int? maxRowsPerBlock = DefaultMaxRowsPerBlock,
+        int maxSendBufferBytes = BlockWriter.DefaultFlushThresholdBytes,
         MetadataHandlers handlers = null,
         CancellationToken cancellationToken = default)
     {
-        ValidateInsertArguments(sql, columns, maxRowsPerBlock, out int rowCount);
+        ValidateInsertArguments(sql, columns, maxRowsPerBlock, maxSendBufferBytes, out int rowCount);
 
         // Bail on cancellation before claiming the connection, so a pre-cancelled call leaves it idle.
         cancellationToken.ThrowIfCancellationRequested();
@@ -455,7 +459,7 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
                         : BuildInsertPlan(columns, schema, validateWritable: rowCount > 0, out mismatchError);
                 }
 
-                await StreamInsertRowsAsync(plan, rowCount, maxRowsPerBlock, negotiated, cancellationToken).ConfigureAwait(false);
+                await StreamInsertRowsAsync(plan, rowCount, maxRowsPerBlock, maxSendBufferBytes, negotiated, cancellationToken).ConfigureAwait(false);
 
                 // Rethrow any server error once the state is back to Ready.
                 pending = await DrainToEndOfStreamAsync(negotiated, readContext, handlers, cancellationToken).ConfigureAwait(false);
@@ -496,6 +500,7 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
         string sql,
         IReadOnlyList<IColumn> columns,
         int? maxRowsPerBlock,
+        int maxSendBufferBytes,
         out int rowCount)
     {
         ArgumentNullException.ThrowIfNull(sql);
@@ -503,6 +508,11 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
         if (maxRowsPerBlock is <= 0)
         {
             throw new ArgumentOutOfRangeException(nameof(maxRowsPerBlock), maxRowsPerBlock, "The rows-per-block cap must be positive.");
+        }
+
+        if (maxSendBufferBytes <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxSendBufferBytes), maxSendBufferBytes, "The send-buffer cap must be positive.");
         }
 
         rowCount = 0;
@@ -544,23 +554,25 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
     /// once everything is flushed.
     /// </summary>
     /// <param name="plan">The per-column write plan in schema order, or null to write only the terminator.</param>
+    /// <param name="flushThresholdBytes">The buffered-byte cap that triggers a between-column flush while a block is written.</param>
     private async ValueTask StreamInsertRowsAsync(
         InsertColumn[] plan,
         int rowCount,
         int? maxRowsPerBlock,
+        int flushThresholdBytes,
         NegotiatedProtocol negotiated,
         CancellationToken cancellationToken)
     {
         if (rowCount > 0 && plan is not null)
         {
             // Split into wire blocks by row count alone (each column is written straight from its ergonomic form,
-            // so there is no intermediate dense buffer to build first). The between-column flush backstop bounds
-            // peak client memory while a block streams.
+            // so there is no intermediate dense buffer to build first). The flush threshold — the write memory
+            // backstop the caller's send-buffer cap tunes — is what bounds peak client memory while a block streams.
             foreach ((int start, int length) in PlanInsertBlocks(rowCount, maxRowsPerBlock))
             {
                 writer.WriteClientPacketType(ClientPacketType.Data);
                 await BlockWriter.WriteDataBlockAsync(
-                    writer, negotiated, plan, start, length, BlockWriter.DefaultFlushThresholdBytes, cancellationToken).ConfigureAwait(false);
+                    writer, negotiated, plan, start, length, flushThresholdBytes, cancellationToken).ConfigureAwait(false);
                 await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
             }
         }

--- a/ClickHouse.Driver.Tcp/Types/ArrayValueColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/ArrayValueColumn.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Buffers;
+
+namespace ClickHouse.Driver.Tcp.Types;
+
+/// <summary>
+/// A ClickHouse <c>Array(T)</c> column: it pairs a flat inner column holding every element of every row
+/// end-to-end with a per-row offsets array, and surfaces each row as a freshly materialized
+/// <typeparamref name="TElement"/>[]. This is the dense shape the wire uses (offsets + a single concatenated
+/// values stream), so it is also the zero-copy source for writing — handed back to the <c>Array(T)</c> codec it
+/// serializes straight from the inner column and offsets without rebuilding anything.
+///
+/// <para>
+/// Not to be confused with <see cref="ArrayColumn{T}"/>, the generic array-backed storage used by leaf columns:
+/// this type is the composite whose <em>values</em> are arrays (its element type is
+/// <typeparamref name="TElement"/>[]). <typeparamref name="TElement"/> may itself be an array
+/// (<c>Array(Array(T))</c>) or a nullable (<c>Array(Nullable(T))</c>) — whatever the inner codec surfaces.
+/// </para>
+///
+/// <para>
+/// The inner column's storage and the offsets are borrowed for this column's lifetime; the inner column is
+/// disposed and the offsets returned (when pooled) on <see cref="Dispose"/>. Each <see cref="this"/> access
+/// copies the row's slice into a new array, so retain those arrays freely, but read the column itself only while
+/// the owning block is alive.
+/// </para>
+/// </summary>
+/// <typeparam name="TElement">The inner codec's CLR element type; each row surfaces as <typeparamref name="TElement"/>[].</typeparam>
+internal sealed class ArrayValueColumn<TElement> : IColumn<TElement[]>, IArrayColumn<TElement>
+{
+    private readonly IColumn<TElement> inner;
+    private readonly int rowCount;
+    private readonly bool pooledOffsets;
+    private int[] offsets;
+    private TElement[][] cache;
+
+    /// <summary>Initializes an array column over a flat inner column and its per-row offsets.</summary>
+    /// <param name="name">The column name.</param>
+    /// <param name="typeName">The full <c>Array(...)</c> type string.</param>
+    /// <param name="inner">The inner column holding every row's elements concatenated end-to-end.</param>
+    /// <param name="offsets">The per-row offsets: <c>offsets[0]</c> is 0 and <c>offsets[i + 1]</c> is the exclusive end of row <c>i</c>'s slice; must have at least <paramref name="rowCount"/> + 1 entries.</param>
+    /// <param name="rowCount">The number of rows.</param>
+    /// <param name="pooledOffsets">Whether <paramref name="offsets"/> was rented and should be returned on dispose.</param>
+    public ArrayValueColumn(string name, string typeName, IColumn<TElement> inner, int[] offsets, int rowCount, bool pooledOffsets)
+    {
+        Name = name;
+        TypeName = typeName;
+        this.inner = inner ?? throw new ArgumentNullException(nameof(inner));
+        this.offsets = offsets ?? throw new ArgumentNullException(nameof(offsets));
+        this.rowCount = rowCount;
+        this.pooledOffsets = pooledOffsets;
+    }
+
+    /// <inheritdoc/>
+    public string Name { get; }
+
+    /// <inheritdoc/>
+    public string TypeName { get; }
+
+    /// <inheritdoc/>
+    public int RowCount => rowCount;
+
+    /// <summary>The flat inner column (every row's elements concatenated) — the zero-copy write source.</summary>
+    internal IColumn<TElement> Inner => inner;
+
+    /// <inheritdoc/>
+    public ReadOnlySpan<TElement> InnerValues => inner.Values;
+
+    /// <inheritdoc/>
+    public ReadOnlySpan<int> Offsets => offsets.AsSpan(0, rowCount + 1);
+
+    /// <summary>
+    /// The rows as arrays, materialized once and cached. Each row is copied out of <see cref="InnerValues"/> into
+    /// a freshly allocated <typeparamref name="TElement"/>[] (plus one outer array for the whole column) — the
+    /// arrays are caller-owned and outlive the block, at the cost of an allocation per row. To read without
+    /// allocating, use <see cref="InnerValues"/> + <see cref="Offsets"/> instead, and copy only if you must retain
+    /// past the block. Prefer the indexer when only some rows are needed, to avoid building the whole jagged array.
+    /// </summary>
+    public ReadOnlySpan<TElement[]> Values
+    {
+        get
+        {
+            if (cache is null)
+            {
+                var decoded = new TElement[rowCount][];
+                for (int i = 0; i < rowCount; i++)
+                {
+                    decoded[i] = Materialize(i);
+                }
+
+                cache = decoded;
+            }
+
+            return cache.AsSpan(0, rowCount);
+        }
+    }
+
+    /// <inheritdoc/>
+    public TElement[] this[int row] => cache is not null ? cache[row] : Materialize(row);
+
+    /// <inheritdoc/>
+    public object GetValue(int row) => this[row];
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        inner.Dispose();
+        if (pooledOffsets && offsets.Length != 0)
+        {
+            ArrayPool<int>.Shared.Return(offsets);
+        }
+
+        offsets = Array.Empty<int>();
+        cache = null;
+    }
+
+    /// <summary>Copies row <paramref name="row"/>'s slice of the inner values into a new array.</summary>
+    private TElement[] Materialize(int row)
+    {
+        int start = offsets[row];
+        int length = offsets[row + 1] - start;
+        return length == 0 ? Array.Empty<TElement>() : inner.Values.Slice(start, length).ToArray();
+    }
+}

--- a/ClickHouse.Driver.Tcp/Types/ArrayValueColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/ArrayValueColumn.cs
@@ -40,6 +40,8 @@ internal sealed class ArrayValueColumn<TElement> : IColumn<TElement[]>, IArrayCo
     /// <param name="offsets">The per-row offsets: <c>offsets[0]</c> is 0 and <c>offsets[i + 1]</c> is the exclusive end of row <c>i</c>'s slice; must have at least <paramref name="rowCount"/> + 1 entries.</param>
     /// <param name="rowCount">The number of rows.</param>
     /// <param name="pooledOffsets">Whether <paramref name="offsets"/> was rented and should be returned on dispose.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="inner"/> or <paramref name="offsets"/> is null.</exception>
+    /// <exception cref="ArgumentException"><paramref name="offsets"/> holds fewer than <paramref name="rowCount"/> + 1 entries.</exception>
     public ArrayValueColumn(string name, string typeName, IColumn<TElement> inner, int[] offsets, int rowCount, bool pooledOffsets)
     {
         Name = name;
@@ -48,6 +50,17 @@ internal sealed class ArrayValueColumn<TElement> : IColumn<TElement[]>, IArrayCo
         this.offsets = offsets ?? throw new ArgumentNullException(nameof(offsets));
         this.rowCount = rowCount;
         this.pooledOffsets = pooledOffsets;
+
+        // The row count cannot be derived here: the inner column is flat (one entry per element across all rows, so
+        // its height is the element total) and the offsets are typically a pooled buffer longer than the column. So
+        // the one input that can disagree is checked instead — a short offsets array would leave the row bounds
+        // reading past its end.
+        if (offsets.Length < rowCount + 1)
+        {
+            throw new ArgumentException(
+                $"The offsets for column '{name}' ({typeName}) hold {offsets.Length} entries, fewer than the {rowCount + 1} needed for {rowCount} rows.",
+                nameof(offsets));
+        }
     }
 
     /// <inheritdoc/>
@@ -116,8 +129,12 @@ internal sealed class ArrayValueColumn<TElement> : IColumn<TElement[]>, IArrayCo
     /// <summary>Copies row <paramref name="row"/>'s slice of the inner values into a new array.</summary>
     private TElement[] Materialize(int row)
     {
-        int start = offsets[row];
-        int length = offsets[row + 1] - start;
+        // Index through the RowCount-sliced offsets, not the raw buffer: the buffer is usually a pooled array longer
+        // than the column, and a stale offset pair left in it by a previous, larger read is still monotonic — so an
+        // out-of-range row would quietly hand back a real-looking slice of the inner column instead of throwing.
+        ReadOnlySpan<int> bounds = Offsets;
+        int start = bounds[row];
+        int length = bounds[row + 1] - start;
         return length == 0 ? Array.Empty<TElement>() : inner.Values.Slice(start, length).ToArray();
     }
 }

--- a/ClickHouse.Driver.Tcp/Types/ArrayValueColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/ArrayValueColumn.cs
@@ -72,8 +72,8 @@ internal sealed class ArrayValueColumn<TElement> : IColumn<TElement[]>, IArrayCo
     /// <inheritdoc/>
     public int RowCount => rowCount;
 
-    /// <summary>The flat inner column (every row's elements concatenated) — the zero-copy write source.</summary>
-    internal IColumn<TElement> Inner => inner;
+    /// <inheritdoc/>
+    public IColumn<TElement> Inner => inner;
 
     /// <inheritdoc/>
     public ReadOnlySpan<TElement> InnerValues => inner.Values;

--- a/ClickHouse.Driver.Tcp/Types/Codecs/ArrayColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/ArrayColumnCodec.cs
@@ -1,0 +1,350 @@
+using System;
+using System.Buffers;
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Protocol;
+
+namespace ClickHouse.Driver.Tcp.Types.Codecs;
+
+/// <summary>
+/// The non-generic entry point for building an <c>Array(T)</c> codec. The codec proper is the generic
+/// <see cref="ArrayColumnCodec{TElement}"/>; this closes it over the inner codec's runtime element type. The
+/// crossing from a runtime <see cref="Type"/> to the closed generic needs one reflective instantiation, so it is
+/// done once per element type and cached as a constructor delegate — every later resolution of that array type
+/// just invokes the delegate with no further reflection.
+/// </summary>
+internal static class ArrayColumnCodec
+{
+    private static readonly ConcurrentDictionary<Type, Func<string, IColumnCodec, IColumnCodec>> Factories = new();
+
+    /// <summary>Builds an <c>Array(T)</c> codec, resolving the inner type <c>T</c> through the registry.</summary>
+    /// <param name="node">The parsed <c>Array</c> type node; its single argument is the inner type.</param>
+    /// <param name="context">The resolution context, forwarded to the inner codec's factory.</param>
+    /// <param name="registry">The registry used to resolve the inner type's codec.</param>
+    /// <returns>The codec, closed over the inner codec's element type.</returns>
+    /// <exception cref="FormatException">The type has other than one argument.</exception>
+    public static IColumnCodec Create(TypeNode node, in ResolveContext context, ColumnCodecRegistry registry)
+    {
+        if (node.Arguments.Count != 1)
+        {
+            throw new FormatException($"Array type '{node}' must have exactly one inner type argument.");
+        }
+
+        IColumnCodec inner = registry.ResolveNode(node.Arguments[0], in context);
+        return Factories.GetOrAdd(inner.ElementType, BuildFactory)(node.ToString(), inner);
+    }
+
+    // Closes ArrayColumnCodec<T> over elementType once — via a generic helper invoked reflectively — and returns a
+    // delegate that constructs instances with no further reflection.
+    private static Func<string, IColumnCodec, IColumnCodec> BuildFactory(Type elementType)
+    {
+        MethodInfo make = typeof(ArrayColumnCodec).GetMethod(nameof(MakeFactory), BindingFlags.Static | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException($"{nameof(MakeFactory)} not found; the {nameof(ArrayColumnCodec)} factory was likely trimmed.");
+        return (Func<string, IColumnCodec, IColumnCodec>)make.MakeGenericMethod(elementType).Invoke(null, null);
+    }
+
+    private static Func<string, IColumnCodec, IColumnCodec> MakeFactory<T>()
+        => static (typeName, inner) => new ArrayColumnCodec<T>(typeName, inner);
+}
+
+/// <summary>
+/// A codec for the ClickHouse <c>Array(T)</c> column. It owns no bytes of its own beyond the offsets: it
+/// delegates the serialization-state prefix to the inner codec, then reads/writes a per-row offsets stream
+/// (<c>num_rows</c> little-endian <c>UInt64</c>, each the cumulative element end after that row) followed by the
+/// inner type's encoding for every element of every row concatenated end-to-end. The decoded column surfaces
+/// each row as the inner CLR value array — <c>Array(UInt32)</c> as <c>uint[]</c>, <c>Array(String)</c> as
+/// <c>string[]</c>, <c>Array(Array(UInt8))</c> as <c>byte[][]</c>.
+///
+/// <para>
+/// The codec is generic over the inner element type <typeparamref name="TElement"/> so it can build the typed
+/// <see cref="ArrayValueColumn{TElement}"/> and slice inner values without boxing; the registry pipeline is
+/// non-generic, so <see cref="ArrayColumnCodec"/> closes this over the inner codec's runtime element type. The
+/// inner codec stays non-generic (<see cref="IColumnCodec"/>), so its column is cast to <c>IColumn&lt;TElement&gt;</c>
+/// once at the read boundary. On the write path a column is accepted as either the dense
+/// <see cref="ArrayValueColumn{TElement}"/> (the wire's own shape, written with no copy) or the ergonomic jagged
+/// form (<c>TElement[]</c> per row, flattened through a pooled buffer).
+/// </para>
+/// </summary>
+/// <typeparam name="TElement">The inner codec's CLR element type; each row surfaces as <typeparamref name="TElement"/>[].</typeparam>
+internal sealed class ArrayColumnCodec<TElement> : IColumnCodec
+{
+    private readonly IColumnCodec inner;
+    private readonly bool innerCanWrite;
+
+    internal ArrayColumnCodec(string typeName, IColumnCodec inner)
+    {
+        TypeName = typeName;
+        this.inner = inner;
+
+        // Whether the inner codec can write at all (e.g. Nothing cannot). Computed once so CanWrite can reject an
+        // Array(non-writable) column up front rather than letting the write fail mid-stream.
+        innerCanWrite = inner.CanWrite(new ArrayColumn<TElement>(string.Empty, inner.TypeName, Array.Empty<TElement>()));
+    }
+
+    /// <inheritdoc/>
+    public string TypeName { get; }
+
+    /// <inheritdoc/>
+    public Type ElementType => typeof(TElement[]);
+
+    /// <summary>
+    /// The placeholder for an absent <c>Array(T)</c> value is the empty array — a row whose offset advances by
+    /// zero and contributes no elements. Relevant only if a composite nests an <c>Array</c> and asks for its
+    /// placeholder.
+    /// </summary>
+    public object NullPlaceholder => Array.Empty<TElement>();
+
+    /// <inheritdoc/>
+    public ValueTask ReadStatePrefixAsync(ClickHouseBinaryReader reader, CancellationToken cancellationToken)
+        => inner.ReadStatePrefixAsync(reader, cancellationToken);
+
+    /// <inheritdoc/>
+    public async ValueTask<IColumn> ReadColumnAsync(ClickHouseBinaryReader reader, string columnName, string columnType, int rowCount, CancellationToken cancellationToken)
+    {
+        if (rowCount == 0)
+        {
+            // An empty column writes no offsets and no values: read a zero-row inner column and wrap it with the
+            // single sentinel offset (offsets[0] = 0) every array column carries.
+            IColumn emptyInner = await inner.ReadColumnAsync(reader, columnName, inner.TypeName, 0, cancellationToken).ConfigureAwait(false);
+            return new ArrayValueColumn<TElement>(columnName, columnType, (IColumn<TElement>)emptyInner, new int[1], rowCount: 0, pooledOffsets: false);
+        }
+
+        long offsetBytes = (long)rowCount * sizeof(ulong);
+        if (offsetBytes > Array.MaxLength)
+        {
+            throw new ClickHouseProtocolException(
+                $"Array column '{columnName}' declares {rowCount} rows, whose offsets stream exceeds the maximum this client can buffer.");
+        }
+
+        int[] offsets = ArrayPool<int>.Shared.Rent(rowCount + 1);
+        byte[] scratch = ArrayPool<byte>.Shared.Rent((int)offsetBytes);
+        IColumn innerColumn = null;
+        try
+        {
+            await reader.ReadBytesAsync(scratch.AsMemory(0, (int)offsetBytes), cancellationToken).ConfigureAwait(false);
+            DecodeOffsets(scratch.AsSpan(0, (int)offsetBytes), offsets, rowCount, columnName);
+
+            innerColumn = await inner.ReadColumnAsync(reader, columnName, inner.TypeName, offsets[rowCount], cancellationToken).ConfigureAwait(false);
+
+            // Cast and wrap inside the try: only a successful wrap takes ownership of the rented offsets and the
+            // inner column, so an element-type mismatch surfacing as a cast failure leaks neither.
+            return new ArrayValueColumn<TElement>(columnName, columnType, (IColumn<TElement>)innerColumn, offsets, rowCount, pooledOffsets: true);
+        }
+        catch
+        {
+            ArrayPool<int>.Shared.Return(offsets);
+            innerColumn?.Dispose();
+            throw;
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(scratch);
+        }
+    }
+
+    /// <summary>
+    /// Decodes the per-row offsets stream — the <paramref name="rowCount"/> little-endian <c>UInt64</c> cumulative
+    /// element ends read into <paramref name="offsetBytes"/> — into <paramref name="offsets"/>, prepending the
+    /// <c>offsets[0] = 0</c> sentinel every array column carries. Validates as it goes that the stream never runs
+    /// backwards and never declares more elements than this client can address.
+    /// </summary>
+    /// <param name="offsetBytes">The raw offsets stream: exactly <paramref name="rowCount"/> little-endian <c>UInt64</c>.</param>
+    /// <param name="offsets">The destination, sized for <paramref name="rowCount"/> + 1 entries.</param>
+    /// <param name="rowCount">The number of rows (and offsets on the wire).</param>
+    /// <param name="columnName">The column name, for diagnostics.</param>
+    /// <exception cref="ClickHouseProtocolException">An offset goes backwards, or exceeds <see cref="int.MaxValue"/>.</exception>
+    private static void DecodeOffsets(ReadOnlySpan<byte> offsetBytes, Span<int> offsets, int rowCount, string columnName)
+    {
+        // Offsets are little-endian UInt64 (this client is little-endian only, like every fixed-width codec).
+        ReadOnlySpan<ulong> wire = MemoryMarshal.Cast<byte, ulong>(offsetBytes);
+        offsets[0] = 0;
+        ulong previous = 0;
+        for (int i = 0; i < rowCount; i++)
+        {
+            ulong end = wire[i];
+            if (end < previous)
+            {
+                throw new ClickHouseProtocolException(
+                    $"Array column '{columnName}' has a non-monotonic offset at row {i} ({end} < {previous}); the stream is corrupt.");
+            }
+
+            if (end > int.MaxValue)
+            {
+                throw new ClickHouseProtocolException(
+                    $"Array column '{columnName}' declares {end} total elements, exceeding the maximum this client can address.");
+            }
+
+            offsets[i + 1] = (int)end;
+            previous = end;
+        }
+    }
+
+    /// <inheritdoc/>
+    public bool CanWrite(IColumn column) => innerCanWrite && column is IColumn<TElement[]>;
+
+    /// <inheritdoc/>
+    public void WriteStatePrefix(ClickHouseBinaryWriter writer) => inner.WriteStatePrefix(writer);
+
+    /// <inheritdoc/>
+    public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
+    {
+        if (column is ArrayValueColumn<TElement> dense)
+        {
+            // Dense form (the wire's own layout): the offsets already exist and the inner column already holds
+            // every element, so write both directly. The wire offsets are relative to this slice's values stream,
+            // so subtract the slice's first element index from each.
+            ReadOnlySpan<int> offsets = dense.Offsets;
+            int elementBase = offsets[start];
+            for (int i = 0; i < length; i++)
+            {
+                writer.WriteUInt64((ulong)(offsets[start + i + 1] - elementBase));
+            }
+
+            inner.WriteColumn(writer, dense.Inner, elementBase, offsets[start + length] - elementBase);
+            return;
+        }
+
+        // Ergonomic jagged form: preflight the whole slice (element count, null-row rejection, size guard) before
+        // writing anything, then emit the offsets stream, then flatten the element arrays into a pooled inner-typed
+        // buffer (copying array references for a composite inner, values for a leaf inner) and hand it to the inner
+        // codec as one contiguous column.
+        //
+        // The flatten is required for correctness, not just to save calls: the inner codec must see every element
+        // at once. A sectioned inner encoding — Nullable's null-map, LowCardinality's dictionary, a nested Array's
+        // offsets — emits its section(s) once spanning the whole element run and only then the values. Writing the
+        // inner codec one row at a time would restart that layout per row (e.g. null-map/values/null-map/values
+        // interleaved) and corrupt the stream, so the elements are gathered contiguous first. A leaf inner that is
+        // a pure per-element concatenation (fixed-width, String) would tolerate per-row writes, but the write path
+        // stays uniform across inner types rather than branching on their layout.
+        //
+        // Array(T) rows are themselves non-nullable, so a null row is rejected rather than silently coerced to an
+        // empty array; callers pass Array.Empty<T>() for an empty row, or use Array(Nullable(T)) to carry null
+        // elements. (ClickHouse rejects Nullable(Array(T)), so an array row itself cannot be null.)
+        var source = (IColumn<TElement[]>)column;
+
+        int total = SumElementCount(source, column.Name, start, length);
+
+        // Offsets stream: each row's cumulative element end, relative to this slice's own values stream.
+        ulong running = 0;
+        for (int i = 0; i < length; i++)
+        {
+            running += (ulong)source[start + i].Length;
+            writer.WriteUInt64(running);
+        }
+
+        var flat = ArrayPool<TElement>.Shared.Rent(total);
+        try
+        {
+            int pos = 0;
+            for (int i = 0; i < length; i++)
+            {
+                TElement[] row = source[start + i];
+                if (row.Length > 0)
+                {
+                    Array.Copy(row, 0, flat, pos, row.Length);
+                    pos += row.Length;
+                }
+            }
+
+            inner.WriteColumn(writer, ArrayColumn<TElement>.OverBuffer(column.Name, inner.TypeName, flat, total), 0, total);
+        }
+        finally
+        {
+            ArrayPool<TElement>.Shared.Return(flat, clearArray: RuntimeHelpers.IsReferenceOrContainsReferences<TElement>());
+        }
+    }
+
+    /// <summary>
+    /// Preflight for the jagged write path: sums the slice's element count, rejecting null rows, before a single
+    /// byte is written. The flat buffer in <see cref="WriteColumn"/> is int-addressed, so a slice whose elements
+    /// sum past <see cref="Array.MaxLength"/> cannot be buffered — catching that here (rather than after the offsets
+    /// are already on the wire) keeps a failed write from leaving a half-written, corrupt column behind.
+    /// </summary>
+    /// <exception cref="ArgumentException">A row in the slice is null; <c>Array(T)</c> rows are non-nullable.</exception>
+    /// <exception cref="NotSupportedException">The slice's elements sum past <see cref="Array.MaxLength"/>.</exception>
+    private static int SumElementCount(IColumn<TElement[]> column, string columnName, int start, int length)
+    {
+        ulong total64 = 0;
+        for (int i = 0; i < length; i++)
+        {
+            TElement[] row = column[start + i];
+            if (row is null)
+            {
+                throw new ArgumentException(
+                    $"Array column '{columnName}' has a null value at row {start + i}; Array(T) rows are non-nullable. Use Array.Empty<T>() for an empty row, or Array(Nullable(T)) to carry null elements.",
+                    nameof(column));
+            }
+
+            total64 += (ulong)row.Length;
+        }
+
+        if (total64 > (ulong)Array.MaxLength)
+        {
+            throw new NotSupportedException(
+                $"Array column '{columnName}' holds {total64} elements in one block, exceeding the maximum ({Array.MaxLength}) this client can buffer.");
+        }
+
+        return (int)total64;
+    }
+
+    /// <inheritdoc/>
+    // One UInt64 offset plus the inner bytes of this row's elements, measured through whichever form the column
+    // takes — the wire-shaped dense column or the ergonomic jagged one.
+    public long MeasureRowBytes(IColumn column, int row)
+        => column is ArrayValueColumn<TElement> dense
+            ? MeasureDenseRow(dense, row)
+            : MeasureJaggedRow(column, row);
+
+    // Dense form: the inner column already holds every element, so this row's elements are just the offset range.
+    private long MeasureDenseRow(ArrayValueColumn<TElement> dense, int row)
+    {
+        ReadOnlySpan<int> offsets = dense.Offsets;
+        int elementStart = offsets[row];
+        int elementEnd = offsets[row + 1];
+        return sizeof(ulong) + MeasureInnerRun(dense.Inner, elementStart, elementEnd - elementStart);
+    }
+
+    // Ergonomic jagged form: this row is its own element array, wrapped (only when non-empty, to skip the wrapper
+    // allocation for an empty row) so the inner codec can price its elements.
+    private long MeasureJaggedRow(IColumn column, int row)
+    {
+        TElement[] value = ((IColumn<TElement[]>)column)[row];
+        if (value is null)
+        {
+            throw new ArgumentException(
+                $"Array column '{column.Name}' has a null value at row {row}; Array(T) rows are non-nullable. Use Array.Empty<T>() for an empty row, or Array(Nullable(T)) to carry null elements.",
+                nameof(column));
+        }
+
+        if (value.Length == 0)
+        {
+            return sizeof(ulong);
+        }
+
+        var wrapped = ArrayColumn<TElement>.OverBuffer(column.Name, inner.TypeName, value, value.Length);
+        return sizeof(ulong) + MeasureInnerRun(wrapped, start: 0, value.Length);
+    }
+
+    // The inner bytes for the contiguous run of count elements starting at start in innerColumn: a fixed-width
+    // inner prices in O(1); a variable-width inner is walked element by element through the inner codec.
+    private long MeasureInnerRun(IColumn innerColumn, int start, int count)
+    {
+        if (inner.FixedRowByteSize is int width)
+        {
+            return (long)count * width;
+        }
+
+        long bytes = 0;
+        int end = start + count;
+        for (int e = start; e < end; e++)
+        {
+            bytes += inner.MeasureRowBytes(innerColumn, e);
+        }
+
+        return bytes;
+    }
+}

--- a/ClickHouse.Driver.Tcp/Types/Codecs/ArrayColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/ArrayColumnCodec.cs
@@ -187,6 +187,45 @@ internal sealed class ArrayColumnCodec<TElement> : IColumnCodec
     public bool CanWrite(IColumn column) => innerCanWrite && column is IColumn<TElement[]>;
 
     /// <inheritdoc/>
+    // Builds the dense wire shape (a per-row offsets array plus a single flat inner column holding every row's
+    // elements end-to-end) from the ergonomic jagged form once, so a later measure/write indexes/slices it with no
+    // re-projection. The flat inner run is itself densified through the inner codec — a no-op for a leaf inner, but
+    // for e.g. Array(Nullable(T)) it turns the concatenated T? run into the dense (inner column + null-map) shape.
+    // An already-dense column is returned unchanged when its inner is already dense.
+    public IColumn Densify(IColumn column)
+    {
+        if (column is ArrayValueColumn<TElement> dense)
+        {
+            IColumn densifiedInner = inner.Densify(dense.Inner);
+            return ReferenceEquals(densifiedInner, dense.Inner)
+                ? column
+                : new ArrayValueColumn<TElement>(dense.Name, dense.TypeName, (IColumn<TElement>)densifiedInner, dense.Offsets.ToArray(), dense.RowCount, pooledOffsets: false);
+        }
+
+        var source = (IColumn<TElement[]>)column;
+        int rowCount = source.RowCount;
+        int total = SumElementCount(source, source.Name, 0, rowCount);
+
+        var offsets = new int[rowCount + 1];
+        var flat = new TElement[total];
+        int pos = 0;
+        for (int i = 0; i < rowCount; i++)
+        {
+            TElement[] row = source[i];
+            if (row.Length > 0)
+            {
+                Array.Copy(row, 0, flat, pos, row.Length);
+                pos += row.Length;
+            }
+
+            offsets[i + 1] = pos;
+        }
+
+        IColumn innerColumn = inner.Densify(new ArrayColumn<TElement>(source.Name, inner.TypeName, flat));
+        return new ArrayValueColumn<TElement>(source.Name, source.TypeName, (IColumn<TElement>)innerColumn, offsets, rowCount, pooledOffsets: false);
+    }
+
+    /// <inheritdoc/>
     public void WriteStatePrefix(ClickHouseBinaryWriter writer) => inner.WriteStatePrefix(writer);
 
     /// <inheritdoc/>

--- a/ClickHouse.Driver.Tcp/Types/Codecs/ArrayColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/ArrayColumnCodec.cs
@@ -65,7 +65,7 @@ internal static class ArrayColumnCodec
 /// inner codec stays non-generic (<see cref="IColumnCodec"/>), so its column is cast to <c>IColumn&lt;TElement&gt;</c>
 /// once at the read boundary. On the write path the column is always the dense
 /// <see cref="ArrayValueColumn{TElement}"/> (the wire's own shape, written with no copy) — the ergonomic jagged
-/// form (<c>TElement[]</c> per row) is projected into it by <see cref="TryDensify"/> before the write.
+/// form (<c>TElement[]</c> per row) is projected into it before the write.
 /// </para>
 /// </summary>
 /// <typeparam name="TElement">The inner codec's CLR element type; each row surfaces as <typeparamref name="TElement"/>[].</typeparam>
@@ -186,131 +186,196 @@ internal sealed class ArrayColumnCodec<TElement> : IColumnCodec
     public bool CanWrite(IColumn column) => innerCanWrite && column is IColumn<TElement[]>;
 
     /// <inheritdoc/>
-    // Builds the dense wire shape (a per-row offsets array plus a single flat inner column holding every row's
-    // elements end-to-end) from the ergonomic jagged form once, so a later measure/write indexes/slices it with no
-    // re-projection. The flat inner run is itself densified through the inner codec — a no-op for a leaf inner, but
-    // for e.g. Array(Nullable(T)) it turns the concatenated T? run into the dense (inner column + null-map) shape.
-    // An already-dense column is returned unchanged (built = false) when its inner is already dense.
-    public IColumn TryDensify(IColumn column, out bool built)
+    // Computes the per-slice scratch the prefix and body phases share. A dense column exposes its flat inner column
+    // and this slice's element range; an ergonomic jagged column has its per-row lengths summed into a slice-
+    // relative offsets array once, and — for a sectioned inner (Nullable, LowCardinality, a nested Array, Dynamic)
+    // — a flattening view so the inner codec sees every element as one column and emits its section once. A leaf
+    // inner with no sections needs neither: its runs are blitted row by row at write time.
+    public IColumnWriteState BeginWrite(IColumn column, int start, int length) => BuildState(column, start, length);
+
+    /// <inheritdoc/>
+    // The Array's own state prefix is the inner codec's, written once over every element of the slice; a leaf inner
+    // has none. When an outer composite (e.g. Variant) forwards its own column here rather than an Array one — its
+    // alternatives' prefixes are all data-independent — there is nothing to flatten, so forward to the inner, which
+    // ignores the column and emits its fixed prefix (or none).
+    public void WriteStatePrefix(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
+    {
+        if (!IsArrayColumn(column))
+        {
+            inner.WriteStatePrefix(writer, column, start, length);
+            return;
+        }
+
+        using ArrayWriteState state = BuildState(column, start, length);
+        WriteStatePrefixCore(writer, state);
+    }
+
+    /// <inheritdoc/>
+    public void WriteStatePrefix(ClickHouseBinaryWriter writer, IColumn column, int start, int length, IColumnWriteState state)
+    {
+        if (state is ArrayWriteState arrayState)
+        {
+            WriteStatePrefixCore(writer, arrayState);
+            return;
+        }
+
+        WriteStatePrefix(writer, column, start, length);
+    }
+
+    private void WriteStatePrefixCore(ClickHouseBinaryWriter writer, ArrayWriteState state)
+    {
+        if (state.Elements is not null)
+        {
+            inner.WriteStatePrefix(writer, state.Elements, state.ElementBase, state.ElementCount, state.InnerState);
+        }
+    }
+
+    /// <inheritdoc/>
+    public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
+    {
+        using ArrayWriteState state = BuildState(column, start, length);
+        WriteBody(writer, column, start, length, state);
+    }
+
+    /// <inheritdoc/>
+    public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length, IColumnWriteState state)
+    {
+        if (state is ArrayWriteState arrayState)
+        {
+            WriteBody(writer, column, start, length, arrayState);
+            return;
+        }
+
+        WriteColumn(writer, column, start, length);
+    }
+
+    // Writes the offsets stream (per-row cumulative element ends, relative to this slice) then the inner body. A
+    // sectioned inner receives every element as one column so a section it emits (Nullable's null-map,
+    // LowCardinality's dictionary, a nested Array's offsets, Dynamic's discriminators) spans the whole run rather
+    // than one row at a time. A leaf inner — whose encoding is a flat per-element stream — is driven one contiguous
+    // per-row run at a time (a bulk blit for a fixed-width inner) straight from the ergonomic arrays, no flat buffer
+    // built. A dense column reads its offsets and flat inner column directly for a zero-copy re-insert.
+    private void WriteBody(ClickHouseBinaryWriter writer, IColumn column, int start, int length, ArrayWriteState state)
     {
         if (column is ArrayValueColumn<TElement> dense)
         {
-            IColumn densifiedInner = inner.TryDensify(dense.Inner, out bool innerBuilt);
-            if (!innerBuilt)
+            ReadOnlySpan<int> offsets = dense.Offsets;
+            int elementBase = offsets[start];
+            for (int i = 0; i < length; i++)
             {
-                built = false;
-                return column;
+                writer.WriteUInt64((ulong)(offsets[start + i + 1] - elementBase));
             }
+        }
+        else
+        {
+            int[] sliceOffsets = state.SliceOffsets;
+            for (int i = 0; i < length; i++)
+            {
+                writer.WriteUInt64((ulong)sliceOffsets[i + 1]);
+            }
+        }
 
-            built = true;
-            return new ArrayValueColumn<TElement>(dense.Name, dense.TypeName, (IColumn<TElement>)densifiedInner, dense.Offsets.ToArray(), dense.RowCount, pooledOffsets: false);
+        if (state.Elements is not null)
+        {
+            inner.WriteColumn(writer, state.Elements, state.ElementBase, state.ElementCount, state.InnerState);
+            return;
+        }
+
+        var spanCodec = (ISpanWritableCodec<TElement>)inner;
+        var source = (IColumn<TElement[]>)column;
+        for (int i = 0; i < length; i++)
+        {
+            spanCodec.WriteValues(writer, source[start + i]);
+        }
+    }
+
+    // Whether the column is one this codec owns — the dense wire column or the ergonomic jagged form — as opposed
+    // to an outer composite's own column forwarded through the prefix phase.
+    private static bool IsArrayColumn(IColumn column) => column is ArrayValueColumn<TElement> || column is IColumn<TElement[]>;
+
+    // Builds the per-slice write scratch: the element range plus the inner codec's own state over the flattened
+    // elements (the dense inner column, or a flattening view over the ergonomic rows) for a sectioned inner, or just
+    // the slice offsets for a leaf inner written as runs.
+    private ArrayWriteState BuildState(IColumn column, int start, int length)
+    {
+        if (column is ArrayValueColumn<TElement> dense)
+        {
+            ReadOnlySpan<int> offsets = dense.Offsets;
+            int elementBase = offsets[start];
+            int elementCount = offsets[start + length] - elementBase;
+            IColumnWriteState innerState = inner.BeginWrite(dense.Inner, elementBase, elementCount);
+            return new ArrayWriteState((IColumn<TElement>)dense.Inner, elementBase, elementCount, innerState, sliceOffsets: null);
         }
 
         var source = (IColumn<TElement[]>)column;
-        int rowCount = source.RowCount;
-        int total = SumElementCount(source, source.Name, 0, rowCount);
-
-        var offsets = new int[rowCount + 1];
-        var flat = new TElement[total];
-        int pos = 0;
-        for (int i = 0; i < rowCount; i++)
+        int[] sliceOffsets = ComputeOffsets(source, start, length);
+        int total = sliceOffsets[length];
+        if (inner is ISpanWritableCodec<TElement>)
         {
-            TElement[] row = source[i];
-            if (row.Length > 0)
-            {
-                Array.Copy(row, 0, flat, pos, row.Length);
-                pos += row.Length;
-            }
-
-            offsets[i + 1] = pos;
+            // Leaf inner: no sectioned prefix and no flattened column — the runs are blitted row by row at write time.
+            return new ArrayWriteState(elements: null, elementBase: 0, total, innerState: null, sliceOffsets);
         }
 
-        IColumn innerColumn = inner.TryDensify(new ArrayColumn<TElement>(source.Name, inner.TypeName, flat), out _);
-        built = true;
-        return new ArrayValueColumn<TElement>(source.Name, source.TypeName, (IColumn<TElement>)innerColumn, offsets, rowCount, pooledOffsets: false);
+        var view = new ConcatColumn<TElement>(inner.TypeName, source, start, sliceOffsets, total);
+        IColumnWriteState viewState = inner.BeginWrite(view, 0, total);
+        return new ArrayWriteState(view, elementBase: 0, total, viewState, sliceOffsets);
     }
 
-    /// <inheritdoc/>
-    public void WriteStatePrefix(ClickHouseBinaryWriter writer) => inner.WriteStatePrefix(writer);
-
-    /// <inheritdoc/>
-    // Every column is densified before the write, so the body is always the dense wire shape: the offsets already
-    // exist and the inner column already holds every element, so both are written directly. The wire offsets are
-    // relative to this slice's values stream, so subtract the slice's first element index from each. The ergonomic
-    // jagged form was flattened into this shape by TryDensify.
-    public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
+    // Sums each row's element count into a slice-relative cumulative offsets array (offsets[0] = 0), rejecting null
+    // rows (Array(T) is element-nullable only through Array(Nullable(T))) and guarding that the run fits one array.
+    private static int[] ComputeOffsets(IColumn<TElement[]> source, int start, int length)
     {
-        var dense = (ArrayValueColumn<TElement>)column;
-        ReadOnlySpan<int> offsets = dense.Offsets;
-        int elementBase = offsets[start];
-        for (int i = 0; i < length; i++)
-        {
-            writer.WriteUInt64((ulong)(offsets[start + i + 1] - elementBase));
-        }
-
-        inner.WriteColumn(writer, dense.Inner, elementBase, offsets[start + length] - elementBase);
-    }
-
-    /// <summary>
-    /// Sums the column's element count, rejecting null rows, and guards that the flat run fits a single array —
-    /// the preflight <see cref="TryDensify"/> runs before flattening the jagged rows into one contiguous inner column.
-    /// </summary>
-    /// <exception cref="ArgumentException">A row is null; <c>Array(T)</c> rows are non-nullable.</exception>
-    /// <exception cref="NotSupportedException">The elements sum past <see cref="Array.MaxLength"/>.</exception>
-    private static int SumElementCount(IColumn<TElement[]> column, string columnName, int start, int length)
-    {
+        var offsets = new int[length + 1];
         ulong total64 = 0;
         for (int i = 0; i < length; i++)
         {
-            TElement[] row = column[start + i];
+            TElement[] row = source[start + i];
             if (row is null)
             {
                 throw new ArgumentException(
-                    $"Array column '{columnName}' has a null value at row {start + i}; Array(T) rows are non-nullable. Use Array.Empty<T>() for an empty row, or Array(Nullable(T)) to carry null elements.",
-                    nameof(column));
+                    $"Array column '{source.Name}' has a null value at row {start + i}; Array(T) rows are non-nullable. Use Array.Empty<T>() for an empty row, or Array(Nullable(T)) to carry null elements.",
+                    nameof(source));
             }
 
             total64 += (ulong)row.Length;
+            if (total64 > (ulong)Array.MaxLength)
+            {
+                throw new NotSupportedException(
+                    $"Array column '{source.Name}' holds more than {Array.MaxLength} elements in one block, exceeding the maximum this client can buffer.");
+            }
+
+            offsets[i + 1] = (int)total64;
         }
 
-        if (total64 > (ulong)Array.MaxLength)
-        {
-            throw new NotSupportedException(
-                $"Array column '{columnName}' holds {total64} elements in one block, exceeding the maximum ({Array.MaxLength}) this client can buffer.");
-        }
-
-        return (int)total64;
+        return offsets;
     }
 
-    /// <inheritdoc/>
-    // One UInt64 offset plus the inner bytes of this row's elements. The column is always the dense wire shape (the
-    // pipeline densifies before measuring), so the inner column already holds every element and this row's elements
-    // are just its offset range.
-    public long MeasureRowBytes(IColumn column, int row)
+    // The write scratch of one slice, shared across the prefix and body phases. For a sectioned inner, Elements is
+    // the flattened element column (the dense inner column, borrowed; or a flattening view over the ergonomic rows)
+    // with its element range and the inner codec's own state. For a leaf inner written as runs, Elements is null and
+    // only SliceOffsets is carried. SliceOffsets is the ergonomic slice's cumulative element ends (null for a dense
+    // column, whose offsets are read directly). Nothing here is pooled; disposing releases the inner state.
+    private sealed class ArrayWriteState : IColumnWriteState
     {
-        var dense = (ArrayValueColumn<TElement>)column;
-        ReadOnlySpan<int> offsets = dense.Offsets;
-        int elementStart = offsets[row];
-        int elementEnd = offsets[row + 1];
-        return sizeof(ulong) + MeasureInnerRun(dense.Inner, elementStart, elementEnd - elementStart);
-    }
-
-    // The inner bytes for the contiguous run of count elements starting at start in innerColumn: a fixed-width
-    // inner prices in O(1); a variable-width inner is walked element by element through the inner codec.
-    private long MeasureInnerRun(IColumn innerColumn, int start, int count)
-    {
-        if (inner.FixedRowByteSize is int width)
+        public ArrayWriteState(IColumn<TElement> elements, int elementBase, int elementCount, IColumnWriteState innerState, int[] sliceOffsets)
         {
-            return (long)count * width;
+            Elements = elements;
+            ElementBase = elementBase;
+            ElementCount = elementCount;
+            InnerState = innerState;
+            SliceOffsets = sliceOffsets;
         }
 
-        long bytes = 0;
-        int end = start + count;
-        for (int e = start; e < end; e++)
-        {
-            bytes += inner.MeasureRowBytes(innerColumn, e);
-        }
+        public IColumn<TElement> Elements { get; }
 
-        return bytes;
+        public int ElementBase { get; }
+
+        public int ElementCount { get; }
+
+        public IColumnWriteState InnerState { get; }
+
+        public int[] SliceOffsets { get; }
+
+        public void Dispose() => InnerState?.Dispose();
     }
 }

--- a/ClickHouse.Driver.Tcp/Types/Codecs/ArrayColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/ArrayColumnCodec.cs
@@ -2,7 +2,6 @@ using System;
 using System.Buffers;
 using System.Collections.Concurrent;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -64,9 +63,9 @@ internal static class ArrayColumnCodec
 /// <see cref="ArrayValueColumn{TElement}"/> and slice inner values without boxing; the registry pipeline is
 /// non-generic, so <see cref="ArrayColumnCodec"/> closes this over the inner codec's runtime element type. The
 /// inner codec stays non-generic (<see cref="IColumnCodec"/>), so its column is cast to <c>IColumn&lt;TElement&gt;</c>
-/// once at the read boundary. On the write path a column is accepted as either the dense
-/// <see cref="ArrayValueColumn{TElement}"/> (the wire's own shape, written with no copy) or the ergonomic jagged
-/// form (<c>TElement[]</c> per row, flattened through a pooled buffer).
+/// once at the read boundary. On the write path the column is always the dense
+/// <see cref="ArrayValueColumn{TElement}"/> (the wire's own shape, written with no copy) — the ergonomic jagged
+/// form (<c>TElement[]</c> per row) is projected into it by <see cref="TryDensify"/> before the write.
 /// </para>
 /// </summary>
 /// <typeparam name="TElement">The inner codec's CLR element type; each row surfaces as <typeparamref name="TElement"/>[].</typeparam>
@@ -191,15 +190,20 @@ internal sealed class ArrayColumnCodec<TElement> : IColumnCodec
     // elements end-to-end) from the ergonomic jagged form once, so a later measure/write indexes/slices it with no
     // re-projection. The flat inner run is itself densified through the inner codec — a no-op for a leaf inner, but
     // for e.g. Array(Nullable(T)) it turns the concatenated T? run into the dense (inner column + null-map) shape.
-    // An already-dense column is returned unchanged when its inner is already dense.
-    public IColumn Densify(IColumn column)
+    // An already-dense column is returned unchanged (built = false) when its inner is already dense.
+    public IColumn TryDensify(IColumn column, out bool built)
     {
         if (column is ArrayValueColumn<TElement> dense)
         {
-            IColumn densifiedInner = inner.Densify(dense.Inner);
-            return ReferenceEquals(densifiedInner, dense.Inner)
-                ? column
-                : new ArrayValueColumn<TElement>(dense.Name, dense.TypeName, (IColumn<TElement>)densifiedInner, dense.Offsets.ToArray(), dense.RowCount, pooledOffsets: false);
+            IColumn densifiedInner = inner.TryDensify(dense.Inner, out bool innerBuilt);
+            if (!innerBuilt)
+            {
+                built = false;
+                return column;
+            }
+
+            built = true;
+            return new ArrayValueColumn<TElement>(dense.Name, dense.TypeName, (IColumn<TElement>)densifiedInner, dense.Offsets.ToArray(), dense.RowCount, pooledOffsets: false);
         }
 
         var source = (IColumn<TElement[]>)column;
@@ -221,7 +225,8 @@ internal sealed class ArrayColumnCodec<TElement> : IColumnCodec
             offsets[i + 1] = pos;
         }
 
-        IColumn innerColumn = inner.Densify(new ArrayColumn<TElement>(source.Name, inner.TypeName, flat));
+        IColumn innerColumn = inner.TryDensify(new ArrayColumn<TElement>(source.Name, inner.TypeName, flat), out _);
+        built = true;
         return new ArrayValueColumn<TElement>(source.Name, source.TypeName, (IColumn<TElement>)innerColumn, offsets, rowCount, pooledOffsets: false);
     }
 
@@ -229,82 +234,29 @@ internal sealed class ArrayColumnCodec<TElement> : IColumnCodec
     public void WriteStatePrefix(ClickHouseBinaryWriter writer) => inner.WriteStatePrefix(writer);
 
     /// <inheritdoc/>
+    // Every column is densified before the write, so the body is always the dense wire shape: the offsets already
+    // exist and the inner column already holds every element, so both are written directly. The wire offsets are
+    // relative to this slice's values stream, so subtract the slice's first element index from each. The ergonomic
+    // jagged form was flattened into this shape by TryDensify.
     public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
     {
-        if (column is ArrayValueColumn<TElement> dense)
-        {
-            // Dense form (the wire's own layout): the offsets already exist and the inner column already holds
-            // every element, so write both directly. The wire offsets are relative to this slice's values stream,
-            // so subtract the slice's first element index from each.
-            ReadOnlySpan<int> offsets = dense.Offsets;
-            int elementBase = offsets[start];
-            for (int i = 0; i < length; i++)
-            {
-                writer.WriteUInt64((ulong)(offsets[start + i + 1] - elementBase));
-            }
-
-            inner.WriteColumn(writer, dense.Inner, elementBase, offsets[start + length] - elementBase);
-            return;
-        }
-
-        // Ergonomic jagged form: preflight the whole slice (element count, null-row rejection, size guard) before
-        // writing anything, then emit the offsets stream, then flatten the element arrays into a pooled inner-typed
-        // buffer (copying array references for a composite inner, values for a leaf inner) and hand it to the inner
-        // codec as one contiguous column.
-        //
-        // The flatten is required for correctness, not just to save calls: the inner codec must see every element
-        // at once. A sectioned inner encoding — Nullable's null-map, LowCardinality's dictionary, a nested Array's
-        // offsets — emits its section(s) once spanning the whole element run and only then the values. Writing the
-        // inner codec one row at a time would restart that layout per row (e.g. null-map/values/null-map/values
-        // interleaved) and corrupt the stream, so the elements are gathered contiguous first. A leaf inner that is
-        // a pure per-element concatenation (fixed-width, String) would tolerate per-row writes, but the write path
-        // stays uniform across inner types rather than branching on their layout.
-        //
-        // Array(T) rows are themselves non-nullable, so a null row is rejected rather than silently coerced to an
-        // empty array; callers pass Array.Empty<T>() for an empty row, or use Array(Nullable(T)) to carry null
-        // elements. (ClickHouse rejects Nullable(Array(T)), so an array row itself cannot be null.)
-        var source = (IColumn<TElement[]>)column;
-
-        int total = SumElementCount(source, column.Name, start, length);
-
-        // Offsets stream: each row's cumulative element end, relative to this slice's own values stream.
-        ulong running = 0;
+        var dense = (ArrayValueColumn<TElement>)column;
+        ReadOnlySpan<int> offsets = dense.Offsets;
+        int elementBase = offsets[start];
         for (int i = 0; i < length; i++)
         {
-            running += (ulong)source[start + i].Length;
-            writer.WriteUInt64(running);
+            writer.WriteUInt64((ulong)(offsets[start + i + 1] - elementBase));
         }
 
-        var flat = ArrayPool<TElement>.Shared.Rent(total);
-        try
-        {
-            int pos = 0;
-            for (int i = 0; i < length; i++)
-            {
-                TElement[] row = source[start + i];
-                if (row.Length > 0)
-                {
-                    Array.Copy(row, 0, flat, pos, row.Length);
-                    pos += row.Length;
-                }
-            }
-
-            inner.WriteColumn(writer, ArrayColumn<TElement>.OverBuffer(column.Name, inner.TypeName, flat, total), 0, total);
-        }
-        finally
-        {
-            ArrayPool<TElement>.Shared.Return(flat, clearArray: RuntimeHelpers.IsReferenceOrContainsReferences<TElement>());
-        }
+        inner.WriteColumn(writer, dense.Inner, elementBase, offsets[start + length] - elementBase);
     }
 
     /// <summary>
-    /// Preflight for the jagged write path: sums the slice's element count, rejecting null rows, before a single
-    /// byte is written. The flat buffer in <see cref="WriteColumn"/> is int-addressed, so a slice whose elements
-    /// sum past <see cref="Array.MaxLength"/> cannot be buffered — catching that here (rather than after the offsets
-    /// are already on the wire) keeps a failed write from leaving a half-written, corrupt column behind.
+    /// Sums the column's element count, rejecting null rows, and guards that the flat run fits a single array —
+    /// the preflight <see cref="TryDensify"/> runs before flattening the jagged rows into one contiguous inner column.
     /// </summary>
-    /// <exception cref="ArgumentException">A row in the slice is null; <c>Array(T)</c> rows are non-nullable.</exception>
-    /// <exception cref="NotSupportedException">The slice's elements sum past <see cref="Array.MaxLength"/>.</exception>
+    /// <exception cref="ArgumentException">A row is null; <c>Array(T)</c> rows are non-nullable.</exception>
+    /// <exception cref="NotSupportedException">The elements sum past <see cref="Array.MaxLength"/>.</exception>
     private static int SumElementCount(IColumn<TElement[]> column, string columnName, int start, int length)
     {
         ulong total64 = 0;
@@ -331,41 +283,16 @@ internal sealed class ArrayColumnCodec<TElement> : IColumnCodec
     }
 
     /// <inheritdoc/>
-    // One UInt64 offset plus the inner bytes of this row's elements, measured through whichever form the column
-    // takes — the wire-shaped dense column or the ergonomic jagged one.
+    // One UInt64 offset plus the inner bytes of this row's elements. The column is always the dense wire shape (the
+    // pipeline densifies before measuring), so the inner column already holds every element and this row's elements
+    // are just its offset range.
     public long MeasureRowBytes(IColumn column, int row)
-        => column is ArrayValueColumn<TElement> dense
-            ? MeasureDenseRow(dense, row)
-            : MeasureJaggedRow(column, row);
-
-    // Dense form: the inner column already holds every element, so this row's elements are just the offset range.
-    private long MeasureDenseRow(ArrayValueColumn<TElement> dense, int row)
     {
+        var dense = (ArrayValueColumn<TElement>)column;
         ReadOnlySpan<int> offsets = dense.Offsets;
         int elementStart = offsets[row];
         int elementEnd = offsets[row + 1];
         return sizeof(ulong) + MeasureInnerRun(dense.Inner, elementStart, elementEnd - elementStart);
-    }
-
-    // Ergonomic jagged form: this row is its own element array, wrapped (only when non-empty, to skip the wrapper
-    // allocation for an empty row) so the inner codec can price its elements.
-    private long MeasureJaggedRow(IColumn column, int row)
-    {
-        TElement[] value = ((IColumn<TElement[]>)column)[row];
-        if (value is null)
-        {
-            throw new ArgumentException(
-                $"Array column '{column.Name}' has a null value at row {row}; Array(T) rows are non-nullable. Use Array.Empty<T>() for an empty row, or Array(Nullable(T)) to carry null elements.",
-                nameof(column));
-        }
-
-        if (value.Length == 0)
-        {
-            return sizeof(ulong);
-        }
-
-        var wrapped = ArrayColumn<TElement>.OverBuffer(column.Name, inner.TypeName, value, value.Length);
-        return sizeof(ulong) + MeasureInnerRun(wrapped, start: 0, value.Length);
     }
 
     // The inner bytes for the contiguous run of count elements starting at start in innerColumn: a fixed-width

--- a/ClickHouse.Driver.Tcp/Types/Codecs/ArrayColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/ArrayColumnCodec.cs
@@ -109,7 +109,17 @@ internal sealed class ArrayColumnCodec<TElement> : IColumnCodec
             // An empty column writes no offsets and no values: read a zero-row inner column and wrap it with the
             // single sentinel offset (offsets[0] = 0) every array column carries.
             IColumn emptyInner = await inner.ReadColumnAsync(reader, columnName, inner.TypeName, 0, cancellationToken).ConfigureAwait(false);
-            return new ArrayValueColumn<TElement>(columnName, columnType, (IColumn<TElement>)emptyInner, new int[1], rowCount: 0, pooledOffsets: false);
+            try
+            {
+                // Cast inside the try so a mismatched inner element type surfacing as a cast failure disposes the
+                // inner column rather than leaking it, matching the non-empty path below.
+                return new ArrayValueColumn<TElement>(columnName, columnType, (IColumn<TElement>)emptyInner, new int[1], rowCount: 0, pooledOffsets: false);
+            }
+            catch
+            {
+                emptyInner.Dispose();
+                throw;
+            }
         }
 
         long offsetBytes = (long)rowCount * sizeof(ulong);
@@ -333,7 +343,7 @@ internal sealed class ArrayColumnCodec<TElement> : IColumnCodec
             if (row is null)
             {
                 throw new ArgumentException(
-                    $"Array column '{source.Name}' has a null value at row {start + i}; Array(T) rows are non-nullable. Use Array.Empty<T>() for an empty row, or Array(Nullable(T)) to carry null elements.",
+                    $"Array column '{source.Name}' has a null value at row {start + i}; Array(T) rows are non-nullable. Use an empty array for an empty row, or declare the column Array(Nullable(T)) to carry null elements.",
                     nameof(source));
             }
 

--- a/ClickHouse.Driver.Tcp/Types/Codecs/ArrayColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/ArrayColumnCodec.cs
@@ -63,9 +63,10 @@ internal static class ArrayColumnCodec
 /// <see cref="ArrayValueColumn{TElement}"/> and slice inner values without boxing; the registry pipeline is
 /// non-generic, so <see cref="ArrayColumnCodec"/> closes this over the inner codec's runtime element type. The
 /// inner codec stays non-generic (<see cref="IColumnCodec"/>), so its column is cast to <c>IColumn&lt;TElement&gt;</c>
-/// once at the read boundary. On the write path the column is always the dense
-/// <see cref="ArrayValueColumn{TElement}"/> (the wire's own shape, written with no copy) — the ergonomic jagged
-/// form (<c>TElement[]</c> per row) is projected into it before the write.
+/// once at the read boundary. The write path takes either shape as it comes: the dense
+/// <see cref="ArrayValueColumn{TElement}"/> is the wire's own layout and is written with no copy, while the
+/// ergonomic jagged form (<c>TElement[]</c> per row) is written from its rows without its elements being copied
+/// into a flat buffer first.
 /// </para>
 /// </summary>
 /// <typeparam name="TElement">The inner codec's CLR element type; each row surfaces as <typeparamref name="TElement"/>[].</typeparam>
@@ -196,18 +197,13 @@ internal sealed class ArrayColumnCodec<TElement> : IColumnCodec
     public bool CanWrite(IColumn column) => innerCanWrite && column is IColumn<TElement[]>;
 
     /// <inheritdoc/>
-    // Computes the per-slice scratch the prefix and body phases share. A dense column exposes its flat inner column
-    // and this slice's element range; an ergonomic jagged column has its per-row lengths summed into a slice-
-    // relative offsets array once, and — for a sectioned inner (Nullable, LowCardinality, a nested Array, Dynamic)
-    // — a flattening view so the inner codec sees every element as one column and emits its section once. A leaf
-    // inner with no sections needs neither: its runs are blitted row by row at write time.
+    // Computed once per slice and handed to both the prefix and body phases; see BuildState for what it holds.
     public IColumnWriteState BeginWrite(IColumn column, int start, int length) => BuildState(column, start, length);
 
     /// <inheritdoc/>
-    // The Array's own state prefix is the inner codec's, written once over every element of the slice; a leaf inner
-    // has none. When an outer composite (e.g. Variant) forwards its own column here rather than an Array one — its
-    // alternatives' prefixes are all data-independent — there is nothing to flatten, so forward to the inner, which
-    // ignores the column and emits its fixed prefix (or none).
+    // The Array's own state prefix is the inner codec's, written once over every element of the slice (a leaf inner
+    // has none). An outer composite (e.g. Variant) may forward its own column here rather than an Array one, since
+    // prefixes are data-independent; there is nothing to flatten then, so the inner emits its fixed prefix directly.
     public void WriteStatePrefix(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
     {
         if (!IsArrayColumn(column))
@@ -259,16 +255,14 @@ internal sealed class ArrayColumnCodec<TElement> : IColumnCodec
         WriteColumn(writer, column, start, length);
     }
 
-    // Writes the offsets stream (per-row cumulative element ends, relative to this slice) then the inner body. A
-    // sectioned inner receives every element as one column so a section it emits (Nullable's null-map,
-    // LowCardinality's dictionary, a nested Array's offsets, Dynamic's discriminators) spans the whole run rather
-    // than one row at a time. A leaf inner — whose encoding is a flat per-element stream — is driven one contiguous
-    // per-row run at a time (a bulk blit for a fixed-width inner) straight from the ergonomic arrays, no flat buffer
-    // built. A dense column reads its offsets and flat inner column directly for a zero-copy re-insert.
+    // Writes this slice's offsets stream — one UInt64 per row, the cumulative element end after that row — then its
+    // elements.
     private void WriteBody(ClickHouseBinaryWriter writer, IColumn column, int start, int length, ArrayWriteState state)
     {
         if (column is ArrayValueColumn<TElement> dense)
         {
+            // A dense column already carries offsets, but they count from the start of the whole column; rebase them
+            // on this slice's first element so each block's stream starts from zero.
             ReadOnlySpan<int> offsets = dense.Offsets;
             int elementBase = offsets[start];
             for (int i = 0; i < length; i++)
@@ -278,6 +272,8 @@ internal sealed class ArrayColumnCodec<TElement> : IColumnCodec
         }
         else
         {
+            // An ergonomic column has no offsets of its own; BuildState summed its per-row lengths into
+            // slice-relative ones.
             int[] sliceOffsets = state.SliceOffsets;
             for (int i = 0; i < length; i++)
             {
@@ -287,10 +283,18 @@ internal sealed class ArrayColumnCodec<TElement> : IColumnCodec
 
         if (state.Elements is not null)
         {
+            // Every element of the slice handed over as one column: the dense column's own flat inner (borrowed, so a
+            // re-insert copies nothing), or a flattening view over the ergonomic rows. A sectioned inner needs this —
+            // it emits each section (Nullable's null-map, LowCardinality's dictionary, a nested Array's offsets,
+            // Dynamic's discriminators) once spanning the whole run, so driving it a row at a time would interleave
+            // those sections and corrupt the stream.
             inner.WriteColumn(writer, state.Elements, state.ElementBase, state.ElementCount, state.InnerState);
             return;
         }
 
+        // A leaf inner (see ISpanWritableCodec) encodes as a flat per-element stream with no sections, so each row's
+        // array goes out as its own contiguous run — a bulk blit for a fixed-width inner — read straight from the
+        // ergonomic column with no flattened view or buffer in between.
         var spanCodec = (ISpanWritableCodec<TElement>)inner;
         var source = (IColumn<TElement[]>)column;
         for (int i = 0; i < length; i++)
@@ -303,13 +307,15 @@ internal sealed class ArrayColumnCodec<TElement> : IColumnCodec
     // to an outer composite's own column forwarded through the prefix phase.
     private static bool IsArrayColumn(IColumn column) => column is ArrayValueColumn<TElement> || column is IColumn<TElement[]>;
 
-    // Builds the per-slice write scratch: the element range plus the inner codec's own state over the flattened
-    // elements (the dense inner column, or a flattening view over the ergonomic rows) for a sectioned inner, or just
-    // the slice offsets for a leaf inner written as runs.
+    // Builds the scratch the prefix and body phases of one slice share: which elements the slice covers, plus
+    // whatever the inner codec needs to write them.
     private ArrayWriteState BuildState(IColumn column, int start, int length)
     {
         if (column is ArrayValueColumn<TElement> dense)
         {
+            // A dense column is already the wire's shape: its flat inner is the element column, and the slice's
+            // element range is the gap between the offsets bracketing the rows. Nothing is summed, and the inner
+            // column is borrowed rather than copied.
             ReadOnlySpan<int> offsets = dense.Offsets;
             int elementBase = offsets[start];
             int elementCount = offsets[start + length] - elementBase;
@@ -317,15 +323,20 @@ internal sealed class ArrayColumnCodec<TElement> : IColumnCodec
             return new ArrayWriteState((IColumn<TElement>)dense.Inner, elementBase, elementCount, innerState, sliceOffsets: null);
         }
 
+        // An ergonomic column has to have its offsets derived from the per-row lengths; doing it here means neither
+        // phase re-walks the rows.
         var source = (IColumn<TElement[]>)column;
         int[] sliceOffsets = ComputeOffsets(source, start, length);
         int total = sliceOffsets[length];
         if (inner is ISpanWritableCodec<TElement>)
         {
-            // Leaf inner: no sectioned prefix and no flattened column — the runs are blitted row by row at write time.
+            // A leaf inner emits no state prefix and needs no element column — the body writes each row as its own
+            // run straight from the source arrays — so the offsets are the whole of the scratch.
             return new ArrayWriteState(elements: null, elementBase: 0, total, innerState: null, sliceOffsets);
         }
 
+        // A sectioned inner has to see every element as one column, so give it a lazy flattening view over the rows
+        // instead of copying the elements into a flat buffer.
         var view = new ConcatColumn<TElement>(inner.TypeName, source, start, sliceOffsets, total);
         IColumnWriteState viewState = inner.BeginWrite(view, 0, total);
         return new ArrayWriteState(view, elementBase: 0, total, viewState, sliceOffsets);
@@ -360,11 +371,10 @@ internal sealed class ArrayColumnCodec<TElement> : IColumnCodec
         return offsets;
     }
 
-    // The write scratch of one slice, shared across the prefix and body phases. For a sectioned inner, Elements is
-    // the flattened element column (the dense inner column, borrowed; or a flattening view over the ergonomic rows)
-    // with its element range and the inner codec's own state. For a leaf inner written as runs, Elements is null and
-    // only SliceOffsets is carried. SliceOffsets is the ergonomic slice's cumulative element ends (null for a dense
-    // column, whose offsets are read directly). Nothing here is pooled; disposing releases the inner state.
+    // The write scratch of one slice, shared across the prefix and body phases; BuildState decides what goes in it.
+    // Elements is the slice's element column, null only for a leaf inner written as runs; SliceOffsets is the
+    // ergonomic slice's cumulative element ends, null for a dense column, which reads its own. Nothing here is
+    // pooled; disposing releases the inner state.
     private sealed class ArrayWriteState : IColumnWriteState
     {
         public ArrayWriteState(IColumn<TElement> elements, int elementBase, int elementCount, IColumnWriteState innerState, int[] sliceOffsets)

--- a/ClickHouse.Driver.Tcp/Types/Codecs/ArrayColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/ArrayColumnCodec.cs
@@ -212,13 +212,14 @@ internal sealed class ArrayColumnCodec<TElement> : IColumnCodec
     /// <inheritdoc/>
     public void WriteStatePrefix(ClickHouseBinaryWriter writer, IColumn column, int start, int length, IColumnWriteState state)
     {
-        if (state is ArrayWriteState arrayState)
+        // A null state is the caller saying it has none to share, so build one for this call alone.
+        if (state is null)
         {
-            WriteStatePrefixCore(writer, arrayState);
+            WriteStatePrefix(writer, column, start, length);
             return;
         }
 
-        WriteStatePrefix(writer, column, start, length);
+        WriteStatePrefixCore(writer, state.Expect<ArrayWriteState>(TypeName));
     }
 
     private void WriteStatePrefixCore(ClickHouseBinaryWriter writer, ArrayWriteState state)
@@ -239,13 +240,13 @@ internal sealed class ArrayColumnCodec<TElement> : IColumnCodec
     /// <inheritdoc/>
     public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length, IColumnWriteState state)
     {
-        if (state is ArrayWriteState arrayState)
+        if (state is null)
         {
-            WriteBody(writer, column, start, length, arrayState);
+            WriteColumn(writer, column, start, length);
             return;
         }
 
-        WriteColumn(writer, column, start, length);
+        WriteBody(writer, column, start, length, state.Expect<ArrayWriteState>(TypeName));
     }
 
     // Writes this slice's offsets stream — one UInt64 per row, the cumulative element end after that row — then its

--- a/ClickHouse.Driver.Tcp/Types/Codecs/ArrayColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/ArrayColumnCodec.cs
@@ -202,16 +202,9 @@ internal sealed class ArrayColumnCodec<TElement> : IColumnCodec
 
     /// <inheritdoc/>
     // The Array's own state prefix is the inner codec's, written once over every element of the slice (a leaf inner
-    // has none). An outer composite (e.g. Variant) may forward its own column here rather than an Array one, since
-    // prefixes are data-independent; there is nothing to flatten then, so the inner emits its fixed prefix directly.
+    // has none). Callers that already hold the slice's state use the overload below; this one builds its own.
     public void WriteStatePrefix(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
     {
-        if (!IsArrayColumn(column))
-        {
-            inner.WriteStatePrefix(writer, column, start, length);
-            return;
-        }
-
         using ArrayWriteState state = BuildState(column, start, length);
         WriteStatePrefixCore(writer, state);
     }
@@ -302,10 +295,6 @@ internal sealed class ArrayColumnCodec<TElement> : IColumnCodec
             spanCodec.WriteValues(writer, source[start + i]);
         }
     }
-
-    // Whether the column is one this codec owns — the dense wire column or the ergonomic jagged form — as opposed
-    // to an outer composite's own column forwarded through the prefix phase.
-    private static bool IsArrayColumn(IColumn column) => column is ArrayValueColumn<TElement> || column is IColumn<TElement[]>;
 
     // Builds the scratch the prefix and body phases of one slice share: which elements the slice covers, plus
     // whatever the inner codec needs to write them.

--- a/ClickHouse.Driver.Tcp/Types/Codecs/ArrayColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/ArrayColumnCodec.cs
@@ -212,13 +212,6 @@ internal sealed class ArrayColumnCodec<TElement> : IColumnCodec
     /// <inheritdoc/>
     public void WriteStatePrefix(ClickHouseBinaryWriter writer, IColumn column, int start, int length, IColumnWriteState state)
     {
-        // A null state is the caller saying it has none to share, so build one for this call alone.
-        if (state is null)
-        {
-            WriteStatePrefix(writer, column, start, length);
-            return;
-        }
-
         WriteStatePrefixCore(writer, state.Expect<ArrayWriteState>(TypeName));
     }
 
@@ -240,12 +233,6 @@ internal sealed class ArrayColumnCodec<TElement> : IColumnCodec
     /// <inheritdoc/>
     public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length, IColumnWriteState state)
     {
-        if (state is null)
-        {
-            WriteColumn(writer, column, start, length);
-            return;
-        }
-
         WriteBody(writer, column, start, length, state.Expect<ArrayWriteState>(TypeName));
     }
 

--- a/ClickHouse.Driver.Tcp/Types/Codecs/NullableColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/NullableColumnCodec.cs
@@ -134,7 +134,11 @@ internal sealed class NullableColumnCodec : IColumnCodec
     public bool CanWrite(IColumn column) => innerCanWrite && ResolveWriteShape(column) is not null;
 
     /// <inheritdoc/>
-    public void WriteStatePrefix(ClickHouseBinaryWriter writer) => inner.WriteStatePrefix(writer);
+    // Every inner type supported today has a data-independent state prefix, so the outer column/slice is
+    // forwarded unchanged and ignored by the inner. A future data-dependent inner (e.g. Dynamic) will need the
+    // inner's own sliced value column projected here, landed with the prefix->data scratch work.
+    public void WriteStatePrefix(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
+        => inner.WriteStatePrefix(writer, column, start, length);
 
     /// <inheritdoc/>
     public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length)

--- a/ClickHouse.Driver.Tcp/Types/ColumnCodecExtensions.cs
+++ b/ClickHouse.Driver.Tcp/Types/ColumnCodecExtensions.cs
@@ -11,4 +11,41 @@ internal static class ColumnCodecExtensions
     /// <param name="column">The column whose values to write; must match the codec's element type.</param>
     public static void WriteColumn(this IColumnCodec codec, ClickHouseBinaryWriter writer, IColumn column)
         => codec.WriteColumn(writer, column, 0, column.RowCount);
+
+    /// <summary>Writes the state prefix for all of the column's rows — [0, <see cref="IColumn.RowCount"/>).</summary>
+    /// <param name="codec">The codec to write with.</param>
+    /// <param name="writer">The writer to encode into.</param>
+    /// <param name="column">The column whose prefix to write; must match the codec's element type.</param>
+    public static void WriteStatePrefix(this IColumnCodec codec, ClickHouseBinaryWriter writer, IColumn column)
+        => codec.WriteStatePrefix(writer, column, 0, column.RowCount);
+
+    /// <summary>
+    /// Writes the whole column the way the block layer does: compute the per-operation scratch, write the state
+    /// prefix and body sharing it, then dispose it. Use this for a codec whose prefix and body must share state
+    /// (a data-dependent prefix); the separate <see cref="WriteStatePrefix(IColumnCodec, ClickHouseBinaryWriter,
+    /// IColumn)"/> / <see cref="WriteColumn(IColumnCodec, ClickHouseBinaryWriter, IColumn)"/> pair does not.
+    /// </summary>
+    /// <param name="codec">The codec to write with.</param>
+    /// <param name="writer">The writer to encode into.</param>
+    /// <param name="column">The column to write; must match the codec's element type.</param>
+    public static void WriteFull(this IColumnCodec codec, ClickHouseBinaryWriter writer, IColumn column)
+    {
+        // A zero-row column has no state prefix and no body — skip both, exactly as the block writer does (some
+        // codecs, e.g. Nothing, treat an empty range as unwritable).
+        if (column.RowCount == 0)
+        {
+            return;
+        }
+
+        IColumnWriteState state = codec.BeginWrite(column, 0, column.RowCount);
+        try
+        {
+            codec.WriteStatePrefix(writer, column, 0, column.RowCount, state);
+            codec.WriteColumn(writer, column, 0, column.RowCount, state);
+        }
+        finally
+        {
+            state?.Dispose();
+        }
+    }
 }

--- a/ClickHouse.Driver.Tcp/Types/ColumnCodecRegistry.cs
+++ b/ClickHouse.Driver.Tcp/Types/ColumnCodecRegistry.cs
@@ -125,6 +125,9 @@ internal sealed class ColumnCodecRegistry
         // Nullable(T) wraps a child codec, resolved recursively through the registry.
         AddFactory("Nullable", static (TypeNode node, in ResolveContext context, ColumnCodecRegistry registry) => NullableColumnCodec.Create(node, context, registry));
 
+        // Array(T) wraps a child codec (offsets + flattened element values), resolved recursively.
+        AddFactory("Array", static (TypeNode node, in ResolveContext context, ColumnCodecRegistry registry) => ArrayColumnCodec.Create(node, context, registry));
+
         return new ColumnCodecRegistry(byName);
     }
 }

--- a/ClickHouse.Driver.Tcp/Types/ConcatColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/ConcatColumn.cs
@@ -1,0 +1,112 @@
+using System;
+
+namespace ClickHouse.Driver.Tcp.Types;
+
+/// <summary>
+/// A lazy write-path view that flattens the per-row arrays of an ergonomic jagged column
+/// (<see cref="IColumn{T}"/> of <c>T[]</c>) into one logical element sequence, so a composite (<c>Array</c>,
+/// <c>Map</c>, <c>Nested</c>) can hand its inner codec every element as a single contiguous-looking column —
+/// which a sectioned inner encoding (a null-map, a dictionary, nested offsets) needs so it emits its section
+/// once spanning the whole run — without copying the elements into a flat buffer first.
+///
+/// <para>
+/// The flat index of an element is mapped to its (row, offset-within-row) through the row offsets. Access is
+/// typically sequential, so a one-row cursor short-circuits the common case; an out-of-order access falls back
+/// to a binary search over the offsets. The view has no contiguous span (its elements live in separate row
+/// arrays), so it is read per element. It borrows the source: disposing it does nothing.
+/// </para>
+/// </summary>
+/// <typeparam name="T">The inner element type.</typeparam>
+internal sealed class ConcatColumn<T> : IColumn<T>
+{
+    private readonly IColumn<T[]> source;
+    private readonly int sliceStart;
+    private readonly int[] offsets;
+    private readonly int total;
+    private int hintRow;
+
+    /// <summary>Initializes a flattening view over the rows [<paramref name="sliceStart"/>, sliceStart + sliceRows) of <paramref name="source"/>.</summary>
+    /// <param name="typeName">The inner element type name the view reports (the inner codec's own type).</param>
+    /// <param name="source">The ergonomic jagged column.</param>
+    /// <param name="sliceStart">The first source row the view flattens.</param>
+    /// <param name="offsets">The slice-relative cumulative per-row element ends: length <c>sliceRows + 1</c>, <c>offsets[0] = 0</c>.</param>
+    /// <param name="total">The total element count in the slice (<c>offsets[sliceRows]</c>).</param>
+    public ConcatColumn(string typeName, IColumn<T[]> source, int sliceStart, int[] offsets, int total)
+    {
+        TypeName = typeName;
+        this.source = source;
+        this.sliceStart = sliceStart;
+        this.offsets = offsets;
+        this.total = total;
+    }
+
+    private int SliceRows => offsets.Length - 1;
+
+    /// <inheritdoc/>
+    public string Name => source.Name;
+
+    /// <inheritdoc/>
+    public string TypeName { get; }
+
+    /// <inheritdoc/>
+    public int RowCount => total;
+
+    /// <inheritdoc/>
+    public T this[int flat]
+    {
+        get
+        {
+            int row = RowOf(flat);
+            return source[sliceStart + row][flat - offsets[row]];
+        }
+    }
+
+    /// <inheritdoc/>
+    public object GetValue(int flat) => this[flat];
+
+    /// <summary>Not supported: the elements live in separate row arrays, so there is no single span.</summary>
+    /// <exception cref="NotSupportedException">Always — read the view per element.</exception>
+    public ReadOnlySpan<T> Values => throw new NotSupportedException($"{nameof(ConcatColumn<T>)} has no contiguous span; read it per element.");
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+    }
+
+    // Maps a flat element index to its source row: offsets[row] <= flat < offsets[row + 1]. Sequential access
+    // walks off the cached row cheaply; anything else binary-searches the offsets. Empty rows (equal consecutive
+    // offsets) hold no flat index, so the search naturally skips them.
+    private int RowOf(int flat)
+    {
+        int row = hintRow;
+        if (row < SliceRows && flat >= offsets[row] && flat < offsets[row + 1])
+        {
+            return row;
+        }
+
+        if (row + 1 < SliceRows && flat >= offsets[row + 1] && flat < offsets[row + 2])
+        {
+            hintRow = row + 1;
+            return row + 1;
+        }
+
+        // Largest row with offsets[row] <= flat, via an upper-bound search over the offset boundaries.
+        int lo = 0;
+        int hi = SliceRows;
+        while (lo < hi)
+        {
+            int mid = lo + ((hi - lo) >> 1);
+            if (offsets[mid] <= flat)
+            {
+                lo = mid + 1;
+            }
+            else
+            {
+                hi = mid;
+            }
+        }
+
+        hintRow = lo - 1;
+        return hintRow;
+    }
+}

--- a/ClickHouse.Driver.Tcp/Types/IArrayColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/IArrayColumn.cs
@@ -1,0 +1,39 @@
+using System;
+
+namespace ClickHouse.Driver.Tcp.Types;
+
+/// <summary>
+/// The zero-copy read surface of a decoded <c>Array(T)</c> column. An array column materializes each row as a
+/// freshly allocated <typeparamref name="TElement"/>[] (see the column's <c>Values</c>/indexer), which is
+/// convenient and lets the arrays outlive the block, but allocates one array per row. This interface exposes the
+/// underlying flat wire layout instead — the elements of every row concatenated end-to-end, plus the per-row
+/// offsets into that run — so a caller that only reads can iterate without allocating.
+///
+/// <para>
+/// Row <c>i</c>'s elements are <c>InnerValues.Slice(Offsets[i], Offsets[i + 1] - Offsets[i])</c>. Both spans are
+/// borrowed views over the owning block's storage: read them in place, and copy out (e.g. <c>ToArray()</c>) only
+/// what must outlive the block.
+/// </para>
+///
+/// <para>
+/// Extends the column contract for <typeparamref name="TElement"/>[] (so <see cref="IColumn{T}.Values"/> and the
+/// indexer give the allocating per-row arrays); obtain this zero-copy view by pattern-matching a column, e.g.
+/// <c>if (column is IArrayColumn&lt;uint&gt; array)</c>.
+/// </para>
+/// </summary>
+/// <typeparam name="TElement">The inner element type; each row is a run of <typeparamref name="TElement"/>.</typeparam>
+public interface IArrayColumn<TElement> : IColumn<TElement[]>
+{
+    /// <summary>
+    /// Every row's elements concatenated end-to-end — the flat wire layout, paired with <see cref="Offsets"/>. A
+    /// borrowed span valid only while the owning block is alive.
+    /// </summary>
+    ReadOnlySpan<TElement> InnerValues { get; }
+
+    /// <summary>
+    /// The per-row offsets into <see cref="InnerValues"/>: <c>[0]</c> is 0 and <c>[i + 1]</c> is the exclusive end
+    /// of row <c>i</c>'s slice; the span has one more entry than the column has rows. A borrowed span valid only
+    /// while the owning block is alive.
+    /// </summary>
+    ReadOnlySpan<int> Offsets { get; }
+}

--- a/ClickHouse.Driver.Tcp/Types/IArrayColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/IArrayColumn.cs
@@ -3,11 +3,11 @@ using System;
 namespace ClickHouse.Driver.Tcp.Types;
 
 /// <summary>
-/// The zero-copy read surface of a decoded <c>Array(T)</c> column. An array column materializes each row as a
+/// The columnar read surface of a decoded <c>Array(T)</c> column. An array column materializes each row as a
 /// freshly allocated <typeparamref name="TElement"/>[] (see the column's <c>Values</c>/indexer), which is
 /// convenient and lets the arrays outlive the block, but allocates one array per row. This interface exposes the
 /// underlying flat wire layout instead — the elements of every row concatenated end-to-end, plus the per-row
-/// offsets into that run — so a caller that only reads can iterate without allocating.
+/// offsets into that run — so a caller that only reads can iterate without allocating a row array.
 ///
 /// <para>
 /// Row <c>i</c>'s elements are <c>InnerValues.Slice(Offsets[i], Offsets[i + 1] - Offsets[i])</c>. Both spans are
@@ -30,13 +30,21 @@ public interface IArrayColumn<TElement> : IColumn<TElement[]>
     /// <see cref="InnerValues"/> would hand back materialized values: for <c>Array(Tuple(...))</c> the inner
     /// column pattern-matches to <see cref="ITupleColumn"/>, for <c>Array(Array(T))</c> to another
     /// <see cref="IArrayColumn{TElement}"/>, and so on, so a nested composite can be walked all the way down
-    /// without materializing an intermediate level. A borrowed view valid only while the owning block is alive.
+    /// without materializing an intermediate level. A borrowed view valid only while the owning block is alive —
+    /// it is the block's to dispose, never the caller's.
     /// </summary>
     IColumn<TElement> Inner { get; }
 
     /// <summary>
     /// Every row's elements concatenated end-to-end — the flat wire layout, paired with <see cref="Offsets"/>. A
     /// borrowed span valid only while the owning block is alive.
+    ///
+    /// <para>
+    /// Free only where <typeparamref name="TElement"/> is a fixed-width value type. For a string-like or composite
+    /// element the span's type is the <em>materialized</em> form, so producing it allocates per element — a
+    /// <c>string</c> each for <c>Array(String)</c>, an inner array each for <c>Array(Array(T))</c>. Prefer
+    /// <see cref="Inner"/> in those cases and recurse into the element type's own columnar view.
+    /// </para>
     /// </summary>
     ReadOnlySpan<TElement> InnerValues { get; }
 

--- a/ClickHouse.Driver.Tcp/Types/IArrayColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/IArrayColumn.cs
@@ -25,6 +25,16 @@ namespace ClickHouse.Driver.Tcp.Types;
 public interface IArrayColumn<TElement> : IColumn<TElement[]>
 {
     /// <summary>
+    /// The flat inner column itself — every row's elements concatenated end-to-end, as a column rather than a
+    /// span. Use this when <typeparamref name="TElement"/> is itself a composite and
+    /// <see cref="InnerValues"/> would hand back materialized values: for <c>Array(Tuple(...))</c> the inner
+    /// column pattern-matches to <see cref="ITupleColumn"/>, for <c>Array(Array(T))</c> to another
+    /// <see cref="IArrayColumn{TElement}"/>, and so on, so a nested composite can be walked all the way down
+    /// without materializing an intermediate level. A borrowed view valid only while the owning block is alive.
+    /// </summary>
+    IColumn<TElement> Inner { get; }
+
+    /// <summary>
     /// Every row's elements concatenated end-to-end — the flat wire layout, paired with <see cref="Offsets"/>. A
     /// borrowed span valid only while the owning block is alive.
     /// </summary>

--- a/ClickHouse.Driver.Tcp/Types/IColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/IColumnCodec.cs
@@ -93,11 +93,49 @@ internal interface IColumnCodec
     /// <returns><see langword="true"/> if <see cref="WriteColumn"/> accepts <paramref name="column"/>.</returns>
     bool CanWrite(IColumn column);
 
-    /// <summary>Writes the column's serialization state prefix, if any. Default: none.</summary>
+    /// <summary>
+    /// Computes any per-operation scratch this codec needs to write rows [<paramref name="start"/>,
+    /// <paramref name="start"/> + <paramref name="length"/>), shared across the following state-prefix and body
+    /// phases so a data-dependent prefix or an element-flattening composite does its discovery/flatten exactly
+    /// once. Default: none — the codec's prefix is absent or a fixed constant, so the phases share nothing.
+    /// When non-null, the returned state is passed to the state-aware
+    /// <see cref="WriteStatePrefix(ClickHouseBinaryWriter, IColumn, int, int, IColumnWriteState)"/> and
+    /// <see cref="WriteColumn(ClickHouseBinaryWriter, IColumn, int, int, IColumnWriteState)"/> overloads, and the
+    /// caller disposes it after the body.
+    /// </summary>
+    /// <param name="column">The column about to be written; must match this codec's element type.</param>
+    /// <param name="start">The zero-based first row the write will cover.</param>
+    /// <param name="length">The number of rows the write will cover.</param>
+    /// <returns>The per-operation write state, or <see langword="null"/> when the codec needs none.</returns>
+    IColumnWriteState BeginWrite(IColumn column, int start, int length) => null;
+
+    /// <summary>
+    /// Writes the column's serialization state prefix for rows [<paramref name="start"/>,
+    /// <paramref name="start"/> + <paramref name="length"/>), if any. Default: none. The slice is supplied
+    /// because a type whose prefix is data-dependent (its bytes derive from the values themselves) must see the
+    /// same rows the following body will write, and each block's prefix reflects only that block's rows. Types
+    /// whose prefix is a fixed constant — or absent — ignore these arguments.
+    /// </summary>
     /// <param name="writer">The writer to encode into.</param>
-    void WriteStatePrefix(ClickHouseBinaryWriter writer)
+    /// <param name="column">The column whose prefix to write; must match this codec's element type.</param>
+    /// <param name="start">The zero-based first row the following body will write.</param>
+    /// <param name="length">The number of rows the following body will write.</param>
+    void WriteStatePrefix(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
     {
     }
+
+    /// <summary>
+    /// Writes the state prefix reusing the scratch from <see cref="BeginWrite"/>. Defaults to the state-free
+    /// <see cref="WriteStatePrefix(ClickHouseBinaryWriter, IColumn, int, int)"/>; a codec that returns non-null
+    /// from <see cref="BeginWrite"/> overrides this to emit its data-dependent prefix from the shared state.
+    /// </summary>
+    /// <param name="writer">The writer to encode into.</param>
+    /// <param name="column">The column whose prefix to write; must match this codec's element type.</param>
+    /// <param name="start">The zero-based first row the following body will write.</param>
+    /// <param name="length">The number of rows the following body will write.</param>
+    /// <param name="state">The scratch from <see cref="BeginWrite"/>, or <see langword="null"/>.</param>
+    void WriteStatePrefix(ClickHouseBinaryWriter writer, IColumn column, int start, int length, IColumnWriteState state)
+        => WriteStatePrefix(writer, column, start, length);
 
     /// <summary>
     /// Writes rows [<paramref name="start"/>, <paramref name="start"/> + <paramref name="length"/>) of the
@@ -110,4 +148,18 @@ internal interface IColumnCodec
     /// <param name="start">The zero-based first row to write.</param>
     /// <param name="length">The number of rows to write.</param>
     void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length);
+
+    /// <summary>
+    /// Writes the column body reusing the scratch from <see cref="BeginWrite"/>. Defaults to the state-free
+    /// <see cref="WriteColumn(ClickHouseBinaryWriter, IColumn, int, int)"/>; a codec that returns non-null from
+    /// <see cref="BeginWrite"/> overrides this to write its body (discriminators, flattened elements) from the
+    /// shared state instead of recomputing it.
+    /// </summary>
+    /// <param name="writer">The writer to encode into.</param>
+    /// <param name="column">The column whose values to write; must match this codec's element type.</param>
+    /// <param name="start">The zero-based first row to write.</param>
+    /// <param name="length">The number of rows to write.</param>
+    /// <param name="state">The scratch from <see cref="BeginWrite"/>, or <see langword="null"/>.</param>
+    void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length, IColumnWriteState state)
+        => WriteColumn(writer, column, start, length);
 }

--- a/ClickHouse.Driver.Tcp/Types/IColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/IColumnCodec.cs
@@ -128,12 +128,20 @@ internal interface IColumnCodec
     /// Writes the state prefix reusing the scratch from <see cref="BeginWrite"/>. Defaults to the state-free
     /// <see cref="WriteStatePrefix(ClickHouseBinaryWriter, IColumn, int, int)"/>; a codec that returns non-null
     /// from <see cref="BeginWrite"/> overrides this to emit its data-dependent prefix from the shared state.
+    ///
+    /// <para>
+    /// A codec that overrides this requires <paramref name="state"/> to be the state its own
+    /// <see cref="BeginWrite"/> returned, and rejects anything else. Call this overload only with that state; to
+    /// write a slice without one, call the state-free overload, which builds and disposes its own. The two must
+    /// not both be reachable inside one codec — a state-aware path that quietly rebuilt a discarded state would
+    /// write correct bytes and hide the caller's mistake.
+    /// </para>
     /// </summary>
     /// <param name="writer">The writer to encode into.</param>
     /// <param name="column">The column whose prefix to write; must match this codec's element type.</param>
     /// <param name="start">The zero-based first row the following body will write.</param>
     /// <param name="length">The number of rows the following body will write.</param>
-    /// <param name="state">The scratch from <see cref="BeginWrite"/>, or <see langword="null"/>.</param>
+    /// <param name="state">The scratch from this codec's <see cref="BeginWrite"/>; null only for a codec that returns null from it.</param>
     void WriteStatePrefix(ClickHouseBinaryWriter writer, IColumn column, int start, int length, IColumnWriteState state)
         => WriteStatePrefix(writer, column, start, length);
 
@@ -159,7 +167,7 @@ internal interface IColumnCodec
     /// <param name="column">The column whose values to write; must match this codec's element type.</param>
     /// <param name="start">The zero-based first row to write.</param>
     /// <param name="length">The number of rows to write.</param>
-    /// <param name="state">The scratch from <see cref="BeginWrite"/>, or <see langword="null"/>.</param>
+    /// <param name="state">The scratch from this codec's <see cref="BeginWrite"/>; null only for a codec that returns null from it.</param>
     void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length, IColumnWriteState state)
         => WriteColumn(writer, column, start, length);
 }

--- a/ClickHouse.Driver.Tcp/Types/IColumnWriteState.cs
+++ b/ClickHouse.Driver.Tcp/Types/IColumnWriteState.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace ClickHouse.Driver.Tcp.Types;
+
+/// <summary>
+/// Per-operation scratch a codec computes once for one slice of one write, then reuses across the state-prefix
+/// and body phases of that same write. Most codecs need none: their prefix is absent or a fixed constant, so the
+/// prefix and body phases share nothing. A codec whose prefix is <em>data-dependent</em> — its bytes derive from
+/// the values themselves (the runtime type list a <c>Dynamic</c> column emits) — must discover that shape before
+/// writing the prefix and reuse it when writing the body; an element-flattening composite wrapping such a codec
+/// must likewise flatten its rows once and hand the same flattened column to both phases. That shared shape lives
+/// here.
+///
+/// <para>
+/// The write layer creates the state with <see cref="IColumnCodec.BeginWrite"/> before the prefix phase, passes
+/// it to <see cref="IColumnCodec.WriteStatePrefix(ClickHouseBinaryWriter, IColumn, int, int, IColumnWriteState)"/>
+/// then <see cref="IColumnCodec.WriteColumn(ClickHouseBinaryWriter, IColumn, int, int, IColumnWriteState)"/>, and
+/// disposes it after the body — returning any rented buffers to the pool. Codecs that need no scratch return
+/// <see langword="null"/> from <see cref="IColumnCodec.BeginWrite"/>, and the state-aware write overloads then
+/// fall back to the self-contained ones.
+/// </para>
+/// </summary>
+internal interface IColumnWriteState : IDisposable
+{
+}

--- a/ClickHouse.Driver.Tcp/Types/IColumnWriteState.cs
+++ b/ClickHouse.Driver.Tcp/Types/IColumnWriteState.cs
@@ -23,3 +23,27 @@ namespace ClickHouse.Driver.Tcp.Types;
 internal interface IColumnWriteState : IDisposable
 {
 }
+
+/// <summary>Helpers for consuming a write state handed back through <see cref="IColumnWriteState"/>.</summary>
+internal static class ColumnWriteStateExtensions
+{
+    /// <summary>
+    /// Narrows the shared scratch to the codec's own state type. A state of any other type means a composite paired
+    /// one codec's scratch with a different codec's column — a bug where it was opened, not something the receiving
+    /// codec can recover from, so this throws instead of quietly rebuilding a state and writing correct bytes that
+    /// hide it.
+    /// </summary>
+    /// <typeparam name="TState">The receiving codec's own state type.</typeparam>
+    /// <param name="state">The state to narrow.</param>
+    /// <param name="typeName">The receiving codec's ClickHouse type name, for the message.</param>
+    /// <returns><paramref name="state"/> as <typeparamref name="TState"/>.</returns>
+    /// <exception cref="ArgumentException"><paramref name="state"/> is null or another codec's state.</exception>
+    public static TState Expect<TState>(this IColumnWriteState state, string typeName)
+        where TState : class, IColumnWriteState
+        => state as TState
+            ?? throw new ArgumentException(
+                $"The codec for '{typeName}' needs a {typeof(TState).Name} write state but was given " +
+                $"{(state is null ? "null" : state.GetType().Name)}. Each child of a composite must be given the " +
+                "state its own BeginWrite returned, alongside the column that state was opened over.",
+                nameof(state));
+}

--- a/ClickHouse.Driver.Tcp/Types/IColumnWriteState.cs
+++ b/ClickHouse.Driver.Tcp/Types/IColumnWriteState.cs
@@ -17,7 +17,13 @@ namespace ClickHouse.Driver.Tcp.Types;
 /// then <see cref="IColumnCodec.WriteColumn(ClickHouseBinaryWriter, IColumn, int, int, IColumnWriteState)"/>, and
 /// disposes it after the body — returning any rented buffers to the pool. Codecs that need no scratch return
 /// <see langword="null"/> from <see cref="IColumnCodec.BeginWrite"/>, and the state-aware write overloads then
-/// fall back to the self-contained ones.
+/// default to the self-contained ones.
+///
+/// <para>
+/// A codec that does need scratch has exactly one way in per phase: the state-aware overload, given the state its
+/// own <see cref="IColumnCodec.BeginWrite"/> returned. It does not also accept null there and rebuild. Writing a
+/// slice without a shared state is what the state-free overloads are for; they build one and dispose it.
+/// </para>
 /// </para>
 /// </summary>
 internal interface IColumnWriteState : IDisposable


### PR DESCRIPTION
Stacked on `tcp/epic-i1-nullable`. Implements `Array(T)` for the TCP/Native client and — because the ergonomic write path needed it — finalizes the codec write interface.

## Write interface: `IColumnWriteState`

`Array` is the first codec whose state prefix and body must agree on work derived from the values, so `IColumnCodec` grows a per-slice scratch phase:

- **`BeginWrite(column, start, length)` → `IColumnWriteState`** (default `null`) — computed once per slice, handed to new state-aware `WriteStatePrefix`/`WriteColumn` overloads, disposed by the caller after the body. A codec needing no scratch returns null and those overloads fall back to the self-contained ones, so every existing codec is unchanged.
- **`WriteStatePrefix` now takes the column slice.** Each block's prefix reflects only that block's rows, and a type whose prefix is *data-dependent* (a future `Dynamic`'s runtime type list) must see the same rows the body will write. Fixed-prefix codecs ignore the arguments; `NullableColumnCodec` forwards them to its inner unchanged.
- `BlockWriter` drives `BeginWrite` → prefix → body → dispose per column. `ColumnCodecExtensions.WriteFull` does the same for callers outside the block layer.

## `Array(T)`

- **`ArrayColumnCodec<TElement>`** — delegates the state prefix to the inner codec, then reads/writes a per-row `num_rows × UInt64 LE` offsets stream (cumulative element ends) followed by the inner type's encoding for every element concatenated end-to-end. An empty column is zero bytes.
- **`ArrayValueColumn<TElement>`** — a flat inner column plus per-row offsets, each row materialized lazily as `TElement[]`. This is the wire's own layout, so it doubles as a **zero-copy write source** when a read-back column is re-inserted.
- **Ergonomic (jagged) write builds no flat buffer.** Per-row lengths are summed once into slice-relative offsets, then the inner is driven by its shape:
  - a **leaf** inner — the fixed-width types and `String`, i.e. those implementing the new internal `ISpanWritableCodec<T>` — takes each row as a contiguous run (a bulk blit for fixed-width), straight from the source arrays;
  - a **sectioned** inner (`Nullable`'s null-map, `LowCardinality`'s dictionary, a nested `Array`'s offsets) has to see every element as one column so each section is emitted once spanning the whole run — driving it row by row would interleave those sections and corrupt the stream. It gets **`ConcatColumn<T>`**, a lazy flattening view (row cursor, binary-search fallback), not a copy.
- The registry pipeline is non-generic (codecs come back as `IColumnCodec` and the inner element type arrives as a runtime `Type`), so a small non-generic `ArrayColumnCodec` factory closes the generic codec over the inner's element type — **one reflective instantiation per element type, cached as a constructor delegate**. The single `(IColumn<TElement>)` cast at the read boundary is the only cast this leaves. Composites recurse: `Array(Array(T))`, `Array(Nullable(T))`.

## New public API: `IArrayColumn<TElement>`

The columnar read surface of a decoded array column. `Values`/the indexer allocate a `TElement[]` per row; this exposes the flat wire layout instead — `InnerValues` + `Offsets`, where row `i` is `InnerValues.Slice(Offsets[i], Offsets[i + 1] - Offsets[i])` — so a read-only caller iterates without allocating a row array. `Inner` hands back the flat inner *column* so a nested composite (`Array(Array(T))`, later `Array(Tuple(...))`) can be walked all the way down without materializing intermediate levels. All borrowed views, valid only while the owning block is alive; `Offsets` is bounded to `RowCount + 1` rather than exposing the rented buffer's length.

## Insert memory bound

Blocks split by row count alone, so peak client memory during a large insert is held by the between-column flush backstop — which is now caller-tunable via a new `maxSendBufferBytes` parameter on the internal `InsertAsync` (default `BlockWriter.DefaultFlushThresholdBytes`, validated positive). A single column larger than the cap still buffers in full. Inserted before `handlers`, so it is source-breaking for positional callers of that internal API.

## Safety / correctness

- **Read**: offsets validated **monotonic** and **in-int-range** as they are decoded; malformed or oversized offsets throw `ClickHouseProtocolException`. The offsets stream's own byte length is checked against `Array.MaxLength` before renting.
- **Write**: the flattened element count is guarded against `Array.MaxLength` rather than truncating `long`→`int`. A null row throws an `ArgumentException` naming the row and pointing at `Array(Nullable(T))`.
- The read path's pooled buffers (offsets, wire scratch) are returned exactly once, and ownership transfers to the column only on success — the read-boundary cast sits inside the `try`, so an element-type mismatch leaks neither the buffer nor the inner column. The write path pools nothing.

## Tests

- **Unit** (`ArrayColumnCodecTests`) — trimmed to what a server round-trip cannot reach: corruption rejection (non-monotonic offsets, an offset past `int.MaxValue`), an empty column consuming no bytes, row access past `RowCount`, the short-offsets constructor guard, `CanWrite`/`ElementType`/`NullPlaceholder`, and the type-resolution errors.
- **Integration** — an `Array(T)` round-trip case for **every supported inner type** (all integer widths, enums, floats, bool, string, dates/datetimes/`DateTime64`, UUID, IPs, all decimal widths, intervals, BFloat16, Time/Time64), plus `Array(Array(T))`, `Array(Nullable(T))` and `Array(Array(Nullable(T)))`; jagged and dense columns split across blocks; a read-back dense column re-inserted; a server-generated array via `range()`; and the `IArrayColumn` zero-copy surface including nested recursion.
- `Nullable(Array(T))` is server-rejected, so `Array` is the one type without a `Nullable`-wrapped case; `Array(Nullable(T))` composes nullability the other way instead.
- One pre-existing test that used `Array` as its "unsupported type" example is repointed at `Tuple` (still unsupported).
- **Nesting depth** — a ladder of shapes from `Array(Array(UInt8))` to five levels, plus a `String` and a `Nullable(UInt32)` leaf under three, in `NestedArrayShape`. Every level of every shape carries an empty row and rows of uneven length, so no level's offsets stream is trivial. Reaching `Cases()` gives each shape the unsplit round-trip, the dense read-back re-insert, and the one-row-per-block slice; `NestedArrayInsertIntegrationTests` adds the case those cannot reach — a slice with a non-zero start **and** a length above one, at depth, for both the jagged and the dense form. Both were confirmed to fail when the slice arithmetic is broken: the dense set catches a missing offset rebase (previously caught only by a single depth-1 test), the jagged set a flattening view that ignores the slice's first row.

Full TCP suite green against a live server: **915 tests** (473 unit + 442 integration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

