### PR TITLE
TCP I3: Add Tuple(T1, ..., Tn) support

### DIFF
--- a/ClickHouse.Driver.Tcp.Tests/Integration/ColumnarReadSurfaceIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ColumnarReadSurfaceIntegrationTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using ClickHouse.Driver.Tcp.Format;
@@ -218,6 +219,87 @@ public class ColumnarReadSurfaceIntegrationTests
             Assert.That(innerOffsets, Is.EqualTo(new[] { 0, 1, 3, 4, 6 }), "four inner arrays, of lengths 1, 2, 1, 2");
             Assert.That(leafValues, Is.EqualTo(new[] { 0, 0, 1, 1, 1, 2 }), "the leaf run, reached without materializing a level");
             Assert.That(materialized, Is.EqualTo(new[] { new[] { new[] { 0 }, new[] { 0, 1 } }, new[] { new[] { 1 }, new[] { 1, 2 } } }));
+        });
+    }
+
+    [Test]
+    public async Task QueryAsync_NamedTupleColumn_ExposesPerElementChildColumnsThroughITupleColumn()
+    {
+        // A Tuple(...) is stored as its N element columns side by side, each as tall as the tuple. Reading one
+        // element through the materialized ValueTuple surface forces every other element to be decoded and boxed
+        // into the tuple too; ITupleColumn.Children hands back the element columns directly, so a caller that wants
+        // one field pays for one field. FieldNames carries the declared names, which the wire layout does not.
+        await using var connection = await TcpServerFixture.ConnectAsync(None);
+
+        bool matched = false;
+        int childCount = 0;
+        string[] fieldNames = null;
+        int[] childRowCounts = null;
+        int[] firstElement = null;
+        string[] secondElement = null;
+        (int, string)[] materialized = null;
+
+        await foreach (Block block in connection.QueryAsync(
+            "SELECT CAST((toInt32(number), concat('n', toString(number))), 'Tuple(a Int32, b String)') FROM system.numbers LIMIT 3",
+            cancellationToken: None))
+        {
+            IColumn column = block[0];
+            matched = column is ITupleColumn;
+
+            var tuple = (ITupleColumn)column;
+            childCount = tuple.Children.Count;
+            fieldNames = tuple.FieldNames?.ToArray();
+            childRowCounts = new[] { tuple.Children[0].RowCount, tuple.Children[1].RowCount };
+            firstElement = ((IColumn<int>)tuple.Children[0]).Values.ToArray();
+            secondElement = ((IColumn<string>)tuple.Children[1]).Values.ToArray();
+            materialized = ((IColumn<(int, string)>)column).Values.ToArray();
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(matched, Is.True);
+            Assert.That(childCount, Is.EqualTo(2), "one child per tuple element, in declaration order");
+            Assert.That(fieldNames, Is.EqualTo(new[] { "a", "b" }), "the declared names, aligned with Children");
+            Assert.That(childRowCounts, Is.EqualTo(new[] { 3, 3 }), "every child is exactly as tall as the tuple");
+            Assert.That(firstElement, Is.EqualTo(new[] { 0, 1, 2 }), "one element read without decoding the other");
+            Assert.That(secondElement, Is.EqualTo(new[] { "n0", "n1", "n2" }));
+            Assert.That(materialized, Is.EqualTo(new[] { (0, "n0"), (1, "n1"), (2, "n2") }));
+        });
+    }
+
+    [Test]
+    public async Task QueryAsync_UnnamedTupleWithCompositeElement_OmitsFieldNamesAndAllowsChildRecursion()
+    {
+        // Two things the named case cannot show: an unnamed tuple carries no names at all (FieldNames is null, not
+        // a list of nulls), and a child that is itself a composite pattern-matches to its own columnar view — so a
+        // Tuple(Array(Int32), ...) can be walked into without materializing the tuple or the array rows.
+        await using var connection = await TcpServerFixture.ConnectAsync(None);
+
+        bool hasFieldNames = true;
+        bool childIsArray = false;
+        int[] childOffsets = null;
+        int[] childInnerValues = null;
+
+        // Rows: ([], 'r0'), ([0], 'r1'), ([0, 1], 'r2').
+        await foreach (Block block in connection.QueryAsync(
+            "SELECT tuple(CAST(range(number), 'Array(Int32)'), concat('r', toString(number))) FROM system.numbers LIMIT 3",
+            cancellationToken: None))
+        {
+            var tuple = (ITupleColumn)block[0];
+            hasFieldNames = tuple.FieldNames is not null;
+
+            childIsArray = tuple.Children[0] is IArrayColumn<int>;
+            var child = (IArrayColumn<int>)tuple.Children[0];
+            childOffsets = child.Offsets.ToArray();
+            childInnerValues = child.InnerValues.ToArray();
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(hasFieldNames, Is.False, "an unnamed tuple reports no names rather than a list of nulls");
+            Assert.That(childIsArray, Is.True, "a composite child re-enters the columnar surface");
+            Assert.That(childOffsets, Is.EqualTo(new[] { 0, 0, 1, 3 }), "the child array's own per-row offsets");
+            Assert.That(childInnerValues, Is.EqualTo(new[] { 0, 0, 1 }));
         });
     }
 }

--- a/ClickHouse.Driver.Tcp.Tests/Types/ColumnCodecRegistryTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/ColumnCodecRegistryTests.cs
@@ -34,7 +34,7 @@ public class ColumnCodecRegistryTests
 
     [Test]
     public void Resolve_UnsupportedButWellFormedType_ThrowsNotSupported()
-        => Assert.Throws<NotSupportedException>(() => ColumnCodecRegistry.Default.Resolve("Tuple(String)", default));
+        => Assert.Throws<NotSupportedException>(() => ColumnCodecRegistry.Default.Resolve("Map(String, Int32)", default));
 
     [Test]
     public void Resolve_MalformedType_ThrowsFormat()

--- a/ClickHouse.Driver.Tcp.Tests/Types/TupleColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/TupleColumnCodecTests.cs
@@ -331,4 +331,61 @@ public class TupleColumnCodecTests
 
         Assert.That(((IColumn<(int, string, double, byte, short, bool, uint)>)read).Values.ToArray(), Is.EqualTo(expected));
     }
+
+    [Test]
+    public async Task Densify_FlatValueTupleColumn_ProducesDenseColumnThatRoundTrips()
+    {
+        // A flat ArrayColumn<ValueTuple> is un-transposed into one child column per element, so a later
+        // measure/write drives the children directly. It must surface the same rows and round-trip.
+        IColumnCodec codec = Resolve("Tuple(Int32, String)");
+        var rows = new (int, string)[] { (1, "a"), (2, "b"), (3, "c") };
+        var flat = new ArrayColumn<(int, string)>("c", "Tuple(Int32, String)", rows);
+
+        IColumn densified = codec.Densify(flat);
+
+        Assert.That(densified, Is.InstanceOf<ITupleColumn>());
+        var dense = (ITupleColumn)densified;
+        Assert.Multiple(() =>
+        {
+            Assert.That(dense.Children.Count, Is.EqualTo(2));
+            Assert.That(((IColumn<int>)dense.Children[0]).Values.ToArray(), Is.EqualTo(new[] { 1, 2, 3 }));
+            Assert.That(((IColumn<string>)dense.Children[1]).Values.ToArray(), Is.EqualTo(new[] { "a", "b", "c" }));
+            Assert.That(((IColumn<(int, string)>)densified).Values.ToArray(), Is.EqualTo(rows));
+        });
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, densified, "Tuple(Int32, String)", rows.Length);
+        Assert.That(((IColumn<(int, string)>)read).Values.ToArray(), Is.EqualTo(rows));
+    }
+
+    [Test]
+    public void Densify_FlatTupleWithArrayElement_DensifiesChildToDenseArray()
+    {
+        // A flat Tuple(Array(UInt8), String): densify un-transposes into per-child columns AND recurses, so the
+        // Array child becomes a dense ArrayValueColumn rather than a jagged ArrayColumn<byte[]>.
+        IColumnCodec codec = Resolve("Tuple(Array(UInt8), String)");
+        var rows = new (byte[], string)[] { (new byte[] { 1, 2 }, "x"), (new byte[] { 3 }, "y") };
+        var flat = new ArrayColumn<(byte[], string)>("c", "Tuple(Array(UInt8), String)", rows);
+
+        var dense = (ITupleColumn)codec.Densify(flat);
+        var arrayChild = (IColumn<byte[]>)dense.Children[0];
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(dense.Children[0], Is.InstanceOf<ArrayValueColumn<byte>>());
+            Assert.That(arrayChild[0], Is.EqualTo(new byte[] { 1, 2 }));
+            Assert.That(arrayChild[1], Is.EqualTo(new byte[] { 3 }));
+            Assert.That(((IColumn<string>)dense.Children[1]).Values.ToArray(), Is.EqualTo(new[] { "x", "y" }));
+        });
+    }
+
+    [Test]
+    public void Densify_AlreadyDenseColumn_ReturnsSameInstance()
+    {
+        // A dense TupleColumn whose children are already dense (leaf columns) has nothing to rebuild, so it is
+        // returned by reference.
+        IColumnCodec codec = Resolve("Tuple(Int32, String)");
+        var dense = new TupleColumn<int, string>("c", "Tuple(Int32, String)", new (int, string)[] { (1, "a"), (2, "b") });
+
+        Assert.That(codec.Densify(dense), Is.SameAs(dense));
+    }
 }

--- a/ClickHouse.Driver.Tcp.Tests/Types/TupleColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/TupleColumnCodecTests.cs
@@ -167,7 +167,7 @@ public class TupleColumnCodecTests
             Assert.That(codec.FixedRowByteSize, Is.Null);
             Assert.That(codec.MeasureRowBytes(dense, 0), Is.EqualTo(4 + (1 + 1))); // Int32 + (varint len + "a")
             Assert.That(codec.MeasureRowBytes(dense, 1), Is.EqualTo(4 + (1 + 4)));
-            Assert.That(codec.MeasureRowBytes(flat, 1), Is.EqualTo(4 + (1 + 4))); // flat path prices the same
+            Assert.That(codec.MeasureRowBytes(codec.TryDensify(flat, out _), 1), Is.EqualTo(4 + (1 + 4))); // flat densifies to the same
         });
     }
 
@@ -333,7 +333,7 @@ public class TupleColumnCodecTests
     }
 
     [Test]
-    public async Task Densify_FlatValueTupleColumn_ProducesDenseColumnThatRoundTrips()
+    public async Task TryDensify_FlatValueTupleColumn_ProducesDenseColumnThatRoundTrips()
     {
         // A flat ArrayColumn<ValueTuple> is un-transposed into one child column per element, so a later
         // measure/write drives the children directly. It must surface the same rows and round-trip.
@@ -341,7 +341,7 @@ public class TupleColumnCodecTests
         var rows = new (int, string)[] { (1, "a"), (2, "b"), (3, "c") };
         var flat = new ArrayColumn<(int, string)>("c", "Tuple(Int32, String)", rows);
 
-        IColumn densified = codec.Densify(flat);
+        IColumn densified = codec.TryDensify(flat, out _);
 
         Assert.That(densified, Is.InstanceOf<ITupleColumn>());
         var dense = (ITupleColumn)densified;
@@ -358,7 +358,7 @@ public class TupleColumnCodecTests
     }
 
     [Test]
-    public void Densify_FlatTupleWithArrayElement_DensifiesChildToDenseArray()
+    public void TryDensify_FlatTupleWithArrayElement_DensifiesChildToDenseArray()
     {
         // A flat Tuple(Array(UInt8), String): densify un-transposes into per-child columns AND recurses, so the
         // Array child becomes a dense ArrayValueColumn rather than a jagged ArrayColumn<byte[]>.
@@ -366,7 +366,7 @@ public class TupleColumnCodecTests
         var rows = new (byte[], string)[] { (new byte[] { 1, 2 }, "x"), (new byte[] { 3 }, "y") };
         var flat = new ArrayColumn<(byte[], string)>("c", "Tuple(Array(UInt8), String)", rows);
 
-        var dense = (ITupleColumn)codec.Densify(flat);
+        var dense = (ITupleColumn)codec.TryDensify(flat, out _);
         var arrayChild = (IColumn<byte[]>)dense.Children[0];
 
         Assert.Multiple(() =>
@@ -379,13 +379,65 @@ public class TupleColumnCodecTests
     }
 
     [Test]
-    public void Densify_AlreadyDenseColumn_ReturnsSameInstance()
+    public void TryDensify_AlreadyDenseColumn_ReturnsSameInstanceNotBuilt()
     {
         // A dense TupleColumn whose children are already dense (leaf columns) has nothing to rebuild, so it is
-        // returned by reference.
+        // returned by reference with built = false.
         IColumnCodec codec = Resolve("Tuple(Int32, String)");
         var dense = new TupleColumn<int, string>("c", "Tuple(Int32, String)", new (int, string)[] { (1, "a"), (2, "b") });
 
-        Assert.That(codec.Densify(dense), Is.SameAs(dense));
+        IColumn result = codec.TryDensify(dense, out bool built);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.SameAs(dense));
+            Assert.That(built, Is.False, "an all-dense tuple is borrowed, not rebuilt");
+        });
+    }
+
+    [Test]
+    public void TryDensify_DenseTupleWithOneErgonomicChild_DisposesOnlyRebuiltChildNotBorrowed()
+    {
+        // A dense TupleColumn whose child 0 is still ergonomic (a jagged ArrayColumn) while child 1 is already dense
+        // (a leaf): TryDensify rebuilds only child 0 into a fresh dense column and keeps child 1 by reference. Disposing
+        // the rebuilt wrapper must free the freshly built child 0 but leave the borrowed child 1 alone — it is still
+        // owned by the source column, so disposing it here would double-dispose it (returning pooled buffers twice).
+        IColumnCodec codec = Resolve("Tuple(Array(Int32), Int32)");
+        var ergonomicArray = new ArrayColumn<int[]>("c", "Array(Int32)", new[] { new[] { 1, 2 }, new[] { 3 } });
+        var borrowedLeaf = new DisposeSpyColumn<int>("c", "Int32", new[] { 9, 8 });
+        // The source borrows both children (this test owns them), like a caller-assembled dense tuple.
+        var source = new TupleColumn<int[], int>("c", "Tuple(Array(Int32), Int32)", new IColumn[] { ergonomicArray, borrowedLeaf }, null, rowCount: 2, ownsChildren: false);
+
+        IColumn densified = codec.TryDensify(source, out bool built);
+        Assert.That(built, Is.True, "child 0 was ergonomic, so a rebuild is expected");
+        Assert.That(densified, Is.Not.SameAs(source));
+        densified.Dispose();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(borrowedLeaf.DisposeCount, Is.EqualTo(0), "the borrowed, already-dense child must not be disposed by the rebuilt wrapper");
+            Assert.That(borrowedLeaf.Values.ToArray(), Is.EqualTo(new[] { 9, 8 }), "the borrowed child is still readable after disposing the wrapper");
+        });
+
+        ergonomicArray.Dispose();
+        borrowedLeaf.Dispose();
+    }
+
+    [Test]
+    public void RestrictOwnership_DisposesOnlyFlaggedChildren()
+    {
+        // The mechanism the partial densify rebuild relies on: after RestrictOwnership, Dispose frees exactly the
+        // children flagged true (the freshly built ones) and leaves the rest (borrowed) untouched.
+        var owned = new DisposeSpyColumn<int>("c", "Int32", new[] { 1 });
+        var borrowed = new DisposeSpyColumn<int>("c", "Int32", new[] { 2 });
+        var tuple = new TupleColumn<int, int>("c", "Tuple(Int32, Int32)", new IColumn[] { owned, borrowed }, null, rowCount: 1, ownsChildren: false);
+
+        tuple.RestrictOwnership(new[] { true, false });
+        tuple.Dispose();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(owned.DisposeCount, Is.EqualTo(1), "a flagged (freshly built) child must be disposed exactly once");
+            Assert.That(borrowed.DisposeCount, Is.EqualTo(0), "an unflagged (borrowed) child must not be disposed");
+        });
     }
 }

--- a/ClickHouse.Driver.Tcp.Tests/Types/TupleColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/TupleColumnCodecTests.cs
@@ -1,0 +1,334 @@
+using System;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Protocol;
+using ClickHouse.Driver.Tcp.Tests.Utilities;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Tests.Types;
+
+[TestFixture]
+public class TupleColumnCodecTests
+{
+    private static IColumnCodec Resolve(string type) => ColumnCodecRegistry.Default.Resolve(type, default);
+
+    [Test]
+    public async Task ReadColumn_WriteThenRead_FixedAndVariableElementsRoundTrip()
+    {
+        IColumnCodec codec = Resolve("Tuple(Int32, String)");
+        var expected = new (int, string)[] { (1, "a"), (-5, string.Empty), (int.MaxValue, "héllo✓") };
+        var column = new TupleColumn<int, string>("c", "Tuple(Int32, String)", expected);
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Tuple(Int32, String)", column.RowCount);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(read.TypeName, Is.EqualTo("Tuple(Int32, String)"));
+            Assert.That(read.RowCount, Is.EqualTo(3));
+            Assert.That(((IColumn<(int, string)>)read).Values.ToArray(), Is.EqualTo(expected));
+            Assert.That(read.GetValue(2), Is.EqualTo((int.MaxValue, "héllo✓")));
+        });
+    }
+
+    [Test]
+    public async Task ReadColumn_WriteThenRead_SingleElementTupleRoundTrips()
+    {
+        IColumnCodec codec = Resolve("Tuple(Int32)");
+        var expected = new[] { new ValueTuple<int>(1), new ValueTuple<int>(-2), new ValueTuple<int>(int.MinValue) };
+        var column = new TupleColumn<int>("c", "Tuple(Int32)", expected);
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Tuple(Int32)", column.RowCount);
+
+        Assert.That(((IColumn<ValueTuple<int>>)read).Values.ToArray(), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public async Task ReadColumn_WriteThenRead_NullableElementRoundTrips()
+    {
+        IColumnCodec codec = Resolve("Tuple(Nullable(UInt32), String)");
+        var expected = new (uint?, string)[] { (1u, "a"), (null, "b"), (3u, "c") };
+        var column = new TupleColumn<uint?, string>("c", "Tuple(Nullable(UInt32), String)", expected);
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Tuple(Nullable(UInt32), String)", column.RowCount);
+
+        Assert.That(((IColumn<(uint?, string)>)read).Values.ToArray(), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public async Task ReadColumn_WriteThenRead_NestedTupleRoundTrips()
+    {
+        IColumnCodec codec = Resolve("Tuple(Int32, Tuple(String, Float64))");
+        var expected = new (int, (string, double))[] { (1, ("a", 1.5)), (2, (string.Empty, -1.5e100)) };
+        var column = new TupleColumn<int, (string, double)>("c", "Tuple(Int32, Tuple(String, Float64))", expected);
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Tuple(Int32, Tuple(String, Float64))", column.RowCount);
+
+        Assert.That(((IColumn<(int, (string, double))>)read).Values.ToArray(), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public async Task ReadColumn_WriteThenRead_ArrayElementRoundTrips()
+    {
+        IColumnCodec codec = Resolve("Tuple(Array(UInt8), String)");
+        var expected = new (byte[], string)[] { (new byte[] { 1, 2 }, "a"), (Array.Empty<byte>(), "b") };
+        var column = new TupleColumn<byte[], string>("c", "Tuple(Array(UInt8), String)", expected);
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Tuple(Array(UInt8), String)", column.RowCount);
+
+        Assert.That(((IColumn<(byte[], string)>)read).Values.ToArray(), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public async Task ReadColumn_ArrayOfTuple_RoundTripsThroughFlatWritePath()
+    {
+        // Array(Tuple(...)) flattens the jagged tuple arrays into one flat ValueTuple column and hands it to the
+        // tuple codec, exercising the boxed per-element projection rather than the dense child-column path.
+        IColumnCodec codec = Resolve("Array(Tuple(Int32, String))");
+        var expected = new[]
+        {
+            new[] { (1, "a"), (2, "b") },
+            Array.Empty<(int, string)>(),
+            new[] { (3, "c") },
+        };
+        var column = new ArrayColumn<(int, string)[]>("c", "Array(Tuple(Int32, String))", expected);
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Array(Tuple(Int32, String))", column.RowCount);
+
+        Assert.That(((IColumn<(int, string)[]>)read).Values.ToArray(), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public async Task WriteColumn_FlatValueTupleColumn_RoundTripsViaProjection()
+    {
+        // A flat ArrayColumn<ValueTuple> is not an ITupleColumn, so it takes the ergonomic (boxed) write path.
+        IColumnCodec codec = Resolve("Tuple(Int32, String)");
+        var rows = new (int, string)[] { (1, "a"), (2, "bb"), (3, "ccc") };
+        var flat = new ArrayColumn<(int, string)>("c", "Tuple(Int32, String)", rows);
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, flat, "Tuple(Int32, String)", rows.Length);
+
+        Assert.That(((IColumn<(int, string)>)read).Values.ToArray(), Is.EqualTo(rows));
+    }
+
+    [Test]
+    public async Task ReadColumn_EmptyColumn_ReadsZeroRowsWithoutConsumingBytes()
+    {
+        IColumnCodec codec = Resolve("Tuple(Int32, String)");
+        var column = new TupleColumn<int, string>("c", "Tuple(Int32, String)", Array.Empty<(int, string)>());
+
+        byte[] bytes = await CodecTestHarness.WriteAsync(w => codec.WriteColumn(w, column, 0, 0));
+        Assert.That(bytes, Is.Empty, "a zero-row tuple writes no child values");
+
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(bytes);
+        using IColumn read = await codec.ReadColumnAsync(reader, "c", "Tuple(Int32, String)", 0, CodecTestHarness.None);
+        Assert.That(read.RowCount, Is.Zero);
+    }
+
+    [Test]
+    public async Task WriteColumn_SlicedRange_WritesOnlyThatSliceOfEachChild()
+    {
+        IColumnCodec codec = Resolve("Tuple(Int32, String)");
+        var full = new TupleColumn<int, string>("c", "Tuple(Int32, String)", new (int, string)[]
+        {
+            (1, "a"),
+            (2, "bb"),
+            (3, "ccc"),
+            (4, "d"),
+        });
+
+        byte[] bytes = await CodecTestHarness.WriteAsync(w => codec.WriteColumn(w, full, start: 1, length: 2));
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(bytes);
+        using IColumn read = await codec.ReadColumnAsync(reader, "c", "Tuple(Int32, String)", 2, CodecTestHarness.None);
+
+        Assert.That(((IColumn<(int, string)>)read).Values.ToArray(), Is.EqualTo(new (int, string)[] { (2, "bb"), (3, "ccc") }));
+    }
+
+    [Test]
+    public void MeasureRowBytes_AllFixedElements_IsConstantSumOfWidths()
+    {
+        IColumnCodec codec = Resolve("Tuple(Int32, UInt8)");
+        var column = new TupleColumn<int, byte>("c", "Tuple(Int32, UInt8)", new (int, byte)[] { (1, 2), (3, 4) });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(codec.FixedRowByteSize, Is.EqualTo(5)); // 4 (Int32) + 1 (UInt8)
+            Assert.That(codec.MeasureRowBytes(column, 0), Is.EqualTo(5));
+        });
+    }
+
+    [Test]
+    public void MeasureRowBytes_VariableElement_SumsPerChild()
+    {
+        IColumnCodec codec = Resolve("Tuple(Int32, String)");
+        var dense = new TupleColumn<int, string>("c", "Tuple(Int32, String)", new (int, string)[] { (1, "a"), (2, "bbbb") });
+        var flat = new ArrayColumn<(int, string)>("c", "Tuple(Int32, String)", new (int, string)[] { (1, "a"), (2, "bbbb") });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(codec.FixedRowByteSize, Is.Null);
+            Assert.That(codec.MeasureRowBytes(dense, 0), Is.EqualTo(4 + (1 + 1))); // Int32 + (varint len + "a")
+            Assert.That(codec.MeasureRowBytes(dense, 1), Is.EqualTo(4 + (1 + 4)));
+            Assert.That(codec.MeasureRowBytes(flat, 1), Is.EqualTo(4 + (1 + 4))); // flat path prices the same
+        });
+    }
+
+    [Test]
+    public void CanWrite_AcceptsDenseAndFlatMatchingTupleColumnsOnly()
+    {
+        IColumnCodec codec = Resolve("Tuple(Int32, String)");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(codec.CanWrite(new TupleColumn<int, string>("c", "Tuple(Int32, String)", new (int, string)[] { (1, "a") })), Is.True);
+            Assert.That(codec.CanWrite(new ArrayColumn<(int, string)>("c", "Tuple(Int32, String)", new (int, string)[] { (1, "a") })), Is.True);
+            Assert.That(codec.CanWrite(new ArrayColumn<(long, string)>("c", "Tuple(Int64, String)", new (long, string)[] { (1L, "a") })), Is.False);
+            Assert.That(codec.CanWrite(PrimitiveColumn<int>.FromValues("c", "Int32", new[] { 1 })), Is.False);
+        });
+    }
+
+    [Test]
+    public void ElementType_IsTheValueTupleOfElementTypes()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(Resolve("Tuple(Int32)").ElementType, Is.EqualTo(typeof(ValueTuple<int>)));
+            Assert.That(Resolve("Tuple(Int32, String)").ElementType, Is.EqualTo(typeof((int, string))));
+            Assert.That(Resolve("Tuple(a Int32, b String)").ElementType, Is.EqualTo(typeof((int, string))));
+            Assert.That(Resolve("Tuple(Int32, Tuple(String, Float64))").ElementType, Is.EqualTo(typeof((int, (string, double)))));
+            Assert.That(Resolve("Tuple(Array(UInt8), Nullable(Int32))").ElementType, Is.EqualTo(typeof((byte[], int?))));
+        });
+    }
+
+    [Test]
+    public void NullPlaceholder_IsTheDefaultValueTuple()
+        => Assert.That(Resolve("Tuple(Int32, String)").NullPlaceholder, Is.EqualTo((0, (string)null)));
+
+    [Test]
+    public void Resolve_UnnamedTuple_StampsFullTypeName()
+        => Assert.That(Resolve("Tuple(Int32, String)").TypeName, Is.EqualTo("Tuple(Int32, String)"));
+
+    [Test]
+    public void Resolve_NamedTuple_PreservesElementNamesInTypeName()
+        => Assert.That(Resolve("Tuple(a Int32, b String)").TypeName, Is.EqualTo("Tuple(a Int32, b String)"));
+
+    [Test]
+    public async Task ReadColumn_NamedTuple_CarriesElementNamesAsMetadata()
+    {
+        IColumnCodec codec = Resolve("Tuple(a Int32, b String)");
+        var column = new TupleColumn<int, string>("c", "Tuple(a Int32, b String)", new (int, string)[] { (1, "a") });
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Tuple(a Int32, b String)", 1);
+
+        Assert.That(((TupleColumnBase)read).FieldNames, Is.EqualTo(new[] { "a", "b" }));
+    }
+
+    [Test]
+    public async Task ReadColumn_NamedParametricElements_ResolveTypesAndRoundTrip()
+    {
+        // The element name is split off at the first space, so a named element whose type is itself parametric
+        // (`a Array(Int32)`, `b Nullable(String)`) must resolve the base type plus its arguments correctly.
+        const string type = "Tuple(a Array(Int32), b Nullable(String))";
+        IColumnCodec codec = Resolve(type);
+        var expected = new (int[], string)[] { (new[] { 1, 2, 3 }, "x"), (Array.Empty<int>(), null), (new[] { -1 }, string.Empty) };
+        var column = new TupleColumn<int[], string>("c", type, expected);
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, type, column.RowCount);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(codec.ElementType, Is.EqualTo(typeof((int[], string))));
+            Assert.That(codec.TypeName, Is.EqualTo(type));
+            Assert.That(((IColumn<(int[], string)>)read).Values.ToArray(), Is.EqualTo(expected));
+            Assert.That(((TupleColumnBase)read).FieldNames, Is.EqualTo(new[] { "a", "b" }));
+        });
+    }
+
+    [Test]
+    public void Resolve_NamedElementWithExtraWhitespace_ResolvesElementTypes()
+    {
+        // The name is split off at the first whitespace and the run before the type is skipped, so a hand-written
+        // type with extra spaces or a tab between name and type ("a  Int32", "b\tString") still resolves the base
+        // types instead of failing with a NotSupportedException on a base name carrying leading whitespace.
+        IColumnCodec codec = Resolve("Tuple(a  Int32, b\tString)");
+        Assert.That(codec.ElementType, Is.EqualTo(typeof((int, string))));
+    }
+
+    [Test]
+    public void CanWrite_NonWritableElement_IsFalse()
+    {
+        // A tuple over a non-writable element (Nothing) resolves for reads but must report it cannot be written.
+        IColumnCodec codec = Resolve("Tuple(Int32, Nothing)");
+        Assert.That(codec.CanWrite(PrimitiveColumn<int>.FromValues("c", "Int32", new[] { 1 })), Is.False);
+    }
+
+    [Test]
+    public void Resolve_NoElements_ThrowsFormat()
+        => Assert.Throws<FormatException>(() => Resolve("Tuple"));
+
+    [Test]
+    public void Resolve_TooManyElements_ThrowsNotSupported()
+        => Assert.Throws<NotSupportedException>(() => Resolve("Tuple(Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32)"));
+
+    [Test]
+    public void Resolve_UnsupportedElement_ThrowsNotSupported()
+        => Assert.Throws<NotSupportedException>(() => Resolve("Tuple(Int32, NoSuchType)"));
+
+    [Test]
+    public async Task ReadColumn_Arity3_RoundTripsViaValues()
+    {
+        IColumnCodec codec = Resolve("Tuple(Int32, String, Float64)");
+        var expected = new (int, string, double)[] { (1, "a", 1.5), (-2, string.Empty, -1.5e100) };
+        var column = new TupleColumn<int, string, double>("c", "Tuple(Int32, String, Float64)", expected);
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Tuple(Int32, String, Float64)", column.RowCount);
+
+        Assert.That(((IColumn<(int, string, double)>)read).Values.ToArray(), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public async Task ReadColumn_Arity4_RoundTripsViaValues()
+    {
+        IColumnCodec codec = Resolve("Tuple(Int32, String, Float64, UInt8)");
+        var expected = new (int, string, double, byte)[] { (1, "a", 1.5, 7), (-2, "bb", -3.5, 255) };
+        var column = new TupleColumn<int, string, double, byte>("c", "Tuple(Int32, String, Float64, UInt8)", expected);
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Tuple(Int32, String, Float64, UInt8)", column.RowCount);
+
+        Assert.That(((IColumn<(int, string, double, byte)>)read).Values.ToArray(), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public async Task ReadColumn_Arity5_RoundTripsViaValues()
+    {
+        IColumnCodec codec = Resolve("Tuple(Int32, String, Float64, UInt8, Int16)");
+        var expected = new (int, string, double, byte, short)[] { (1, "a", 1.5, 7, -3), (-2, "bb", -3.5, 255, short.MaxValue) };
+        var column = new TupleColumn<int, string, double, byte, short>("c", "Tuple(Int32, String, Float64, UInt8, Int16)", expected);
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Tuple(Int32, String, Float64, UInt8, Int16)", column.RowCount);
+
+        Assert.That(((IColumn<(int, string, double, byte, short)>)read).Values.ToArray(), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public async Task ReadColumn_Arity6_RoundTripsViaValues()
+    {
+        IColumnCodec codec = Resolve("Tuple(Int32, String, Float64, UInt8, Int16, Bool)");
+        var expected = new (int, string, double, byte, short, bool)[] { (1, "a", 1.5, 7, -3, true), (-2, "bb", -3.5, 255, short.MaxValue, false) };
+        var column = new TupleColumn<int, string, double, byte, short, bool>("c", "Tuple(Int32, String, Float64, UInt8, Int16, Bool)", expected);
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Tuple(Int32, String, Float64, UInt8, Int16, Bool)", column.RowCount);
+
+        Assert.That(((IColumn<(int, string, double, byte, short, bool)>)read).Values.ToArray(), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public async Task ReadColumn_Arity7_RoundTripsViaValues()
+    {
+        IColumnCodec codec = Resolve("Tuple(Int32, String, Float64, UInt8, Int16, Bool, UInt32)");
+        var expected = new (int, string, double, byte, short, bool, uint)[] { (1, "a", 1.5, 7, -3, true, 9u), (-2, "bb", -3.5, 255, short.MaxValue, false, uint.MaxValue) };
+        var column = new TupleColumn<int, string, double, byte, short, bool, uint>("c", "Tuple(Int32, String, Float64, UInt8, Int16, Bool, UInt32)", expected);
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Tuple(Int32, String, Float64, UInt8, Int16, Bool, UInt32)", column.RowCount);
+
+        Assert.That(((IColumn<(int, string, double, byte, short, bool, uint)>)read).Values.ToArray(), Is.EqualTo(expected));
+    }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Types/TupleColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/TupleColumnCodecTests.cs
@@ -143,35 +143,6 @@ public class TupleColumnCodecTests
     }
 
     [Test]
-    public void MeasureRowBytes_AllFixedElements_IsConstantSumOfWidths()
-    {
-        IColumnCodec codec = Resolve("Tuple(Int32, UInt8)");
-        var column = new TupleColumn<int, byte>("c", "Tuple(Int32, UInt8)", new (int, byte)[] { (1, 2), (3, 4) });
-
-        Assert.Multiple(() =>
-        {
-            Assert.That(codec.FixedRowByteSize, Is.EqualTo(5)); // 4 (Int32) + 1 (UInt8)
-            Assert.That(codec.MeasureRowBytes(column, 0), Is.EqualTo(5));
-        });
-    }
-
-    [Test]
-    public void MeasureRowBytes_VariableElement_SumsPerChild()
-    {
-        IColumnCodec codec = Resolve("Tuple(Int32, String)");
-        var dense = new TupleColumn<int, string>("c", "Tuple(Int32, String)", new (int, string)[] { (1, "a"), (2, "bbbb") });
-        var flat = new ArrayColumn<(int, string)>("c", "Tuple(Int32, String)", new (int, string)[] { (1, "a"), (2, "bbbb") });
-
-        Assert.Multiple(() =>
-        {
-            Assert.That(codec.FixedRowByteSize, Is.Null);
-            Assert.That(codec.MeasureRowBytes(dense, 0), Is.EqualTo(4 + (1 + 1))); // Int32 + (varint len + "a")
-            Assert.That(codec.MeasureRowBytes(dense, 1), Is.EqualTo(4 + (1 + 4)));
-            Assert.That(codec.MeasureRowBytes(codec.TryDensify(flat, out _), 1), Is.EqualTo(4 + (1 + 4))); // flat densifies to the same
-        });
-    }
-
-    [Test]
     public void CanWrite_AcceptsDenseAndFlatMatchingTupleColumnsOnly()
     {
         IColumnCodec codec = Resolve("Tuple(Int32, String)");
@@ -330,96 +301,6 @@ public class TupleColumnCodecTests
         using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Tuple(Int32, String, Float64, UInt8, Int16, Bool, UInt32)", column.RowCount);
 
         Assert.That(((IColumn<(int, string, double, byte, short, bool, uint)>)read).Values.ToArray(), Is.EqualTo(expected));
-    }
-
-    [Test]
-    public async Task TryDensify_FlatValueTupleColumn_ProducesDenseColumnThatRoundTrips()
-    {
-        // A flat ArrayColumn<ValueTuple> is un-transposed into one child column per element, so a later
-        // measure/write drives the children directly. It must surface the same rows and round-trip.
-        IColumnCodec codec = Resolve("Tuple(Int32, String)");
-        var rows = new (int, string)[] { (1, "a"), (2, "b"), (3, "c") };
-        var flat = new ArrayColumn<(int, string)>("c", "Tuple(Int32, String)", rows);
-
-        IColumn densified = codec.TryDensify(flat, out _);
-
-        Assert.That(densified, Is.InstanceOf<ITupleColumn>());
-        var dense = (ITupleColumn)densified;
-        Assert.Multiple(() =>
-        {
-            Assert.That(dense.Children.Count, Is.EqualTo(2));
-            Assert.That(((IColumn<int>)dense.Children[0]).Values.ToArray(), Is.EqualTo(new[] { 1, 2, 3 }));
-            Assert.That(((IColumn<string>)dense.Children[1]).Values.ToArray(), Is.EqualTo(new[] { "a", "b", "c" }));
-            Assert.That(((IColumn<(int, string)>)densified).Values.ToArray(), Is.EqualTo(rows));
-        });
-
-        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, densified, "Tuple(Int32, String)", rows.Length);
-        Assert.That(((IColumn<(int, string)>)read).Values.ToArray(), Is.EqualTo(rows));
-    }
-
-    [Test]
-    public void TryDensify_FlatTupleWithArrayElement_DensifiesChildToDenseArray()
-    {
-        // A flat Tuple(Array(UInt8), String): densify un-transposes into per-child columns AND recurses, so the
-        // Array child becomes a dense ArrayValueColumn rather than a jagged ArrayColumn<byte[]>.
-        IColumnCodec codec = Resolve("Tuple(Array(UInt8), String)");
-        var rows = new (byte[], string)[] { (new byte[] { 1, 2 }, "x"), (new byte[] { 3 }, "y") };
-        var flat = new ArrayColumn<(byte[], string)>("c", "Tuple(Array(UInt8), String)", rows);
-
-        var dense = (ITupleColumn)codec.TryDensify(flat, out _);
-        var arrayChild = (IColumn<byte[]>)dense.Children[0];
-
-        Assert.Multiple(() =>
-        {
-            Assert.That(dense.Children[0], Is.InstanceOf<ArrayValueColumn<byte>>());
-            Assert.That(arrayChild[0], Is.EqualTo(new byte[] { 1, 2 }));
-            Assert.That(arrayChild[1], Is.EqualTo(new byte[] { 3 }));
-            Assert.That(((IColumn<string>)dense.Children[1]).Values.ToArray(), Is.EqualTo(new[] { "x", "y" }));
-        });
-    }
-
-    [Test]
-    public void TryDensify_AlreadyDenseColumn_ReturnsSameInstanceNotBuilt()
-    {
-        // A dense TupleColumn whose children are already dense (leaf columns) has nothing to rebuild, so it is
-        // returned by reference with built = false.
-        IColumnCodec codec = Resolve("Tuple(Int32, String)");
-        var dense = new TupleColumn<int, string>("c", "Tuple(Int32, String)", new (int, string)[] { (1, "a"), (2, "b") });
-
-        IColumn result = codec.TryDensify(dense, out bool built);
-        Assert.Multiple(() =>
-        {
-            Assert.That(result, Is.SameAs(dense));
-            Assert.That(built, Is.False, "an all-dense tuple is borrowed, not rebuilt");
-        });
-    }
-
-    [Test]
-    public void TryDensify_DenseTupleWithOneErgonomicChild_DisposesOnlyRebuiltChildNotBorrowed()
-    {
-        // A dense TupleColumn whose child 0 is still ergonomic (a jagged ArrayColumn) while child 1 is already dense
-        // (a leaf): TryDensify rebuilds only child 0 into a fresh dense column and keeps child 1 by reference. Disposing
-        // the rebuilt wrapper must free the freshly built child 0 but leave the borrowed child 1 alone — it is still
-        // owned by the source column, so disposing it here would double-dispose it (returning pooled buffers twice).
-        IColumnCodec codec = Resolve("Tuple(Array(Int32), Int32)");
-        var ergonomicArray = new ArrayColumn<int[]>("c", "Array(Int32)", new[] { new[] { 1, 2 }, new[] { 3 } });
-        var borrowedLeaf = new DisposeSpyColumn<int>("c", "Int32", new[] { 9, 8 });
-        // The source borrows both children (this test owns them), like a caller-assembled dense tuple.
-        var source = new TupleColumn<int[], int>("c", "Tuple(Array(Int32), Int32)", new IColumn[] { ergonomicArray, borrowedLeaf }, null, rowCount: 2, ownsChildren: false);
-
-        IColumn densified = codec.TryDensify(source, out bool built);
-        Assert.That(built, Is.True, "child 0 was ergonomic, so a rebuild is expected");
-        Assert.That(densified, Is.Not.SameAs(source));
-        densified.Dispose();
-
-        Assert.Multiple(() =>
-        {
-            Assert.That(borrowedLeaf.DisposeCount, Is.EqualTo(0), "the borrowed, already-dense child must not be disposed by the rebuilt wrapper");
-            Assert.That(borrowedLeaf.Values.ToArray(), Is.EqualTo(new[] { 9, 8 }), "the borrowed child is still readable after disposing the wrapper");
-        });
-
-        ergonomicArray.Dispose();
-        borrowedLeaf.Dispose();
     }
 
     [Test]

--- a/ClickHouse.Driver.Tcp.Tests/Types/TupleColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/TupleColumnCodecTests.cs
@@ -232,4 +232,103 @@ public class TupleColumnCodecTests
             Assert.That(borrowed.DisposeCount, Is.EqualTo(0), "an unflagged (borrowed) child must not be disposed");
         });
     }
+
+    [Test]
+    public void Resolve_EmptyTuple_IsTheEmptyTupleCodec_AndABareTupleIsRejected()
+    {
+        // Tuple() and Tuple both parse to zero arguments, so only the argument list separates the legal
+        // zero-element tuple from a type naming no elements at all. Neither branch is reachable from a round-trip.
+        Assert.Multiple(() =>
+        {
+            IColumnCodec codec = Resolve("Tuple()");
+            Assert.That(codec.TypeName, Is.EqualTo("Tuple()"));
+            Assert.That(codec.ElementType, Is.EqualTo(typeof(ValueTuple)));
+            Assert.That(codec.NullPlaceholder, Is.EqualTo(default(ValueTuple)));
+            Assert.That(
+                () => Resolve("Tuple"),
+                Throws.TypeOf<FormatException>().With.Message.Contains("at least one element"));
+        });
+    }
+
+    [Test]
+    public void Resolve_NamedEmptyTupleElement_KeepsItsArgumentList()
+    {
+        // A named element arrives as one token ("y Tuple") that NamedElementParser has to split and rebuild into a
+        // node. Rebuilding must carry the argument list over rather than re-derive it from the argument count,
+        // which is zero here — otherwise the element becomes a bare, malformed Tuple and resolution throws.
+        Assert.Multiple(() =>
+        {
+            Assert.That(Resolve("Tuple(x Int32, y Tuple())").ElementType, Is.EqualTo(typeof((int, ValueTuple))));
+            Assert.That(Resolve("Tuple(x Int32, y Tuple())").TypeName, Is.EqualTo("Tuple(x Int32, y Tuple())"));
+            Assert.That(Resolve("Array(Tuple(y Tuple()))").ElementType, Is.EqualTo(typeof(ValueTuple<ValueTuple>[])));
+        });
+    }
+
+    [Test]
+    public async Task EmptyTuple_WritesOnePlaceholderBytePerRow_WithNoStatePrefix()
+    {
+        // The wire shape a round-trip cannot observe: the server ignores the placeholder byte's value, so only a
+        // byte-level assertion pins that the client emits one per row, emits the same ASCII '0' the server does,
+        // and writes no serialization state prefix.
+        IColumnCodec codec = Resolve("Tuple()");
+        var column = new ArrayColumn<ValueTuple>("c", "Tuple()", new ValueTuple[3]);
+
+        byte[] prefix = await CodecTestHarness.WriteAsync(w => codec.WriteStatePrefix(w, column, 0, 3));
+        byte[] body = await CodecTestHarness.WriteAsync(w => codec.WriteColumn(w, column, 0, 3));
+        byte[] slice = await CodecTestHarness.WriteSliceAsync(codec, column, 1, 2);
+        byte[] empty = await CodecTestHarness.WriteAsync(w => codec.WriteColumn(w, column, 0, 0));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(prefix, Is.Empty, "the empty tuple has no state prefix");
+            Assert.That(body, Is.EqualTo(new byte[] { (byte)'0', (byte)'0', (byte)'0' }));
+            Assert.That(slice, Is.EqualTo(new byte[] { (byte)'0', (byte)'0' }), "a slice writes one byte per row written");
+            Assert.That(empty, Is.Empty, "a zero-row write emits nothing");
+        });
+    }
+
+    [Test]
+    public async Task EmptyTuple_ReadColumn_ConsumesOneBytePerRow_AndLeavesTheStreamAligned()
+    {
+        // The read discards the placeholder bytes, so nothing downstream of it can prove they were consumed. The
+        // sentinel does: if the read stopped short the stream would be misaligned and the next column would be
+        // decoded from the wrong offset.
+        IColumnCodec codec = Resolve("Tuple()");
+        byte[] bytes = await CodecTestHarness.WriteAsync(w =>
+        {
+            w.WriteByte((byte)'0');
+            w.WriteByte((byte)'0');
+            w.WriteByte(0x7F);
+        });
+
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(bytes);
+        using IColumn column = await codec.ReadColumnAsync(reader, "c", "Tuple()", 2, CodecTestHarness.None);
+        byte sentinel = await reader.ReadByteAsync(CodecTestHarness.None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(column.RowCount, Is.EqualTo(2));
+            Assert.That(column.TypeName, Is.EqualTo("Tuple()"));
+            Assert.That(column.GetValue(0), Is.EqualTo(default(ValueTuple)));
+            Assert.That(((IColumn<ValueTuple>)column).Values.ToArray(), Is.EqualTo(new ValueTuple[2]));
+            Assert.That(sentinel, Is.EqualTo(0x7F), "the placeholder bytes must all be consumed");
+        });
+    }
+
+    [Test]
+    public void EmptyTuple_CanWrite_RejectsAnotherElementType()
+    {
+        // The write ignores the values entirely, so a mismatched column would otherwise be serialized as the right
+        // number of placeholder bytes instead of being refused.
+        IColumnCodec codec = Resolve("Tuple()");
+        var wrong = new ArrayColumn<int>("c", "Int32", new[] { 1, 2 });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(codec.CanWrite(new ArrayColumn<ValueTuple>("c", "Tuple()", new ValueTuple[1])), Is.True);
+            Assert.That(codec.CanWrite(wrong), Is.False);
+            Assert.ThrowsAsync<InvalidCastException>(
+                async () => await CodecTestHarness.WriteAsync(w => codec.WriteColumn(w, wrong, 0, 2)));
+        });
+    }
 }

--- a/ClickHouse.Driver.Tcp.Tests/Types/TupleColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/TupleColumnCodecTests.cs
@@ -190,13 +190,38 @@ public class TupleColumnCodecTests
         => Assert.Throws<NotSupportedException>(() => Resolve("Tuple(Int32, NoSuchType)"));
 
     [Test]
+    public void Constructor_ChildrenDisagreeingOnRowCount_Throws()
+    {
+        // A tuple stores one value per element per row, so its children are its height and no separate row count is
+        // accepted — those two can no longer disagree. What a caller can still get wrong is handing over children of
+        // different heights, which would otherwise surface much later as one child's out-of-range read partway
+        // through materializing a row.
+        var two = new ArrayColumn<int>("c", "Int32", new[] { 1, 2 });
+        var three = new ArrayColumn<int>("c", "Int32", new[] { 1, 2, 3 });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                () => new TupleColumn<int, int>("c", "Tuple(Int32, Int32)", new IColumn[] { two, three }, null, ownsChildren: false),
+                Throws.ArgumentException.With.Message.Contains("disagree on their row count"));
+            Assert.That(
+                () => new TupleColumn<int, int>("c", "Tuple(Int32, Int32)", Array.Empty<IColumn>(), null, ownsChildren: false),
+                Throws.ArgumentException.With.Message.Contains("at least one child"));
+            Assert.That(
+                new TupleColumn<int, int>("c", "Tuple(Int32, Int32)", new IColumn[] { two, two }, null, ownsChildren: false).RowCount,
+                Is.EqualTo(2),
+                "the row count comes from the children");
+        });
+    }
+
+    [Test]
     public void RestrictOwnership_DisposesOnlyFlaggedChildren()
     {
         // The mechanism the partial densify rebuild relies on: after RestrictOwnership, Dispose frees exactly the
         // children flagged true (the freshly built ones) and leaves the rest (borrowed) untouched.
         var owned = new DisposeSpyColumn<int>("c", "Int32", new[] { 1 });
         var borrowed = new DisposeSpyColumn<int>("c", "Int32", new[] { 2 });
-        var tuple = new TupleColumn<int, int>("c", "Tuple(Int32, Int32)", new IColumn[] { owned, borrowed }, null, rowCount: 1, ownsChildren: false);
+        var tuple = new TupleColumn<int, int>("c", "Tuple(Int32, Int32)", new IColumn[] { owned, borrowed }, null, ownsChildren: false);
 
         tuple.RestrictOwnership(new[] { true, false });
         tuple.Dispose();

--- a/ClickHouse.Driver.Tcp.Tests/Types/TupleColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/TupleColumnCodecTests.cs
@@ -12,101 +12,48 @@ public class TupleColumnCodecTests
     private static IColumnCodec Resolve(string type) => ColumnCodecRegistry.Default.Resolve(type, default);
 
     [Test]
-    public async Task ReadColumn_WriteThenRead_FixedAndVariableElementsRoundTrip()
+    public async Task Values_EveryArity_MaterializesEveryRow()
     {
-        IColumnCodec codec = Resolve("Tuple(Int32, String)");
-        var expected = new (int, string)[] { (1, "a"), (-5, string.Empty), (int.MaxValue, "héllo✓") };
-        var column = new TupleColumn<int, string>("c", "Tuple(Int32, String)", expected);
+        // TupleColumn has a separate lazily-built Values cache per arity — seven independent materialization
+        // loops. The integration comparison only ever calls GetValue(row), which takes the uncached branch, so
+        // none of those loops runs anywhere else. Row values per element type are covered against a real server
+        // by the Tuple cases in InsertRoundTripCase; this exists to touch all seven Values implementations, and
+        // the read column's stamped TypeName, which the integration comparison never inspects.
+        const string t1 = "Tuple(Int32)";
+        const string t2 = "Tuple(Int32, String)";
+        const string t3 = "Tuple(Int32, String, Float64)";
+        const string t4 = "Tuple(Int32, String, Float64, UInt8)";
+        const string t5 = "Tuple(Int32, String, Float64, UInt8, Int16)";
+        const string t6 = "Tuple(Int32, String, Float64, UInt8, Int16, Bool)";
+        const string t7 = "Tuple(Int32, String, Float64, UInt8, Int16, Bool, UInt32)";
 
-        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Tuple(Int32, String)", column.RowCount);
+        var a1 = new[] { new ValueTuple<int>(1), new ValueTuple<int>(int.MinValue) };
+        var a2 = new (int, string)[] { (1, "a"), (int.MaxValue, "héllo✓") };
+        var a3 = new (int, string, double)[] { (1, "a", 1.5), (-2, string.Empty, -1.5e100) };
+        var a4 = new (int, string, double, byte)[] { (1, "a", 1.5, 7), (-2, "bb", -3.5, 255) };
+        var a5 = new (int, string, double, byte, short)[] { (1, "a", 1.5, 7, -3), (-2, "bb", -3.5, 255, short.MaxValue) };
+        var a6 = new (int, string, double, byte, short, bool)[] { (1, "a", 1.5, 7, -3, true), (-2, "bb", -3.5, 255, short.MaxValue, false) };
+        var a7 = new (int, string, double, byte, short, bool, uint)[] { (1, "a", 1.5, 7, -3, true, 9u), (-2, "bb", -3.5, 255, short.MaxValue, false, uint.MaxValue) };
+
+        using IColumn r1 = await CodecTestHarness.RoundTripAsync(Resolve(t1), new TupleColumn<int>("c", t1, a1), t1, a1.Length);
+        using IColumn r2 = await CodecTestHarness.RoundTripAsync(Resolve(t2), new TupleColumn<int, string>("c", t2, a2), t2, a2.Length);
+        using IColumn r3 = await CodecTestHarness.RoundTripAsync(Resolve(t3), new TupleColumn<int, string, double>("c", t3, a3), t3, a3.Length);
+        using IColumn r4 = await CodecTestHarness.RoundTripAsync(Resolve(t4), new TupleColumn<int, string, double, byte>("c", t4, a4), t4, a4.Length);
+        using IColumn r5 = await CodecTestHarness.RoundTripAsync(Resolve(t5), new TupleColumn<int, string, double, byte, short>("c", t5, a5), t5, a5.Length);
+        using IColumn r6 = await CodecTestHarness.RoundTripAsync(Resolve(t6), new TupleColumn<int, string, double, byte, short, bool>("c", t6, a6), t6, a6.Length);
+        using IColumn r7 = await CodecTestHarness.RoundTripAsync(Resolve(t7), new TupleColumn<int, string, double, byte, short, bool, uint>("c", t7, a7), t7, a7.Length);
 
         Assert.Multiple(() =>
         {
-            Assert.That(read.TypeName, Is.EqualTo("Tuple(Int32, String)"));
-            Assert.That(read.RowCount, Is.EqualTo(3));
-            Assert.That(((IColumn<(int, string)>)read).Values.ToArray(), Is.EqualTo(expected));
-            Assert.That(read.GetValue(2), Is.EqualTo((int.MaxValue, "héllo✓")));
+            Assert.That(((IColumn<ValueTuple<int>>)r1).Values.ToArray(), Is.EqualTo(a1), "arity 1");
+            Assert.That(((IColumn<(int, string)>)r2).Values.ToArray(), Is.EqualTo(a2), "arity 2");
+            Assert.That(((IColumn<(int, string, double)>)r3).Values.ToArray(), Is.EqualTo(a3), "arity 3");
+            Assert.That(((IColumn<(int, string, double, byte)>)r4).Values.ToArray(), Is.EqualTo(a4), "arity 4");
+            Assert.That(((IColumn<(int, string, double, byte, short)>)r5).Values.ToArray(), Is.EqualTo(a5), "arity 5");
+            Assert.That(((IColumn<(int, string, double, byte, short, bool)>)r6).Values.ToArray(), Is.EqualTo(a6), "arity 6");
+            Assert.That(((IColumn<(int, string, double, byte, short, bool, uint)>)r7).Values.ToArray(), Is.EqualTo(a7), "arity 7");
+            Assert.That(r2.TypeName, Is.EqualTo(t2));
         });
-    }
-
-    [Test]
-    public async Task ReadColumn_WriteThenRead_SingleElementTupleRoundTrips()
-    {
-        IColumnCodec codec = Resolve("Tuple(Int32)");
-        var expected = new[] { new ValueTuple<int>(1), new ValueTuple<int>(-2), new ValueTuple<int>(int.MinValue) };
-        var column = new TupleColumn<int>("c", "Tuple(Int32)", expected);
-
-        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Tuple(Int32)", column.RowCount);
-
-        Assert.That(((IColumn<ValueTuple<int>>)read).Values.ToArray(), Is.EqualTo(expected));
-    }
-
-    [Test]
-    public async Task ReadColumn_WriteThenRead_NullableElementRoundTrips()
-    {
-        IColumnCodec codec = Resolve("Tuple(Nullable(UInt32), String)");
-        var expected = new (uint?, string)[] { (1u, "a"), (null, "b"), (3u, "c") };
-        var column = new TupleColumn<uint?, string>("c", "Tuple(Nullable(UInt32), String)", expected);
-
-        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Tuple(Nullable(UInt32), String)", column.RowCount);
-
-        Assert.That(((IColumn<(uint?, string)>)read).Values.ToArray(), Is.EqualTo(expected));
-    }
-
-    [Test]
-    public async Task ReadColumn_WriteThenRead_NestedTupleRoundTrips()
-    {
-        IColumnCodec codec = Resolve("Tuple(Int32, Tuple(String, Float64))");
-        var expected = new (int, (string, double))[] { (1, ("a", 1.5)), (2, (string.Empty, -1.5e100)) };
-        var column = new TupleColumn<int, (string, double)>("c", "Tuple(Int32, Tuple(String, Float64))", expected);
-
-        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Tuple(Int32, Tuple(String, Float64))", column.RowCount);
-
-        Assert.That(((IColumn<(int, (string, double))>)read).Values.ToArray(), Is.EqualTo(expected));
-    }
-
-    [Test]
-    public async Task ReadColumn_WriteThenRead_ArrayElementRoundTrips()
-    {
-        IColumnCodec codec = Resolve("Tuple(Array(UInt8), String)");
-        var expected = new (byte[], string)[] { (new byte[] { 1, 2 }, "a"), (Array.Empty<byte>(), "b") };
-        var column = new TupleColumn<byte[], string>("c", "Tuple(Array(UInt8), String)", expected);
-
-        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Tuple(Array(UInt8), String)", column.RowCount);
-
-        Assert.That(((IColumn<(byte[], string)>)read).Values.ToArray(), Is.EqualTo(expected));
-    }
-
-    [Test]
-    public async Task ReadColumn_ArrayOfTuple_RoundTripsThroughFlatWritePath()
-    {
-        // Array(Tuple(...)) flattens the jagged tuple arrays into one flat ValueTuple column and hands it to the
-        // tuple codec, exercising the boxed per-element projection rather than the dense child-column path.
-        IColumnCodec codec = Resolve("Array(Tuple(Int32, String))");
-        var expected = new[]
-        {
-            new[] { (1, "a"), (2, "b") },
-            Array.Empty<(int, string)>(),
-            new[] { (3, "c") },
-        };
-        var column = new ArrayColumn<(int, string)[]>("c", "Array(Tuple(Int32, String))", expected);
-
-        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Array(Tuple(Int32, String))", column.RowCount);
-
-        Assert.That(((IColumn<(int, string)[]>)read).Values.ToArray(), Is.EqualTo(expected));
-    }
-
-    [Test]
-    public async Task WriteColumn_FlatValueTupleColumn_RoundTripsViaProjection()
-    {
-        // A flat ArrayColumn<ValueTuple> is not an ITupleColumn, so it takes the ergonomic (boxed) write path.
-        IColumnCodec codec = Resolve("Tuple(Int32, String)");
-        var rows = new (int, string)[] { (1, "a"), (2, "bb"), (3, "ccc") };
-        var flat = new ArrayColumn<(int, string)>("c", "Tuple(Int32, String)", rows);
-
-        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, flat, "Tuple(Int32, String)", rows.Length);
-
-        Assert.That(((IColumn<(int, string)>)read).Values.ToArray(), Is.EqualTo(rows));
     }
 
     [Test]
@@ -208,7 +155,6 @@ public class TupleColumnCodecTests
         {
             Assert.That(codec.ElementType, Is.EqualTo(typeof((int[], string))));
             Assert.That(codec.TypeName, Is.EqualTo(type));
-            Assert.That(((IColumn<(int[], string)>)read).Values.ToArray(), Is.EqualTo(expected));
             Assert.That(((TupleColumnBase)read).FieldNames, Is.EqualTo(new[] { "a", "b" }));
         });
     }
@@ -242,66 +188,6 @@ public class TupleColumnCodecTests
     [Test]
     public void Resolve_UnsupportedElement_ThrowsNotSupported()
         => Assert.Throws<NotSupportedException>(() => Resolve("Tuple(Int32, NoSuchType)"));
-
-    [Test]
-    public async Task ReadColumn_Arity3_RoundTripsViaValues()
-    {
-        IColumnCodec codec = Resolve("Tuple(Int32, String, Float64)");
-        var expected = new (int, string, double)[] { (1, "a", 1.5), (-2, string.Empty, -1.5e100) };
-        var column = new TupleColumn<int, string, double>("c", "Tuple(Int32, String, Float64)", expected);
-
-        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Tuple(Int32, String, Float64)", column.RowCount);
-
-        Assert.That(((IColumn<(int, string, double)>)read).Values.ToArray(), Is.EqualTo(expected));
-    }
-
-    [Test]
-    public async Task ReadColumn_Arity4_RoundTripsViaValues()
-    {
-        IColumnCodec codec = Resolve("Tuple(Int32, String, Float64, UInt8)");
-        var expected = new (int, string, double, byte)[] { (1, "a", 1.5, 7), (-2, "bb", -3.5, 255) };
-        var column = new TupleColumn<int, string, double, byte>("c", "Tuple(Int32, String, Float64, UInt8)", expected);
-
-        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Tuple(Int32, String, Float64, UInt8)", column.RowCount);
-
-        Assert.That(((IColumn<(int, string, double, byte)>)read).Values.ToArray(), Is.EqualTo(expected));
-    }
-
-    [Test]
-    public async Task ReadColumn_Arity5_RoundTripsViaValues()
-    {
-        IColumnCodec codec = Resolve("Tuple(Int32, String, Float64, UInt8, Int16)");
-        var expected = new (int, string, double, byte, short)[] { (1, "a", 1.5, 7, -3), (-2, "bb", -3.5, 255, short.MaxValue) };
-        var column = new TupleColumn<int, string, double, byte, short>("c", "Tuple(Int32, String, Float64, UInt8, Int16)", expected);
-
-        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Tuple(Int32, String, Float64, UInt8, Int16)", column.RowCount);
-
-        Assert.That(((IColumn<(int, string, double, byte, short)>)read).Values.ToArray(), Is.EqualTo(expected));
-    }
-
-    [Test]
-    public async Task ReadColumn_Arity6_RoundTripsViaValues()
-    {
-        IColumnCodec codec = Resolve("Tuple(Int32, String, Float64, UInt8, Int16, Bool)");
-        var expected = new (int, string, double, byte, short, bool)[] { (1, "a", 1.5, 7, -3, true), (-2, "bb", -3.5, 255, short.MaxValue, false) };
-        var column = new TupleColumn<int, string, double, byte, short, bool>("c", "Tuple(Int32, String, Float64, UInt8, Int16, Bool)", expected);
-
-        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Tuple(Int32, String, Float64, UInt8, Int16, Bool)", column.RowCount);
-
-        Assert.That(((IColumn<(int, string, double, byte, short, bool)>)read).Values.ToArray(), Is.EqualTo(expected));
-    }
-
-    [Test]
-    public async Task ReadColumn_Arity7_RoundTripsViaValues()
-    {
-        IColumnCodec codec = Resolve("Tuple(Int32, String, Float64, UInt8, Int16, Bool, UInt32)");
-        var expected = new (int, string, double, byte, short, bool, uint)[] { (1, "a", 1.5, 7, -3, true, 9u), (-2, "bb", -3.5, 255, short.MaxValue, false, uint.MaxValue) };
-        var column = new TupleColumn<int, string, double, byte, short, bool, uint>("c", "Tuple(Int32, String, Float64, UInt8, Int16, Bool, UInt32)", expected);
-
-        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Tuple(Int32, String, Float64, UInt8, Int16, Bool, UInt32)", column.RowCount);
-
-        Assert.That(((IColumn<(int, string, double, byte, short, bool, uint)>)read).Values.ToArray(), Is.EqualTo(expected));
-    }
 
     [Test]
     public void RestrictOwnership_DisposesOnlyFlaggedChildren()

--- a/ClickHouse.Driver.Tcp.Tests/Types/TypeParserTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/TypeParserTests.cs
@@ -104,6 +104,44 @@ public class TypeParserTests
     }
 
     [Test]
+    public void Parse_EmptyArgumentList_HasNoArgumentsButKeepsTheParentheses()
+    {
+        // Tuple() is a legal ClickHouse type, so an empty argument list parses rather than throwing. Arguments is
+        // empty either way, so HasArgumentList is what separates it from a bare Tuple, and ToString must keep the
+        // parentheses or the two collapse into one string.
+        TypeNode node = TypeParser.Parse("Tuple()");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(node.Name, Is.EqualTo("Tuple"));
+            Assert.That(node.Arguments, Is.Empty);
+            Assert.That(node.HasArgumentList, Is.True);
+            Assert.That(node.ToString(), Is.EqualTo("Tuple()"));
+        });
+    }
+
+    [Test]
+    public void Parse_NameWithoutParentheses_HasNoArgumentList()
+    {
+        TypeNode node = TypeParser.Parse("Tuple");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(node.Arguments, Is.Empty);
+            Assert.That(node.HasArgumentList, Is.False);
+            Assert.That(node.ToString(), Is.EqualTo("Tuple"));
+        });
+    }
+
+    [Test]
+    public void Parse_EmptyArgumentListNested_RoundTripsThroughToString()
+    {
+        TypeNode node = TypeParser.Parse("Array(Tuple(Int32, Tuple()))");
+
+        Assert.That(node.ToString(), Is.EqualTo("Array(Tuple(Int32, Tuple()))"));
+    }
+
+    [Test]
     public void Parse_Null_ThrowsArgumentNull()
         => Assert.Throws<ArgumentNullException>(() => TypeParser.Parse(null));
 

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/DisposeSpyColumn.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/DisposeSpyColumn.cs
@@ -1,0 +1,37 @@
+using System;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Tests.Utilities;
+
+/// <summary>
+/// A minimal leaf <see cref="IColumn{T}"/> backed by an array that records how many times it was disposed. Used by
+/// the composite codec tests to assert a borrowed child column is not disposed by a wrapper that only borrows it,
+/// and that an owned child column is disposed exactly once.
+/// </summary>
+internal sealed class DisposeSpyColumn<T> : IColumn<T>
+{
+    private readonly T[] values;
+
+    public DisposeSpyColumn(string name, string typeName, T[] values)
+    {
+        Name = name;
+        TypeName = typeName;
+        this.values = values;
+    }
+
+    public int DisposeCount { get; private set; }
+
+    public string Name { get; }
+
+    public string TypeName { get; }
+
+    public int RowCount => values.Length;
+
+    public ReadOnlySpan<T> Values => values;
+
+    public T this[int row] => values[row];
+
+    public object GetValue(int row) => values[row];
+
+    public void Dispose() => DisposeCount++;
+}

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
@@ -335,6 +335,156 @@ public sealed class InsertRoundTripCase
         {
             yield return Same(shape.ToString(), shape.ClickHouseType, shape.BuildColumn);
         }
+
+        // Tuple(...): a heterogeneous fixed-arity composite serialized as N side-by-side element columns. The
+        // cases below collectively touch every supported element type across various arities (1 through the
+        // supported maximum of 7), then compose tuples with named elements, nesting, Nullable and Array elements,
+        // and an Array(Tuple(...)) that flattens through the tuple codec's per-element write path. Element names
+        // do not change the CLR value (a ValueTuple either way); they only ride along in the type string.
+        yield return Same(
+            "Tuple(Int32) [arity 1]",
+            "Tuple(Int32)",
+            name => new TupleColumn<int>(name, "Tuple(Int32)", new[] { new ValueTuple<int>(1), new ValueTuple<int>(int.MinValue), new ValueTuple<int>(int.MaxValue) }));
+
+        yield return Same(
+            "Tuple(UInt8, Int8, UInt16, Int16, UInt32, Int32)",
+            "Tuple(UInt8, Int8, UInt16, Int16, UInt32, Int32)",
+            name => new TupleColumn<byte, sbyte, ushort, short, uint, int>(name, "Tuple(UInt8, Int8, UInt16, Int16, UInt32, Int32)", new (byte, sbyte, ushort, short, uint, int)[]
+            {
+                (0, -128, 0, short.MinValue, 0, int.MinValue),
+                (255, 127, ushort.MaxValue, short.MaxValue, uint.MaxValue, int.MaxValue),
+            }));
+
+        yield return Same(
+            "Tuple(UInt64, Int64, UInt128, Int128, UInt256, Int256)",
+            "Tuple(UInt64, Int64, UInt128, Int128, UInt256, Int256)",
+            name => new TupleColumn<ulong, long, UInt128, Int128, UInt256, Int256>(name, "Tuple(UInt64, Int64, UInt128, Int128, UInt256, Int256)", new (ulong, long, UInt128, Int128, UInt256, Int256)[]
+            {
+                (0, long.MinValue, UInt128.Zero, Int128.MinValue, UInt256.Zero, Int256.FromBigInteger(-System.Numerics.BigInteger.Pow(2, 200))),
+                (ulong.MaxValue, long.MaxValue, UInt128.MaxValue, Int128.MaxValue, UInt256.FromBigInteger(System.Numerics.BigInteger.Pow(2, 200)), Int256.FromBigInteger(System.Numerics.BigInteger.Pow(2, 200))),
+            }));
+
+        yield return Same(
+            "Tuple(Float32, Float64, Bool, String)",
+            "Tuple(Float32, Float64, Bool, String)",
+            name => new TupleColumn<float, double, bool, string>(name, "Tuple(Float32, Float64, Bool, String)", new (float, double, bool, string)[]
+            {
+                (0f, 0d, false, string.Empty),
+                (1.5f, -1.5e100, true, "héllo✓"),
+            }));
+
+        yield return Same(
+            "Tuple(Enum8, Enum16)",
+            "Tuple(Enum8('a' = -1, 'b' = 127), Enum16('x' = -32768, 'y' = 32767))",
+            name => new TupleColumn<sbyte, short>(name, "Tuple(Enum8('a' = -1, 'b' = 127), Enum16('x' = -32768, 'y' = 32767))", new (sbyte, short)[]
+            {
+                (-1, -32768),
+                (127, 32767),
+            }));
+
+        // DateTime reads back a DateTimeOffset and DateTime64 a ClickHouseDateTime64; equality is by instant, so
+        // insert-as-UTC matches whatever offset the server presents on read.
+        yield return Same(
+            "Tuple(Date, Date32, DateTime, DateTime64(3), UUID)",
+            "Tuple(Date, Date32, DateTime, DateTime64(3), UUID)",
+            name => new TupleColumn<DateOnly, DateOnly, DateTimeOffset, ClickHouseDateTime64, Guid>(name, "Tuple(Date, Date32, DateTime, DateTime64(3), UUID)", new (DateOnly, DateOnly, DateTimeOffset, ClickHouseDateTime64, Guid)[]
+            {
+                (new DateOnly(1970, 1, 1), new DateOnly(1900, 1, 1), DateTimeOffset.UnixEpoch, new ClickHouseDateTime64(0L, 3, TimeSpan.Zero), Guid.Empty),
+                (new DateOnly(2149, 6, 6), new DateOnly(2299, 12, 31), new DateTimeOffset(2024, 1, 15, 10, 30, 0, TimeSpan.Zero), new ClickHouseDateTime64(1_700_000_000_123L, 3, TimeSpan.Zero), new Guid("00112233-4455-6677-8899-aabbccddeeff")),
+            }));
+
+        yield return Same(
+            "Tuple(IPv4, IPv6)",
+            "Tuple(IPv4, IPv6)",
+            name => new TupleColumn<IPAddress, IPAddress>(name, "Tuple(IPv4, IPv6)", new (IPAddress, IPAddress)[]
+            {
+                (IPAddress.Parse("0.0.0.0"), IPAddress.Parse("::")),
+                (IPAddress.Parse("255.255.255.255"), IPAddress.Parse("2001:db8::1")),
+            }));
+
+        // Decimal32/64 surface as System.Decimal, Decimal128/256 as ClickHouseDecimal — one tuple spans all four.
+        yield return Same(
+            "Tuple(Decimal(9, 2), Decimal(18, 4), Decimal(38, 10), Decimal(76, 20))",
+            "Tuple(Decimal(9, 2), Decimal(18, 4), Decimal(38, 10), Decimal(76, 20))",
+            name => new TupleColumn<decimal, decimal, ClickHouseDecimal, ClickHouseDecimal>(name, "Tuple(Decimal(9, 2), Decimal(18, 4), Decimal(38, 10), Decimal(76, 20))", new (decimal, decimal, ClickHouseDecimal, ClickHouseDecimal)[]
+            {
+                (0m, 0m, ParseWide("0"), ParseWide("0")),
+                (1.23m, 12345.6789m, ParseWide("12345.6789"), ParseWide("1.00000000000000000001")),
+            }));
+
+        yield return Same(
+            "Tuple(IntervalSecond, IntervalDay)",
+            "Tuple(IntervalSecond, IntervalDay)",
+            name => new TupleColumn<long, long>(name, "Tuple(IntervalSecond, IntervalDay)", new (long, long)[] { (0L, 0L), (-5L, 7L) }));
+
+        // Experimental element types need their enabling flag on the round-trip.
+        yield return Same(
+            "Tuple(BFloat16, Float32)",
+            "Tuple(BFloat16, Float32)",
+            name => new TupleColumn<float, float>(name, "Tuple(BFloat16, Float32)", new (float, float)[] { (0f, 0f), (1f, 1.5f), (-2f, 100f) }),
+            BFloat16Settings);
+
+        yield return Same(
+            "Tuple(Time, Time64(3))",
+            "Tuple(Time, Time64(3))",
+            name => new TupleColumn<TimeSpan, TimeSpan>(name, "Tuple(Time, Time64(3))", new (TimeSpan, TimeSpan)[]
+            {
+                (TimeSpan.Zero, TimeSpan.Zero),
+                (new TimeSpan(12, 34, 56), new TimeSpan(0, 1, 2, 3, 456)),
+            }),
+            TimeSettings);
+
+        // A named tuple: element names ride in the type string; the value is the same ValueTuple as the unnamed form.
+        yield return Same(
+            "Tuple(a Int32, b String) [named]",
+            "Tuple(a Int32, b String)",
+            name => new TupleColumn<int, string>(name, "Tuple(a Int32, b String)", new (int, string)[] { (1, "a"), (-5, string.Empty), (int.MaxValue, "héllo✓") }));
+
+        // A named tuple whose elements are themselves parametric — the name/type split must survive nesting.
+        yield return Same(
+            "Tuple(a Array(Int32), b Nullable(String)) [named parametric]",
+            "Tuple(a Array(Int32), b Nullable(String))",
+            name => new TupleColumn<int[], string>(name, "Tuple(a Array(Int32), b Nullable(String))", new (int[], string)[] { (new[] { 1, 2, 3 }, "x"), (Array.Empty<int>(), null), (new[] { -1 }, string.Empty) }));
+
+        // A nested tuple recurses through the same codec one level down.
+        yield return Same(
+            "Tuple(Int32, Tuple(String, Float64)) [nested]",
+            "Tuple(Int32, Tuple(String, Float64))",
+            name => new TupleColumn<int, (string, double)>(name, "Tuple(Int32, Tuple(String, Float64))", new (int, (string, double))[] { (1, ("a", 1.5)), (2, (string.Empty, -1.5e100)) }));
+
+        // Nullable elements, interleaving nulls with present values.
+        yield return Same(
+            "Tuple(Nullable(Int32), Nullable(String)) [nullable elements]",
+            "Tuple(Nullable(Int32), Nullable(String))",
+            name => new TupleColumn<int?, string>(name, "Tuple(Nullable(Int32), Nullable(String))", new (int?, string)[] { (1, "a"), (null, null), (int.MinValue, string.Empty) }));
+
+        // An Array element inside a tuple.
+        yield return Same(
+            "Tuple(Array(UInt32), String) [array element]",
+            "Tuple(Array(UInt32), String)",
+            name => new TupleColumn<uint[], string>(name, "Tuple(Array(UInt32), String)", new (uint[], string)[] { (new uint[] { 1, 2, 3 }, "a"), (Array.Empty<uint>(), "b") }));
+
+        // A max-arity (7) tuple mixing fixed-width and variable-width elements.
+        yield return Same(
+            "Tuple(UInt8, Int8, UInt16, Int16, UInt32, Int32, String) [arity 7]",
+            "Tuple(UInt8, Int8, UInt16, Int16, UInt32, Int32, String)",
+            name => new TupleColumn<byte, sbyte, ushort, short, uint, int, string>(name, "Tuple(UInt8, Int8, UInt16, Int16, UInt32, Int32, String)", new (byte, sbyte, ushort, short, uint, int, string)[]
+            {
+                (0, -128, 0, short.MinValue, 0, int.MinValue, string.Empty),
+                (255, 127, ushort.MaxValue, short.MaxValue, uint.MaxValue, int.MaxValue, "héllo✓"),
+            }));
+
+        // Array(Tuple(...)): the array flattens its jagged tuple rows into one values stream handed to the tuple
+        // codec, exercising the boxed per-element write path; empty rows and an empty column ride along.
+        yield return Same(
+            "Array(Tuple(Int32, String))",
+            "Array(Tuple(Int32, String))",
+            name => new ArrayColumn<(int, string)[]>(name, "Array(Tuple(Int32, String))", new[]
+            {
+                new[] { (1, "a"), (2, "b") },
+                Array.Empty<(int, string)>(),
+                new[] { (3, "c") },
+            }));
     }
 
     // Array(T) inserts and reads back the inner element arrays; the ergonomic jagged column doubles as expected.

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
@@ -382,15 +382,14 @@ public sealed class InsertRoundTripCase
                 (127, 32767),
             }));
 
-        // DateTime reads back a DateTimeOffset and DateTime64 a ClickHouseDateTime64; equality is by instant, so
-        // insert-as-UTC matches whatever offset the server presents on read.
+        // DateTime reads back the raw uint epoch seconds and DateTime64 the raw long count at the column scale.
         yield return Same(
             "Tuple(Date, Date32, DateTime, DateTime64(3), UUID)",
             "Tuple(Date, Date32, DateTime, DateTime64(3), UUID)",
-            name => new TupleColumn<DateOnly, DateOnly, DateTimeOffset, ClickHouseDateTime64, Guid>(name, "Tuple(Date, Date32, DateTime, DateTime64(3), UUID)", new (DateOnly, DateOnly, DateTimeOffset, ClickHouseDateTime64, Guid)[]
+            name => new TupleColumn<DateOnly, DateOnly, uint, long, Guid>(name, "Tuple(Date, Date32, DateTime, DateTime64(3), UUID)", new (DateOnly, DateOnly, uint, long, Guid)[]
             {
-                (new DateOnly(1970, 1, 1), new DateOnly(1900, 1, 1), DateTimeOffset.UnixEpoch, new ClickHouseDateTime64(0L, 3, TimeSpan.Zero), Guid.Empty),
-                (new DateOnly(2149, 6, 6), new DateOnly(2299, 12, 31), new DateTimeOffset(2024, 1, 15, 10, 30, 0, TimeSpan.Zero), new ClickHouseDateTime64(1_700_000_000_123L, 3, TimeSpan.Zero), new Guid("00112233-4455-6677-8899-aabbccddeeff")),
+                (new DateOnly(1970, 1, 1), new DateOnly(1900, 1, 1), 0u, 0L, Guid.Empty),
+                (new DateOnly(2149, 6, 6), new DateOnly(2299, 12, 31), (uint)new DateTimeOffset(2024, 1, 15, 10, 30, 0, TimeSpan.Zero).ToUnixTimeSeconds(), 1_700_000_000_123L, new Guid("00112233-4455-6677-8899-aabbccddeeff")),
             }));
 
         yield return Same(
@@ -427,10 +426,10 @@ public sealed class InsertRoundTripCase
         yield return Same(
             "Tuple(Time, Time64(3))",
             "Tuple(Time, Time64(3))",
-            name => new TupleColumn<TimeSpan, TimeSpan>(name, "Tuple(Time, Time64(3))", new (TimeSpan, TimeSpan)[]
+            name => new TupleColumn<int, long>(name, "Tuple(Time, Time64(3))", new (int, long)[]
             {
-                (TimeSpan.Zero, TimeSpan.Zero),
-                (new TimeSpan(12, 34, 56), new TimeSpan(0, 1, 2, 3, 456)),
+                (0, 0L),
+                ((12 * 3600) + (34 * 60) + 56, (((1 * 3600) + (2 * 60) + 3) * 1000L) + 456),
             }),
             TimeSettings);
 

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
@@ -495,6 +495,40 @@ public sealed class InsertRoundTripCase
                 (255, 127, ushort.MaxValue, short.MaxValue, uint.MaxValue, int.MaxValue, "héllo✓"),
             }));
 
+        // Tuple(): the zero-element tuple is a legal type, but it has none of the layout above — no element
+        // streams and no state prefix, just one placeholder byte per row, the way Nothing is serialized. Rows
+        // carry no data, so the row count is the only thing the round-trip can get wrong.
+        yield return Same(
+            "Tuple() [3 rows]",
+            "Tuple()",
+            name => new ArrayColumn<ValueTuple>(name, "Tuple()", new ValueTuple[3]));
+
+        // The empty tuple as an element of a real one: the per-element codec has to interleave a child that
+        // contributes a placeholder byte run between children that contribute values.
+        yield return Same(
+            "Tuple(Int32, Tuple(), String)",
+            "Tuple(Int32, Tuple(), String)",
+            name => new TupleColumn<int, ValueTuple, string>(name, "Tuple(Int32, Tuple(), String)", new (int, ValueTuple, string)[]
+            {
+                (1, default, "a"),
+                (int.MinValue, default, string.Empty),
+            }));
+
+        // Naming the empty element makes the parser rebuild its node from the glued "y Tuple" token, which is where
+        // the empty argument list is easiest to drop.
+        yield return Same(
+            "Tuple(x Int32, y Tuple())",
+            "Tuple(x Int32, y Tuple())",
+            name => new TupleColumn<int, ValueTuple>(name, "Tuple(x Int32, y Tuple())", new (int, ValueTuple)[]
+            {
+                (1, default),
+                (-2, default),
+            }));
+
+        // Array(Tuple()) flattens to a placeholder byte per element rather than per row, so the offsets are the
+        // only thing carrying the shape; an empty row and an uneven run keep them non-trivial.
+        yield return Arrays<ValueTuple>("Tuple()", new ValueTuple[2], Array.Empty<ValueTuple>(), new ValueTuple[1]);
+
         // Array(Tuple(...)): the array flattens its jagged tuple rows into one values stream handed to the tuple
         // codec, exercising the boxed per-element write path; empty rows and an empty column ride along.
         yield return Same(

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
@@ -346,6 +346,28 @@ public sealed class InsertRoundTripCase
             "Tuple(Int32)",
             name => new TupleColumn<int>(name, "Tuple(Int32)", new[] { new ValueTuple<int>(1), new ValueTuple<int>(int.MinValue), new ValueTuple<int>(int.MaxValue) }));
 
+        // Arity 3 was the one arity between 1 and 7 with no case at all.
+        yield return Same(
+            "Tuple(Int32, String, Float64) [arity 3]",
+            "Tuple(Int32, String, Float64)",
+            name => new TupleColumn<int, string, double>(name, "Tuple(Int32, String, Float64)", new (int, string, double)[]
+            {
+                (1, "a", 1.5),
+                (-2, string.Empty, -1.5e100),
+            }));
+
+        // A flat ArrayColumn<ValueTuple> is not an ITupleColumn, so a top-level Tuple supplied that way takes the
+        // ergonomic boxed per-element projection instead of the dense child-column path. Every other Tuple case
+        // builds the dense TupleColumn, so the projection was only reachable at top level from a unit test; the
+        // read still comes back dense, hence the differing expected builder.
+        var flatTupleRows = new (int, string)[] { (1, "a"), (2, "bb"), (3, "ccc") };
+        yield return new InsertRoundTripCase(
+            "Tuple(Int32, String) <- flat ArrayColumn",
+            "Tuple(Int32, String)",
+            name => new ArrayColumn<(int, string)>(name, "Tuple(Int32, String)", flatTupleRows),
+            name => new TupleColumn<int, string>(name, "Tuple(Int32, String)", flatTupleRows),
+            settings: null);
+
         yield return Same(
             "Tuple(UInt8, Int8, UInt16, Int16, UInt32, Int32)",
             "Tuple(UInt8, Int8, UInt16, Int16, UInt32, Int32)",

--- a/ClickHouse.Driver.Tcp/Types/Codecs/EmptyTupleColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/EmptyTupleColumnCodec.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Buffers;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Protocol;
+
+namespace ClickHouse.Driver.Tcp.Types.Codecs;
+
+/// <summary>
+/// A codec for the zero-element ClickHouse <c>Tuple()</c> — a legal column type, produced by expressions such as
+/// <c>tuple()</c> or a cast. It has no element streams, so it does not share the <see cref="TupleColumnCodec"/>
+/// layout: like <c>Nothing</c> (see <see cref="NothingColumnCodec"/>), it occupies exactly one placeholder byte
+/// per row and has no serialization state prefix. The byte carries no value — the server emits ASCII <c>'0'</c>
+/// and ignores what it reads back — so it is discarded on read and every row surfaces as the one value the type
+/// has, the empty <see cref="ValueTuple"/>.
+///
+/// <para>
+/// Kept separate from <see cref="TupleColumnCodec"/>, whose body is entirely a loop over child codecs: an empty
+/// tuple has no children, so the two share no code, and a tuple column could not hold the result anyway —
+/// <c>TupleColumnBase</c> takes its row count from its children. The duplication that does remain is the
+/// placeholder read, shared with <see cref="NothingColumnCodec"/>; merging those two is a cleanup of its own.
+/// </para>
+/// </summary>
+internal sealed class EmptyTupleColumnCodec : IColumnCodec
+{
+    /// <summary>The shared, stateless instance.</summary>
+    public static readonly EmptyTupleColumnCodec Instance = new();
+
+    // Matches what the server writes. Neither side reads the value back, so this only keeps a capture of the
+    // client's bytes indistinguishable from the server's.
+    private const byte Placeholder = (byte)'0';
+
+    private EmptyTupleColumnCodec()
+    {
+    }
+
+    /// <inheritdoc/>
+    public string TypeName => "Tuple()";
+
+    /// <inheritdoc/>
+    public Type ElementType => typeof(ValueTuple);
+
+    /// <inheritdoc/>
+    // The server rejects Nullable(Tuple(...)), so no null map ever selects a placeholder here; this satisfies the
+    // interface with the type's only value.
+    public object NullPlaceholder => default(ValueTuple);
+
+    /// <inheritdoc/>
+    public async ValueTask<IColumn> ReadColumnAsync(ClickHouseBinaryReader reader, string columnName, string columnType, int rowCount, CancellationToken cancellationToken)
+    {
+        // The placeholder bytes must be consumed to keep the stream aligned, even though they carry no value.
+        if (rowCount > 0)
+        {
+            byte[] rented = ArrayPool<byte>.Shared.Rent(rowCount);
+            try
+            {
+                await reader.ReadBytesAsync(rented.AsMemory(0, rowCount), cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(rented);
+            }
+        }
+
+        // Every element of a fresh ValueTuple[] already is the empty tuple, so there is nothing to fill in.
+        return new ArrayColumn<ValueTuple>(columnName, columnType, new ValueTuple[rowCount]);
+    }
+
+    /// <inheritdoc/>
+    public bool CanWrite(IColumn column) => column is IColumn<ValueTuple>;
+
+    /// <inheritdoc/>
+    public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
+    {
+        // The rows hold no data, so the column contributes only its element type: this cast rejects a mismatched
+        // one the way every other codec's write does.
+        _ = (IColumn<ValueTuple>)column;
+
+        for (int i = 0; i < length; i++)
+        {
+            writer.WriteByte(Placeholder);
+        }
+    }
+}

--- a/ClickHouse.Driver.Tcp/Types/Codecs/TupleColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/TupleColumnCodec.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Buffers;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -24,10 +23,10 @@ namespace ClickHouse.Driver.Tcp.Types.Codecs;
 /// </para>
 ///
 /// <para>
-/// On the write path a dense <c>TupleColumn</c> (whose child columns already exist) is serialized straight from
-/// those children with no copy. A flat column of <c>ValueTuple</c> values — the buffer an
-/// <c>Array(Tuple(...))</c> flattens into, or one a caller builds directly — is projected element-by-element into
-/// per-child columns, which boxes each element; this is the ergonomic, not the hot, path.
+/// On the write path the column is always the dense <c>TupleColumn</c> (whose child columns already exist),
+/// serialized straight from those children with no copy. A flat column of <c>ValueTuple</c> values — the buffer
+/// an <c>Array(Tuple(...))</c> flattens into, or one a caller builds directly — is un-transposed into the
+/// per-child columns by <see cref="TryDensify"/> before the write.
 /// </para>
 /// </summary>
 internal sealed class TupleColumnCodec : IColumnCodec
@@ -238,27 +237,13 @@ internal sealed class TupleColumnCodec : IColumnCodec
             return width;
         }
 
-        // The fixed-width children contribute the same bytes every row, so only the variable-width ones are
-        // measured per row.
+        // The column is always the dense TupleColumn (the pipeline densifies first). The fixed-width children
+        // contribute the same bytes every row, so only the variable-width ones are measured per row.
+        var dense = (ITupleColumn)column;
         long total = fixedChildrenByteTotal;
-        if (column is ITupleColumn dense && dense.Children.Count == children.Length)
-        {
-            foreach (int i in variableChildIndices)
-            {
-                total += children[i].MeasureRowBytes(dense.Children[i], row);
-            }
-
-            return total;
-        }
-
-        // Flat column: measure each variable child by projecting its single value into a one-row child column.
-        var tuple = (ITuple)column.GetValue(row);
-        var single = new object[1];
         foreach (int i in variableChildIndices)
         {
-            single[0] = tuple[i];
-            IColumn childColumn = childFlatBuilders[i](column.Name, children[i].TypeName, single, 1);
-            total += children[i].MeasureRowBytes(childColumn, 0);
+            total += children[i].MeasureRowBytes(dense.Children[i], row);
         }
 
         return total;
@@ -272,22 +257,24 @@ internal sealed class TupleColumnCodec : IColumnCodec
     // directly with no per-row projection. A flat column of ValueTuple values is un-transposed once: each element
     // position is gathered into a per-child column (boxing each value, as the ergonomic write path does), and each
     // child is itself densified so a nested composite element (e.g. Tuple(Array(T)) / Tuple(Nullable(T))) becomes
-    // dense too. An already-dense tuple recurses into its children and is returned unchanged (by reference) when
+    // dense too. An already-dense tuple recurses into its children and is returned unchanged (built = false) when
     // they are all already dense.
-    public IColumn Densify(IColumn column)
+    public IColumn TryDensify(IColumn column, out bool built)
     {
         int rowCount = column.RowCount;
 
         if (column is ITupleColumn tuple && tuple.Children.Count == children.Length)
         {
             IColumn[] densified = null;
+            bool[] owned = null;
             for (int i = 0; i < children.Length; i++)
             {
                 IColumn original = tuple.Children[i];
-                IColumn child = children[i].Densify(original);
-                if (densified is null && !ReferenceEquals(child, original))
+                IColumn child = children[i].TryDensify(original, out bool childBuilt);
+                if (densified is null && childBuilt)
                 {
                     densified = new IColumn[children.Length];
+                    owned = new bool[children.Length];
                     for (int j = 0; j < i; j++)
                     {
                         densified[j] = tuple.Children[j];
@@ -297,17 +284,25 @@ internal sealed class TupleColumnCodec : IColumnCodec
                 if (densified is not null)
                 {
                     densified[i] = child;
+                    owned[i] = childBuilt;
                 }
             }
 
             if (densified is null)
             {
+                built = false;
                 return column;
             }
 
-            // The rebuilt wrapper borrows its children — the freshly densified ones are unpooled and the unchanged
-            // ones are still owned by the original column — so it does not dispose them (ownsChildren: false).
-            return (IColumn)columnConstructor.Invoke(new object[] { column.Name, column.TypeName, densified, fieldNames, rowCount, false });
+            // The rebuilt wrapper mixes children: the freshly densified ones are new columns this wrapper must
+            // dispose, while the unchanged ones are borrowed by reference and stay owned by the source column. Build
+            // it borrowing everything (ownsChildren: false), then restrict disposal to exactly the columns we built
+            // — the per-child `owned` flags come straight from each child's `built` signal, so disposing the wrapper
+            // frees the new children without double-disposing the borrowed ones.
+            var rebuilt = (TupleColumnBase)columnConstructor.Invoke(new object[] { column.Name, column.TypeName, densified, fieldNames, rowCount, false });
+            rebuilt.RestrictOwnership(owned);
+            built = true;
+            return rebuilt;
         }
 
         var childBoxed = new object[children.Length][];
@@ -328,10 +323,11 @@ internal sealed class TupleColumnCodec : IColumnCodec
         var childColumns = new IColumn[children.Length];
         for (int i = 0; i < children.Length; i++)
         {
-            IColumn built = childFlatBuilders[i](column.Name, children[i].TypeName, childBoxed[i], rowCount);
-            childColumns[i] = children[i].Densify(built);
+            IColumn flat = childFlatBuilders[i](column.Name, children[i].TypeName, childBoxed[i], rowCount);
+            childColumns[i] = children[i].TryDensify(flat, out _);
         }
 
+        built = true;
         return (IColumn)columnConstructor.Invoke(new object[] { column.Name, column.TypeName, childColumns, fieldNames, rowCount, true });
     }
 
@@ -345,23 +341,20 @@ internal sealed class TupleColumnCodec : IColumnCodec
     }
 
     /// <inheritdoc/>
+    // Every column is densified before the write, so it is always the dense TupleColumn: each child column already
+    // exists, so serialize each with its own codec, no copy. The flat ValueTuple form was un-transposed into the
+    // per-child columns by TryDensify.
     public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
     {
-        if (column is ITupleColumn dense && dense.Children.Count == children.Length)
+        var dense = (ITupleColumn)column;
+        for (int i = 0; i < children.Length; i++)
         {
-            // Dense: each child column already exists, so serialize each with its own codec, no copy.
-            for (int i = 0; i < children.Length; i++)
-            {
-                children[i].WriteColumn(writer, dense.Children[i], start, length);
-            }
-
-            return;
+            children[i].WriteColumn(writer, dense.Children[i], start, length);
         }
-
-        WriteFlat(writer, column, start, length);
     }
 
-    // Builds a flat typed column from boxed element values — the ergonomic write path's per-child projection.
+    // Builds a flat typed column from boxed element values — the per-child projection TryDensify uses to un-transpose
+    // a flat ValueTuple column (reached through the cached childFlatBuilders delegates).
     private static IColumn BuildFlatColumn<T>(string name, string typeName, object[] boxed, int count)
     {
         var values = new T[count];
@@ -371,42 +364,5 @@ internal sealed class TupleColumnCodec : IColumnCodec
         }
 
         return new ArrayColumn<T>(name, typeName, values);
-    }
-
-    // Serializes a flat column of ValueTuple values by projecting each element position into a per-child column.
-    // Reads each row's tuple once and distributes its elements across the child buffers (boxing each element).
-    private void WriteFlat(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
-    {
-        int arity = children.Length;
-        var childBoxed = new object[arity][];
-        for (int i = 0; i < arity; i++)
-        {
-            childBoxed[i] = ArrayPool<object>.Shared.Rent(length);
-        }
-
-        try
-        {
-            for (int row = 0; row < length; row++)
-            {
-                var tuple = (ITuple)column.GetValue(start + row);
-                for (int i = 0; i < arity; i++)
-                {
-                    childBoxed[i][row] = tuple[i];
-                }
-            }
-
-            for (int i = 0; i < arity; i++)
-            {
-                IColumn childColumn = childFlatBuilders[i](column.Name, children[i].TypeName, childBoxed[i], length);
-                children[i].WriteColumn(writer, childColumn, 0, length);
-            }
-        }
-        finally
-        {
-            for (int i = 0; i < arity; i++)
-            {
-                ArrayPool<object>.Shared.Return(childBoxed[i], clearArray: true);
-            }
-        }
     }
 }

--- a/ClickHouse.Driver.Tcp/Types/Codecs/TupleColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/TupleColumnCodec.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using ClickHouse.Driver.Tcp.Protocol;
@@ -26,7 +25,7 @@ namespace ClickHouse.Driver.Tcp.Types.Codecs;
 /// On the write path the column is always the dense <c>TupleColumn</c> (whose child columns already exist),
 /// serialized straight from those children with no copy. A flat column of <c>ValueTuple</c> values — the buffer
 /// an <c>Array(Tuple(...))</c> flattens into, or one a caller builds directly — is un-transposed into the
-/// per-child columns by <see cref="TryDensify"/> before the write.
+/// per-child columns before the write.
 /// </para>
 /// </summary>
 internal sealed class TupleColumnCodec : IColumnCodec
@@ -63,15 +62,8 @@ internal sealed class TupleColumnCodec : IColumnCodec
     private readonly string[] fieldNames;
     private readonly ConstructorInfo columnConstructor;
     private readonly Type icolumnOfTupleType;
-    private readonly Func<string, string, object[], int, IColumn>[] childFlatBuilders;
+    private readonly Func<string, IColumn, int, IColumn>[] childProjectionBuilders;
     private readonly bool allChildrenWritable;
-    private readonly int? fixedRowByteSize;
-
-    // The per-row byte size splits into a constant part — the fixed-width children, summed once — and the
-    // variable-width children, which are the only ones that must be measured per row. Used when the tuple as a
-    // whole is variable-width (at least one variable child); an all-fixed tuple takes the FixedRowByteSize path.
-    private readonly long fixedChildrenByteTotal;
-    private readonly int[] variableChildIndices;
 
     private TupleColumnCodec(string typeName, IColumnCodec[] children, string[] fieldNames)
     {
@@ -104,45 +96,33 @@ internal sealed class TupleColumnCodec : IColumnCodec
             modifiers: null)
             ?? throw new InvalidOperationException($"The tuple column type '{columnType}' is missing its expected constructor.");
 
-        // One cached delegate per element for the "flat" write path (where the source is a single column of
-        // whole ValueTuple rows, not N per-element columns as in the dense path.)
-        // Writing it means un-transposing: gather each element position's values (pulled out of the
-        // tuples boxed) into a temporary per-element column the child codec can serialize. Each delegate is
-        // BuildFlatColumn<T> closed over the child's element type, signature
-        // (columnName, typeName, boxed values, count) -> IColumn. Closing the generics once here keeps that write
-        // path reflection-free.
-        childFlatBuilders = new Func<string, string, object[], int, IColumn>[arity];
-        MethodInfo builderTemplate = typeof(TupleColumnCodec).GetMethod(nameof(BuildFlatColumn), BindingFlags.NonPublic | BindingFlags.Static)
-            ?? throw new InvalidOperationException($"Method '{nameof(BuildFlatColumn)}' was not found.");
+        // One cached delegate per element for the ergonomic write path: a lazy projection view over the flat
+        // ValueTuple column that surfaces one element position, so the child codec writes strided through the tuples
+        // with no per-child buffer materialized. BuildProjection<T> closed over the child's element type once.
+        childProjectionBuilders = new Func<string, IColumn, int, IColumn>[arity];
+        MethodInfo projectionTemplate = typeof(TupleColumnCodec).GetMethod(nameof(BuildProjection), BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException($"Method '{nameof(BuildProjection)}' was not found.");
+
+        // Closed once per element type to build an empty child column for the up-front writability probe below.
+        MethodInfo emptyTemplate = typeof(TupleColumnCodec).GetMethod(nameof(BuildEmptyColumn), BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException($"Method '{nameof(BuildEmptyColumn)}' was not found.");
 
         bool writable = true;
-        int fixedTotal = 0;
-        var variableIndices = new List<int>();
         for (int i = 0; i < arity; i++)
         {
-            childFlatBuilders[i] = (Func<string, string, object[], int, IColumn>)builderTemplate
+            childProjectionBuilders[i] = (Func<string, IColumn, int, IColumn>)projectionTemplate
                 .MakeGenericMethod(elementTypes[i])
-                .CreateDelegate(typeof(Func<string, string, object[], int, IColumn>));
+                .CreateDelegate(typeof(Func<string, IColumn, int, IColumn>));
 
             // Probe writability with an empty child column so a Tuple over a non-writable element (e.g. Nothing)
             // is rejected up front rather than mid-write.
-            IColumn probe = childFlatBuilders[i](string.Empty, children[i].TypeName, Array.Empty<object>(), 0);
-            writable &= children[i].CanWrite(probe);
-
-            if (children[i].FixedRowByteSize is int width)
-            {
-                fixedTotal += width;
-            }
-            else
-            {
-                variableIndices.Add(i);
-            }
+            var emptyBuilder = (Func<string, IColumn>)emptyTemplate
+                .MakeGenericMethod(elementTypes[i])
+                .CreateDelegate(typeof(Func<string, IColumn>));
+            writable &= children[i].CanWrite(emptyBuilder(children[i].TypeName));
         }
 
         allChildrenWritable = writable;
-        fixedChildrenByteTotal = fixedTotal;
-        variableChildIndices = variableIndices.ToArray();
-        fixedRowByteSize = variableIndices.Count == 0 ? fixedTotal : null;
     }
 
     /// <inheritdoc/>
@@ -153,9 +133,6 @@ internal sealed class TupleColumnCodec : IColumnCodec
 
     /// <inheritdoc/>
     public object NullPlaceholder { get; }
-
-    /// <inheritdoc/>
-    public int? FixedRowByteSize => fixedRowByteSize;
 
     /// <summary>Builds a <c>Tuple(...)</c> codec, resolving each element's codec through the registry.</summary>
     /// <param name="node">The parsed <c>Tuple</c> node; its arguments are the element types (each optionally name-prefixed).</param>
@@ -230,139 +207,155 @@ internal sealed class TupleColumnCodec : IColumnCodec
     }
 
     /// <inheritdoc/>
-    public long MeasureRowBytes(IColumn column, int row)
-    {
-        if (fixedRowByteSize is int width)
-        {
-            return width;
-        }
-
-        // The column is always the dense TupleColumn (the pipeline densifies first). The fixed-width children
-        // contribute the same bytes every row, so only the variable-width ones are measured per row.
-        var dense = (ITupleColumn)column;
-        long total = fixedChildrenByteTotal;
-        foreach (int i in variableChildIndices)
-        {
-            total += children[i].MeasureRowBytes(dense.Children[i], row);
-        }
-
-        return total;
-    }
-
-    /// <inheritdoc/>
     public bool CanWrite(IColumn column) => allChildrenWritable && icolumnOfTupleType.IsInstanceOfType(column);
 
     /// <inheritdoc/>
-    // Produces the dense TupleColumn (one child column per element) so a later measure/write drives the children
-    // directly with no per-row projection. A flat column of ValueTuple values is un-transposed once: each element
-    // position is gathered into a per-child column (boxing each value, as the ergonomic write path does), and each
-    // child is itself densified so a nested composite element (e.g. Tuple(Array(T)) / Tuple(Nullable(T))) becomes
-    // dense too. An already-dense tuple recurses into its children and is returned unchanged (built = false) when
-    // they are all already dense.
-    public IColumn TryDensify(IColumn column, out bool built)
-    {
-        int rowCount = column.RowCount;
-
-        if (column is ITupleColumn tuple && tuple.Children.Count == children.Length)
-        {
-            IColumn[] densified = null;
-            bool[] owned = null;
-            for (int i = 0; i < children.Length; i++)
-            {
-                IColumn original = tuple.Children[i];
-                IColumn child = children[i].TryDensify(original, out bool childBuilt);
-                if (densified is null && childBuilt)
-                {
-                    densified = new IColumn[children.Length];
-                    owned = new bool[children.Length];
-                    for (int j = 0; j < i; j++)
-                    {
-                        densified[j] = tuple.Children[j];
-                    }
-                }
-
-                if (densified is not null)
-                {
-                    densified[i] = child;
-                    owned[i] = childBuilt;
-                }
-            }
-
-            if (densified is null)
-            {
-                built = false;
-                return column;
-            }
-
-            // The rebuilt wrapper mixes children: the freshly densified ones are new columns this wrapper must
-            // dispose, while the unchanged ones are borrowed by reference and stay owned by the source column. Build
-            // it borrowing everything (ownsChildren: false), then restrict disposal to exactly the columns we built
-            // — the per-child `owned` flags come straight from each child's `built` signal, so disposing the wrapper
-            // frees the new children without double-disposing the borrowed ones.
-            var rebuilt = (TupleColumnBase)columnConstructor.Invoke(new object[] { column.Name, column.TypeName, densified, fieldNames, rowCount, false });
-            rebuilt.RestrictOwnership(owned);
-            built = true;
-            return rebuilt;
-        }
-
-        var childBoxed = new object[children.Length][];
-        for (int i = 0; i < children.Length; i++)
-        {
-            childBoxed[i] = new object[rowCount];
-        }
-
-        for (int r = 0; r < rowCount; r++)
-        {
-            var tupleValue = (ITuple)column.GetValue(r);
-            for (int i = 0; i < children.Length; i++)
-            {
-                childBoxed[i][r] = tupleValue[i];
-            }
-        }
-
-        var childColumns = new IColumn[children.Length];
-        for (int i = 0; i < children.Length; i++)
-        {
-            IColumn flat = childFlatBuilders[i](column.Name, children[i].TypeName, childBoxed[i], rowCount);
-            childColumns[i] = children[i].TryDensify(flat, out _);
-        }
-
-        built = true;
-        return (IColumn)columnConstructor.Invoke(new object[] { column.Name, column.TypeName, childColumns, fieldNames, rowCount, true });
-    }
+    // Project each element position into its own child column once (dense children as-is, a flat tuple column
+    // distributed into per-child buffers), and create each child's own write state over it, so a data-dependent
+    // child (Dynamic) sees its real values at prefix time and the projection is not repeated between phases.
+    public IColumnWriteState BeginWrite(IColumn column, int start, int length) => BuildState(column, start, length);
 
     /// <inheritdoc/>
-    public void WriteStatePrefix(ClickHouseBinaryWriter writer)
+    public void WriteStatePrefix(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
     {
+        if (IsTupleColumn(column))
+        {
+            using TupleWriteState state = BuildState(column, start, length);
+            WriteStatePrefixCore(writer, state);
+            return;
+        }
+
+        // An outer composite forwarded its own column (its children's prefixes are written from its own slice);
+        // the children ignore it, preserving the prior contract for a Tuple nested in Variant/Map/Nested.
         foreach (IColumnCodec child in children)
         {
-            child.WriteStatePrefix(writer);
+            child.WriteStatePrefix(writer, column, start, length);
         }
     }
 
     /// <inheritdoc/>
-    // Every column is densified before the write, so it is always the dense TupleColumn: each child column already
-    // exists, so serialize each with its own codec, no copy. The flat ValueTuple form was un-transposed into the
-    // per-child columns by TryDensify.
+    public void WriteStatePrefix(ClickHouseBinaryWriter writer, IColumn column, int start, int length, IColumnWriteState state)
+    {
+        if (state is TupleWriteState tupleState)
+        {
+            WriteStatePrefixCore(writer, tupleState);
+            return;
+        }
+
+        WriteStatePrefix(writer, column, start, length);
+    }
+
+    /// <inheritdoc/>
+    // Every column is densified before the write, so it is always the dense TupleColumn; each child is written
+    // through its own codec and pre-built state, no copy. The flat ValueTuple form was un-transposed into the
+    // per-child columns before the write.
     public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
     {
-        var dense = (ITupleColumn)column;
+        using TupleWriteState state = BuildState(column, start, length);
+        WriteBodyCore(writer, state);
+    }
+
+    /// <inheritdoc/>
+    public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length, IColumnWriteState state)
+    {
+        if (state is TupleWriteState tupleState)
+        {
+            WriteBodyCore(writer, tupleState);
+            return;
+        }
+
+        WriteColumn(writer, column, start, length);
+    }
+
+    private void WriteStatePrefixCore(ClickHouseBinaryWriter writer, TupleWriteState state)
+    {
         for (int i = 0; i < children.Length; i++)
         {
-            children[i].WriteColumn(writer, dense.Children[i], start, length);
+            children[i].WriteStatePrefix(writer, state.ChildColumns[i], state.ChildStart, state.Length, state.ChildStates[i]);
         }
     }
 
-    // Builds a flat typed column from boxed element values — the per-child projection TryDensify uses to un-transpose
-    // a flat ValueTuple column (reached through the cached childFlatBuilders delegates).
-    private static IColumn BuildFlatColumn<T>(string name, string typeName, object[] boxed, int count)
+    private void WriteBodyCore(ClickHouseBinaryWriter writer, TupleWriteState state)
     {
-        var values = new T[count];
-        for (int i = 0; i < count; i++)
+        for (int i = 0; i < children.Length; i++)
         {
-            values[i] = (T)boxed[i];
+            children[i].WriteColumn(writer, state.ChildColumns[i], state.ChildStart, state.Length, state.ChildStates[i]);
+        }
+    }
+
+    private bool IsTupleColumn(IColumn column)
+        => (column is ITupleColumn dense && dense.Children.Count == children.Length) || icolumnOfTupleType.IsInstanceOfType(column);
+
+    // Builds the per-element write state for a slice. A dense tuple column exposes each child column directly; an
+    // ergonomic flat ValueTuple column is projected into one lazy per-element view per child (strided through the
+    // tuples, no per-child buffer materialized). Each child's own BeginWrite runs over its column so a data-
+    // dependent child (Dynamic) sees its real values at prefix time.
+    private TupleWriteState BuildState(IColumn column, int start, int length)
+    {
+        int arity = children.Length;
+        var childColumns = new IColumn[arity];
+        var childStates = new IColumnWriteState[arity];
+        ITupleColumn dense = column is ITupleColumn tuple && tuple.Children.Count == arity ? tuple : null;
+
+        int built = 0;
+        try
+        {
+            for (int i = 0; i < arity; i++)
+            {
+                childColumns[i] = dense is not null
+                    ? dense.Children[i]
+                    : childProjectionBuilders[i](children[i].TypeName, column, i);
+                childStates[i] = children[i].BeginWrite(childColumns[i], start, length);
+                built = i + 1;
+            }
+        }
+        catch
+        {
+            // A later child's BeginWrite throwing must not leak the states already built (each may hold rented buffers).
+            DisposeStates(childStates, built);
+            throw;
         }
 
-        return new ArrayColumn<T>(name, typeName, values);
+        return new TupleWriteState { ChildColumns = childColumns, ChildStart = start, Length = length, ChildStates = childStates };
+    }
+
+    // Disposes the first count child write states after a mid-construction failure, so their pooled buffers are
+    // returned rather than leaked.
+    private static void DisposeStates(IColumnWriteState[] states, int count)
+    {
+        for (int i = 0; i < count; i++)
+        {
+            states[i]?.Dispose();
+        }
+    }
+
+    // Builds an empty typed column for the constructor's up-front child writability probe.
+    private static IColumn BuildEmptyColumn<T>(string typeName)
+        => new ArrayColumn<T>(string.Empty, typeName, Array.Empty<T>());
+
+    // Builds the lazy per-element projection view the ergonomic write path hands each child codec (reached through
+    // the cached childProjectionBuilders delegates).
+    private static IColumn BuildProjection<T>(string typeName, IColumn source, int fieldIndex)
+        => new TupleFieldColumn<T>(typeName, source, fieldIndex);
+
+    // The per-element write state of one slice, shared across the prefix and body phases: each element's dense
+    // child column plus the child codec's own state.
+    private sealed class TupleWriteState : IColumnWriteState
+    {
+        public IColumn[] ChildColumns;
+        public int ChildStart;
+        public int Length;
+        public IColumnWriteState[] ChildStates;
+
+        public void Dispose()
+        {
+            if (ChildStates is not null)
+            {
+                foreach (IColumnWriteState state in ChildStates)
+                {
+                    state?.Dispose();
+                }
+            }
+        }
     }
 }

--- a/ClickHouse.Driver.Tcp/Types/Codecs/TupleColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/TupleColumnCodec.cs
@@ -268,6 +268,74 @@ internal sealed class TupleColumnCodec : IColumnCodec
     public bool CanWrite(IColumn column) => allChildrenWritable && icolumnOfTupleType.IsInstanceOfType(column);
 
     /// <inheritdoc/>
+    // Produces the dense TupleColumn (one child column per element) so a later measure/write drives the children
+    // directly with no per-row projection. A flat column of ValueTuple values is un-transposed once: each element
+    // position is gathered into a per-child column (boxing each value, as the ergonomic write path does), and each
+    // child is itself densified so a nested composite element (e.g. Tuple(Array(T)) / Tuple(Nullable(T))) becomes
+    // dense too. An already-dense tuple recurses into its children and is returned unchanged (by reference) when
+    // they are all already dense.
+    public IColumn Densify(IColumn column)
+    {
+        int rowCount = column.RowCount;
+
+        if (column is ITupleColumn tuple && tuple.Children.Count == children.Length)
+        {
+            IColumn[] densified = null;
+            for (int i = 0; i < children.Length; i++)
+            {
+                IColumn original = tuple.Children[i];
+                IColumn child = children[i].Densify(original);
+                if (densified is null && !ReferenceEquals(child, original))
+                {
+                    densified = new IColumn[children.Length];
+                    for (int j = 0; j < i; j++)
+                    {
+                        densified[j] = tuple.Children[j];
+                    }
+                }
+
+                if (densified is not null)
+                {
+                    densified[i] = child;
+                }
+            }
+
+            if (densified is null)
+            {
+                return column;
+            }
+
+            // The rebuilt wrapper borrows its children — the freshly densified ones are unpooled and the unchanged
+            // ones are still owned by the original column — so it does not dispose them (ownsChildren: false).
+            return (IColumn)columnConstructor.Invoke(new object[] { column.Name, column.TypeName, densified, fieldNames, rowCount, false });
+        }
+
+        var childBoxed = new object[children.Length][];
+        for (int i = 0; i < children.Length; i++)
+        {
+            childBoxed[i] = new object[rowCount];
+        }
+
+        for (int r = 0; r < rowCount; r++)
+        {
+            var tupleValue = (ITuple)column.GetValue(r);
+            for (int i = 0; i < children.Length; i++)
+            {
+                childBoxed[i][r] = tupleValue[i];
+            }
+        }
+
+        var childColumns = new IColumn[children.Length];
+        for (int i = 0; i < children.Length; i++)
+        {
+            IColumn built = childFlatBuilders[i](column.Name, children[i].TypeName, childBoxed[i], rowCount);
+            childColumns[i] = children[i].Densify(built);
+        }
+
+        return (IColumn)columnConstructor.Invoke(new object[] { column.Name, column.TypeName, childColumns, fieldNames, rowCount, true });
+    }
+
+    /// <inheritdoc/>
     public void WriteStatePrefix(ClickHouseBinaryWriter writer)
     {
         foreach (IColumnCodec child in children)

--- a/ClickHouse.Driver.Tcp/Types/Codecs/TupleColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/TupleColumnCodec.cs
@@ -1,0 +1,344 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Protocol;
+
+namespace ClickHouse.Driver.Tcp.Types.Codecs;
+
+/// <summary>
+/// A codec for the ClickHouse <c>Tuple(...)</c> column. A tuple is serialized as its N element columns side by
+/// side: every child's serialization-state prefix in order, then every child's full column body in order, each
+/// body holding exactly <c>num_rows</c> values (no offsets, no null map). This codec owns one child codec per
+/// element and drives each phase by looping the children — the layout, and therefore the codec, is independent
+/// of how many elements the tuple has.
+///
+/// <para>
+/// The decoded column is the typed <c>TupleColumn</c> for the element count (1 through 7), surfacing each row as
+/// a <c>ValueTuple</c> of the element values. Wider tuples are rejected rather than silently mishandled. Element
+/// names (a named tuple such as <c>Tuple(a Int32, b String)</c>) do not affect the wire layout or the CLR value;
+/// they are preserved in the type string and carried on the column as metadata.
+/// </para>
+///
+/// <para>
+/// On the write path a dense <c>TupleColumn</c> (whose child columns already exist) is serialized straight from
+/// those children with no copy. A flat column of <c>ValueTuple</c> values — the buffer an
+/// <c>Array(Tuple(...))</c> flattens into, or one a caller builds directly — is projected element-by-element into
+/// per-child columns, which boxes each element; this is the ergonomic, not the hot, path.
+/// </para>
+/// </summary>
+internal sealed class TupleColumnCodec : IColumnCodec
+{
+    private const int MaxArity = 7;
+
+    // The open generic ValueTuple / TupleColumn definitions indexed by arity (index 0 unused). MakeGenericType
+    // closes them over the child element types once, at resolution time.
+    private static readonly Type[] ValueTupleDefinitions =
+    {
+        null,
+        typeof(ValueTuple<>),
+        typeof(ValueTuple<,>),
+        typeof(ValueTuple<,,>),
+        typeof(ValueTuple<,,,>),
+        typeof(ValueTuple<,,,,>),
+        typeof(ValueTuple<,,,,,>),
+        typeof(ValueTuple<,,,,,,>),
+    };
+
+    private static readonly Type[] ColumnDefinitions =
+    {
+        null,
+        typeof(TupleColumn<>),
+        typeof(TupleColumn<,>),
+        typeof(TupleColumn<,,>),
+        typeof(TupleColumn<,,,>),
+        typeof(TupleColumn<,,,,>),
+        typeof(TupleColumn<,,,,,>),
+        typeof(TupleColumn<,,,,,,>),
+    };
+
+    private readonly IColumnCodec[] children;
+    private readonly string[] fieldNames;
+    private readonly ConstructorInfo columnConstructor;
+    private readonly Type icolumnOfTupleType;
+    private readonly Func<string, string, object[], int, IColumn>[] childFlatBuilders;
+    private readonly bool allChildrenWritable;
+    private readonly int? fixedRowByteSize;
+
+    // The per-row byte size splits into a constant part — the fixed-width children, summed once — and the
+    // variable-width children, which are the only ones that must be measured per row. Used when the tuple as a
+    // whole is variable-width (at least one variable child); an all-fixed tuple takes the FixedRowByteSize path.
+    private readonly long fixedChildrenByteTotal;
+    private readonly int[] variableChildIndices;
+
+    private TupleColumnCodec(string typeName, IColumnCodec[] children, string[] fieldNames)
+    {
+        TypeName = typeName;
+        this.children = children;
+        this.fieldNames = fieldNames;
+
+        int arity = children.Length;
+        var elementTypes = new Type[arity];
+        for (int i = 0; i < arity; i++)
+        {
+            elementTypes[i] = children[i].ElementType;
+        }
+
+        ElementType = ValueTupleDefinitions[arity].MakeGenericType(elementTypes);
+        icolumnOfTupleType = typeof(IColumn<>).MakeGenericType(ElementType);
+
+        // A tuple is never nested inside Nullable (the server rejects Nullable(Tuple(...))), so this placeholder
+        // is a formality the interface requires: the default ValueTuple of the element types.
+        NullPlaceholder = Activator.CreateInstance(ElementType);
+
+        // Cache the arity-specific column's constructor once. The parameter-type array is the exact signature of
+        // the children-based constructor, disambiguating it from the ValueTuple[] convenience one; NonPublic is
+        // what reaches it, since that constructor is internal.
+        Type columnType = ColumnDefinitions[arity].MakeGenericType(elementTypes);
+        columnConstructor = columnType.GetConstructor(
+            BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public,
+            binder: null,
+            new[] { typeof(string), typeof(string), typeof(IColumn[]), typeof(IReadOnlyList<string>), typeof(int), typeof(bool) },
+            modifiers: null)
+            ?? throw new InvalidOperationException($"The tuple column type '{columnType}' is missing its expected constructor.");
+
+        // One cached delegate per element for the "flat" write path (where the source is a single column of
+        // whole ValueTuple rows, not N per-element columns as in the dense path.)
+        // Writing it means un-transposing: gather each element position's values (pulled out of the
+        // tuples boxed) into a temporary per-element column the child codec can serialize. Each delegate is
+        // BuildFlatColumn<T> closed over the child's element type, signature
+        // (columnName, typeName, boxed values, count) -> IColumn. Closing the generics once here keeps that write
+        // path reflection-free.
+        childFlatBuilders = new Func<string, string, object[], int, IColumn>[arity];
+        MethodInfo builderTemplate = typeof(TupleColumnCodec).GetMethod(nameof(BuildFlatColumn), BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException($"Method '{nameof(BuildFlatColumn)}' was not found.");
+
+        bool writable = true;
+        int fixedTotal = 0;
+        var variableIndices = new List<int>();
+        for (int i = 0; i < arity; i++)
+        {
+            childFlatBuilders[i] = (Func<string, string, object[], int, IColumn>)builderTemplate
+                .MakeGenericMethod(elementTypes[i])
+                .CreateDelegate(typeof(Func<string, string, object[], int, IColumn>));
+
+            // Probe writability with an empty child column so a Tuple over a non-writable element (e.g. Nothing)
+            // is rejected up front rather than mid-write.
+            IColumn probe = childFlatBuilders[i](string.Empty, children[i].TypeName, Array.Empty<object>(), 0);
+            writable &= children[i].CanWrite(probe);
+
+            if (children[i].FixedRowByteSize is int width)
+            {
+                fixedTotal += width;
+            }
+            else
+            {
+                variableIndices.Add(i);
+            }
+        }
+
+        allChildrenWritable = writable;
+        fixedChildrenByteTotal = fixedTotal;
+        variableChildIndices = variableIndices.ToArray();
+        fixedRowByteSize = variableIndices.Count == 0 ? fixedTotal : null;
+    }
+
+    /// <inheritdoc/>
+    public string TypeName { get; }
+
+    /// <inheritdoc/>
+    public Type ElementType { get; }
+
+    /// <inheritdoc/>
+    public object NullPlaceholder { get; }
+
+    /// <inheritdoc/>
+    public int? FixedRowByteSize => fixedRowByteSize;
+
+    /// <summary>Builds a <c>Tuple(...)</c> codec, resolving each element's codec through the registry.</summary>
+    /// <param name="node">The parsed <c>Tuple</c> node; its arguments are the element types (each optionally name-prefixed).</param>
+    /// <param name="context">The resolution context, forwarded to each element codec's factory.</param>
+    /// <param name="registry">The registry used to resolve the element codecs.</param>
+    /// <returns>The codec.</returns>
+    /// <exception cref="FormatException">The tuple has no elements.</exception>
+    /// <exception cref="NotSupportedException">The tuple has more elements than this client supports.</exception>
+    public static TupleColumnCodec Create(TypeNode node, in ResolveContext context, ColumnCodecRegistry registry)
+    {
+        if (node.Arguments.Count == 0)
+        {
+            throw new FormatException($"Tuple type '{node}' must have at least one element type argument.");
+        }
+
+        if (node.Arguments.Count > MaxArity)
+        {
+            throw new NotSupportedException(
+                $"Tuple type '{node}' has {node.Arguments.Count} elements; this client supports at most {MaxArity} (wider tuples are not yet implemented).");
+        }
+
+        (string Name, TypeNode Type)[] elements = NamedElementParser.Split(node);
+        var childCodecs = new IColumnCodec[elements.Length];
+        var names = new string[elements.Length];
+        bool anyNamed = false;
+        for (int i = 0; i < elements.Length; i++)
+        {
+            childCodecs[i] = registry.ResolveNode(elements[i].Type, in context);
+            names[i] = elements[i].Name;
+            anyNamed |= elements[i].Name is not null;
+        }
+
+        return new TupleColumnCodec(node.ToString(), childCodecs, anyNamed ? names : null);
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask ReadStatePrefixAsync(ClickHouseBinaryReader reader, CancellationToken cancellationToken)
+    {
+        foreach (IColumnCodec child in children)
+        {
+            await child.ReadStatePrefixAsync(reader, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask<IColumn> ReadColumnAsync(ClickHouseBinaryReader reader, string columnName, string columnType, int rowCount, CancellationToken cancellationToken)
+    {
+        var childColumns = new IColumn[children.Length];
+        int read = 0;
+        try
+        {
+            for (int i = 0; i < children.Length; i++)
+            {
+                childColumns[i] = await children[i].ReadColumnAsync(reader, columnName, children[i].TypeName, rowCount, cancellationToken).ConfigureAwait(false);
+                read = i + 1;
+            }
+        }
+        catch
+        {
+            // Dispose whatever children were read before the failure; the tuple column that would have owned
+            // them was never constructed.
+            for (int i = 0; i < read; i++)
+            {
+                childColumns[i].Dispose();
+            }
+
+            throw;
+        }
+
+        // The constructed column takes ownership of the child columns and disposes them with the block.
+        return (IColumn)columnConstructor.Invoke(new object[] { columnName, columnType, childColumns, fieldNames, rowCount, true });
+    }
+
+    /// <inheritdoc/>
+    public long MeasureRowBytes(IColumn column, int row)
+    {
+        if (fixedRowByteSize is int width)
+        {
+            return width;
+        }
+
+        // The fixed-width children contribute the same bytes every row, so only the variable-width ones are
+        // measured per row.
+        long total = fixedChildrenByteTotal;
+        if (column is ITupleColumn dense && dense.Children.Count == children.Length)
+        {
+            foreach (int i in variableChildIndices)
+            {
+                total += children[i].MeasureRowBytes(dense.Children[i], row);
+            }
+
+            return total;
+        }
+
+        // Flat column: measure each variable child by projecting its single value into a one-row child column.
+        var tuple = (ITuple)column.GetValue(row);
+        var single = new object[1];
+        foreach (int i in variableChildIndices)
+        {
+            single[0] = tuple[i];
+            IColumn childColumn = childFlatBuilders[i](column.Name, children[i].TypeName, single, 1);
+            total += children[i].MeasureRowBytes(childColumn, 0);
+        }
+
+        return total;
+    }
+
+    /// <inheritdoc/>
+    public bool CanWrite(IColumn column) => allChildrenWritable && icolumnOfTupleType.IsInstanceOfType(column);
+
+    /// <inheritdoc/>
+    public void WriteStatePrefix(ClickHouseBinaryWriter writer)
+    {
+        foreach (IColumnCodec child in children)
+        {
+            child.WriteStatePrefix(writer);
+        }
+    }
+
+    /// <inheritdoc/>
+    public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
+    {
+        if (column is ITupleColumn dense && dense.Children.Count == children.Length)
+        {
+            // Dense: each child column already exists, so serialize each with its own codec, no copy.
+            for (int i = 0; i < children.Length; i++)
+            {
+                children[i].WriteColumn(writer, dense.Children[i], start, length);
+            }
+
+            return;
+        }
+
+        WriteFlat(writer, column, start, length);
+    }
+
+    // Builds a flat typed column from boxed element values — the ergonomic write path's per-child projection.
+    private static IColumn BuildFlatColumn<T>(string name, string typeName, object[] boxed, int count)
+    {
+        var values = new T[count];
+        for (int i = 0; i < count; i++)
+        {
+            values[i] = (T)boxed[i];
+        }
+
+        return new ArrayColumn<T>(name, typeName, values);
+    }
+
+    // Serializes a flat column of ValueTuple values by projecting each element position into a per-child column.
+    // Reads each row's tuple once and distributes its elements across the child buffers (boxing each element).
+    private void WriteFlat(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
+    {
+        int arity = children.Length;
+        var childBoxed = new object[arity][];
+        for (int i = 0; i < arity; i++)
+        {
+            childBoxed[i] = ArrayPool<object>.Shared.Rent(length);
+        }
+
+        try
+        {
+            for (int row = 0; row < length; row++)
+            {
+                var tuple = (ITuple)column.GetValue(start + row);
+                for (int i = 0; i < arity; i++)
+                {
+                    childBoxed[i][row] = tuple[i];
+                }
+            }
+
+            for (int i = 0; i < arity; i++)
+            {
+                IColumn childColumn = childFlatBuilders[i](column.Name, children[i].TypeName, childBoxed[i], length);
+                children[i].WriteColumn(writer, childColumn, 0, length);
+            }
+        }
+        finally
+        {
+            for (int i = 0; i < arity; i++)
+            {
+                ArrayPool<object>.Shared.Return(childBoxed[i], clearArray: true);
+            }
+        }
+    }
+}

--- a/ClickHouse.Driver.Tcp/Types/Codecs/TupleColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/TupleColumnCodec.cs
@@ -219,19 +219,8 @@ internal sealed class TupleColumnCodec : IColumnCodec
     /// <inheritdoc/>
     public void WriteStatePrefix(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
     {
-        if (IsTupleColumn(column))
-        {
-            using TupleWriteState state = BuildState(column, start, length);
-            WriteStatePrefixCore(writer, state);
-            return;
-        }
-
-        // An outer composite forwarded its own column (its children's prefixes are written from its own slice);
-        // the children ignore it, preserving the prior contract for a Tuple nested in Variant/Map/Nested.
-        foreach (IColumnCodec child in children)
-        {
-            child.WriteStatePrefix(writer, column, start, length);
-        }
+        using TupleWriteState state = BuildState(column, start, length);
+        WriteStatePrefixCore(writer, state);
     }
 
     /// <inheritdoc/>
@@ -283,9 +272,6 @@ internal sealed class TupleColumnCodec : IColumnCodec
             children[i].WriteColumn(writer, state.ChildColumns[i], state.ChildStart, state.Length, state.ChildStates[i]);
         }
     }
-
-    private bool IsTupleColumn(IColumn column)
-        => (column is ITupleColumn dense && dense.Children.Count == children.Length) || icolumnOfTupleType.IsInstanceOfType(column);
 
     // Builds the per-element write state for a slice. A dense tuple column exposes each child column directly; an
     // ergonomic flat ValueTuple column is projected into one lazy per-element view per child (strided through the

--- a/ClickHouse.Driver.Tcp/Types/Codecs/TupleColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/TupleColumnCodec.cs
@@ -226,19 +226,20 @@ internal sealed class TupleColumnCodec : IColumnCodec
     /// <inheritdoc/>
     public void WriteStatePrefix(ClickHouseBinaryWriter writer, IColumn column, int start, int length, IColumnWriteState state)
     {
-        if (state is TupleWriteState tupleState)
+        // A null state is the caller saying it has none to share, so build one for this call alone.
+        if (state is null)
         {
-            WriteStatePrefixCore(writer, tupleState);
+            WriteStatePrefix(writer, column, start, length);
             return;
         }
 
-        WriteStatePrefix(writer, column, start, length);
+        WriteStatePrefixCore(writer, state.Expect<TupleWriteState>(TypeName));
     }
 
     /// <inheritdoc/>
-    // Every column is densified before the write, so it is always the dense TupleColumn; each child is written
-    // through its own codec and pre-built state, no copy. The flat ValueTuple form was un-transposed into the
-    // per-child columns before the write.
+    // Each child writes its own element column through its own codec and pre-built state. Which column that is
+    // depends on the shape BuildState was handed: a dense TupleColumn exposes its children directly, while a flat
+    // ValueTuple column is projected into one lazy per-element view per child.
     public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
     {
         using TupleWriteState state = BuildState(column, start, length);
@@ -248,13 +249,13 @@ internal sealed class TupleColumnCodec : IColumnCodec
     /// <inheritdoc/>
     public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length, IColumnWriteState state)
     {
-        if (state is TupleWriteState tupleState)
+        if (state is null)
         {
-            WriteBodyCore(writer, tupleState);
+            WriteColumn(writer, column, start, length);
             return;
         }
 
-        WriteColumn(writer, column, start, length);
+        WriteBodyCore(writer, state.Expect<TupleWriteState>(TypeName));
     }
 
     private void WriteStatePrefixCore(ClickHouseBinaryWriter writer, TupleWriteState state)

--- a/ClickHouse.Driver.Tcp/Types/Codecs/TupleColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/TupleColumnCodec.cs
@@ -138,13 +138,21 @@ internal sealed class TupleColumnCodec : IColumnCodec
     /// <param name="node">The parsed <c>Tuple</c> node; its arguments are the element types (each optionally name-prefixed).</param>
     /// <param name="context">The resolution context, forwarded to each element codec's factory.</param>
     /// <param name="registry">The registry used to resolve the element codecs.</param>
-    /// <returns>The codec.</returns>
-    /// <exception cref="FormatException">The tuple has no elements.</exception>
+    /// <returns>The codec: <see cref="EmptyTupleColumnCodec"/> for <c>Tuple()</c>, otherwise this per-element one.</returns>
+    /// <exception cref="FormatException">The type names no elements and has no argument list either.</exception>
     /// <exception cref="NotSupportedException">The tuple has more elements than this client supports.</exception>
-    public static TupleColumnCodec Create(TypeNode node, in ResolveContext context, ColumnCodecRegistry registry)
+    public static IColumnCodec Create(TypeNode node, in ResolveContext context, ColumnCodecRegistry registry)
     {
         if (node.Arguments.Count == 0)
         {
+            // Tuple() is the legal zero-element tuple. It has no element streams, so it is not this codec's
+            // layout at all — one placeholder byte per row, like Nothing. A bare Tuple names no elements and
+            // carries no argument list, and stays malformed.
+            if (node.HasArgumentList)
+            {
+                return EmptyTupleColumnCodec.Instance;
+            }
+
             throw new FormatException($"Tuple type '{node}' must have at least one element type argument.");
         }
 

--- a/ClickHouse.Driver.Tcp/Types/Codecs/TupleColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/TupleColumnCodec.cs
@@ -189,6 +189,12 @@ internal sealed class TupleColumnCodec : IColumnCodec
                 childColumns[i] = await children[i].ReadColumnAsync(reader, columnName, children[i].TypeName, rowCount, cancellationToken).ConfigureAwait(false);
                 read = i + 1;
             }
+
+            // Construct inside the try, because ownership transfers only once the column exists: a child whose
+            // element type does not match this arity's IColumn<Ti> surfaces as a cast failure out of the reflected
+            // constructor, and the catch below then disposes the children rather than leaking them. The column's row
+            // count comes from the children, every one of which was just read at this block's rowCount.
+            return (IColumn)columnConstructor.Invoke(new object[] { columnName, columnType, childColumns, fieldNames, true });
         }
         catch
         {
@@ -201,10 +207,6 @@ internal sealed class TupleColumnCodec : IColumnCodec
 
             throw;
         }
-
-        // The constructed column takes ownership of the child columns and disposes them with the block. Its row count
-        // comes from the children, every one of which was just read at this block's rowCount.
-        return (IColumn)columnConstructor.Invoke(new object[] { columnName, columnType, childColumns, fieldNames, true });
     }
 
     /// <inheritdoc/>

--- a/ClickHouse.Driver.Tcp/Types/Codecs/TupleColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/TupleColumnCodec.cs
@@ -92,7 +92,7 @@ internal sealed class TupleColumnCodec : IColumnCodec
         columnConstructor = columnType.GetConstructor(
             BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public,
             binder: null,
-            new[] { typeof(string), typeof(string), typeof(IColumn[]), typeof(IReadOnlyList<string>), typeof(int), typeof(bool) },
+            new[] { typeof(string), typeof(string), typeof(IColumn[]), typeof(IReadOnlyList<string>), typeof(bool) },
             modifiers: null)
             ?? throw new InvalidOperationException($"The tuple column type '{columnType}' is missing its expected constructor.");
 
@@ -202,8 +202,9 @@ internal sealed class TupleColumnCodec : IColumnCodec
             throw;
         }
 
-        // The constructed column takes ownership of the child columns and disposes them with the block.
-        return (IColumn)columnConstructor.Invoke(new object[] { columnName, columnType, childColumns, fieldNames, rowCount, true });
+        // The constructed column takes ownership of the child columns and disposes them with the block. Its row count
+        // comes from the children, every one of which was just read at this block's rowCount.
+        return (IColumn)columnConstructor.Invoke(new object[] { columnName, columnType, childColumns, fieldNames, true });
     }
 
     /// <inheritdoc/>

--- a/ClickHouse.Driver.Tcp/Types/Codecs/TupleColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/TupleColumnCodec.cs
@@ -228,13 +228,6 @@ internal sealed class TupleColumnCodec : IColumnCodec
     /// <inheritdoc/>
     public void WriteStatePrefix(ClickHouseBinaryWriter writer, IColumn column, int start, int length, IColumnWriteState state)
     {
-        // A null state is the caller saying it has none to share, so build one for this call alone.
-        if (state is null)
-        {
-            WriteStatePrefix(writer, column, start, length);
-            return;
-        }
-
         WriteStatePrefixCore(writer, state.Expect<TupleWriteState>(TypeName));
     }
 
@@ -251,12 +244,6 @@ internal sealed class TupleColumnCodec : IColumnCodec
     /// <inheritdoc/>
     public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length, IColumnWriteState state)
     {
-        if (state is null)
-        {
-            WriteColumn(writer, column, start, length);
-            return;
-        }
-
         WriteBodyCore(writer, state.Expect<TupleWriteState>(TypeName));
     }
 

--- a/ClickHouse.Driver.Tcp/Types/ColumnCodecRegistry.cs
+++ b/ClickHouse.Driver.Tcp/Types/ColumnCodecRegistry.cs
@@ -128,6 +128,10 @@ internal sealed class ColumnCodecRegistry
         // Array(T) wraps a child codec (offsets + flattened element values), resolved recursively.
         AddFactory("Array", static (TypeNode node, in ResolveContext context, ColumnCodecRegistry registry) => ArrayColumnCodec.Create(node, context, registry));
 
+        // Tuple(T1, ..., Tn) serializes its elements as N independent child columns (all prefixes then all
+        // bodies, in order); each element codec is resolved recursively and element names, if any, are kept.
+        AddFactory("Tuple", static (TypeNode node, in ResolveContext context, ColumnCodecRegistry registry) => TupleColumnCodec.Create(node, context, registry));
+
         return new ColumnCodecRegistry(byName);
     }
 }

--- a/ClickHouse.Driver.Tcp/Types/ITupleColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/ITupleColumn.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+
+namespace ClickHouse.Driver.Tcp.Types;
+
+/// <summary>
+/// The read surface of a decoded <c>Tuple(...)</c> column. A tuple is stored on the wire — and here — as its N
+/// element columns laid side by side, one per tuple element in declaration order; the column materializes each
+/// row as a <c>ValueTuple</c> pairing the elements (see the typed <see cref="IColumn{T}.Values"/>). This
+/// interface also exposes the underlying per-element child columns, so a caller can read a single element's
+/// values without materializing the whole tuple, and can recurse into a child that is itself a composite (e.g. a
+/// tuple nesting an <see cref="IArrayColumn{TElement}"/>).
+///
+/// <para>
+/// When returned by the client, child columns are borrowed views over the owning block's storage:
+/// read them in place, and copy out (e.g. <c>ToArray()</c>) only what must outlive the block.
+/// </para>
+/// </summary>
+public interface ITupleColumn : IColumn
+{
+    /// <summary>
+    /// The child columns, one per tuple element, in declaration order. Each is an <see cref="IColumn{T}"/> of
+    /// that element's type with the tuple's row count. Borrowed views valid only while the owning block is alive.
+    /// </summary>
+    IReadOnlyList<IColumn> Children { get; }
+
+    /// <summary>
+    /// The element names for a named tuple (<c>Tuple(a Int32, b String)</c>) — one entry per element, aligned
+    /// with <see cref="Children"/>, with a null entry for an unnamed element; null when the tuple carries no
+    /// names at all. Names are metadata only: they do not affect the wire layout or the materialized
+    /// <c>ValueTuple</c> value.
+    /// </summary>
+    IReadOnlyList<string> FieldNames { get; }
+}

--- a/ClickHouse.Driver.Tcp/Types/NamedElementParser.cs
+++ b/ClickHouse.Driver.Tcp/Types/NamedElementParser.cs
@@ -1,0 +1,85 @@
+using System;
+
+namespace ClickHouse.Driver.Tcp.Types;
+
+/// <summary>
+/// Splits a composite type node whose arguments use the <c>name Type</c> element syntax — <c>Tuple(a Int32, …)</c>
+/// and <c>Nested(a T1, …)</c> — into its elements, separating each element's name from its type.
+/// </summary>
+internal static class NamedElementParser
+{
+    /// <summary>
+    /// Splits a composite node's argument nodes into (element name, element type) pairs. The tokenizer breaks only
+    /// on <c>,</c> <c>(</c> <c>)</c>, so a named element arrives as a single node whose <see cref="TypeNode.Name"/>
+    /// glues the element name to the base type name with a space — <c>a Int32</c>, or <c>a Array</c> with the
+    /// array's own argument nodes hanging off it. An unnamed element's name has no space. The name is taken up to
+    /// the first space; the remainder plus the node's arguments reconstruct the element's own type node.
+    /// </summary>
+    /// <param name="composite">The parsed composite node (e.g. a <c>Tuple(...)</c> or <c>Nested(...)</c>).</param>
+    /// <returns>One pair per element, in declaration order; the name is null for an unnamed element.</returns>
+    public static (string Name, TypeNode Type)[] Split(TypeNode composite)
+    {
+        var elements = new (string, TypeNode)[composite.Arguments.Count];
+        for (int i = 0; i < composite.Arguments.Count; i++)
+        {
+            TypeNode argument = composite.Arguments[i];
+            int space = IndexOfWhitespace(argument.Name);
+            if (space < 0)
+            {
+                elements[i] = (null, argument);
+            }
+            else
+            {
+                // Take the field name up to the first whitespace, then skip the whole whitespace run before the type
+                // so a hand-written type with extra spaces or a tab (e.g. "a  Int32") doesn't leave the base name
+                // with a leading space that would then fail codec resolution.
+                string fieldName = argument.Name.Substring(0, space);
+                string baseName = argument.Name.Substring(space).TrimStart();
+                elements[i] = (fieldName, new TypeNode(baseName, argument.Arguments));
+            }
+        }
+
+        return elements;
+    }
+
+    private static int IndexOfWhitespace(string value)
+    {
+        for (int i = 0; i < value.Length; i++)
+        {
+            if (char.IsWhiteSpace(value[i]))
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    /// <summary>
+    /// Parses a full <c>Tuple(...)</c> type string and returns its per-element type strings (names stripped),
+    /// validating that the element count matches <paramref name="expectedArity"/>. Used by a typed tuple column's
+    /// convenience constructor to stamp its child columns with the right element type.
+    /// </summary>
+    /// <param name="tupleTypeName">The full tuple type string.</param>
+    /// <param name="expectedArity">The number of elements the caller expects.</param>
+    /// <returns>The element type strings, in order.</returns>
+    /// <exception cref="FormatException">The type is not a tuple of exactly <paramref name="expectedArity"/> elements.</exception>
+    public static string[] ElementTypeStrings(string tupleTypeName, int expectedArity)
+    {
+        TypeNode node = TypeParser.Parse(tupleTypeName);
+        if (node.Name != "Tuple" || node.Arguments.Count != expectedArity)
+        {
+            throw new FormatException(
+                $"Type '{tupleTypeName}' is not a Tuple of {expectedArity} element(s).");
+        }
+
+        (string Name, TypeNode Type)[] elements = Split(node);
+        var types = new string[expectedArity];
+        for (int i = 0; i < expectedArity; i++)
+        {
+            types[i] = elements[i].Type.ToString();
+        }
+
+        return types;
+    }
+}

--- a/ClickHouse.Driver.Tcp/Types/NamedElementParser.cs
+++ b/ClickHouse.Driver.Tcp/Types/NamedElementParser.cs
@@ -35,7 +35,10 @@ internal static class NamedElementParser
                 // with a leading space that would then fail codec resolution.
                 string fieldName = argument.Name.Substring(0, space);
                 string baseName = argument.Name.Substring(space).TrimStart();
-                elements[i] = (fieldName, new TypeNode(baseName, argument.Arguments));
+
+                // Carry the argument list forward rather than re-deriving it from the argument count, or a named
+                // element of the zero-element type (e.g. "y Tuple()") would come out as a bare, malformed Tuple.
+                elements[i] = (fieldName, new TypeNode(baseName, argument.Arguments, argument.HasArgumentList));
             }
         }
 

--- a/ClickHouse.Driver.Tcp/Types/TupleColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/TupleColumn.cs
@@ -1,0 +1,583 @@
+using System;
+using System.Collections.Generic;
+
+namespace ClickHouse.Driver.Tcp.Types;
+
+/// <summary>
+/// The arity-independent state of a tuple column: the child columns, the optional element names, the row count,
+/// and lifetime. The generic <c>TupleColumn</c> subclasses add the typed <c>ValueTuple</c> materialization for a
+/// specific number of elements (1 through 7).
+/// </summary>
+internal abstract class TupleColumnBase : ITupleColumn
+{
+    private readonly IColumn[] children;
+    private readonly bool ownsChildren;
+
+    /// <summary>Initializes the shared tuple-column state.</summary>
+    /// <param name="name">The column name.</param>
+    /// <param name="typeName">The full <c>Tuple(...)</c> type string (element names included when named).</param>
+    /// <param name="children">The child columns, one per element; each must be an <see cref="IColumn{T}"/> of the corresponding element type.</param>
+    /// <param name="fieldNames">The element names (one per element, null entry for an unnamed element), or null when the tuple is unnamed.</param>
+    /// <param name="rowCount">The number of rows; every child must have this many.</param>
+    /// <param name="ownsChildren">Whether disposing this column disposes the child columns.</param>
+    protected TupleColumnBase(string name, string typeName, IColumn[] children, IReadOnlyList<string> fieldNames, int rowCount, bool ownsChildren)
+    {
+        this.children = children ?? throw new ArgumentNullException(nameof(children));
+        Name = name;
+        TypeName = typeName;
+        FieldNames = fieldNames;
+        RowCount = rowCount;
+        this.ownsChildren = ownsChildren;
+    }
+
+    /// <inheritdoc/>
+    public string Name { get; }
+
+    /// <inheritdoc/>
+    public string TypeName { get; }
+
+    /// <inheritdoc/>
+    public int RowCount { get; }
+
+    /// <inheritdoc/>
+    public IReadOnlyList<IColumn> Children => children;
+
+    /// <inheritdoc/>
+    public IReadOnlyList<string> FieldNames { get; }
+
+    /// <inheritdoc/>
+    public abstract object GetValue(int row);
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        if (!ownsChildren)
+        {
+            return;
+        }
+
+        foreach (IColumn child in children)
+        {
+            child.Dispose();
+        }
+    }
+
+    /// <summary>The child column at <paramref name="index"/>, for a subclass to cast to its typed element column.</summary>
+    protected IColumn Child(int index) => children[index];
+}
+
+/// <summary>A single-element tuple column, surfacing each row as <see cref="ValueTuple{T1}"/>.</summary>
+/// <typeparam name="T1">The element type.</typeparam>
+internal sealed class TupleColumn<T1> : TupleColumnBase, IColumn<ValueTuple<T1>>
+{
+    private readonly IColumn<T1> item1;
+    private ValueTuple<T1>[] cache;
+
+    internal TupleColumn(string name, string typeName, IColumn[] children, IReadOnlyList<string> fieldNames, int rowCount, bool ownsChildren)
+        : base(name, typeName, children, fieldNames, rowCount, ownsChildren)
+    {
+        item1 = (IColumn<T1>)Child(0);
+    }
+
+    internal TupleColumn(string name, string typeName, ValueTuple<T1>[] rows)
+        : this(name, typeName, BuildChildren(name, typeName, rows), null, rows.Length, ownsChildren: true)
+    {
+    }
+
+    /// <inheritdoc/>
+    public ReadOnlySpan<ValueTuple<T1>> Values
+    {
+        get
+        {
+            if (cache is null)
+            {
+                var decoded = new ValueTuple<T1>[RowCount];
+                for (int i = 0; i < RowCount; i++)
+                {
+                    decoded[i] = new ValueTuple<T1>(item1[i]);
+                }
+
+                cache = decoded;
+            }
+
+            return cache.AsSpan(0, RowCount);
+        }
+    }
+
+    /// <inheritdoc/>
+    public ValueTuple<T1> this[int row] => cache is not null ? cache[row] : new ValueTuple<T1>(item1[row]);
+
+    /// <inheritdoc/>
+    public override object GetValue(int row) => this[row];
+
+    private static IColumn[] BuildChildren(string name, string typeName, ValueTuple<T1>[] rows)
+    {
+        string[] types = NamedElementParser.ElementTypeStrings(typeName, 1);
+        var values1 = new T1[rows.Length];
+        for (int i = 0; i < rows.Length; i++)
+        {
+            values1[i] = rows[i].Item1;
+        }
+
+        return new IColumn[] { new ArrayColumn<T1>(name, types[0], values1) };
+    }
+}
+
+/// <summary>A two-element tuple column, surfacing each row as <c>(T1, T2)</c>.</summary>
+internal sealed class TupleColumn<T1, T2> : TupleColumnBase, IColumn<(T1, T2)>
+{
+    private readonly IColumn<T1> item1;
+    private readonly IColumn<T2> item2;
+    private (T1, T2)[] cache;
+
+    internal TupleColumn(string name, string typeName, IColumn[] children, IReadOnlyList<string> fieldNames, int rowCount, bool ownsChildren)
+        : base(name, typeName, children, fieldNames, rowCount, ownsChildren)
+    {
+        item1 = (IColumn<T1>)Child(0);
+        item2 = (IColumn<T2>)Child(1);
+    }
+
+    internal TupleColumn(string name, string typeName, (T1, T2)[] rows)
+        : this(name, typeName, BuildChildren(name, typeName, rows), null, rows.Length, ownsChildren: true)
+    {
+    }
+
+    /// <inheritdoc/>
+    public ReadOnlySpan<(T1, T2)> Values
+    {
+        get
+        {
+            if (cache is null)
+            {
+                var decoded = new (T1, T2)[RowCount];
+                for (int i = 0; i < RowCount; i++)
+                {
+                    decoded[i] = (item1[i], item2[i]);
+                }
+
+                cache = decoded;
+            }
+
+            return cache.AsSpan(0, RowCount);
+        }
+    }
+
+    /// <inheritdoc/>
+    public (T1, T2) this[int row] => cache is not null ? cache[row] : (item1[row], item2[row]);
+
+    /// <inheritdoc/>
+    public override object GetValue(int row) => this[row];
+
+    private static IColumn[] BuildChildren(string name, string typeName, (T1, T2)[] rows)
+    {
+        string[] types = NamedElementParser.ElementTypeStrings(typeName, 2);
+        var values1 = new T1[rows.Length];
+        var values2 = new T2[rows.Length];
+        for (int i = 0; i < rows.Length; i++)
+        {
+            values1[i] = rows[i].Item1;
+            values2[i] = rows[i].Item2;
+        }
+
+        return new IColumn[]
+        {
+            new ArrayColumn<T1>(name, types[0], values1),
+            new ArrayColumn<T2>(name, types[1], values2),
+        };
+    }
+}
+
+/// <summary>A three-element tuple column, surfacing each row as <c>(T1, T2, T3)</c>.</summary>
+internal sealed class TupleColumn<T1, T2, T3> : TupleColumnBase, IColumn<(T1, T2, T3)>
+{
+    private readonly IColumn<T1> item1;
+    private readonly IColumn<T2> item2;
+    private readonly IColumn<T3> item3;
+    private (T1, T2, T3)[] cache;
+
+    internal TupleColumn(string name, string typeName, IColumn[] children, IReadOnlyList<string> fieldNames, int rowCount, bool ownsChildren)
+        : base(name, typeName, children, fieldNames, rowCount, ownsChildren)
+    {
+        item1 = (IColumn<T1>)Child(0);
+        item2 = (IColumn<T2>)Child(1);
+        item3 = (IColumn<T3>)Child(2);
+    }
+
+    internal TupleColumn(string name, string typeName, (T1, T2, T3)[] rows)
+        : this(name, typeName, BuildChildren(name, typeName, rows), null, rows.Length, ownsChildren: true)
+    {
+    }
+
+    /// <inheritdoc/>
+    public ReadOnlySpan<(T1, T2, T3)> Values
+    {
+        get
+        {
+            if (cache is null)
+            {
+                var decoded = new (T1, T2, T3)[RowCount];
+                for (int i = 0; i < RowCount; i++)
+                {
+                    decoded[i] = (item1[i], item2[i], item3[i]);
+                }
+
+                cache = decoded;
+            }
+
+            return cache.AsSpan(0, RowCount);
+        }
+    }
+
+    /// <inheritdoc/>
+    public (T1, T2, T3) this[int row] => cache is not null ? cache[row] : (item1[row], item2[row], item3[row]);
+
+    /// <inheritdoc/>
+    public override object GetValue(int row) => this[row];
+
+    private static IColumn[] BuildChildren(string name, string typeName, (T1, T2, T3)[] rows)
+    {
+        string[] types = NamedElementParser.ElementTypeStrings(typeName, 3);
+        var values1 = new T1[rows.Length];
+        var values2 = new T2[rows.Length];
+        var values3 = new T3[rows.Length];
+        for (int i = 0; i < rows.Length; i++)
+        {
+            values1[i] = rows[i].Item1;
+            values2[i] = rows[i].Item2;
+            values3[i] = rows[i].Item3;
+        }
+
+        return new IColumn[]
+        {
+            new ArrayColumn<T1>(name, types[0], values1),
+            new ArrayColumn<T2>(name, types[1], values2),
+            new ArrayColumn<T3>(name, types[2], values3),
+        };
+    }
+}
+
+/// <summary>A four-element tuple column, surfacing each row as <c>(T1, T2, T3, T4)</c>.</summary>
+internal sealed class TupleColumn<T1, T2, T3, T4> : TupleColumnBase, IColumn<(T1, T2, T3, T4)>
+{
+    private readonly IColumn<T1> item1;
+    private readonly IColumn<T2> item2;
+    private readonly IColumn<T3> item3;
+    private readonly IColumn<T4> item4;
+    private (T1, T2, T3, T4)[] cache;
+
+    internal TupleColumn(string name, string typeName, IColumn[] children, IReadOnlyList<string> fieldNames, int rowCount, bool ownsChildren)
+        : base(name, typeName, children, fieldNames, rowCount, ownsChildren)
+    {
+        item1 = (IColumn<T1>)Child(0);
+        item2 = (IColumn<T2>)Child(1);
+        item3 = (IColumn<T3>)Child(2);
+        item4 = (IColumn<T4>)Child(3);
+    }
+
+    internal TupleColumn(string name, string typeName, (T1, T2, T3, T4)[] rows)
+        : this(name, typeName, BuildChildren(name, typeName, rows), null, rows.Length, ownsChildren: true)
+    {
+    }
+
+    /// <inheritdoc/>
+    public ReadOnlySpan<(T1, T2, T3, T4)> Values
+    {
+        get
+        {
+            if (cache is null)
+            {
+                var decoded = new (T1, T2, T3, T4)[RowCount];
+                for (int i = 0; i < RowCount; i++)
+                {
+                    decoded[i] = (item1[i], item2[i], item3[i], item4[i]);
+                }
+
+                cache = decoded;
+            }
+
+            return cache.AsSpan(0, RowCount);
+        }
+    }
+
+    /// <inheritdoc/>
+    public (T1, T2, T3, T4) this[int row] => cache is not null ? cache[row] : (item1[row], item2[row], item3[row], item4[row]);
+
+    /// <inheritdoc/>
+    public override object GetValue(int row) => this[row];
+
+    private static IColumn[] BuildChildren(string name, string typeName, (T1, T2, T3, T4)[] rows)
+    {
+        string[] types = NamedElementParser.ElementTypeStrings(typeName, 4);
+        var values1 = new T1[rows.Length];
+        var values2 = new T2[rows.Length];
+        var values3 = new T3[rows.Length];
+        var values4 = new T4[rows.Length];
+        for (int i = 0; i < rows.Length; i++)
+        {
+            values1[i] = rows[i].Item1;
+            values2[i] = rows[i].Item2;
+            values3[i] = rows[i].Item3;
+            values4[i] = rows[i].Item4;
+        }
+
+        return new IColumn[]
+        {
+            new ArrayColumn<T1>(name, types[0], values1),
+            new ArrayColumn<T2>(name, types[1], values2),
+            new ArrayColumn<T3>(name, types[2], values3),
+            new ArrayColumn<T4>(name, types[3], values4),
+        };
+    }
+}
+
+/// <summary>A five-element tuple column, surfacing each row as <c>(T1, T2, T3, T4, T5)</c>.</summary>
+internal sealed class TupleColumn<T1, T2, T3, T4, T5> : TupleColumnBase, IColumn<(T1, T2, T3, T4, T5)>
+{
+    private readonly IColumn<T1> item1;
+    private readonly IColumn<T2> item2;
+    private readonly IColumn<T3> item3;
+    private readonly IColumn<T4> item4;
+    private readonly IColumn<T5> item5;
+    private (T1, T2, T3, T4, T5)[] cache;
+
+    internal TupleColumn(string name, string typeName, IColumn[] children, IReadOnlyList<string> fieldNames, int rowCount, bool ownsChildren)
+        : base(name, typeName, children, fieldNames, rowCount, ownsChildren)
+    {
+        item1 = (IColumn<T1>)Child(0);
+        item2 = (IColumn<T2>)Child(1);
+        item3 = (IColumn<T3>)Child(2);
+        item4 = (IColumn<T4>)Child(3);
+        item5 = (IColumn<T5>)Child(4);
+    }
+
+    internal TupleColumn(string name, string typeName, (T1, T2, T3, T4, T5)[] rows)
+        : this(name, typeName, BuildChildren(name, typeName, rows), null, rows.Length, ownsChildren: true)
+    {
+    }
+
+    /// <inheritdoc/>
+    public ReadOnlySpan<(T1, T2, T3, T4, T5)> Values
+    {
+        get
+        {
+            if (cache is null)
+            {
+                var decoded = new (T1, T2, T3, T4, T5)[RowCount];
+                for (int i = 0; i < RowCount; i++)
+                {
+                    decoded[i] = (item1[i], item2[i], item3[i], item4[i], item5[i]);
+                }
+
+                cache = decoded;
+            }
+
+            return cache.AsSpan(0, RowCount);
+        }
+    }
+
+    /// <inheritdoc/>
+    public (T1, T2, T3, T4, T5) this[int row] => cache is not null ? cache[row] : (item1[row], item2[row], item3[row], item4[row], item5[row]);
+
+    /// <inheritdoc/>
+    public override object GetValue(int row) => this[row];
+
+    private static IColumn[] BuildChildren(string name, string typeName, (T1, T2, T3, T4, T5)[] rows)
+    {
+        string[] types = NamedElementParser.ElementTypeStrings(typeName, 5);
+        var values1 = new T1[rows.Length];
+        var values2 = new T2[rows.Length];
+        var values3 = new T3[rows.Length];
+        var values4 = new T4[rows.Length];
+        var values5 = new T5[rows.Length];
+        for (int i = 0; i < rows.Length; i++)
+        {
+            values1[i] = rows[i].Item1;
+            values2[i] = rows[i].Item2;
+            values3[i] = rows[i].Item3;
+            values4[i] = rows[i].Item4;
+            values5[i] = rows[i].Item5;
+        }
+
+        return new IColumn[]
+        {
+            new ArrayColumn<T1>(name, types[0], values1),
+            new ArrayColumn<T2>(name, types[1], values2),
+            new ArrayColumn<T3>(name, types[2], values3),
+            new ArrayColumn<T4>(name, types[3], values4),
+            new ArrayColumn<T5>(name, types[4], values5),
+        };
+    }
+}
+
+/// <summary>A six-element tuple column, surfacing each row as <c>(T1, T2, T3, T4, T5, T6)</c>.</summary>
+internal sealed class TupleColumn<T1, T2, T3, T4, T5, T6> : TupleColumnBase, IColumn<(T1, T2, T3, T4, T5, T6)>
+{
+    private readonly IColumn<T1> item1;
+    private readonly IColumn<T2> item2;
+    private readonly IColumn<T3> item3;
+    private readonly IColumn<T4> item4;
+    private readonly IColumn<T5> item5;
+    private readonly IColumn<T6> item6;
+    private (T1, T2, T3, T4, T5, T6)[] cache;
+
+    internal TupleColumn(string name, string typeName, IColumn[] children, IReadOnlyList<string> fieldNames, int rowCount, bool ownsChildren)
+        : base(name, typeName, children, fieldNames, rowCount, ownsChildren)
+    {
+        item1 = (IColumn<T1>)Child(0);
+        item2 = (IColumn<T2>)Child(1);
+        item3 = (IColumn<T3>)Child(2);
+        item4 = (IColumn<T4>)Child(3);
+        item5 = (IColumn<T5>)Child(4);
+        item6 = (IColumn<T6>)Child(5);
+    }
+
+    internal TupleColumn(string name, string typeName, (T1, T2, T3, T4, T5, T6)[] rows)
+        : this(name, typeName, BuildChildren(name, typeName, rows), null, rows.Length, ownsChildren: true)
+    {
+    }
+
+    /// <inheritdoc/>
+    public ReadOnlySpan<(T1, T2, T3, T4, T5, T6)> Values
+    {
+        get
+        {
+            if (cache is null)
+            {
+                var decoded = new (T1, T2, T3, T4, T5, T6)[RowCount];
+                for (int i = 0; i < RowCount; i++)
+                {
+                    decoded[i] = (item1[i], item2[i], item3[i], item4[i], item5[i], item6[i]);
+                }
+
+                cache = decoded;
+            }
+
+            return cache.AsSpan(0, RowCount);
+        }
+    }
+
+    /// <inheritdoc/>
+    public (T1, T2, T3, T4, T5, T6) this[int row] => cache is not null ? cache[row] : (item1[row], item2[row], item3[row], item4[row], item5[row], item6[row]);
+
+    /// <inheritdoc/>
+    public override object GetValue(int row) => this[row];
+
+    private static IColumn[] BuildChildren(string name, string typeName, (T1, T2, T3, T4, T5, T6)[] rows)
+    {
+        string[] types = NamedElementParser.ElementTypeStrings(typeName, 6);
+        var values1 = new T1[rows.Length];
+        var values2 = new T2[rows.Length];
+        var values3 = new T3[rows.Length];
+        var values4 = new T4[rows.Length];
+        var values5 = new T5[rows.Length];
+        var values6 = new T6[rows.Length];
+        for (int i = 0; i < rows.Length; i++)
+        {
+            values1[i] = rows[i].Item1;
+            values2[i] = rows[i].Item2;
+            values3[i] = rows[i].Item3;
+            values4[i] = rows[i].Item4;
+            values5[i] = rows[i].Item5;
+            values6[i] = rows[i].Item6;
+        }
+
+        return new IColumn[]
+        {
+            new ArrayColumn<T1>(name, types[0], values1),
+            new ArrayColumn<T2>(name, types[1], values2),
+            new ArrayColumn<T3>(name, types[2], values3),
+            new ArrayColumn<T4>(name, types[3], values4),
+            new ArrayColumn<T5>(name, types[4], values5),
+            new ArrayColumn<T6>(name, types[5], values6),
+        };
+    }
+}
+
+/// <summary>A seven-element tuple column, surfacing each row as <c>(T1, T2, T3, T4, T5, T6, T7)</c>.</summary>
+internal sealed class TupleColumn<T1, T2, T3, T4, T5, T6, T7> : TupleColumnBase, IColumn<(T1, T2, T3, T4, T5, T6, T7)>
+{
+    private readonly IColumn<T1> item1;
+    private readonly IColumn<T2> item2;
+    private readonly IColumn<T3> item3;
+    private readonly IColumn<T4> item4;
+    private readonly IColumn<T5> item5;
+    private readonly IColumn<T6> item6;
+    private readonly IColumn<T7> item7;
+    private (T1, T2, T3, T4, T5, T6, T7)[] cache;
+
+    internal TupleColumn(string name, string typeName, IColumn[] children, IReadOnlyList<string> fieldNames, int rowCount, bool ownsChildren)
+        : base(name, typeName, children, fieldNames, rowCount, ownsChildren)
+    {
+        item1 = (IColumn<T1>)Child(0);
+        item2 = (IColumn<T2>)Child(1);
+        item3 = (IColumn<T3>)Child(2);
+        item4 = (IColumn<T4>)Child(3);
+        item5 = (IColumn<T5>)Child(4);
+        item6 = (IColumn<T6>)Child(5);
+        item7 = (IColumn<T7>)Child(6);
+    }
+
+    internal TupleColumn(string name, string typeName, (T1, T2, T3, T4, T5, T6, T7)[] rows)
+        : this(name, typeName, BuildChildren(name, typeName, rows), null, rows.Length, ownsChildren: true)
+    {
+    }
+
+    /// <inheritdoc/>
+    public ReadOnlySpan<(T1, T2, T3, T4, T5, T6, T7)> Values
+    {
+        get
+        {
+            if (cache is null)
+            {
+                var decoded = new (T1, T2, T3, T4, T5, T6, T7)[RowCount];
+                for (int i = 0; i < RowCount; i++)
+                {
+                    decoded[i] = (item1[i], item2[i], item3[i], item4[i], item5[i], item6[i], item7[i]);
+                }
+
+                cache = decoded;
+            }
+
+            return cache.AsSpan(0, RowCount);
+        }
+    }
+
+    /// <inheritdoc/>
+    public (T1, T2, T3, T4, T5, T6, T7) this[int row] => cache is not null ? cache[row] : (item1[row], item2[row], item3[row], item4[row], item5[row], item6[row], item7[row]);
+
+    /// <inheritdoc/>
+    public override object GetValue(int row) => this[row];
+
+    private static IColumn[] BuildChildren(string name, string typeName, (T1, T2, T3, T4, T5, T6, T7)[] rows)
+    {
+        string[] types = NamedElementParser.ElementTypeStrings(typeName, 7);
+        var values1 = new T1[rows.Length];
+        var values2 = new T2[rows.Length];
+        var values3 = new T3[rows.Length];
+        var values4 = new T4[rows.Length];
+        var values5 = new T5[rows.Length];
+        var values6 = new T6[rows.Length];
+        var values7 = new T7[rows.Length];
+        for (int i = 0; i < rows.Length; i++)
+        {
+            values1[i] = rows[i].Item1;
+            values2[i] = rows[i].Item2;
+            values3[i] = rows[i].Item3;
+            values4[i] = rows[i].Item4;
+            values5[i] = rows[i].Item5;
+            values6[i] = rows[i].Item6;
+            values7[i] = rows[i].Item7;
+        }
+
+        return new IColumn[]
+        {
+            new ArrayColumn<T1>(name, types[0], values1),
+            new ArrayColumn<T2>(name, types[1], values2),
+            new ArrayColumn<T3>(name, types[2], values3),
+            new ArrayColumn<T4>(name, types[3], values4),
+            new ArrayColumn<T5>(name, types[4], values5),
+            new ArrayColumn<T6>(name, types[5], values6),
+            new ArrayColumn<T7>(name, types[6], values7),
+        };
+    }
+}

--- a/ClickHouse.Driver.Tcp/Types/TupleColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/TupleColumn.cs
@@ -13,6 +13,11 @@ internal abstract class TupleColumnBase : ITupleColumn
     private readonly IColumn[] children;
     private readonly bool ownsChildren;
 
+    // When non-null, overrides ownsChildren per child: Dispose disposes child i only when childOwnership[i] is true.
+    // Set once by RestrictOwnership immediately after construction (before the column is observed) so a wrapper that
+    // mixes freshly built children with children borrowed from another column disposes only the ones it created.
+    private bool[] childOwnership;
+
     /// <summary>Initializes the shared tuple-column state.</summary>
     /// <param name="name">The column name.</param>
     /// <param name="typeName">The full <c>Tuple(...)</c> type string (element names included when named).</param>
@@ -51,15 +56,34 @@ internal abstract class TupleColumnBase : ITupleColumn
     /// <inheritdoc/>
     public void Dispose()
     {
-        if (!ownsChildren)
+        if (childOwnership is null && !ownsChildren)
         {
             return;
         }
 
-        foreach (IColumn child in children)
+        for (int i = 0; i < children.Length; i++)
         {
-            child.Dispose();
+            if (childOwnership is null || childOwnership[i])
+            {
+                children[i].Dispose();
+            }
         }
+    }
+
+    /// <summary>
+    /// Restricts disposal to the children flagged in <paramref name="owned"/> (one entry per child), overriding the
+    /// all-or-nothing <c>ownsChildren</c> passed at construction. Used when rebuilding a densified tuple that keeps
+    /// some children by reference (owned by the source column) and replaces others with freshly built ones, so
+    /// disposing this wrapper frees only the columns it created. Must be called before the column is observed.
+    /// </summary>
+    internal void RestrictOwnership(bool[] owned)
+    {
+        if (owned is null || owned.Length != children.Length)
+        {
+            throw new ArgumentException("Ownership mask must have one entry per child column.", nameof(owned));
+        }
+
+        childOwnership = owned;
     }
 
     /// <summary>The child column at <paramref name="index"/>, for a subclass to cast to its typed element column.</summary>

--- a/ClickHouse.Driver.Tcp/Types/TupleColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/TupleColumn.cs
@@ -23,16 +23,36 @@ internal abstract class TupleColumnBase : ITupleColumn
     /// <param name="typeName">The full <c>Tuple(...)</c> type string (element names included when named).</param>
     /// <param name="children">The child columns, one per element; each must be an <see cref="IColumn{T}"/> of the corresponding element type.</param>
     /// <param name="fieldNames">The element names (one per element, null entry for an unnamed element), or null when the tuple is unnamed.</param>
-    /// <param name="rowCount">The number of rows; every child must have this many.</param>
     /// <param name="ownsChildren">Whether disposing this column disposes the child columns.</param>
-    protected TupleColumnBase(string name, string typeName, IColumn[] children, IReadOnlyList<string> fieldNames, int rowCount, bool ownsChildren)
+    /// <exception cref="ArgumentNullException"><paramref name="children"/> is null.</exception>
+    /// <exception cref="ArgumentException"><paramref name="children"/> is empty, or the children disagree on their row count.</exception>
+    protected TupleColumnBase(string name, string typeName, IColumn[] children, IReadOnlyList<string> fieldNames, bool ownsChildren)
     {
         this.children = children ?? throw new ArgumentNullException(nameof(children));
         Name = name;
         TypeName = typeName;
         FieldNames = fieldNames;
-        RowCount = rowCount;
         this.ownsChildren = ownsChildren;
+
+        // A tuple stores one value per element per row, so every child is exactly as tall as the tuple and no
+        // separate row count is accepted — the children are the height. They do have to agree on it, which is the
+        // one thing a caller can still get wrong, so it is checked here rather than surfacing later as a child's
+        // own out-of-range read partway through materializing a row.
+        if (children.Length == 0)
+        {
+            throw new ArgumentException("A tuple column must have at least one child column.", nameof(children));
+        }
+
+        RowCount = children[0].RowCount;
+        for (int i = 1; i < children.Length; i++)
+        {
+            if (children[i].RowCount != RowCount)
+            {
+                throw new ArgumentException(
+                    $"The children of column '{name}' ({typeName}) disagree on their row count: child 0 has {RowCount} rows, child {i} has {children[i].RowCount}.",
+                    nameof(children));
+            }
+        }
     }
 
     /// <inheritdoc/>
@@ -97,14 +117,14 @@ internal sealed class TupleColumn<T1> : TupleColumnBase, IColumn<ValueTuple<T1>>
     private readonly IColumn<T1> item1;
     private ValueTuple<T1>[] cache;
 
-    internal TupleColumn(string name, string typeName, IColumn[] children, IReadOnlyList<string> fieldNames, int rowCount, bool ownsChildren)
-        : base(name, typeName, children, fieldNames, rowCount, ownsChildren)
+    internal TupleColumn(string name, string typeName, IColumn[] children, IReadOnlyList<string> fieldNames, bool ownsChildren)
+        : base(name, typeName, children, fieldNames, ownsChildren)
     {
         item1 = (IColumn<T1>)Child(0);
     }
 
     internal TupleColumn(string name, string typeName, ValueTuple<T1>[] rows)
-        : this(name, typeName, BuildChildren(name, typeName, rows), null, rows.Length, ownsChildren: true)
+        : this(name, typeName, BuildChildren(name, typeName, rows), null, ownsChildren: true)
     {
     }
 
@@ -154,15 +174,15 @@ internal sealed class TupleColumn<T1, T2> : TupleColumnBase, IColumn<(T1, T2)>
     private readonly IColumn<T2> item2;
     private (T1, T2)[] cache;
 
-    internal TupleColumn(string name, string typeName, IColumn[] children, IReadOnlyList<string> fieldNames, int rowCount, bool ownsChildren)
-        : base(name, typeName, children, fieldNames, rowCount, ownsChildren)
+    internal TupleColumn(string name, string typeName, IColumn[] children, IReadOnlyList<string> fieldNames, bool ownsChildren)
+        : base(name, typeName, children, fieldNames, ownsChildren)
     {
         item1 = (IColumn<T1>)Child(0);
         item2 = (IColumn<T2>)Child(1);
     }
 
     internal TupleColumn(string name, string typeName, (T1, T2)[] rows)
-        : this(name, typeName, BuildChildren(name, typeName, rows), null, rows.Length, ownsChildren: true)
+        : this(name, typeName, BuildChildren(name, typeName, rows), null, ownsChildren: true)
     {
     }
 
@@ -219,8 +239,8 @@ internal sealed class TupleColumn<T1, T2, T3> : TupleColumnBase, IColumn<(T1, T2
     private readonly IColumn<T3> item3;
     private (T1, T2, T3)[] cache;
 
-    internal TupleColumn(string name, string typeName, IColumn[] children, IReadOnlyList<string> fieldNames, int rowCount, bool ownsChildren)
-        : base(name, typeName, children, fieldNames, rowCount, ownsChildren)
+    internal TupleColumn(string name, string typeName, IColumn[] children, IReadOnlyList<string> fieldNames, bool ownsChildren)
+        : base(name, typeName, children, fieldNames, ownsChildren)
     {
         item1 = (IColumn<T1>)Child(0);
         item2 = (IColumn<T2>)Child(1);
@@ -228,7 +248,7 @@ internal sealed class TupleColumn<T1, T2, T3> : TupleColumnBase, IColumn<(T1, T2
     }
 
     internal TupleColumn(string name, string typeName, (T1, T2, T3)[] rows)
-        : this(name, typeName, BuildChildren(name, typeName, rows), null, rows.Length, ownsChildren: true)
+        : this(name, typeName, BuildChildren(name, typeName, rows), null, ownsChildren: true)
     {
     }
 
@@ -289,8 +309,8 @@ internal sealed class TupleColumn<T1, T2, T3, T4> : TupleColumnBase, IColumn<(T1
     private readonly IColumn<T4> item4;
     private (T1, T2, T3, T4)[] cache;
 
-    internal TupleColumn(string name, string typeName, IColumn[] children, IReadOnlyList<string> fieldNames, int rowCount, bool ownsChildren)
-        : base(name, typeName, children, fieldNames, rowCount, ownsChildren)
+    internal TupleColumn(string name, string typeName, IColumn[] children, IReadOnlyList<string> fieldNames, bool ownsChildren)
+        : base(name, typeName, children, fieldNames, ownsChildren)
     {
         item1 = (IColumn<T1>)Child(0);
         item2 = (IColumn<T2>)Child(1);
@@ -299,7 +319,7 @@ internal sealed class TupleColumn<T1, T2, T3, T4> : TupleColumnBase, IColumn<(T1
     }
 
     internal TupleColumn(string name, string typeName, (T1, T2, T3, T4)[] rows)
-        : this(name, typeName, BuildChildren(name, typeName, rows), null, rows.Length, ownsChildren: true)
+        : this(name, typeName, BuildChildren(name, typeName, rows), null, ownsChildren: true)
     {
     }
 
@@ -364,8 +384,8 @@ internal sealed class TupleColumn<T1, T2, T3, T4, T5> : TupleColumnBase, IColumn
     private readonly IColumn<T5> item5;
     private (T1, T2, T3, T4, T5)[] cache;
 
-    internal TupleColumn(string name, string typeName, IColumn[] children, IReadOnlyList<string> fieldNames, int rowCount, bool ownsChildren)
-        : base(name, typeName, children, fieldNames, rowCount, ownsChildren)
+    internal TupleColumn(string name, string typeName, IColumn[] children, IReadOnlyList<string> fieldNames, bool ownsChildren)
+        : base(name, typeName, children, fieldNames, ownsChildren)
     {
         item1 = (IColumn<T1>)Child(0);
         item2 = (IColumn<T2>)Child(1);
@@ -375,7 +395,7 @@ internal sealed class TupleColumn<T1, T2, T3, T4, T5> : TupleColumnBase, IColumn
     }
 
     internal TupleColumn(string name, string typeName, (T1, T2, T3, T4, T5)[] rows)
-        : this(name, typeName, BuildChildren(name, typeName, rows), null, rows.Length, ownsChildren: true)
+        : this(name, typeName, BuildChildren(name, typeName, rows), null, ownsChildren: true)
     {
     }
 
@@ -444,8 +464,8 @@ internal sealed class TupleColumn<T1, T2, T3, T4, T5, T6> : TupleColumnBase, ICo
     private readonly IColumn<T6> item6;
     private (T1, T2, T3, T4, T5, T6)[] cache;
 
-    internal TupleColumn(string name, string typeName, IColumn[] children, IReadOnlyList<string> fieldNames, int rowCount, bool ownsChildren)
-        : base(name, typeName, children, fieldNames, rowCount, ownsChildren)
+    internal TupleColumn(string name, string typeName, IColumn[] children, IReadOnlyList<string> fieldNames, bool ownsChildren)
+        : base(name, typeName, children, fieldNames, ownsChildren)
     {
         item1 = (IColumn<T1>)Child(0);
         item2 = (IColumn<T2>)Child(1);
@@ -456,7 +476,7 @@ internal sealed class TupleColumn<T1, T2, T3, T4, T5, T6> : TupleColumnBase, ICo
     }
 
     internal TupleColumn(string name, string typeName, (T1, T2, T3, T4, T5, T6)[] rows)
-        : this(name, typeName, BuildChildren(name, typeName, rows), null, rows.Length, ownsChildren: true)
+        : this(name, typeName, BuildChildren(name, typeName, rows), null, ownsChildren: true)
     {
     }
 
@@ -529,8 +549,8 @@ internal sealed class TupleColumn<T1, T2, T3, T4, T5, T6, T7> : TupleColumnBase,
     private readonly IColumn<T7> item7;
     private (T1, T2, T3, T4, T5, T6, T7)[] cache;
 
-    internal TupleColumn(string name, string typeName, IColumn[] children, IReadOnlyList<string> fieldNames, int rowCount, bool ownsChildren)
-        : base(name, typeName, children, fieldNames, rowCount, ownsChildren)
+    internal TupleColumn(string name, string typeName, IColumn[] children, IReadOnlyList<string> fieldNames, bool ownsChildren)
+        : base(name, typeName, children, fieldNames, ownsChildren)
     {
         item1 = (IColumn<T1>)Child(0);
         item2 = (IColumn<T2>)Child(1);
@@ -542,7 +562,7 @@ internal sealed class TupleColumn<T1, T2, T3, T4, T5, T6, T7> : TupleColumnBase,
     }
 
     internal TupleColumn(string name, string typeName, (T1, T2, T3, T4, T5, T6, T7)[] rows)
-        : this(name, typeName, BuildChildren(name, typeName, rows), null, rows.Length, ownsChildren: true)
+        : this(name, typeName, BuildChildren(name, typeName, rows), null, ownsChildren: true)
     {
     }
 

--- a/ClickHouse.Driver.Tcp/Types/TupleFieldColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/TupleFieldColumn.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace ClickHouse.Driver.Tcp.Types;
+
+/// <summary>
+/// A lazy write-path view that projects one element position out of a flat column of <c>ValueTuple</c> rows, so a
+/// child codec can write that element's column straight from the ergonomic tuple column without un-transposing all
+/// elements into per-child buffers first. Each access boxes the row's tuple and its element (the accepted cost of
+/// the tuple transpose today; a typed accessor would remove it). The view is read per element — the child columns
+/// are strided through the tuples, so there is no contiguous span. It borrows the source: disposing it does nothing.
+/// </summary>
+/// <typeparam name="T">The element type at this position.</typeparam>
+internal sealed class TupleFieldColumn<T> : IColumn<T>
+{
+    private readonly IColumn source;
+    private readonly int fieldIndex;
+
+    /// <summary>Initializes a projection of element <paramref name="fieldIndex"/> out of <paramref name="source"/>.</summary>
+    /// <param name="typeName">The element type name the view reports (the child codec's own type).</param>
+    /// <param name="source">The flat column of <c>ValueTuple</c> rows.</param>
+    /// <param name="fieldIndex">The zero-based element position to project.</param>
+    public TupleFieldColumn(string typeName, IColumn source, int fieldIndex)
+    {
+        TypeName = typeName;
+        this.source = source;
+        this.fieldIndex = fieldIndex;
+    }
+
+    /// <inheritdoc/>
+    public string Name => source.Name;
+
+    /// <inheritdoc/>
+    public string TypeName { get; }
+
+    /// <inheritdoc/>
+    public int RowCount => source.RowCount;
+
+    /// <inheritdoc/>
+    public T this[int row] => (T)((ITuple)source.GetValue(row))[fieldIndex];
+
+    /// <inheritdoc/>
+    public object GetValue(int row) => this[row];
+
+    /// <summary>Not supported: the element is strided through the tuple rows, so there is no contiguous span.</summary>
+    /// <exception cref="NotSupportedException">Always — read the view per element.</exception>
+    public ReadOnlySpan<T> Values => throw new NotSupportedException($"{nameof(TupleFieldColumn<T>)} has no contiguous span; read it per element.");
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+    }
+}

--- a/ClickHouse.Driver.Tcp/Types/TypeNode.cs
+++ b/ClickHouse.Driver.Tcp/Types/TypeNode.cs
@@ -12,13 +12,23 @@ namespace ClickHouse.Driver.Tcp.Types;
 /// </summary>
 internal sealed class TypeNode
 {
-    /// <summary>Initializes a new instance of the <see cref="TypeNode"/> class.</summary>
+    /// <summary>Initializes a new instance of the <see cref="TypeNode"/> class, with an argument list iff there are arguments.</summary>
     /// <param name="name">The base type name, or the raw token for a non-type argument.</param>
     /// <param name="arguments">The argument nodes; empty for a plain type or a leaf token.</param>
     public TypeNode(string name, IReadOnlyList<TypeNode> arguments)
+        : this(name, arguments, arguments.Count > 0)
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="TypeNode"/> class.</summary>
+    /// <param name="name">The base type name, or the raw token for a non-type argument.</param>
+    /// <param name="arguments">The argument nodes; empty for a plain type or a leaf token.</param>
+    /// <param name="hasArgumentList">Whether the type string carried parentheses, even around nothing.</param>
+    public TypeNode(string name, IReadOnlyList<TypeNode> arguments, bool hasArgumentList)
     {
         Name = name;
         Arguments = arguments;
+        HasArgumentList = hasArgumentList;
     }
 
     /// <summary>The base type name (e.g. <c>UInt64</c>, <c>Array</c>), or the raw token of a non-type argument.</summary>
@@ -27,11 +37,18 @@ internal sealed class TypeNode
     /// <summary>The argument nodes, in source order; empty when the type takes none.</summary>
     public IReadOnlyList<TypeNode> Arguments { get; }
 
+    /// <summary>
+    /// Whether the type string carried a parenthesized argument list, even an empty one. Only an empty list makes
+    /// this differ from <c><see cref="Arguments"/>.Count > 0</c>, which separates the legal zero-element
+    /// <c>Tuple()</c> from a bare <c>Tuple</c> that names no elements at all.
+    /// </summary>
+    public bool HasArgumentList { get; }
+
     /// <summary>Reconstructs a canonical type string (arguments comma-separated), useful for diagnostics.</summary>
     /// <returns>The type string.</returns>
     public override string ToString()
     {
-        if (Arguments.Count == 0)
+        if (Arguments.Count == 0 && !HasArgumentList)
         {
             return Name;
         }

--- a/ClickHouse.Driver.Tcp/Types/TypeParser.cs
+++ b/ClickHouse.Driver.Tcp/Types/TypeParser.cs
@@ -59,6 +59,15 @@ internal static class TypeParser
         }
 
         position++; // consume '('
+
+        // An immediately closing paren is an empty argument list, which the zero-element Tuple() needs. It stays
+        // distinct from a bare name so a type that requires arguments can still reject it.
+        if (position < tokens.Count && tokens[position] == ")")
+        {
+            position++;
+            return new TypeNode(name, Array.Empty<TypeNode>(), hasArgumentList: true);
+        }
+
         var arguments = new List<TypeNode>();
         while (true)
         {


### PR DESCRIPTION
Stacked on `tcp/epic-i2-arrays` (#435). Implements **I3 `Tuple(...)`** (read + write) for the native/TCP client (`ClickHouse.Driver.Tcp`) — the first heterogeneous composite in the stack.

## Wire format

A `Tuple(T1, …, Tn)` serializes as its N element columns side by side: **every child's serialization-state prefix in order, then every child's full column body in order**, each body holding exactly `num_rows` values. The codec owns one child codec per element and drives each phase by looping the children, so the codec itself is **arity-agnostic**; only the decoded column type is per-arity.

## CLR representation

The decoded column is the typed `TupleColumn<T1..Tn>` for the element count, surfacing each row as a `ValueTuple`. This is a deliberate choice over `object[]`/`ITuple`: it gives zero-boxing typed access **and** lets tuples nest inside other composites (`Array(Tuple)` needs the tuple column to be `IColumn<concrete-ValueTuple>`).

- **Arity capped at 7.** ≥8 → `NotSupportedException`; nested-`TRest` continuation is deferred. A bare `Tuple`, which names no elements and has no argument list, stays a `FormatException`.
- **Named tuples** (`Tuple(a Int32, b String)`) are supported: names are preserved in the type string and carried on the column as metadata, but do not affect the wire layout or the CLR value. Nullability composes as `Tuple(Nullable(T), …)` since the server rejects `Nullable(Tuple(...))`.

## Write paths

- **Dense** (`ITupleColumn` — child columns already exist): each child is serialized straight from its column, no copy.
- **Flat** (`IColumn<ValueTuple>` — e.g. what `Array(Tuple(...))` flattens into): projected element-by-element into pooled per-child columns. This boxes each element; it's the ergonomic, not the hot, path.

## The zero-element `Tuple()`

`Tuple()` is a legal type (`CREATE TABLE t (a Tuple())` succeeds, and it nests as `Array(Tuple())`, `Tuple(Int32, Tuple())`). It was refused at four layers, so a `SELECT` returning it failed the whole query: `TypeParser` rejected the empty argument list, `TypeNode` could not tell `Tuple()` from a bare `Tuple`, `NamedElementParser` dropped the empty argument list when it rebuilt a named element's node (so `Tuple(x Int32, y Tuple())` resolved to a bare `Tuple`), and the codec threw for arity 0.

It has **no element streams**. Like `Nothing`, it occupies one placeholder byte per row and has no state prefix. The server writes ASCII `'0'` and ignores what it reads back (verified: a Native insert with `0x00` filler is also accepted).

**Why a separate `EmptyTupleColumnCodec` rather than a branch in `TupleColumnCodec`:** the tuple codec's body is entirely a loop over child codecs, and an empty tuple has none — the two share no code. Decisively, the tuple codec could not return a tuple column at all: `TupleColumnBase` derives `RowCount` from its children, so with no children a row count cannot be expressed (it throws on empty children, and a test pins that). `TupleColumnCodec.Create` stays the single entry point and dispatches arity 0. The duplication that remains is the ~12-line placeholder read, shared with `NothingColumnCodec`, whose wire layout is identical; merging those two would rewrite an earlier epic's codec under 13 stacked PRs, so it is left as its own cleanup.

`Nullable(Tuple())` is rejected by the server, consistent with tuples generally, so there is no case for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
