### PR TITLE
TCP I4: Add Map(K, V) support

### DIFF
--- a/ClickHouse.Driver.Tcp.Tests/Integration/ColumnarReadSurfaceIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ColumnarReadSurfaceIntegrationTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -300,6 +301,94 @@ public class ColumnarReadSurfaceIntegrationTests
             Assert.That(childIsArray, Is.True, "a composite child re-enters the columnar surface");
             Assert.That(childOffsets, Is.EqualTo(new[] { 0, 0, 1, 3 }), "the child array's own per-row offsets");
             Assert.That(childInnerValues, Is.EqualTo(new[] { 0, 0, 1 }));
+        });
+    }
+
+    [Test]
+    public async Task QueryAsync_MapColumn_ExposesFlatKeyAndValueColumnsThroughIMapColumn()
+    {
+        // A Map(K, V) is byte-identical to Array(Tuple(K, V)) on the wire: per-row offsets over two flat, aligned
+        // runs. The materialized surface builds a KeyValuePair[] per row; IMapColumn hands back the two columns, so
+        // a caller wanting only the keys — a common case — never builds a pair at all.
+        await using var connection = await TcpServerFixture.ConnectAsync(None);
+
+        bool matched = false;
+        int rowCount = 0;
+        int[] offsets = null;
+        string[] flatKeys = null;
+        int[] flatValues = null;
+        int keyColumnRowCount = 0;
+        var keysPerRow = new List<string[]>();
+        KeyValuePair<string, int>[][] materialized = null;
+
+        // Rows: {}, {'k0': 0}, {'k0': 0, 'k1': 100} — an empty leading row keeps a zero-length range in play.
+        await foreach (Block block in connection.QueryAsync(
+            """
+            SELECT CAST(
+                arrayMap(i -> (concat('k', toString(i)), toInt32(i * 100)), range(number)),
+                'Map(String, Int32)')
+            FROM system.numbers LIMIT 3
+            """,
+            cancellationToken: None))
+        {
+            IColumn column = block[0];
+            matched = column is IMapColumn<string, int>;
+
+            var map = (IMapColumn<string, int>)column;
+            rowCount = map.RowCount;
+            offsets = map.Offsets.ToArray();
+            flatKeys = map.KeyColumn.Values.ToArray();
+            flatValues = map.ValueColumn.Values.ToArray();
+            keyColumnRowCount = map.KeyColumn.RowCount;
+            materialized = ((IColumn<KeyValuePair<string, int>[]>)column).Values.ToArray();
+
+            // Take just the keys of each row, without materializing the values or the pairs.
+            for (int row = 0; row < map.RowCount; row++)
+            {
+                int start = map.Offsets[row];
+                keysPerRow.Add(map.KeyColumn.Values.Slice(start, map.Offsets[row + 1] - start).ToArray());
+            }
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(matched, Is.True);
+            Assert.That(rowCount, Is.EqualTo(3));
+            Assert.That(offsets, Is.EqualTo(new[] { 0, 0, 1, 3 }), "one more entry than rows");
+            Assert.That(offsets.Length, Is.EqualTo(rowCount + 1), "sliced to the row count, not the pooled buffer length");
+            Assert.That(flatKeys, Is.EqualTo(new[] { "k0", "k0", "k1" }), "every row's keys end-to-end");
+            Assert.That(flatValues, Is.EqualTo(new[] { 0, 0, 100 }), "and the values, aligned entry-for-entry");
+            Assert.That(keyColumnRowCount, Is.EqualTo(3), "the key column is flat: one entry per pair, not per row");
+            Assert.That(keysPerRow, Is.EqualTo(new[] { Array.Empty<string>(), new[] { "k0" }, new[] { "k0", "k1" } }));
+            Assert.That(materialized.Select(r => r.Length), Is.EqualTo(new[] { 0, 1, 2 }));
+            Assert.That(materialized[2], Is.EqualTo(new[] { new KeyValuePair<string, int>("k0", 0), new KeyValuePair<string, int>("k1", 100) }));
+        });
+    }
+
+    [Test]
+    public async Task QueryAsync_MapColumnWithDuplicateKeys_PreservesWireOrderAndDuplicates()
+    {
+        // The flat columns are the wire's own bytes, so they carry duplicate keys and entry order intact — the
+        // property a Dictionary-shaped view would destroy. ClickHouse itself permits a literal map with a repeated
+        // key, so this is reachable data, not a hypothetical.
+        await using var connection = await TcpServerFixture.ConnectAsync(None);
+
+        string[] flatKeys = null;
+        int[] flatValues = null;
+
+        await foreach (Block block in connection.QueryAsync(
+            "SELECT CAST([('dup', 1), ('dup', 2), ('other', 3)], 'Map(String, Int32)')",
+            cancellationToken: None))
+        {
+            var map = (IMapColumn<string, int>)block[0];
+            flatKeys = map.KeyColumn.Values.ToArray();
+            flatValues = map.ValueColumn.Values.ToArray();
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(flatKeys, Is.EqualTo(new[] { "dup", "dup", "other" }), "the duplicate survives");
+            Assert.That(flatValues, Is.EqualTo(new[] { 1, 2, 3 }), "in wire order, so both entries stay addressable");
         });
     }
 }

--- a/ClickHouse.Driver.Tcp.Tests/Types/ColumnCodecRegistryTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/ColumnCodecRegistryTests.cs
@@ -34,7 +34,7 @@ public class ColumnCodecRegistryTests
 
     [Test]
     public void Resolve_UnsupportedButWellFormedType_ThrowsNotSupported()
-        => Assert.Throws<NotSupportedException>(() => ColumnCodecRegistry.Default.Resolve("Map(String, Int32)", default));
+        => Assert.Throws<NotSupportedException>(() => ColumnCodecRegistry.Default.Resolve("Nested(a Int32, b String)", default));
 
     [Test]
     public void Resolve_MalformedType_ThrowsFormat()

--- a/ClickHouse.Driver.Tcp.Tests/Types/MapColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/MapColumnCodecTests.cs
@@ -344,4 +344,46 @@ public class MapColumnCodecTests
             Assert.Throws<NotSupportedException>(() => Resolve("Map(String, NoSuchType)"));
         });
     }
+
+    [Test]
+    public void TryDensify_DenseMapWithErgonomicValueColumn_DisposesOnlyRebuiltColumnNotBorrowed()
+    {
+        // A dense MapColumn whose value column is still ergonomic (a jagged ArrayColumn) while its key column is
+        // already dense (a leaf): TryDensify rebuilds only the value column and keeps the key column by reference.
+        // Disposing the rebuilt wrapper must free the freshly built value column but leave the borrowed key column
+        // alone — it is still owned by the source column, so disposing it here would double-dispose it.
+        IColumnCodec codec = Resolve("Map(Int32, Array(Int32))");
+        var borrowedKeys = new DisposeSpyColumn<int>("c", "Int32", new[] { 7 });
+        var ergonomicValues = new ArrayColumn<int[]>("c", "Array(Int32)", new[] { new[] { 1, 2 } });
+        var source = new MapColumn<int, int[]>("c", "Map(Int32, Array(Int32))", borrowedKeys, ergonomicValues, new[] { 0, 1 }, rowCount: 1, pooledOffsets: false);
+
+        IColumn densified = codec.TryDensify(source, out bool built);
+        Assert.That(built, Is.True, "the value column was ergonomic, so a rebuild is expected");
+        Assert.That(densified, Is.Not.SameAs(source));
+        densified.Dispose();
+
+        Assert.That(borrowedKeys.DisposeCount, Is.EqualTo(0), "the borrowed, already-dense key column must not be disposed by the rebuilt wrapper");
+
+        ergonomicValues.Dispose();
+        borrowedKeys.Dispose();
+    }
+
+    [Test]
+    public void RestrictOwnership_DisposesOnlyOwnedChildColumn()
+    {
+        // The mechanism the partial densify rebuild relies on: after RestrictOwnership, Dispose frees exactly the
+        // child (key/value) column flagged owned (the freshly built one) and leaves the borrowed one untouched.
+        var ownedKeys = new DisposeSpyColumn<int>("c", "Int32", new[] { 1 });
+        var borrowedValues = new DisposeSpyColumn<int[]>("c", "Array(Int32)", new[] { new[] { 2 } });
+        var map = new MapColumn<int, int[]>("c", "Map(Int32, Array(Int32))", ownedKeys, borrowedValues, new[] { 0, 1 }, rowCount: 1, pooledOffsets: false);
+
+        map.RestrictOwnership(keysOwned: true, valuesOwned: false);
+        map.Dispose();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(ownedKeys.DisposeCount, Is.EqualTo(1), "the owned (freshly built) column must be disposed exactly once");
+            Assert.That(borrowedValues.DisposeCount, Is.EqualTo(0), "the borrowed column must not be disposed");
+        });
+    }
 }

--- a/ClickHouse.Driver.Tcp.Tests/Types/MapColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/MapColumnCodecTests.cs
@@ -1,0 +1,347 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Protocol;
+using ClickHouse.Driver.Tcp.Tests.Utilities;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Tests.Types;
+
+[TestFixture]
+public class MapColumnCodecTests
+{
+    private static IColumnCodec Resolve(string type) => ColumnCodecRegistry.Default.Resolve(type, default);
+
+    private static KeyValuePair<TKey, TValue>[] Row<TKey, TValue>(params (TKey Key, TValue Value)[] pairs)
+    {
+        var result = new KeyValuePair<TKey, TValue>[pairs.Length];
+        for (int i = 0; i < pairs.Length; i++)
+        {
+            result[i] = new KeyValuePair<TKey, TValue>(pairs[i].Key, pairs[i].Value);
+        }
+
+        return result;
+    }
+
+    [Test]
+    public async Task ReadColumn_WriteThenRead_FixedWidthKeyAndValueRoundTripsWithEmptyRows()
+    {
+        IColumnCodec codec = Resolve("Map(UInt8, UInt8)");
+        var expected = new[]
+        {
+            Row<byte, byte>((1, 10), (2, 20)),
+            Array.Empty<KeyValuePair<byte, byte>>(),
+            Row<byte, byte>((3, 30)),
+        };
+        var column = new ArrayColumn<KeyValuePair<byte, byte>[]>("c", "Map(UInt8, UInt8)", expected);
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Map(UInt8, UInt8)", column.RowCount);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(read.TypeName, Is.EqualTo("Map(UInt8, UInt8)"));
+            Assert.That(read.RowCount, Is.EqualTo(3));
+            Assert.That(((IColumn<KeyValuePair<byte, byte>[]>)read).Values.ToArray(), Is.EqualTo(expected));
+            Assert.That(read.GetValue(1), Is.EqualTo(Array.Empty<KeyValuePair<byte, byte>>()));
+        });
+    }
+
+    [Test]
+    public async Task ReadColumn_WriteThenRead_StringKeyRoundTrips()
+    {
+        IColumnCodec codec = Resolve("Map(String, UInt32)");
+        var expected = new[]
+        {
+            Row<string, uint>(("a", 1), ("b", 2)),
+            Row<string, uint>(("héllo✓", uint.MaxValue)),
+        };
+        var column = new ArrayColumn<KeyValuePair<string, uint>[]>("c", "Map(String, UInt32)", expected);
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Map(String, UInt32)", column.RowCount);
+
+        Assert.That(((IColumn<KeyValuePair<string, uint>[]>)read).Values.ToArray(), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public async Task ReadColumn_WriteThenRead_DuplicateKeysWithinRowArePreserved()
+    {
+        // A Map surfaces as KeyValuePair<K, V>[] precisely so duplicate keys and pair order round-trip intact —
+        // a Dictionary would silently collapse the duplicate. The wire tolerates duplicates within a row.
+        IColumnCodec codec = Resolve("Map(String, UInt8)");
+        var expected = new[] { Row<string, byte>(("A", 1), ("A", 2), ("B", 3)) };
+        var column = new ArrayColumn<KeyValuePair<string, byte>[]>("c", "Map(String, UInt8)", expected);
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Map(String, UInt8)", column.RowCount);
+
+        Assert.That(((IColumn<KeyValuePair<string, byte>[]>)read).Values.ToArray(), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public async Task ReadColumn_WriteThenRead_NullableValueRoundTrips()
+    {
+        // Map keys are non-nullable in ClickHouse and Nullable(Map(...)) is server-rejected, so nullability
+        // composes inside the value: Map(K, Nullable(V)).
+        IColumnCodec codec = Resolve("Map(String, Nullable(UInt32))");
+        var expected = new[]
+        {
+            Row<string, uint?>(("a", 1), ("b", null)),
+            Array.Empty<KeyValuePair<string, uint?>>(),
+            Row<string, uint?>(("c", null)),
+        };
+        var column = new ArrayColumn<KeyValuePair<string, uint?>[]>("c", "Map(String, Nullable(UInt32))", expected);
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Map(String, Nullable(UInt32))", column.RowCount);
+
+        Assert.That(((IColumn<KeyValuePair<string, uint?>[]>)read).Values.ToArray(), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public async Task ReadColumn_WriteThenRead_ArrayValueRoundTrips()
+    {
+        IColumnCodec codec = Resolve("Map(String, Array(Int32))");
+        var expected = new[]
+        {
+            Row<string, int[]>(("a", new[] { 1, 2, 3 }), ("b", Array.Empty<int>())),
+            Row<string, int[]>(("c", new[] { -1 })),
+        };
+        var column = new ArrayColumn<KeyValuePair<string, int[]>[]>("c", "Map(String, Array(Int32))", expected);
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Map(String, Array(Int32))", column.RowCount);
+
+        Assert.That(((IColumn<KeyValuePair<string, int[]>[]>)read).Values.ToArray(), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public async Task ReadColumn_EmptyColumn_ReadsZeroRowsWithoutConsumingBytes()
+    {
+        IColumnCodec codec = Resolve("Map(String, UInt32)");
+        var column = new ArrayColumn<KeyValuePair<string, uint>[]>("c", "Map(String, UInt32)", Array.Empty<KeyValuePair<string, uint>[]>());
+
+        byte[] bytes = await CodecTestHarness.WriteAsync(w => codec.WriteColumn(w, column, 0, 0));
+        Assert.That(bytes, Is.Empty, "an empty map column writes no offsets and no streams");
+
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(bytes);
+        using IColumn read = await codec.ReadColumnAsync(reader, "c", "Map(String, UInt32)", 0, CodecTestHarness.None);
+        Assert.That(read.RowCount, Is.Zero);
+    }
+
+    [Test]
+    public async Task ReadColumn_EveryRowEmpty_RoundTripsAsAllEmpty()
+    {
+        IColumnCodec codec = Resolve("Map(String, UInt32)");
+        var expected = new[]
+        {
+            Array.Empty<KeyValuePair<string, uint>>(),
+            Array.Empty<KeyValuePair<string, uint>>(),
+        };
+        var column = new ArrayColumn<KeyValuePair<string, uint>[]>("c", "Map(String, UInt32)", expected);
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Map(String, UInt32)", column.RowCount);
+
+        Assert.That(((IColumn<KeyValuePair<string, uint>[]>)read).Values.ToArray(), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public async Task WriteColumn_DenseMapColumn_RoundTripsWithoutRebuildingStreams()
+    {
+        // A dense MapColumn<TKey, TValue> (flat key/value columns + offsets, the wire's own layout) is the
+        // zero-copy write path — the same shape a read produces. Writing one and reading it back preserves the rows.
+        IColumnCodec codec = Resolve("Map(String, UInt32)");
+        var keys = new ArrayColumn<string>("c", "String", new[] { "a", "b", "c" });
+        var values = PrimitiveColumn<uint>.FromValues("c", "UInt32", new uint[] { 1, 2, 3 });
+        var dense = new MapColumn<string, uint>("c", "Map(String, UInt32)", keys, values, new[] { 0, 2, 3 }, rowCount: 2, pooledOffsets: false);
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, dense, "Map(String, UInt32)", dense.RowCount);
+
+        Assert.That(((IColumn<KeyValuePair<string, uint>[]>)read).Values.ToArray(), Is.EqualTo(new[]
+        {
+            Row<string, uint>(("a", 1), ("b", 2)),
+            Row<string, uint>(("c", 3)),
+        }));
+    }
+
+    [Test]
+    public async Task WriteColumn_SlicedRange_WritesOffsetsRelativeToTheSlice()
+    {
+        // Writing only rows [1, 3) of a four-row column (the insert splitter's per-block path) must emit offsets
+        // relative to that block's own streams, not the full column.
+        IColumnCodec codec = Resolve("Map(String, UInt8)");
+        var full = new ArrayColumn<KeyValuePair<string, byte>[]>("c", "Map(String, UInt8)", new[]
+        {
+            Row<string, byte>(("a", 1)),
+            Row<string, byte>(("b", 2), ("c", 3)),
+            Array.Empty<KeyValuePair<string, byte>>(),
+            Row<string, byte>(("d", 4), ("e", 5), ("f", 6)),
+        });
+
+        byte[] bytes = await CodecTestHarness.WriteAsync(w => codec.WriteColumn(w, full, start: 1, length: 2));
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(bytes);
+        using IColumn read = await codec.ReadColumnAsync(reader, "c", "Map(String, UInt8)", 2, CodecTestHarness.None);
+
+        Assert.That(((IColumn<KeyValuePair<string, byte>[]>)read).Values.ToArray(), Is.EqualTo(new[]
+        {
+            Row<string, byte>(("b", 2), ("c", 3)),
+            Array.Empty<KeyValuePair<string, byte>>(),
+        }));
+    }
+
+    [Test]
+    public void MeasureRowBytes_FixedWidthKeyAndValue_CountsOneOffsetPlusPairs()
+    {
+        IColumnCodec codec = Resolve("Map(UInt8, UInt32)");
+        var column = new ArrayColumn<KeyValuePair<byte, uint>[]>("c", "Map(UInt8, UInt32)", new[]
+        {
+            Row<byte, uint>((1, 10), (2, 20), (3, 30)),
+            Array.Empty<KeyValuePair<byte, uint>>(),
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(codec.MeasureRowBytes(column, 0), Is.EqualTo(8 + (3 * (1 + 4)))); // one offset + three (UInt8 + UInt32) pairs
+            Assert.That(codec.MeasureRowBytes(column, 1), Is.EqualTo(8));                  // one offset, no pairs
+            Assert.That(codec.FixedRowByteSize, Is.Null);
+        });
+    }
+
+    [Test]
+    public void MeasureRowBytes_VariableKeyOrValue_WalksEachPair()
+    {
+        IColumnCodec codec = Resolve("Map(String, UInt32)");
+        var column = new ArrayColumn<KeyValuePair<string, uint>[]>("c", "Map(String, UInt32)", new[]
+        {
+            Row<string, uint>(("a", 1), ("bb", 2)),
+            Array.Empty<KeyValuePair<string, uint>>(),
+        });
+
+        Assert.Multiple(() =>
+        {
+            // offset + ("a" = 1+1) + ("bb" = 1+2) keys + two UInt32 values
+            Assert.That(codec.MeasureRowBytes(column, 0), Is.EqualTo(8 + (1 + 1) + (1 + 2) + (2 * 4)));
+            Assert.That(codec.MeasureRowBytes(column, 1), Is.EqualTo(8));
+        });
+    }
+
+    [Test]
+    public async Task MeasureRowBytes_DenseColumn_PricesFromOffsetsAndStreams()
+    {
+        // A dense MapColumn (the read-back shape) re-inserted goes through the offsets-based measure path, distinct
+        // from the jagged-column path.
+        IColumnCodec codec = Resolve("Map(String, UInt32)");
+        var jagged = new ArrayColumn<KeyValuePair<string, uint>[]>("c", "Map(String, UInt32)", new[]
+        {
+            Row<string, uint>(("a", 1), ("bb", 2)),
+            Array.Empty<KeyValuePair<string, uint>>(),
+        });
+        using IColumn dense = await CodecTestHarness.RoundTripAsync(codec, jagged, "Map(String, UInt32)", 2);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(codec.MeasureRowBytes(dense, 0), Is.EqualTo(8 + (1 + 1) + (1 + 2) + (2 * 4)));
+            Assert.That(codec.MeasureRowBytes(dense, 1), Is.EqualTo(8));
+        });
+    }
+
+    [Test]
+    public void WriteColumn_NullRow_ThrowsArgumentException()
+    {
+        // Map(K, V) rows are non-nullable, so a null row is rejected rather than silently written as an empty map.
+        IColumnCodec codec = Resolve("Map(String, UInt8)");
+        var column = new ArrayColumn<KeyValuePair<string, byte>[]>("c", "Map(String, UInt8)", new[]
+        {
+            Row<string, byte>(("a", 1)),
+            null,
+        });
+
+        Assert.ThrowsAsync<ArgumentException>(() => CodecTestHarness.WriteAsync(w => codec.WriteColumn(w, column)));
+    }
+
+    [Test]
+    public void MeasureRowBytes_NullRow_ThrowsArgumentException()
+    {
+        // Sizing must agree with the write path: a null row is invalid, not empty.
+        IColumnCodec codec = Resolve("Map(String, UInt8)");
+        var column = new ArrayColumn<KeyValuePair<string, byte>[]>("c", "Map(String, UInt8)", new[]
+        {
+            Row<string, byte>(("a", 1)),
+            null,
+        });
+
+        Assert.Throws<ArgumentException>(() => codec.MeasureRowBytes(column, 1));
+    }
+
+    [Test]
+    public void CanWrite_AcceptsOnlyMatchingMapColumn()
+    {
+        IColumnCodec codec = Resolve("Map(String, UInt32)");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(codec.CanWrite(new ArrayColumn<KeyValuePair<string, uint>[]>("c", "Map(String, UInt32)", new[] { Row<string, uint>(("a", 1)) })), Is.True);
+            Assert.That(codec.CanWrite(new ArrayColumn<KeyValuePair<string, int>[]>("c", "Map(String, Int32)", new[] { Row<string, int>(("a", 1)) })), Is.False);
+            Assert.That(codec.CanWrite(PrimitiveColumn<uint>.FromValues("c", "UInt32", new uint[] { 1 })), Is.False);
+        });
+    }
+
+    [Test]
+    public void ElementType_IsKeyValuePairArray()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(Resolve("Map(String, UInt32)").ElementType, Is.EqualTo(typeof(KeyValuePair<string, uint>[])));
+            Assert.That(Resolve("Map(UInt8, String)").ElementType, Is.EqualTo(typeof(KeyValuePair<byte, string>[])));
+            Assert.That(Resolve("Map(String, Nullable(UInt32))").ElementType, Is.EqualTo(typeof(KeyValuePair<string, uint?>[])));
+            Assert.That(Resolve("Map(String, Array(Int32))").ElementType, Is.EqualTo(typeof(KeyValuePair<string, int[]>[])));
+        });
+    }
+
+    [Test]
+    public void NullPlaceholder_IsEmptyPairArray()
+        => Assert.That(Resolve("Map(String, UInt32)").NullPlaceholder, Is.EqualTo(Array.Empty<KeyValuePair<string, uint>>()));
+
+    [Test]
+    public async Task ReadColumn_NonMonotonicOffsets_ThrowsProtocol()
+    {
+        // Offsets must be non-decreasing; a decrease is corruption. Wire: two UInt64 offsets [2, 1].
+        IColumnCodec codec = Resolve("Map(UInt8, UInt8)");
+        byte[] wire = new byte[16];
+        BitConverter.TryWriteBytes(wire.AsSpan(0, 8), 2UL);
+        BitConverter.TryWriteBytes(wire.AsSpan(8, 8), 1UL);
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(wire);
+
+        Assert.ThrowsAsync<ClickHouseProtocolException>(async () =>
+            await codec.ReadColumnAsync(reader, "c", "Map(UInt8, UInt8)", 2, CodecTestHarness.None));
+    }
+
+    [Test]
+    public async Task ReadColumn_OffsetBeyondInt32_ThrowsProtocol()
+    {
+        // An offset larger than int.MaxValue cannot be addressed by this client and is rejected up front.
+        IColumnCodec codec = Resolve("Map(UInt8, UInt8)");
+        byte[] wire = new byte[8];
+        BitConverter.TryWriteBytes(wire.AsSpan(0, 8), (ulong)int.MaxValue + 1);
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(wire);
+
+        Assert.ThrowsAsync<ClickHouseProtocolException>(async () =>
+            await codec.ReadColumnAsync(reader, "c", "Map(UInt8, UInt8)", 1, CodecTestHarness.None));
+    }
+
+    [Test]
+    public void Resolve_Map_StampsFullTypeName()
+        => Assert.That(Resolve("Map(String, Array(UInt32))").TypeName, Is.EqualTo("Map(String, Array(UInt32))"));
+
+    [TestCase("Map(String)")]
+    [TestCase("Map(String, UInt32, UInt8)")]
+    [TestCase("Map()")]
+    public void Resolve_WrongArgumentCount_ThrowsFormat(string type)
+        => Assert.Throws<FormatException>(() => Resolve(type));
+
+    [Test]
+    public void Resolve_UnsupportedKeyOrValue_ThrowsNotSupported()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.Throws<NotSupportedException>(() => Resolve("Map(NoSuchType, UInt32)"));
+            Assert.Throws<NotSupportedException>(() => Resolve("Map(String, NoSuchType)"));
+        });
+    }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Types/MapColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/MapColumnCodecTests.cs
@@ -186,62 +186,6 @@ public class MapColumnCodecTests
     }
 
     [Test]
-    public void MeasureRowBytes_FixedWidthKeyAndValue_CountsOneOffsetPlusPairs()
-    {
-        IColumnCodec codec = Resolve("Map(UInt8, UInt32)");
-        var column = new ArrayColumn<KeyValuePair<byte, uint>[]>("c", "Map(UInt8, UInt32)", new[]
-        {
-            Row<byte, uint>((1, 10), (2, 20), (3, 30)),
-            Array.Empty<KeyValuePair<byte, uint>>(),
-        });
-
-        Assert.Multiple(() =>
-        {
-            Assert.That(codec.MeasureRowBytes(column, 0), Is.EqualTo(8 + (3 * (1 + 4)))); // one offset + three (UInt8 + UInt32) pairs
-            Assert.That(codec.MeasureRowBytes(column, 1), Is.EqualTo(8));                  // one offset, no pairs
-            Assert.That(codec.FixedRowByteSize, Is.Null);
-        });
-    }
-
-    [Test]
-    public void MeasureRowBytes_VariableKeyOrValue_WalksEachPair()
-    {
-        IColumnCodec codec = Resolve("Map(String, UInt32)");
-        var column = new ArrayColumn<KeyValuePair<string, uint>[]>("c", "Map(String, UInt32)", new[]
-        {
-            Row<string, uint>(("a", 1), ("bb", 2)),
-            Array.Empty<KeyValuePair<string, uint>>(),
-        });
-
-        Assert.Multiple(() =>
-        {
-            // offset + ("a" = 1+1) + ("bb" = 1+2) keys + two UInt32 values
-            Assert.That(codec.MeasureRowBytes(column, 0), Is.EqualTo(8 + (1 + 1) + (1 + 2) + (2 * 4)));
-            Assert.That(codec.MeasureRowBytes(column, 1), Is.EqualTo(8));
-        });
-    }
-
-    [Test]
-    public async Task MeasureRowBytes_DenseColumn_PricesFromOffsetsAndStreams()
-    {
-        // A dense MapColumn (the read-back shape) re-inserted goes through the offsets-based measure path, distinct
-        // from the jagged-column path.
-        IColumnCodec codec = Resolve("Map(String, UInt32)");
-        var jagged = new ArrayColumn<KeyValuePair<string, uint>[]>("c", "Map(String, UInt32)", new[]
-        {
-            Row<string, uint>(("a", 1), ("bb", 2)),
-            Array.Empty<KeyValuePair<string, uint>>(),
-        });
-        using IColumn dense = await CodecTestHarness.RoundTripAsync(codec, jagged, "Map(String, UInt32)", 2);
-
-        Assert.Multiple(() =>
-        {
-            Assert.That(codec.MeasureRowBytes(dense, 0), Is.EqualTo(8 + (1 + 1) + (1 + 2) + (2 * 4)));
-            Assert.That(codec.MeasureRowBytes(dense, 1), Is.EqualTo(8));
-        });
-    }
-
-    [Test]
     public void WriteColumn_NullRow_ThrowsArgumentException()
     {
         // Map(K, V) rows are non-nullable, so a null row is rejected rather than silently written as an empty map.
@@ -253,20 +197,6 @@ public class MapColumnCodecTests
         });
 
         Assert.ThrowsAsync<ArgumentException>(() => CodecTestHarness.WriteAsync(w => codec.WriteColumn(w, column)));
-    }
-
-    [Test]
-    public void MeasureRowBytes_NullRow_ThrowsArgumentException()
-    {
-        // Sizing must agree with the write path: a null row is invalid, not empty.
-        IColumnCodec codec = Resolve("Map(String, UInt8)");
-        var column = new ArrayColumn<KeyValuePair<string, byte>[]>("c", "Map(String, UInt8)", new[]
-        {
-            Row<string, byte>(("a", 1)),
-            null,
-        });
-
-        Assert.Throws<ArgumentException>(() => codec.MeasureRowBytes(column, 1));
     }
 
     [Test]
@@ -343,29 +273,6 @@ public class MapColumnCodecTests
             Assert.Throws<NotSupportedException>(() => Resolve("Map(NoSuchType, UInt32)"));
             Assert.Throws<NotSupportedException>(() => Resolve("Map(String, NoSuchType)"));
         });
-    }
-
-    [Test]
-    public void TryDensify_DenseMapWithErgonomicValueColumn_DisposesOnlyRebuiltColumnNotBorrowed()
-    {
-        // A dense MapColumn whose value column is still ergonomic (a jagged ArrayColumn) while its key column is
-        // already dense (a leaf): TryDensify rebuilds only the value column and keeps the key column by reference.
-        // Disposing the rebuilt wrapper must free the freshly built value column but leave the borrowed key column
-        // alone — it is still owned by the source column, so disposing it here would double-dispose it.
-        IColumnCodec codec = Resolve("Map(Int32, Array(Int32))");
-        var borrowedKeys = new DisposeSpyColumn<int>("c", "Int32", new[] { 7 });
-        var ergonomicValues = new ArrayColumn<int[]>("c", "Array(Int32)", new[] { new[] { 1, 2 } });
-        var source = new MapColumn<int, int[]>("c", "Map(Int32, Array(Int32))", borrowedKeys, ergonomicValues, new[] { 0, 1 }, rowCount: 1, pooledOffsets: false);
-
-        IColumn densified = codec.TryDensify(source, out bool built);
-        Assert.That(built, Is.True, "the value column was ergonomic, so a rebuild is expected");
-        Assert.That(densified, Is.Not.SameAs(source));
-        densified.Dispose();
-
-        Assert.That(borrowedKeys.DisposeCount, Is.EqualTo(0), "the borrowed, already-dense key column must not be disposed by the rebuilt wrapper");
-
-        ergonomicValues.Dispose();
-        borrowedKeys.Dispose();
     }
 
     [Test]

--- a/ClickHouse.Driver.Tcp.Tests/Types/MapColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/MapColumnCodecTests.cs
@@ -174,6 +174,37 @@ public class MapColumnCodecTests
     }
 
     [Test]
+    public void Indexer_RowPastRowCount_ThrowsRatherThanReadingStaleOffsets()
+    {
+        // The offsets buffer is normally a pooled array longer than the column, and a previous, larger read leaves
+        // monotonic offsets behind in the tail. Reading a row past RowCount through the raw buffer would therefore
+        // hand back real-looking pairs instead of failing — silent wrong data, not a crash. Here row 0 is the whole
+        // column; the 4 is the stale tail a longer read would have left.
+        var keys = new ArrayColumn<int>("c", "Int32", new[] { 1, 2, 3, 4 });
+        var values = new ArrayColumn<string>("c", "String", new[] { "a", "b", "c", "d" });
+        using var map = new MapColumn<int, string>("c", "Map(Int32, String)", keys, values, new[] { 0, 2, 4 }, rowCount: 1, pooledOffsets: false);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(map[0], Is.EqualTo(new[] { new KeyValuePair<int, string>(1, "a"), new KeyValuePair<int, string>(2, "b") }));
+            Assert.That(() => map[1], Throws.InstanceOf<IndexOutOfRangeException>());
+        });
+    }
+
+    [Test]
+    public void Constructor_OffsetsShorterThanRowCountPlusOne_Throws()
+    {
+        // rowCount is load-bearing here — the key and value columns are flat and the offsets are pooled — so it is
+        // validated rather than derived. One offset per row plus the leading zero is the minimum.
+        var keys = new ArrayColumn<int>("c", "Int32", new[] { 1, 2 });
+        var values = new ArrayColumn<string>("c", "String", new[] { "a", "b" });
+
+        Assert.That(
+            () => new MapColumn<int, string>("c", "Map(Int32, String)", keys, values, new[] { 0, 2 }, rowCount: 2, pooledOffsets: false),
+            Throws.ArgumentException.With.Message.Contains("fewer than"));
+    }
+
+    [Test]
     public void RestrictOwnership_DisposesOnlyOwnedChildColumn()
     {
         // The mechanism the partial densify rebuild relies on: after RestrictOwnership, Dispose frees exactly the

--- a/ClickHouse.Driver.Tcp.Tests/Types/MapColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/MapColumnCodecTests.cs
@@ -24,91 +24,24 @@ public class MapColumnCodecTests
     }
 
     [Test]
-    public async Task ReadColumn_WriteThenRead_FixedWidthKeyAndValueRoundTripsWithEmptyRows()
-    {
-        IColumnCodec codec = Resolve("Map(UInt8, UInt8)");
-        var expected = new[]
-        {
-            Row<byte, byte>((1, 10), (2, 20)),
-            Array.Empty<KeyValuePair<byte, byte>>(),
-            Row<byte, byte>((3, 30)),
-        };
-        var column = new ArrayColumn<KeyValuePair<byte, byte>[]>("c", "Map(UInt8, UInt8)", expected);
-
-        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Map(UInt8, UInt8)", column.RowCount);
-
-        Assert.Multiple(() =>
-        {
-            Assert.That(read.TypeName, Is.EqualTo("Map(UInt8, UInt8)"));
-            Assert.That(read.RowCount, Is.EqualTo(3));
-            Assert.That(((IColumn<KeyValuePair<byte, byte>[]>)read).Values.ToArray(), Is.EqualTo(expected));
-            Assert.That(read.GetValue(1), Is.EqualTo(Array.Empty<KeyValuePair<byte, byte>>()));
-        });
-    }
-
-    [Test]
-    public async Task ReadColumn_WriteThenRead_StringKeyRoundTrips()
-    {
-        IColumnCodec codec = Resolve("Map(String, UInt32)");
-        var expected = new[]
-        {
-            Row<string, uint>(("a", 1), ("b", 2)),
-            Row<string, uint>(("héllo✓", uint.MaxValue)),
-        };
-        var column = new ArrayColumn<KeyValuePair<string, uint>[]>("c", "Map(String, UInt32)", expected);
-
-        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Map(String, UInt32)", column.RowCount);
-
-        Assert.That(((IColumn<KeyValuePair<string, uint>[]>)read).Values.ToArray(), Is.EqualTo(expected));
-    }
-
-    [Test]
     public async Task ReadColumn_WriteThenRead_DuplicateKeysWithinRowArePreserved()
     {
         // A Map surfaces as KeyValuePair<K, V>[] precisely so duplicate keys and pair order round-trip intact —
         // a Dictionary would silently collapse the duplicate. The wire tolerates duplicates within a row.
+        // It also owns the Values coverage for Map: MapColumn.Values materializes the whole jagged cache in one
+        // pass, while GetValue -- the only accessor AssertColumnsEqual uses -- goes through the uncached indexer.
+        // The empty row is here for the same reason: Values' length == 0 branch is otherwise unreached.
         IColumnCodec codec = Resolve("Map(String, UInt8)");
-        var expected = new[] { Row<string, byte>(("A", 1), ("A", 2), ("B", 3)) };
+        var expected = new[] { Row<string, byte>(("A", 1), ("A", 2), ("B", 3)), Array.Empty<KeyValuePair<string, byte>>() };
         var column = new ArrayColumn<KeyValuePair<string, byte>[]>("c", "Map(String, UInt8)", expected);
 
         using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Map(String, UInt8)", column.RowCount);
 
-        Assert.That(((IColumn<KeyValuePair<string, byte>[]>)read).Values.ToArray(), Is.EqualTo(expected));
-    }
-
-    [Test]
-    public async Task ReadColumn_WriteThenRead_NullableValueRoundTrips()
-    {
-        // Map keys are non-nullable in ClickHouse and Nullable(Map(...)) is server-rejected, so nullability
-        // composes inside the value: Map(K, Nullable(V)).
-        IColumnCodec codec = Resolve("Map(String, Nullable(UInt32))");
-        var expected = new[]
+        Assert.Multiple(() =>
         {
-            Row<string, uint?>(("a", 1), ("b", null)),
-            Array.Empty<KeyValuePair<string, uint?>>(),
-            Row<string, uint?>(("c", null)),
-        };
-        var column = new ArrayColumn<KeyValuePair<string, uint?>[]>("c", "Map(String, Nullable(UInt32))", expected);
-
-        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Map(String, Nullable(UInt32))", column.RowCount);
-
-        Assert.That(((IColumn<KeyValuePair<string, uint?>[]>)read).Values.ToArray(), Is.EqualTo(expected));
-    }
-
-    [Test]
-    public async Task ReadColumn_WriteThenRead_ArrayValueRoundTrips()
-    {
-        IColumnCodec codec = Resolve("Map(String, Array(Int32))");
-        var expected = new[]
-        {
-            Row<string, int[]>(("a", new[] { 1, 2, 3 }), ("b", Array.Empty<int>())),
-            Row<string, int[]>(("c", new[] { -1 })),
-        };
-        var column = new ArrayColumn<KeyValuePair<string, int[]>[]>("c", "Map(String, Array(Int32))", expected);
-
-        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Map(String, Array(Int32))", column.RowCount);
-
-        Assert.That(((IColumn<KeyValuePair<string, int[]>[]>)read).Values.ToArray(), Is.EqualTo(expected));
+            Assert.That(read.RowCount, Is.EqualTo(2));
+            Assert.That(((IColumn<KeyValuePair<string, byte>[]>)read).Values.ToArray(), Is.EqualTo(expected));
+        });
     }
 
     [Test]
@@ -123,41 +56,6 @@ public class MapColumnCodecTests
         using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(bytes);
         using IColumn read = await codec.ReadColumnAsync(reader, "c", "Map(String, UInt32)", 0, CodecTestHarness.None);
         Assert.That(read.RowCount, Is.Zero);
-    }
-
-    [Test]
-    public async Task ReadColumn_EveryRowEmpty_RoundTripsAsAllEmpty()
-    {
-        IColumnCodec codec = Resolve("Map(String, UInt32)");
-        var expected = new[]
-        {
-            Array.Empty<KeyValuePair<string, uint>>(),
-            Array.Empty<KeyValuePair<string, uint>>(),
-        };
-        var column = new ArrayColumn<KeyValuePair<string, uint>[]>("c", "Map(String, UInt32)", expected);
-
-        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "Map(String, UInt32)", column.RowCount);
-
-        Assert.That(((IColumn<KeyValuePair<string, uint>[]>)read).Values.ToArray(), Is.EqualTo(expected));
-    }
-
-    [Test]
-    public async Task WriteColumn_DenseMapColumn_RoundTripsWithoutRebuildingStreams()
-    {
-        // A dense MapColumn<TKey, TValue> (flat key/value columns + offsets, the wire's own layout) is the
-        // zero-copy write path — the same shape a read produces. Writing one and reading it back preserves the rows.
-        IColumnCodec codec = Resolve("Map(String, UInt32)");
-        var keys = new ArrayColumn<string>("c", "String", new[] { "a", "b", "c" });
-        var values = PrimitiveColumn<uint>.FromValues("c", "UInt32", new uint[] { 1, 2, 3 });
-        var dense = new MapColumn<string, uint>("c", "Map(String, UInt32)", keys, values, new[] { 0, 2, 3 }, rowCount: 2, pooledOffsets: false);
-
-        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, dense, "Map(String, UInt32)", dense.RowCount);
-
-        Assert.That(((IColumn<KeyValuePair<string, uint>[]>)read).Values.ToArray(), Is.EqualTo(new[]
-        {
-            Row<string, uint>(("a", 1), ("b", 2)),
-            Row<string, uint>(("c", 3)),
-        }));
     }
 
     [Test]

--- a/ClickHouse.Driver.Tcp.Tests/Types/MapColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/MapColumnCodecTests.cs
@@ -97,6 +97,38 @@ public class MapColumnCodecTests
         Assert.ThrowsAsync<ArgumentException>(() => CodecTestHarness.WriteAsync(w => codec.WriteColumn(w, column)));
     }
 
+    // The state-aware overloads take the state this codec's own BeginWrite returned, and nothing else. They used to
+    // treat null as "the caller has none to share" and rebuild one, which meant a caller that lost or never opened
+    // the state still got correct bytes, so the mistake could not be seen.
+    [Test]
+    public async Task WriteColumn_StateAwareOverloadGivenNoState_ThrowsArgument()
+    {
+        IColumnCodec codec = Resolve("Map(String, UInt8)");
+        var column = new ArrayColumn<KeyValuePair<string, byte>[]>("c", "Map(String, UInt8)", new[]
+        {
+            Row<string, byte>(("a", 1)),
+        });
+
+        ArgumentException thrown = null;
+        await CodecTestHarness.WriteAsync(writer =>
+            thrown = Assert.Throws<ArgumentException>(() => codec.WriteColumn(writer, column, 0, 1, state: null)));
+
+        Assert.That(thrown.Message, Does.Contain("Map(String, UInt8)"));
+    }
+
+    [Test]
+    public async Task WriteStatePrefix_StateAwareOverloadGivenNoState_ThrowsArgument()
+    {
+        IColumnCodec codec = Resolve("Map(String, UInt8)");
+        var column = new ArrayColumn<KeyValuePair<string, byte>[]>("c", "Map(String, UInt8)", new[]
+        {
+            Row<string, byte>(("a", 1)),
+        });
+
+        await CodecTestHarness.WriteAsync(writer =>
+            Assert.Throws<ArgumentException>(() => codec.WriteStatePrefix(writer, column, 0, 1, state: null)));
+    }
+
     [Test]
     public void CanWrite_AcceptsOnlyMatchingMapColumn()
     {

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
@@ -540,6 +540,48 @@ public sealed class InsertRoundTripCase
                 Array.Empty<(int, string)>(),
                 new[] { (3, "c") },
             }));
+
+        // Map(K, V): byte-identical to Array(Tuple(K, V)) — offsets + a keys stream + a values stream. Each row
+        // surfaces as a KeyValuePair<K, V>[] (not a Dictionary), so pair order round-trips; empty-map rows and an
+        // all-empty column ride along. Keys within a row are kept unique here because the server rejects duplicate
+        // keys on insert — duplicate-key preservation is a wire property proven by the codec unit test instead.
+        // Map is, like Array/Tuple, an exception to the "wrap every type in Nullable" rule (the server rejects
+        // Nullable(Map(...))), so nullability is composed inside the value as Map(K, Nullable(V)); Map keys are
+        // themselves non-nullable in ClickHouse.
+        yield return Maps<string, uint>("String", "UInt32", Pairs<string, uint>(("a", 1), ("b", 2)), Array.Empty<KeyValuePair<string, uint>>(), Pairs<string, uint>(("x", uint.MaxValue)));
+        yield return Maps<byte, string>("UInt8", "String", Pairs<byte, string>((1, "a"), (2, "héllo✓")), Array.Empty<KeyValuePair<byte, string>>());
+        yield return Maps<string, uint>("String", "UInt32", Array.Empty<KeyValuePair<string, uint>>(), Array.Empty<KeyValuePair<string, uint>>()); // every row empty
+
+        // Value composites: Nullable (the Nullable stand-in) and Array inside the value.
+        yield return Maps<string, uint?>("String", "Nullable(UInt32)", Pairs<string, uint?>(("a", 1), ("b", null)), Array.Empty<KeyValuePair<string, uint?>>(), Pairs<string, uint?>(("c", null)));
+        yield return Maps<string, int[]>("String", "Array(Int32)", Pairs<string, int[]>(("a", new[] { 1, 2, 3 }), ("b", Array.Empty<int>())), Pairs<string, int[]>(("c", new[] { -1 })));
+        yield return Maps<string, (int, string)>("String", "Tuple(Int32, String)", Pairs<string, (int, string)>(("a", (1, "x")), ("b", (-5, string.Empty))), Array.Empty<KeyValuePair<string, (int, string)>>());
+
+        // Nested: Array(Map(...)) recurses the offsets-plus-streams shape one level up through the array codec.
+        yield return Arrays<KeyValuePair<string, uint>[]>("Map(String, UInt32)", new[]
+        {
+            new[] { Pairs<string, uint>(("a", 1)), Pairs<string, uint>(("b", 2), ("c", 3)) },
+            Array.Empty<KeyValuePair<string, uint>[]>(),
+        });
+    }
+
+    // Map(K, V) inserts and reads back the ergonomic jagged column of KeyValuePair arrays, which doubles as expected.
+    private static InsertRoundTripCase Maps<TKey, TValue>(string keyType, string valueType, params KeyValuePair<TKey, TValue>[][] rows)
+    {
+        string type = $"Map({keyType}, {valueType})";
+        return Same($"{type} [{rows.Length} rows]", type, name => new ArrayColumn<KeyValuePair<TKey, TValue>[]>(name, type, rows));
+    }
+
+    // Builds one map row's pairs, preserving the given order.
+    private static KeyValuePair<TKey, TValue>[] Pairs<TKey, TValue>(params (TKey Key, TValue Value)[] pairs)
+    {
+        var result = new KeyValuePair<TKey, TValue>[pairs.Length];
+        for (int i = 0; i < pairs.Length; i++)
+        {
+            result[i] = new KeyValuePair<TKey, TValue>(pairs[i].Key, pairs[i].Value);
+        }
+
+        return result;
     }
 
     // Array(T) inserts and reads back the inner element arrays; the ergonomic jagged column doubles as expected.

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
@@ -485,6 +485,20 @@ public sealed class InsertRoundTripCase
             "Tuple(Array(UInt32), String)",
             name => new TupleColumn<uint[], string>(name, "Tuple(Array(UInt32), String)", new (uint[], string)[] { (new uint[] { 1, 2, 3 }, "a"), (Array.Empty<uint>(), "b") }));
 
+        // A Map element inside a tuple: the map's own offsets and key/value streams have to be emitted from the
+        // per-element column the tuple projects, not from the tuple's own column.
+        yield return Same(
+            "Tuple(Map(String, UInt32), String) [map element]",
+            "Tuple(Map(String, UInt32), String)",
+            name => new TupleColumn<KeyValuePair<string, uint>[], string>(
+                name,
+                "Tuple(Map(String, UInt32), String)",
+                new (KeyValuePair<string, uint>[], string)[]
+                {
+                    (Pairs<string, uint>(("a", 1), ("b", 2)), "first"),
+                    (Array.Empty<KeyValuePair<string, uint>>(), "second"),
+                }));
+
         // A max-arity (7) tuple mixing fixed-width and variable-width elements.
         yield return Same(
             "Tuple(UInt8, Int8, UInt16, Int16, UInt32, Int32, String) [arity 7]",

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
@@ -557,6 +557,18 @@ public sealed class InsertRoundTripCase
         yield return Maps<string, int[]>("String", "Array(Int32)", Pairs<string, int[]>(("a", new[] { 1, 2, 3 }), ("b", Array.Empty<int>())), Pairs<string, int[]>(("c", new[] { -1 })));
         yield return Maps<string, (int, string)>("String", "Tuple(Int32, String)", Pairs<string, (int, string)>(("a", (1, "x")), ("b", (-5, string.Empty))), Array.Empty<KeyValuePair<string, (int, string)>>());
 
+        // Both key and value fixed-width: the cases above pair a variable key with a fixed value or the reverse,
+        // never both fixed.
+        yield return Maps<byte, byte>("UInt8", "UInt8", Pairs<byte, byte>((1, 10), (2, 20)), Array.Empty<KeyValuePair<byte, byte>>(), Pairs<byte, byte>((3, 30)));
+
+        // A Map whose value is itself a Map — the only path that recurses the map shape through itself. Neither a
+        // unit test nor an integration case reached it; Array(Map(...)) covers a different composition.
+        yield return Maps<string, KeyValuePair<string, uint>[]>(
+            "String",
+            "Map(String, UInt32)",
+            Pairs<string, KeyValuePair<string, uint>[]>(("outer", Pairs<string, uint>(("x", 1), ("y", 2)))),
+            Array.Empty<KeyValuePair<string, KeyValuePair<string, uint>[]>>());
+
         // Nested: Array(Map(...)) recurses the offsets-plus-streams shape one level up through the array codec.
         yield return Arrays<KeyValuePair<string, uint>[]>("Map(String, UInt32)", new[]
         {

--- a/ClickHouse.Driver.Tcp/Types/Codecs/MapColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/MapColumnCodec.cs
@@ -184,6 +184,13 @@ internal sealed class MapColumnCodec : IColumnCodec
     public bool CanWrite(IColumn column) => childrenCanWrite && shape.CanWrite(column);
 
     /// <inheritdoc/>
+    // Projects the ergonomic KeyValuePair[]-per-row form into the dense map column (offsets + a flat key column and
+    // a flat value column) once, recursing the key and value codecs' own TryDensify so a composite key/value becomes
+    // dense too. An already-dense map recurses into its key/value columns and is returned unchanged (built = false)
+    // when neither changed.
+    public IColumn TryDensify(IColumn column, out bool built) => shape.TryDensify(keyCodec, valueCodec, column, out built);
+
+    /// <inheritdoc/>
     public void WriteStatePrefix(ClickHouseBinaryWriter writer)
     {
         keyCodec.WriteStatePrefix(writer);
@@ -218,6 +225,15 @@ internal interface IMapShape
 
     /// <summary>Whether both the key and value codecs can write their typed column at all (e.g. <c>Nothing</c> cannot).</summary>
     bool CanInnerWrite(IColumnCodec keyCodec, IColumnCodec valueCodec);
+
+    /// <summary>
+    /// Projects an ergonomic <c>KeyValuePair&lt;K, V&gt;[]</c>-per-row column into the dense map column — a flat key
+    /// column and a flat value column paired with the per-row offsets — recursing the key and value codecs' own
+    /// <see cref="IColumnCodec.TryDensify"/>. An already-dense column is returned unchanged with
+    /// <paramref name="built"/> = <see langword="false"/>; a freshly built column sets <paramref name="built"/> =
+    /// <see langword="true"/> and transfers ownership to the caller.
+    /// </summary>
+    IColumn TryDensify(IColumnCodec keyCodec, IColumnCodec valueCodec, IColumn column, out bool built);
 
     /// <summary>
     /// Writes the map body for rows [<paramref name="start"/>, start + length): the offsets stream (each offset
@@ -269,6 +285,77 @@ internal sealed class MapShape<TKey, TValue> : IMapShape
     public bool CanInnerWrite(IColumnCodec keyCodec, IColumnCodec valueCodec)
         => keyCodec.CanWrite(new ArrayColumn<TKey>(string.Empty, keyCodec.TypeName, Array.Empty<TKey>()))
         && valueCodec.CanWrite(new ArrayColumn<TValue>(string.Empty, valueCodec.TypeName, Array.Empty<TValue>()));
+
+    /// <inheritdoc/>
+    public IColumn TryDensify(IColumnCodec keyCodec, IColumnCodec valueCodec, IColumn column, out bool built)
+    {
+        if (column is MapColumn<TKey, TValue> dense)
+        {
+            IColumn densifiedKeys = keyCodec.TryDensify(dense.KeyColumn, out bool keysRebuilt);
+            IColumn densifiedValues = valueCodec.TryDensify(dense.ValueColumn, out bool valuesRebuilt);
+            if (!keysRebuilt && !valuesRebuilt)
+            {
+                built = false;
+                return column;
+            }
+
+            // The rebuilt map mixes children: a rebuilt key/value column is new and this wrapper must dispose it,
+            // while an unchanged one is borrowed by reference and stays owned by the source column. Own only the
+            // ones we rebuilt so disposing this wrapper does not double-dispose a borrowed child.
+            var rebuilt = new MapColumn<TKey, TValue>(dense.Name, dense.TypeName, (IColumn<TKey>)densifiedKeys, (IColumn<TValue>)densifiedValues, dense.Offsets.ToArray(), dense.RowCount, pooledOffsets: false);
+            rebuilt.RestrictOwnership(keysRebuilt, valuesRebuilt);
+            built = true;
+            return rebuilt;
+        }
+
+        // Ergonomic pair-array form: sum the pairs (rejecting null rows), then flatten the pair arrays into a flat
+        // key column and a flat value column with the per-row offsets, and densify each through its codec so a
+        // composite key/value becomes dense too. Map(K, V) rows are non-nullable, matching the write path.
+        var source = (IColumn<KeyValuePair<TKey, TValue>[]>)column;
+        int rowCount = source.RowCount;
+        ulong total64 = 0;
+        for (int i = 0; i < rowCount; i++)
+        {
+            KeyValuePair<TKey, TValue>[] row = source[i];
+            if (row is null)
+            {
+                throw new ArgumentException(
+                    $"Map column '{source.Name}' has a null value at row {i}; Map(K, V) rows are non-nullable. Use Array.Empty<KeyValuePair<K, V>>() for an empty row, or Map(K, Nullable(V)) to carry null values.",
+                    nameof(column));
+            }
+
+            total64 += (ulong)row.Length;
+        }
+
+        if (total64 > (ulong)Array.MaxLength)
+        {
+            throw new NotSupportedException(
+                $"Map column '{source.Name}' holds {total64} pairs in one block, exceeding the maximum ({Array.MaxLength}) this client can buffer.");
+        }
+
+        int total = (int)total64;
+        var offsets = new int[rowCount + 1];
+        var flatKeys = new TKey[total];
+        var flatValues = new TValue[total];
+        int pos = 0;
+        for (int i = 0; i < rowCount; i++)
+        {
+            KeyValuePair<TKey, TValue>[] row = source[i];
+            for (int p = 0; p < row.Length; p++)
+            {
+                flatKeys[pos] = row[p].Key;
+                flatValues[pos] = row[p].Value;
+                pos++;
+            }
+
+            offsets[i + 1] = pos;
+        }
+
+        IColumn keyColumn = keyCodec.TryDensify(new ArrayColumn<TKey>(source.Name, keyCodec.TypeName, flatKeys), out _);
+        IColumn valueColumn = valueCodec.TryDensify(new ArrayColumn<TValue>(source.Name, valueCodec.TypeName, flatValues), out _);
+        built = true;
+        return new MapColumn<TKey, TValue>(source.Name, source.TypeName, (IColumn<TKey>)keyColumn, (IColumn<TValue>)valueColumn, offsets, rowCount, pooledOffsets: false);
+    }
 
     /// <inheritdoc/>
     public void WriteBody(IColumnCodec keyCodec, IColumnCodec valueCodec, ClickHouseBinaryWriter writer, IColumn column, int start, int length)

--- a/ClickHouse.Driver.Tcp/Types/Codecs/MapColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/MapColumnCodec.cs
@@ -57,9 +57,6 @@ internal sealed class MapColumnCodec : IColumnCodec
     /// </summary>
     public object NullPlaceholder => shape.EmptyMap;
 
-    /// <summary>A map row is variable-width (its pair count, keys, and values all vary), so it has no fixed byte size.</summary>
-    public int? FixedRowByteSize => null;
-
     /// <summary>Builds a <c>Map(K, V)</c> codec, resolving the key and value types through the registry.</summary>
     /// <param name="node">The parsed <c>Map</c> type node; its two arguments are the key and value types.</param>
     /// <param name="context">The resolution context, forwarded to the key/value codec factories.</param>
@@ -178,28 +175,60 @@ internal sealed class MapColumnCodec : IColumnCodec
     }
 
     /// <inheritdoc/>
-    public long MeasureRowBytes(IColumn column, int row) => shape.MeasureRow(keyCodec, valueCodec, column, row);
-
-    /// <inheritdoc/>
     public bool CanWrite(IColumn column) => childrenCanWrite && shape.CanWrite(column);
 
     /// <inheritdoc/>
-    // Projects the ergonomic KeyValuePair[]-per-row form into the dense map column (offsets + a flat key column and
-    // a flat value column) once, recursing the key and value codecs' own TryDensify so a composite key/value becomes
-    // dense too. An already-dense map recurses into its key/value columns and is returned unchanged (built = false)
-    // when neither changed.
-    public IColumn TryDensify(IColumn column, out bool built) => shape.TryDensify(keyCodec, valueCodec, column, out built);
+    // Flatten the slice's keys and values once and create the key/value codecs' own write states over them, so a
+    // data-dependent value (Dynamic) sees its real values at prefix time and the flatten spans both phases.
+    public IColumnWriteState BeginWrite(IColumn column, int start, int length)
+        => shape.BeginWrite(keyCodec, valueCodec, column, start, length);
 
     /// <inheritdoc/>
-    public void WriteStatePrefix(ClickHouseBinaryWriter writer)
+    public void WriteStatePrefix(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
     {
-        keyCodec.WriteStatePrefix(writer);
-        valueCodec.WriteStatePrefix(writer);
+        if (shape.CanWrite(column))
+        {
+            using IColumnWriteState state = shape.BeginWrite(keyCodec, valueCodec, column, start, length);
+            shape.WriteStatePrefix(keyCodec, valueCodec, writer, state);
+            return;
+        }
+
+        // An outer composite forwarded its own column (its children's prefixes are written from its own slice);
+        // the key/value codecs ignore it, preserving the prior contract for a Map nested in Variant/Nested/Tuple.
+        keyCodec.WriteStatePrefix(writer, column, start, length);
+        valueCodec.WriteStatePrefix(writer, column, start, length);
+    }
+
+    /// <inheritdoc/>
+    public void WriteStatePrefix(ClickHouseBinaryWriter writer, IColumn column, int start, int length, IColumnWriteState state)
+    {
+        if (state is not null)
+        {
+            shape.WriteStatePrefix(keyCodec, valueCodec, writer, state);
+            return;
+        }
+
+        WriteStatePrefix(writer, column, start, length);
     }
 
     /// <inheritdoc/>
     public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
-        => shape.WriteBody(keyCodec, valueCodec, writer, column, start, length);
+    {
+        using IColumnWriteState state = shape.BeginWrite(keyCodec, valueCodec, column, start, length);
+        shape.WriteBody(keyCodec, valueCodec, writer, column, start, length, state);
+    }
+
+    /// <inheritdoc/>
+    public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length, IColumnWriteState state)
+    {
+        if (state is not null)
+        {
+            shape.WriteBody(keyCodec, valueCodec, writer, column, start, length, state);
+            return;
+        }
+
+        WriteColumn(writer, column, start, length);
+    }
 }
 
 /// <summary>
@@ -227,24 +256,22 @@ internal interface IMapShape
     bool CanInnerWrite(IColumnCodec keyCodec, IColumnCodec valueCodec);
 
     /// <summary>
-    /// Projects an ergonomic <c>KeyValuePair&lt;K, V&gt;[]</c>-per-row column into the dense map column — a flat key
-    /// column and a flat value column paired with the per-row offsets — recursing the key and value codecs' own
-    /// <see cref="IColumnCodec.TryDensify"/>. An already-dense column is returned unchanged with
-    /// <paramref name="built"/> = <see langword="false"/>; a freshly built column sets <paramref name="built"/> =
-    /// <see langword="true"/> and transfers ownership to the caller.
+    /// Flattens the slice's keys and values into contiguous columns once and creates the key and value codecs'
+    /// own write states over them, so a data-dependent inner (Dynamic) sees its real values at prefix time and the
+    /// flatten is shared across the prefix and body phases.
     /// </summary>
-    IColumn TryDensify(IColumnCodec keyCodec, IColumnCodec valueCodec, IColumn column, out bool built);
+    IColumnWriteState BeginWrite(IColumnCodec keyCodec, IColumnCodec valueCodec, IColumn column, int start, int length);
+
+    /// <summary>Writes the key then value serialization-state prefixes from a computed <see cref="BeginWrite"/> state.</summary>
+    void WriteStatePrefix(IColumnCodec keyCodec, IColumnCodec valueCodec, ClickHouseBinaryWriter writer, IColumnWriteState state);
 
     /// <summary>
     /// Writes the map body for rows [<paramref name="start"/>, start + length): the offsets stream (each offset
-    /// relative to this slice's own pairs), then the concatenated keys stream, then the concatenated values stream.
-    /// A dense <see cref="MapColumn{TKey, TValue}"/> is written with no intermediate copy; the ergonomic jagged
-    /// form is flattened through pooled key/value buffers.
+    /// relative to this slice's own pairs), then the flattened keys stream, then the flattened values stream, the
+    /// latter two from the pre-flattened <paramref name="state"/>. A dense <see cref="MapColumn{TKey, TValue}"/> is
+    /// written with no intermediate copy; the ergonomic jagged form uses the state's pooled key/value buffers.
     /// </summary>
-    void WriteBody(IColumnCodec keyCodec, IColumnCodec valueCodec, ClickHouseBinaryWriter writer, IColumn column, int start, int length);
-
-    /// <summary>The encoded byte length of row <paramref name="row"/>: one offset plus its pairs' key and value bytes.</summary>
-    long MeasureRow(IColumnCodec keyCodec, IColumnCodec valueCodec, IColumn column, int row);
+    void WriteBody(IColumnCodec keyCodec, IColumnCodec valueCodec, ClickHouseBinaryWriter writer, IColumn column, int start, int length, IColumnWriteState state);
 }
 
 /// <summary>Resolves and caches the <see cref="IMapShape"/> for a given key/value element type pair.</summary>
@@ -287,100 +314,31 @@ internal sealed class MapShape<TKey, TValue> : IMapShape
         && valueCodec.CanWrite(new ArrayColumn<TValue>(string.Empty, valueCodec.TypeName, Array.Empty<TValue>()));
 
     /// <inheritdoc/>
-    public IColumn TryDensify(IColumnCodec keyCodec, IColumnCodec valueCodec, IColumn column, out bool built)
+    public IColumnWriteState BeginWrite(IColumnCodec keyCodec, IColumnCodec valueCodec, IColumn column, int start, int length)
     {
         if (column is MapColumn<TKey, TValue> dense)
         {
-            IColumn densifiedKeys = keyCodec.TryDensify(dense.KeyColumn, out bool keysRebuilt);
-            IColumn densifiedValues = valueCodec.TryDensify(dense.ValueColumn, out bool valuesRebuilt);
-            if (!keysRebuilt && !valuesRebuilt)
-            {
-                built = false;
-                return column;
-            }
-
-            // The rebuilt map mixes children: a rebuilt key/value column is new and this wrapper must dispose it,
-            // while an unchanged one is borrowed by reference and stays owned by the source column. Own only the
-            // ones we rebuilt so disposing this wrapper does not double-dispose a borrowed child.
-            var rebuilt = new MapColumn<TKey, TValue>(dense.Name, dense.TypeName, (IColumn<TKey>)densifiedKeys, (IColumn<TValue>)densifiedValues, dense.Offsets.ToArray(), dense.RowCount, pooledOffsets: false);
-            rebuilt.RestrictOwnership(keysRebuilt, valuesRebuilt);
-            built = true;
-            return rebuilt;
-        }
-
-        // Ergonomic pair-array form: sum the pairs (rejecting null rows), then flatten the pair arrays into a flat
-        // key column and a flat value column with the per-row offsets, and densify each through its codec so a
-        // composite key/value becomes dense too. Map(K, V) rows are non-nullable, matching the write path.
-        var source = (IColumn<KeyValuePair<TKey, TValue>[]>)column;
-        int rowCount = source.RowCount;
-        ulong total64 = 0;
-        for (int i = 0; i < rowCount; i++)
-        {
-            KeyValuePair<TKey, TValue>[] row = source[i];
-            if (row is null)
-            {
-                throw new ArgumentException(
-                    $"Map column '{source.Name}' has a null value at row {i}; Map(K, V) rows are non-nullable. Use Array.Empty<KeyValuePair<K, V>>() for an empty row, or Map(K, Nullable(V)) to carry null values.",
-                    nameof(column));
-            }
-
-            total64 += (ulong)row.Length;
-        }
-
-        if (total64 > (ulong)Array.MaxLength)
-        {
-            throw new NotSupportedException(
-                $"Map column '{source.Name}' holds {total64} pairs in one block, exceeding the maximum ({Array.MaxLength}) this client can buffer.");
-        }
-
-        int total = (int)total64;
-        var offsets = new int[rowCount + 1];
-        var flatKeys = new TKey[total];
-        var flatValues = new TValue[total];
-        int pos = 0;
-        for (int i = 0; i < rowCount; i++)
-        {
-            KeyValuePair<TKey, TValue>[] row = source[i];
-            for (int p = 0; p < row.Length; p++)
-            {
-                flatKeys[pos] = row[p].Key;
-                flatValues[pos] = row[p].Value;
-                pos++;
-            }
-
-            offsets[i + 1] = pos;
-        }
-
-        IColumn keyColumn = keyCodec.TryDensify(new ArrayColumn<TKey>(source.Name, keyCodec.TypeName, flatKeys), out _);
-        IColumn valueColumn = valueCodec.TryDensify(new ArrayColumn<TValue>(source.Name, valueCodec.TypeName, flatValues), out _);
-        built = true;
-        return new MapColumn<TKey, TValue>(source.Name, source.TypeName, (IColumn<TKey>)keyColumn, (IColumn<TValue>)valueColumn, offsets, rowCount, pooledOffsets: false);
-    }
-
-    /// <inheritdoc/>
-    public void WriteBody(IColumnCodec keyCodec, IColumnCodec valueCodec, ClickHouseBinaryWriter writer, IColumn column, int start, int length)
-    {
-        if (column is MapColumn<TKey, TValue> dense)
-        {
-            // Dense form (the wire's own layout): the offsets already exist and the key/value columns already hold
-            // every pair, so write them directly. The wire offsets are relative to this slice's pair streams, so
-            // subtract the slice's first pair index from each.
             ReadOnlySpan<int> offsets = dense.Offsets;
             int pairBase = offsets[start];
-            for (int i = 0; i < length; i++)
+            int pairCount = offsets[start + length] - pairBase;
+            IColumnWriteState denseKeyState = keyCodec.BeginWrite(dense.KeyColumn, pairBase, pairCount);
+            IColumnWriteState denseValueState;
+            try
             {
-                writer.WriteUInt64((ulong)(offsets[start + i + 1] - pairBase));
+                denseValueState = valueCodec.BeginWrite(dense.ValueColumn, pairBase, pairCount);
+            }
+            catch
+            {
+                // The value codec throwing must not leak the key state (it may hold rented buffers).
+                denseKeyState?.Dispose();
+                throw;
             }
 
-            int pairCount = offsets[start + length] - pairBase;
-            keyCodec.WriteColumn(writer, dense.KeyColumn, pairBase, pairCount);
-            valueCodec.WriteColumn(writer, dense.ValueColumn, pairBase, pairCount);
-            return;
+            return new MapWriteState((IColumn<TKey>)dense.KeyColumn, (IColumn<TValue>)dense.ValueColumn, pairBase, pairCount, denseKeyState, denseValueState, keyBuffer: null, valueBuffer: null);
         }
 
-        // Ergonomic jagged form: write the offsets from each row's pair count, then flatten the pair arrays into
-        // pooled key and value buffers (copying references for a composite inner, values for a leaf inner) and hand
-        // each to its codec as one contiguous column. Map(K, V) rows are themselves non-nullable, so a null row is
+        // Ergonomic jagged form: flatten the pair arrays into pooled key and value buffers (copying references for
+        // a composite inner, values for a leaf inner). Map(K, V) rows are themselves non-nullable, so a null row is
         // rejected rather than silently coerced to an empty map; callers pass Array.Empty<KeyValuePair<K, V>>() for
         // an empty row, or use Map(K, Nullable(V)) to carry null values.
         var source = (IColumn<KeyValuePair<TKey, TValue>[]>)column;
@@ -396,7 +354,6 @@ internal sealed class MapShape<TKey, TValue> : IMapShape
             }
 
             running += (ulong)row.Length;
-            writer.WriteUInt64(running);
         }
 
         // The flat buffers are addressed with an int length, so a slice whose pairs sum past Array.MaxLength cannot
@@ -408,129 +365,123 @@ internal sealed class MapShape<TKey, TValue> : IMapShape
         }
 
         int total = (int)running;
-        var flatKeys = ArrayPool<TKey>.Shared.Rent(total);
-        var flatValues = ArrayPool<TValue>.Shared.Rent(total);
+        TKey[] flatKeys = ArrayPool<TKey>.Shared.Rent(total);
+        TValue[] flatValues = ArrayPool<TValue>.Shared.Rent(total);
+        IColumnWriteState keyState = null;
         try
         {
             int pos = 0;
             for (int i = 0; i < length; i++)
             {
                 KeyValuePair<TKey, TValue>[] row = source[start + i];
-                if (row is { Length: > 0 })
+                for (int p = 0; p < row.Length; p++)
                 {
-                    for (int p = 0; p < row.Length; p++)
-                    {
-                        flatKeys[pos] = row[p].Key;
-                        flatValues[pos] = row[p].Value;
-                        pos++;
-                    }
+                    flatKeys[pos] = row[p].Key;
+                    flatValues[pos] = row[p].Value;
+                    pos++;
                 }
             }
 
-            keyCodec.WriteColumn(writer, ArrayColumn<TKey>.OverBuffer(column.Name, keyCodec.TypeName, flatKeys, total), 0, total);
-            valueCodec.WriteColumn(writer, ArrayColumn<TValue>.OverBuffer(column.Name, valueCodec.TypeName, flatValues, total), 0, total);
+            var keyColumn = ArrayColumn<TKey>.OverBuffer(column.Name, keyCodec.TypeName, flatKeys, total);
+            var valueColumn = ArrayColumn<TValue>.OverBuffer(column.Name, valueCodec.TypeName, flatValues, total);
+            keyState = keyCodec.BeginWrite(keyColumn, 0, total);
+            IColumnWriteState valueState = valueCodec.BeginWrite(valueColumn, 0, total);
+            return new MapWriteState(keyColumn, valueColumn, pairBase: 0, total, keyState, valueState, flatKeys, flatValues);
         }
-        finally
+        catch
         {
+            // Dispose a key state already created (the value codec may have thrown) before returning the buffers.
+            keyState?.Dispose();
             ArrayPool<TKey>.Shared.Return(flatKeys, clearArray: RuntimeHelpers.IsReferenceOrContainsReferences<TKey>());
             ArrayPool<TValue>.Shared.Return(flatValues, clearArray: RuntimeHelpers.IsReferenceOrContainsReferences<TValue>());
+            throw;
         }
     }
 
     /// <inheritdoc/>
-    public long MeasureRow(IColumnCodec keyCodec, IColumnCodec valueCodec, IColumn column, int row)
+    public void WriteStatePrefix(IColumnCodec keyCodec, IColumnCodec valueCodec, ClickHouseBinaryWriter writer, IColumnWriteState state)
     {
-        // One UInt64 offset plus the key and value bytes of this row's pairs. Fixed-width inners price in O(1); a
-        // variable-width inner is walked pair by pair through its codec.
+        var mapState = (MapWriteState)state;
+        keyCodec.WriteStatePrefix(writer, mapState.FlatKeys, mapState.PairBase, mapState.PairCount, mapState.KeyState);
+        valueCodec.WriteStatePrefix(writer, mapState.FlatValues, mapState.PairBase, mapState.PairCount, mapState.ValueState);
+    }
+
+    /// <inheritdoc/>
+    public void WriteBody(IColumnCodec keyCodec, IColumnCodec valueCodec, ClickHouseBinaryWriter writer, IColumn column, int start, int length, IColumnWriteState state)
+    {
+        var mapState = (MapWriteState)state;
+
+        // Offsets, relative to this slice's own pair streams: from the dense column's offsets, or each jagged row's
+        // pair count. The key/value bodies come from the pre-flattened state.
         if (column is MapColumn<TKey, TValue> dense)
         {
             ReadOnlySpan<int> offsets = dense.Offsets;
-            int pairStart = offsets[row];
-            int pairEnd = offsets[row + 1];
-            long bytes = sizeof(ulong);
-            bytes += MeasureStream(keyCodec, dense.KeyColumn, pairStart, pairEnd);
-            bytes += MeasureStream(valueCodec, dense.ValueColumn, pairStart, pairEnd);
-            return bytes;
-        }
-
-        KeyValuePair<TKey, TValue>[] value = ((IColumn<KeyValuePair<TKey, TValue>[]>)column)[row];
-        if (value is null)
-        {
-            throw new ArgumentException(
-                $"Map column '{column.Name}' has a null value at row {row}; Map(K, V) rows are non-nullable. Use Array.Empty<KeyValuePair<K, V>>() for an empty row, or Map(K, Nullable(V)) to carry null values.",
-                nameof(column));
-        }
-
-        int count = value.Length;
-        long total = sizeof(ulong);
-        if (count == 0)
-        {
-            return total;
-        }
-
-        if (keyCodec.FixedRowByteSize is int keyWidth)
-        {
-            total += (long)count * keyWidth;
+            int pairBase = offsets[start];
+            for (int i = 0; i < length; i++)
+            {
+                writer.WriteUInt64((ulong)(offsets[start + i + 1] - pairBase));
+            }
         }
         else
         {
-            // Variable-width key: project the row's keys into a pooled scratch buffer (returned below) and price
-            // them through the codec. Map(String, ...) — the common shape — takes this path once per row.
-            var keys = ArrayPool<TKey>.Shared.Rent(count);
-            try
+            var source = (IColumn<KeyValuePair<TKey, TValue>[]>)column;
+            ulong running = 0;
+            for (int i = 0; i < length; i++)
             {
-                for (int i = 0; i < count; i++)
-                {
-                    keys[i] = value[i].Key;
-                }
-
-                total += MeasureStream(keyCodec, ArrayColumn<TKey>.OverBuffer(column.Name, keyCodec.TypeName, keys, count), 0, count);
-            }
-            finally
-            {
-                ArrayPool<TKey>.Shared.Return(keys, clearArray: RuntimeHelpers.IsReferenceOrContainsReferences<TKey>());
+                running += (ulong)source[start + i].Length;
+                writer.WriteUInt64(running);
             }
         }
 
-        if (valueCodec.FixedRowByteSize is int valueWidth)
-        {
-            total += (long)count * valueWidth;
-        }
-        else
-        {
-            var values = ArrayPool<TValue>.Shared.Rent(count);
-            try
-            {
-                for (int i = 0; i < count; i++)
-                {
-                    values[i] = value[i].Value;
-                }
-
-                total += MeasureStream(valueCodec, ArrayColumn<TValue>.OverBuffer(column.Name, valueCodec.TypeName, values, count), 0, count);
-            }
-            finally
-            {
-                ArrayPool<TValue>.Shared.Return(values, clearArray: RuntimeHelpers.IsReferenceOrContainsReferences<TValue>());
-            }
-        }
-
-        return total;
+        keyCodec.WriteColumn(writer, mapState.FlatKeys, mapState.PairBase, mapState.PairCount, mapState.KeyState);
+        valueCodec.WriteColumn(writer, mapState.FlatValues, mapState.PairBase, mapState.PairCount, mapState.ValueState);
     }
 
-    // Sums a codec's encoded bytes for the [start, end) slice of a flat column: O(1) when fixed-width, else per row.
-    private static long MeasureStream(IColumnCodec codec, IColumn column, int start, int end)
+    // The flatten of one slice's keys and values, shared across the prefix and body phases. For the ergonomic
+    // jagged form the columns are backed by pooled buffers returned on dispose; for the dense form they are the
+    // borrowed key/value columns (no buffers to return).
+    private sealed class MapWriteState : IColumnWriteState
     {
-        if (codec.FixedRowByteSize is int width)
+        private readonly TKey[] keyBuffer;
+        private readonly TValue[] valueBuffer;
+
+        public MapWriteState(IColumn<TKey> flatKeys, IColumn<TValue> flatValues, int pairBase, int pairCount, IColumnWriteState keyState, IColumnWriteState valueState, TKey[] keyBuffer, TValue[] valueBuffer)
         {
-            return (long)(end - start) * width;
+            FlatKeys = flatKeys;
+            FlatValues = flatValues;
+            PairBase = pairBase;
+            PairCount = pairCount;
+            KeyState = keyState;
+            ValueState = valueState;
+            this.keyBuffer = keyBuffer;
+            this.valueBuffer = valueBuffer;
         }
 
-        long bytes = 0;
-        for (int i = start; i < end; i++)
-        {
-            bytes += codec.MeasureRowBytes(column, i);
-        }
+        public IColumn<TKey> FlatKeys { get; }
 
-        return bytes;
+        public IColumn<TValue> FlatValues { get; }
+
+        public int PairBase { get; }
+
+        public int PairCount { get; }
+
+        public IColumnWriteState KeyState { get; }
+
+        public IColumnWriteState ValueState { get; }
+
+        public void Dispose()
+        {
+            KeyState?.Dispose();
+            ValueState?.Dispose();
+            if (keyBuffer is not null)
+            {
+                ArrayPool<TKey>.Shared.Return(keyBuffer, clearArray: RuntimeHelpers.IsReferenceOrContainsReferences<TKey>());
+            }
+
+            if (valueBuffer is not null)
+            {
+                ArrayPool<TValue>.Shared.Return(valueBuffer, clearArray: RuntimeHelpers.IsReferenceOrContainsReferences<TValue>());
+            }
+        }
     }
 }

--- a/ClickHouse.Driver.Tcp/Types/Codecs/MapColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/MapColumnCodec.cs
@@ -1,0 +1,449 @@
+using System;
+using System.Buffers;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Protocol;
+
+namespace ClickHouse.Driver.Tcp.Types.Codecs;
+
+/// <summary>
+/// A codec for the ClickHouse <c>Map(K, V)</c> column. The wire layout is byte-identical to
+/// <c>Array(Tuple(K, V))</c>: it delegates the serialization-state prefix to the key then the value codec, then
+/// reads/writes a per-row offsets stream (<c>num_rows</c> little-endian <c>UInt64</c>, each the cumulative pair
+/// end after that row) followed by two concatenated streams — every row's keys, then every row's values,
+/// positionally aligned so pair <c>i</c> is <c>(keys[i], values[i])</c>. The decoded column surfaces each row as
+/// a <see cref="KeyValuePair{TKey, TValue}"/>[]; a pair array (not a dictionary) is used so duplicate keys and
+/// pair order round-trip intact.
+///
+/// <para>
+/// The generic bridge from the non-generic key/value codecs to the right typed <see cref="MapColumn{TKey, TValue}"/>
+/// lives in the cached per-type-pair <see cref="IMapShape"/>; the codec itself stays non-generic. On the write
+/// path it accepts a column of <c>KeyValuePair&lt;K, V&gt;[]</c> (the dense <see cref="MapColumn{TKey, TValue}"/>,
+/// written with no copy, or the ergonomic jagged form, flattened through pooled key/value buffers).
+/// </para>
+/// </summary>
+internal sealed class MapColumnCodec : IColumnCodec
+{
+    private readonly IColumnCodec keyCodec;
+    private readonly IColumnCodec valueCodec;
+    private readonly IMapShape shape;
+    private readonly bool childrenCanWrite;
+
+    private MapColumnCodec(string typeName, IColumnCodec keyCodec, IColumnCodec valueCodec)
+    {
+        TypeName = typeName;
+        this.keyCodec = keyCodec;
+        this.valueCodec = valueCodec;
+        shape = MapShapes.For(keyCodec.ElementType, valueCodec.ElementType);
+
+        // Whether both the key and value codecs can write at all (e.g. Nothing cannot). Computed once so CanWrite
+        // can reject a Map(non-writable, ...) column up front rather than letting the write fail mid-stream.
+        childrenCanWrite = shape.CanInnerWrite(keyCodec, valueCodec);
+    }
+
+    /// <inheritdoc/>
+    public string TypeName { get; }
+
+    /// <inheritdoc/>
+    public Type ElementType => shape.MapElementType;
+
+    /// <summary>
+    /// The placeholder for an absent <c>Map(K, V)</c> value is the empty pair array — a row whose offset advances
+    /// by zero and contributes no pairs. Relevant only if a composite nests a <c>Map</c> and asks for its placeholder.
+    /// </summary>
+    public object NullPlaceholder => shape.EmptyMap;
+
+    /// <summary>A map row is variable-width (its pair count, keys, and values all vary), so it has no fixed byte size.</summary>
+    public int? FixedRowByteSize => null;
+
+    /// <summary>Builds a <c>Map(K, V)</c> codec, resolving the key and value types through the registry.</summary>
+    /// <param name="node">The parsed <c>Map</c> type node; its two arguments are the key and value types.</param>
+    /// <param name="context">The resolution context, forwarded to the key/value codec factories.</param>
+    /// <param name="registry">The registry used to resolve the key and value codecs.</param>
+    /// <returns>The codec.</returns>
+    /// <exception cref="FormatException">The type has other than two arguments.</exception>
+    public static MapColumnCodec Create(TypeNode node, in ResolveContext context, ColumnCodecRegistry registry)
+    {
+        if (node.Arguments.Count != 2)
+        {
+            throw new FormatException($"Map type '{node}' must have exactly two type arguments (a key type and a value type).");
+        }
+
+        IColumnCodec keyCodec = registry.ResolveNode(node.Arguments[0], in context);
+        IColumnCodec valueCodec = registry.ResolveNode(node.Arguments[1], in context);
+        return new MapColumnCodec(node.ToString(), keyCodec, valueCodec);
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask ReadStatePrefixAsync(ClickHouseBinaryReader reader, CancellationToken cancellationToken)
+    {
+        // A Map has no prefix of its own; it delegates the prefix phase to its element serializations, key first
+        // then value, matching the inner Tuple(K, V) it is byte-compatible with. Empty unless K or V is versioned.
+        await keyCodec.ReadStatePrefixAsync(reader, cancellationToken).ConfigureAwait(false);
+        await valueCodec.ReadStatePrefixAsync(reader, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask<IColumn> ReadColumnAsync(ClickHouseBinaryReader reader, string columnName, string columnType, int rowCount, CancellationToken cancellationToken)
+    {
+        if (rowCount == 0)
+        {
+            // An empty column writes no offsets and no values: read zero-row key/value columns and wrap them with
+            // the single sentinel offset (offsets[0] = 0) every map column carries.
+            IColumn emptyKeys = await keyCodec.ReadColumnAsync(reader, columnName, keyCodec.TypeName, 0, cancellationToken).ConfigureAwait(false);
+            IColumn emptyValues;
+            try
+            {
+                emptyValues = await valueCodec.ReadColumnAsync(reader, columnName, valueCodec.TypeName, 0, cancellationToken).ConfigureAwait(false);
+            }
+            catch
+            {
+                emptyKeys.Dispose();
+                throw;
+            }
+
+            try
+            {
+                return shape.Wrap(columnName, columnType, emptyKeys, emptyValues, new int[1], rowCount: 0, pooledOffsets: false);
+            }
+            catch
+            {
+                emptyKeys.Dispose();
+                emptyValues.Dispose();
+                throw;
+            }
+        }
+
+        long offsetBytes = (long)rowCount * sizeof(ulong);
+        if (offsetBytes > Array.MaxLength)
+        {
+            throw new ClickHouseProtocolException(
+                $"Map column '{columnName}' declares {rowCount} rows, whose offsets stream exceeds the maximum this client can buffer.");
+        }
+
+        int[] offsets = ArrayPool<int>.Shared.Rent(rowCount + 1);
+        byte[] scratch = ArrayPool<byte>.Shared.Rent((int)offsetBytes);
+        IColumn keyColumn = null;
+        IColumn valueColumn = null;
+        try
+        {
+            await reader.ReadBytesAsync(scratch.AsMemory(0, (int)offsetBytes), cancellationToken).ConfigureAwait(false);
+
+            // Offsets are little-endian UInt64 (this client is little-endian only, like every fixed-width codec).
+            ReadOnlySpan<ulong> wire = MemoryMarshal.Cast<byte, ulong>(scratch.AsSpan(0, (int)offsetBytes));
+            offsets[0] = 0;
+            ulong previous = 0;
+            for (int i = 0; i < rowCount; i++)
+            {
+                ulong end = wire[i];
+                if (end < previous)
+                {
+                    throw new ClickHouseProtocolException(
+                        $"Map column '{columnName}' has a non-monotonic offset at row {i} ({end} < {previous}); the stream is corrupt.");
+                }
+
+                if (end > int.MaxValue)
+                {
+                    throw new ClickHouseProtocolException(
+                        $"Map column '{columnName}' declares {end} total pairs, exceeding the maximum this client can address.");
+                }
+
+                offsets[i + 1] = (int)end;
+                previous = end;
+            }
+
+            int totalPairs = offsets[rowCount];
+            keyColumn = await keyCodec.ReadColumnAsync(reader, columnName, keyCodec.TypeName, totalPairs, cancellationToken).ConfigureAwait(false);
+            valueColumn = await valueCodec.ReadColumnAsync(reader, columnName, valueCodec.TypeName, totalPairs, cancellationToken).ConfigureAwait(false);
+
+            // Wrap inside the try: only a successful Wrap takes ownership of the rented offsets and the inner
+            // columns, so a throw (e.g. an element-type mismatch surfacing as a cast failure) leaks none of them.
+            return shape.Wrap(columnName, columnType, keyColumn, valueColumn, offsets, rowCount, pooledOffsets: true);
+        }
+        catch
+        {
+            ArrayPool<int>.Shared.Return(offsets);
+            keyColumn?.Dispose();
+            valueColumn?.Dispose();
+            throw;
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(scratch);
+        }
+    }
+
+    /// <inheritdoc/>
+    public long MeasureRowBytes(IColumn column, int row) => shape.MeasureRow(keyCodec, valueCodec, column, row);
+
+    /// <inheritdoc/>
+    public bool CanWrite(IColumn column) => childrenCanWrite && shape.CanWrite(column);
+
+    /// <inheritdoc/>
+    public void WriteStatePrefix(ClickHouseBinaryWriter writer)
+    {
+        keyCodec.WriteStatePrefix(writer);
+        valueCodec.WriteStatePrefix(writer);
+    }
+
+    /// <inheritdoc/>
+    public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
+        => shape.WriteBody(keyCodec, valueCodec, writer, column, start, length);
+}
+
+/// <summary>
+/// The generic bridge for one map key/value type pair: it knows how to build the typed
+/// <see cref="MapColumn{TKey, TValue}"/>, test a writable column, drive the offsets-plus-two-streams write, and
+/// price a row. One implementation covers every type pair (a <c>KeyValuePair&lt;K, V&gt;[]</c> is a reference
+/// type, so unlike the nullable bridge there is no value/reference split); the concrete instance is chosen once
+/// per type pair.
+/// </summary>
+internal interface IMapShape
+{
+    /// <summary>The CLR element type the wrapped column surfaces (<c>KeyValuePair&lt;K, V&gt;[]</c>).</summary>
+    Type MapElementType { get; }
+
+    /// <summary>The empty pair array — a map column's null/absent placeholder.</summary>
+    object EmptyMap { get; }
+
+    /// <summary>Wraps decoded flat key/value columns and their shared offsets into the typed map column.</summary>
+    IColumn Wrap(string name, string typeName, IColumn keys, IColumn values, int[] offsets, int rowCount, bool pooledOffsets);
+
+    /// <summary>Whether <paramref name="column"/> is a map column of this key/value type pair, writable by the codec.</summary>
+    bool CanWrite(IColumn column);
+
+    /// <summary>Whether both the key and value codecs can write their typed column at all (e.g. <c>Nothing</c> cannot).</summary>
+    bool CanInnerWrite(IColumnCodec keyCodec, IColumnCodec valueCodec);
+
+    /// <summary>
+    /// Writes the map body for rows [<paramref name="start"/>, start + length): the offsets stream (each offset
+    /// relative to this slice's own pairs), then the concatenated keys stream, then the concatenated values stream.
+    /// A dense <see cref="MapColumn{TKey, TValue}"/> is written with no intermediate copy; the ergonomic jagged
+    /// form is flattened through pooled key/value buffers.
+    /// </summary>
+    void WriteBody(IColumnCodec keyCodec, IColumnCodec valueCodec, ClickHouseBinaryWriter writer, IColumn column, int start, int length);
+
+    /// <summary>The encoded byte length of row <paramref name="row"/>: one offset plus its pairs' key and value bytes.</summary>
+    long MeasureRow(IColumnCodec keyCodec, IColumnCodec valueCodec, IColumn column, int row);
+}
+
+/// <summary>Resolves and caches the <see cref="IMapShape"/> for a given key/value element type pair.</summary>
+internal static class MapShapes
+{
+    private static readonly ConcurrentDictionary<(Type Key, Type Value), IMapShape> Cache = new();
+
+    /// <summary>Returns the shape for the (<paramref name="keyType"/>, <paramref name="valueType"/>) pair, building it once and caching it.</summary>
+    /// <param name="keyType">The key codec's CLR element type.</param>
+    /// <param name="valueType">The value codec's CLR element type.</param>
+    /// <returns>The shape.</returns>
+    public static IMapShape For(Type keyType, Type valueType) => Cache.GetOrAdd((keyType, valueType), Build);
+
+    // nonPublic: true so the shape's (implicit, but internal-assembly) constructor is always reachable here.
+    private static IMapShape Build((Type Key, Type Value) pair)
+        => (IMapShape)Activator.CreateInstance(typeof(MapShape<,>).MakeGenericType(pair.Key, pair.Value), nonPublic: true);
+}
+
+/// <summary>The shape for a key type <typeparamref name="TKey"/> and value type <typeparamref name="TValue"/>: the map column surfaces <c>KeyValuePair&lt;TKey, TValue&gt;[]</c>.</summary>
+/// <typeparam name="TKey">The key codec's element type.</typeparam>
+/// <typeparam name="TValue">The value codec's element type.</typeparam>
+internal sealed class MapShape<TKey, TValue> : IMapShape
+{
+    /// <inheritdoc/>
+    public Type MapElementType => typeof(KeyValuePair<TKey, TValue>[]);
+
+    /// <inheritdoc/>
+    public object EmptyMap => Array.Empty<KeyValuePair<TKey, TValue>>();
+
+    /// <inheritdoc/>
+    public IColumn Wrap(string name, string typeName, IColumn keys, IColumn values, int[] offsets, int rowCount, bool pooledOffsets)
+        => new MapColumn<TKey, TValue>(name, typeName, (IColumn<TKey>)keys, (IColumn<TValue>)values, offsets, rowCount, pooledOffsets);
+
+    /// <inheritdoc/>
+    public bool CanWrite(IColumn column) => column is IColumn<KeyValuePair<TKey, TValue>[]>;
+
+    /// <inheritdoc/>
+    public bool CanInnerWrite(IColumnCodec keyCodec, IColumnCodec valueCodec)
+        => keyCodec.CanWrite(new ArrayColumn<TKey>(string.Empty, keyCodec.TypeName, Array.Empty<TKey>()))
+        && valueCodec.CanWrite(new ArrayColumn<TValue>(string.Empty, valueCodec.TypeName, Array.Empty<TValue>()));
+
+    /// <inheritdoc/>
+    public void WriteBody(IColumnCodec keyCodec, IColumnCodec valueCodec, ClickHouseBinaryWriter writer, IColumn column, int start, int length)
+    {
+        if (column is MapColumn<TKey, TValue> dense)
+        {
+            // Dense form (the wire's own layout): the offsets already exist and the key/value columns already hold
+            // every pair, so write them directly. The wire offsets are relative to this slice's pair streams, so
+            // subtract the slice's first pair index from each.
+            ReadOnlySpan<int> offsets = dense.Offsets;
+            int pairBase = offsets[start];
+            for (int i = 0; i < length; i++)
+            {
+                writer.WriteUInt64((ulong)(offsets[start + i + 1] - pairBase));
+            }
+
+            int pairCount = offsets[start + length] - pairBase;
+            keyCodec.WriteColumn(writer, dense.KeyColumn, pairBase, pairCount);
+            valueCodec.WriteColumn(writer, dense.ValueColumn, pairBase, pairCount);
+            return;
+        }
+
+        // Ergonomic jagged form: write the offsets from each row's pair count, then flatten the pair arrays into
+        // pooled key and value buffers (copying references for a composite inner, values for a leaf inner) and hand
+        // each to its codec as one contiguous column. Map(K, V) rows are themselves non-nullable, so a null row is
+        // rejected rather than silently coerced to an empty map; callers pass Array.Empty<KeyValuePair<K, V>>() for
+        // an empty row, or use Map(K, Nullable(V)) to carry null values.
+        var source = (IColumn<KeyValuePair<TKey, TValue>[]>)column;
+        ulong running = 0;
+        for (int i = 0; i < length; i++)
+        {
+            KeyValuePair<TKey, TValue>[] row = source[start + i];
+            if (row is null)
+            {
+                throw new ArgumentException(
+                    $"Map column '{column.Name}' has a null value at row {start + i}; Map(K, V) rows are non-nullable. Use Array.Empty<KeyValuePair<K, V>>() for an empty row, or Map(K, Nullable(V)) to carry null values.",
+                    nameof(column));
+            }
+
+            running += (ulong)row.Length;
+            writer.WriteUInt64(running);
+        }
+
+        // The flat buffers are addressed with an int length, so a slice whose pairs sum past Array.MaxLength cannot
+        // be buffered — reject it cleanly rather than truncate the cast and corrupt the streams.
+        if (running > (ulong)Array.MaxLength)
+        {
+            throw new NotSupportedException(
+                $"Map column '{column.Name}' holds {running} pairs in one block, exceeding the maximum ({Array.MaxLength}) this client can buffer.");
+        }
+
+        int total = (int)running;
+        var flatKeys = ArrayPool<TKey>.Shared.Rent(total);
+        var flatValues = ArrayPool<TValue>.Shared.Rent(total);
+        try
+        {
+            int pos = 0;
+            for (int i = 0; i < length; i++)
+            {
+                KeyValuePair<TKey, TValue>[] row = source[start + i];
+                if (row is { Length: > 0 })
+                {
+                    for (int p = 0; p < row.Length; p++)
+                    {
+                        flatKeys[pos] = row[p].Key;
+                        flatValues[pos] = row[p].Value;
+                        pos++;
+                    }
+                }
+            }
+
+            keyCodec.WriteColumn(writer, ArrayColumn<TKey>.OverBuffer(column.Name, keyCodec.TypeName, flatKeys, total), 0, total);
+            valueCodec.WriteColumn(writer, ArrayColumn<TValue>.OverBuffer(column.Name, valueCodec.TypeName, flatValues, total), 0, total);
+        }
+        finally
+        {
+            ArrayPool<TKey>.Shared.Return(flatKeys, clearArray: RuntimeHelpers.IsReferenceOrContainsReferences<TKey>());
+            ArrayPool<TValue>.Shared.Return(flatValues, clearArray: RuntimeHelpers.IsReferenceOrContainsReferences<TValue>());
+        }
+    }
+
+    /// <inheritdoc/>
+    public long MeasureRow(IColumnCodec keyCodec, IColumnCodec valueCodec, IColumn column, int row)
+    {
+        // One UInt64 offset plus the key and value bytes of this row's pairs. Fixed-width inners price in O(1); a
+        // variable-width inner is walked pair by pair through its codec.
+        if (column is MapColumn<TKey, TValue> dense)
+        {
+            ReadOnlySpan<int> offsets = dense.Offsets;
+            int pairStart = offsets[row];
+            int pairEnd = offsets[row + 1];
+            long bytes = sizeof(ulong);
+            bytes += MeasureStream(keyCodec, dense.KeyColumn, pairStart, pairEnd);
+            bytes += MeasureStream(valueCodec, dense.ValueColumn, pairStart, pairEnd);
+            return bytes;
+        }
+
+        KeyValuePair<TKey, TValue>[] value = ((IColumn<KeyValuePair<TKey, TValue>[]>)column)[row];
+        if (value is null)
+        {
+            throw new ArgumentException(
+                $"Map column '{column.Name}' has a null value at row {row}; Map(K, V) rows are non-nullable. Use Array.Empty<KeyValuePair<K, V>>() for an empty row, or Map(K, Nullable(V)) to carry null values.",
+                nameof(column));
+        }
+
+        int count = value.Length;
+        long total = sizeof(ulong);
+        if (count == 0)
+        {
+            return total;
+        }
+
+        if (keyCodec.FixedRowByteSize is int keyWidth)
+        {
+            total += (long)count * keyWidth;
+        }
+        else
+        {
+            // Variable-width key: project the row's keys into a pooled scratch buffer (returned below) and price
+            // them through the codec. Map(String, ...) — the common shape — takes this path once per row.
+            var keys = ArrayPool<TKey>.Shared.Rent(count);
+            try
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    keys[i] = value[i].Key;
+                }
+
+                total += MeasureStream(keyCodec, ArrayColumn<TKey>.OverBuffer(column.Name, keyCodec.TypeName, keys, count), 0, count);
+            }
+            finally
+            {
+                ArrayPool<TKey>.Shared.Return(keys, clearArray: RuntimeHelpers.IsReferenceOrContainsReferences<TKey>());
+            }
+        }
+
+        if (valueCodec.FixedRowByteSize is int valueWidth)
+        {
+            total += (long)count * valueWidth;
+        }
+        else
+        {
+            var values = ArrayPool<TValue>.Shared.Rent(count);
+            try
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    values[i] = value[i].Value;
+                }
+
+                total += MeasureStream(valueCodec, ArrayColumn<TValue>.OverBuffer(column.Name, valueCodec.TypeName, values, count), 0, count);
+            }
+            finally
+            {
+                ArrayPool<TValue>.Shared.Return(values, clearArray: RuntimeHelpers.IsReferenceOrContainsReferences<TValue>());
+            }
+        }
+
+        return total;
+    }
+
+    // Sums a codec's encoded bytes for the [start, end) slice of a flat column: O(1) when fixed-width, else per row.
+    private static long MeasureStream(IColumnCodec codec, IColumn column, int start, int end)
+    {
+        if (codec.FixedRowByteSize is int width)
+        {
+            return (long)(end - start) * width;
+        }
+
+        long bytes = 0;
+        for (int i = start; i < end; i++)
+        {
+            bytes += codec.MeasureRowBytes(column, i);
+        }
+
+        return bytes;
+    }
+}

--- a/ClickHouse.Driver.Tcp/Types/Codecs/MapColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/MapColumnCodec.cs
@@ -193,13 +193,7 @@ internal sealed class MapColumnCodec : IColumnCodec
     /// <inheritdoc/>
     public void WriteStatePrefix(ClickHouseBinaryWriter writer, IColumn column, int start, int length, IColumnWriteState state)
     {
-        if (state is not null)
-        {
-            shape.WriteStatePrefix(keyCodec, valueCodec, writer, state);
-            return;
-        }
-
-        WriteStatePrefix(writer, column, start, length);
+        shape.WriteStatePrefix(keyCodec, valueCodec, writer, state);
     }
 
     /// <inheritdoc/>
@@ -212,13 +206,7 @@ internal sealed class MapColumnCodec : IColumnCodec
     /// <inheritdoc/>
     public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length, IColumnWriteState state)
     {
-        if (state is not null)
-        {
-            shape.WriteBody(keyCodec, valueCodec, writer, column, start, length, state);
-            return;
-        }
-
-        WriteColumn(writer, column, start, length);
+        shape.WriteBody(keyCodec, valueCodec, writer, column, start, length, state);
     }
 }
 

--- a/ClickHouse.Driver.Tcp/Types/Codecs/MapColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/MapColumnCodec.cs
@@ -392,7 +392,7 @@ internal sealed class MapShape<TKey, TValue> : IMapShape
     /// <inheritdoc/>
     public void WriteStatePrefix(IColumnCodec keyCodec, IColumnCodec valueCodec, ClickHouseBinaryWriter writer, IColumnWriteState state)
     {
-        var mapState = (MapWriteState)state;
+        MapWriteState mapState = StateOf(state, keyCodec, valueCodec);
         keyCodec.WriteStatePrefix(writer, mapState.FlatKeys, mapState.PairBase, mapState.PairCount, mapState.KeyState);
         valueCodec.WriteStatePrefix(writer, mapState.FlatValues, mapState.PairBase, mapState.PairCount, mapState.ValueState);
     }
@@ -400,7 +400,7 @@ internal sealed class MapShape<TKey, TValue> : IMapShape
     /// <inheritdoc/>
     public void WriteBody(IColumnCodec keyCodec, IColumnCodec valueCodec, ClickHouseBinaryWriter writer, IColumn column, int start, int length, IColumnWriteState state)
     {
-        var mapState = (MapWriteState)state;
+        MapWriteState mapState = StateOf(state, keyCodec, valueCodec);
 
         // Offsets, relative to this slice's own pair streams: from the dense column's offsets, or each jagged row's
         // pair count. The key/value bodies come from the pre-flattened state.
@@ -431,6 +431,13 @@ internal sealed class MapShape<TKey, TValue> : IMapShape
     // The flatten of one slice's keys and values, shared across the prefix and body phases. For the ergonomic
     // jagged form the columns are backed by pooled buffers returned on dispose; for the dense form they are the
     // borrowed key/value columns (no buffers to return).
+    // Narrows the shared scratch to this shape's own state. The cast comes first so the succeeding path never builds
+    // the type name, which the shape has no way to cache: one shape instance is shared by every map codec with the
+    // same key and value CLR types, so it holds no per-codec data.
+    private static MapWriteState StateOf(IColumnWriteState state, IColumnCodec keyCodec, IColumnCodec valueCodec)
+        => state as MapWriteState
+            ?? state.Expect<MapWriteState>($"Map({keyCodec.TypeName}, {valueCodec.TypeName})");
+
     private sealed class MapWriteState : IColumnWriteState
     {
         private readonly TKey[] keyBuffer;

--- a/ClickHouse.Driver.Tcp/Types/Codecs/MapColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/MapColumnCodec.cs
@@ -186,17 +186,8 @@ internal sealed class MapColumnCodec : IColumnCodec
     /// <inheritdoc/>
     public void WriteStatePrefix(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
     {
-        if (shape.CanWrite(column))
-        {
-            using IColumnWriteState state = shape.BeginWrite(keyCodec, valueCodec, column, start, length);
-            shape.WriteStatePrefix(keyCodec, valueCodec, writer, state);
-            return;
-        }
-
-        // An outer composite forwarded its own column (its children's prefixes are written from its own slice);
-        // the key/value codecs ignore it, preserving the prior contract for a Map nested in Variant/Nested/Tuple.
-        keyCodec.WriteStatePrefix(writer, column, start, length);
-        valueCodec.WriteStatePrefix(writer, column, start, length);
+        using IColumnWriteState state = shape.BeginWrite(keyCodec, valueCodec, column, start, length);
+        shape.WriteStatePrefix(keyCodec, valueCodec, writer, state);
     }
 
     /// <inheritdoc/>

--- a/ClickHouse.Driver.Tcp/Types/ColumnCodecRegistry.cs
+++ b/ClickHouse.Driver.Tcp/Types/ColumnCodecRegistry.cs
@@ -132,6 +132,10 @@ internal sealed class ColumnCodecRegistry
         // bodies, in order); each element codec is resolved recursively and element names, if any, are kept.
         AddFactory("Tuple", static (TypeNode node, in ResolveContext context, ColumnCodecRegistry registry) => TupleColumnCodec.Create(node, context, registry));
 
+        // Map(K, V) is byte-identical to Array(Tuple(K, V)): offsets + a keys stream + a values stream. The key
+        // and value codecs are resolved recursively; each row surfaces as a KeyValuePair<K, V>[].
+        AddFactory("Map", static (TypeNode node, in ResolveContext context, ColumnCodecRegistry registry) => MapColumnCodec.Create(node, context, registry));
+
         return new ColumnCodecRegistry(byName);
     }
 }

--- a/ClickHouse.Driver.Tcp/Types/IMapColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/IMapColumn.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+
+namespace ClickHouse.Driver.Tcp.Types;
+
+/// <summary>
+/// The zero-copy read surface of a decoded <c>Map(K, V)</c> column. A map column materializes each row as a freshly
+/// allocated <see cref="KeyValuePair{TKey, TValue}"/>[] (see the column's <c>Values</c>/indexer), which is
+/// convenient and lets the pairs outlive the block, but allocates an array — and a pair struct per entry — for
+/// every row. This interface exposes the underlying wire layout instead: two flat, positionally aligned columns
+/// holding every row's keys and every row's values concatenated end-to-end, plus the per-row offsets that delimit
+/// them. It is byte-identical to <c>Array(Tuple(K, V))</c>, so the shape is the same one
+/// <see cref="IArrayColumn{TElement}"/> exposes, with the run split across a key and a value column.
+///
+/// <para>
+/// Row <c>i</c>'s entries are <c>Offsets[i]</c> (inclusive) to <c>Offsets[i + 1]</c> (exclusive) in both
+/// <see cref="KeyColumn"/> and <see cref="ValueColumn"/>: entry <c>j</c> of that range pairs
+/// <c>KeyColumn[j]</c> with <c>ValueColumn[j]</c>. Reading the two columns directly also lets a caller take only
+/// the keys, or only the values, without building the pairs at all. Both are borrowed views over the owning
+/// block's storage, as is <see cref="Offsets"/>: read them in place, and copy out only what must outlive the block.
+/// </para>
+///
+/// <para>
+/// The key and value columns preserve duplicate keys and entry order exactly as the wire carried them — the same
+/// reason a row materializes as a pair array rather than a <see cref="Dictionary{TKey, TValue}"/>, which would
+/// silently collapse duplicates. Either may itself be a composite (<c>Map(String, Array(UInt32))</c>), in which
+/// case it pattern-matches to that type's own columnar view. Obtain this view by pattern-matching a column, e.g.
+/// <c>if (column is IMapColumn&lt;string, uint&gt; map)</c>.
+/// </para>
+/// </summary>
+/// <typeparam name="TKey">The key codec's CLR element type.</typeparam>
+/// <typeparam name="TValue">The value codec's CLR element type.</typeparam>
+public interface IMapColumn<TKey, TValue> : IColumn<KeyValuePair<TKey, TValue>[]>
+{
+    /// <summary>
+    /// The flat key column: every row's keys concatenated end-to-end, addressed through <see cref="Offsets"/> and
+    /// positionally aligned with <see cref="ValueColumn"/>. Its row count is the total entry count across all
+    /// rows, not the map's row count. A borrowed view valid only while the owning block is alive.
+    /// </summary>
+    IColumn<TKey> KeyColumn { get; }
+
+    /// <summary>
+    /// The flat value column: every row's values concatenated end-to-end, aligned entry-for-entry with
+    /// <see cref="KeyColumn"/>. A borrowed view valid only while the owning block is alive.
+    /// </summary>
+    IColumn<TValue> ValueColumn { get; }
+
+    /// <summary>
+    /// The per-row offsets into <see cref="KeyColumn"/> and <see cref="ValueColumn"/>: <c>[0]</c> is 0 and
+    /// <c>[i + 1]</c> is the exclusive end of row <c>i</c>'s entries; the span has one more entry than the column
+    /// has rows. A borrowed span valid only while the owning block is alive.
+    /// </summary>
+    ReadOnlySpan<int> Offsets { get; }
+}

--- a/ClickHouse.Driver.Tcp/Types/IMapColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/IMapColumn.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 namespace ClickHouse.Driver.Tcp.Types;
 
 /// <summary>
-/// The zero-copy read surface of a decoded <c>Map(K, V)</c> column. A map column materializes each row as a freshly
+/// The columnar read surface of a decoded <c>Map(K, V)</c> column. A map column materializes each row as a freshly
 /// allocated <see cref="KeyValuePair{TKey, TValue}"/>[] (see the column's <c>Values</c>/indexer), which is
 /// convenient and lets the pairs outlive the block, but allocates an array — and a pair struct per entry — for
 /// every row. This interface exposes the underlying wire layout instead: two flat, positionally aligned columns
@@ -35,13 +35,14 @@ public interface IMapColumn<TKey, TValue> : IColumn<KeyValuePair<TKey, TValue>[]
     /// <summary>
     /// The flat key column: every row's keys concatenated end-to-end, addressed through <see cref="Offsets"/> and
     /// positionally aligned with <see cref="ValueColumn"/>. Its row count is the total entry count across all
-    /// rows, not the map's row count. A borrowed view valid only while the owning block is alive.
+    /// rows, not the map's row count. A borrowed view valid only while the owning block is alive — it is the
+    /// block's to dispose, never the caller's.
     /// </summary>
     IColumn<TKey> KeyColumn { get; }
 
     /// <summary>
     /// The flat value column: every row's values concatenated end-to-end, aligned entry-for-entry with
-    /// <see cref="KeyColumn"/>. A borrowed view valid only while the owning block is alive.
+    /// <see cref="KeyColumn"/>. Borrowed on the same terms as <see cref="KeyColumn"/>.
     /// </summary>
     IColumn<TValue> ValueColumn { get; }
 

--- a/ClickHouse.Driver.Tcp/Types/MapColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/MapColumn.cs
@@ -38,6 +38,11 @@ internal sealed class MapColumn<TKey, TValue> : IColumn<KeyValuePair<TKey, TValu
     private int[] offsets;
     private KeyValuePair<TKey, TValue>[][] cache;
 
+    // Whether Dispose disposes the key / value column. Both true by default (this column owns its inner columns);
+    // RestrictOwnership flips one off when a densified wrapper keeps that child by reference from another column.
+    private bool ownsKeys = true;
+    private bool ownsValues = true;
+
     /// <summary>Initializes a map column over the flat key and value columns and their shared per-row offsets.</summary>
     /// <param name="name">The column name.</param>
     /// <param name="typeName">The full <c>Map(...)</c> type string.</param>
@@ -55,6 +60,18 @@ internal sealed class MapColumn<TKey, TValue> : IColumn<KeyValuePair<TKey, TValu
         this.offsets = offsets ?? throw new ArgumentNullException(nameof(offsets));
         this.rowCount = rowCount;
         this.pooledOffsets = pooledOffsets;
+    }
+
+    /// <summary>
+    /// Restricts which inner columns <see cref="Dispose"/> disposes, overriding the default of owning both. Used
+    /// when a densified map rebuilds only one of the key/value columns and keeps the other by reference (owned by
+    /// the source column), so disposing this wrapper frees only the column it built. Must be called before the
+    /// column is observed.
+    /// </summary>
+    internal void RestrictOwnership(bool keysOwned, bool valuesOwned)
+    {
+        ownsKeys = keysOwned;
+        ownsValues = valuesOwned;
     }
 
     /// <inheritdoc/>
@@ -110,8 +127,16 @@ internal sealed class MapColumn<TKey, TValue> : IColumn<KeyValuePair<TKey, TValu
     /// <inheritdoc/>
     public void Dispose()
     {
-        keys.Dispose();
-        values.Dispose();
+        if (ownsKeys)
+        {
+            keys.Dispose();
+        }
+
+        if (ownsValues)
+        {
+            values.Dispose();
+        }
+
         if (pooledOffsets && offsets.Length != 0)
         {
             ArrayPool<int>.Shared.Return(offsets);

--- a/ClickHouse.Driver.Tcp/Types/MapColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/MapColumn.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+
+namespace ClickHouse.Driver.Tcp.Types;
+
+/// <summary>
+/// A ClickHouse <c>Map(K, V)</c> column: it pairs two flat inner columns — every row's keys and every row's
+/// values concatenated end-to-end, positionally aligned — with a per-row offsets array, and surfaces each row as
+/// a freshly materialized <see cref="KeyValuePair{TKey, TValue}"/>[]. This is the dense shape the wire uses
+/// (offsets + a keys stream + a values stream, byte-identical to <c>Array(Tuple(K, V))</c>), so it is also the
+/// zero-copy source for writing — handed back to the <c>Map(K, V)</c> codec it serializes straight from the two
+/// inner columns and offsets without rebuilding anything.
+///
+/// <para>
+/// Each row surfaces as a <see cref="KeyValuePair{TKey, TValue}"/>[] rather than a <see cref="Dictionary{TKey, TValue}"/>
+/// so that duplicate keys and pair order — both meaningful on the wire — round-trip intact; a dictionary would
+/// silently collapse duplicates. <typeparamref name="TKey"/> and <typeparamref name="TValue"/> may themselves be
+/// composites (<c>Map(String, Array(UInt32))</c>, <c>Map(String, Tuple(...))</c>) — whatever the key/value codecs
+/// surface.
+/// </para>
+///
+/// <para>
+/// The inner columns' storage and the offsets are borrowed for this column's lifetime; the inner columns are
+/// disposed and the offsets returned (when pooled) on <see cref="Dispose"/>. Each <see cref="this"/> access
+/// copies the row's pairs into a new array, so retain those arrays freely, but read the column itself only while
+/// the owning block is alive.
+/// </para>
+/// </summary>
+/// <typeparam name="TKey">The key codec's CLR element type.</typeparam>
+/// <typeparam name="TValue">The value codec's CLR element type.</typeparam>
+internal sealed class MapColumn<TKey, TValue> : IColumn<KeyValuePair<TKey, TValue>[]>
+{
+    private readonly IColumn<TKey> keys;
+    private readonly IColumn<TValue> values;
+    private readonly int rowCount;
+    private readonly bool pooledOffsets;
+    private int[] offsets;
+    private KeyValuePair<TKey, TValue>[][] cache;
+
+    /// <summary>Initializes a map column over the flat key and value columns and their shared per-row offsets.</summary>
+    /// <param name="name">The column name.</param>
+    /// <param name="typeName">The full <c>Map(...)</c> type string.</param>
+    /// <param name="keys">The key column holding every row's keys concatenated end-to-end.</param>
+    /// <param name="values">The value column holding every row's values concatenated end-to-end, aligned with <paramref name="keys"/>.</param>
+    /// <param name="offsets">The per-row offsets: <c>offsets[0]</c> is 0 and <c>offsets[i + 1]</c> is the exclusive end of row <c>i</c>'s pairs; must have at least <paramref name="rowCount"/> + 1 entries.</param>
+    /// <param name="rowCount">The number of rows.</param>
+    /// <param name="pooledOffsets">Whether <paramref name="offsets"/> was rented and should be returned on dispose.</param>
+    public MapColumn(string name, string typeName, IColumn<TKey> keys, IColumn<TValue> values, int[] offsets, int rowCount, bool pooledOffsets)
+    {
+        Name = name;
+        TypeName = typeName;
+        this.keys = keys ?? throw new ArgumentNullException(nameof(keys));
+        this.values = values ?? throw new ArgumentNullException(nameof(values));
+        this.offsets = offsets ?? throw new ArgumentNullException(nameof(offsets));
+        this.rowCount = rowCount;
+        this.pooledOffsets = pooledOffsets;
+    }
+
+    /// <inheritdoc/>
+    public string Name { get; }
+
+    /// <inheritdoc/>
+    public string TypeName { get; }
+
+    /// <inheritdoc/>
+    public int RowCount => rowCount;
+
+    /// <summary>The flat key column (every row's keys concatenated) — a zero-copy write source.</summary>
+    internal IColumn<TKey> KeyColumn => keys;
+
+    /// <summary>The flat value column (every row's values concatenated, aligned with <see cref="KeyColumn"/>) — a zero-copy write source.</summary>
+    internal IColumn<TValue> ValueColumn => values;
+
+    /// <summary>
+    /// The per-row offsets, sliced to <see cref="RowCount"/> + 1 entries: <c>[0]</c> is 0 and <c>[i + 1]</c> is
+    /// the exclusive end of row <c>i</c>'s slice of the key/value columns — a zero-copy write source.
+    /// </summary>
+    internal ReadOnlySpan<int> Offsets => offsets.AsSpan(0, rowCount + 1);
+
+    /// <summary>
+    /// The rows as key/value-pair arrays, materialized once and cached. Prefer the indexer when only some rows are
+    /// needed, to avoid building the whole jagged array.
+    /// </summary>
+    public ReadOnlySpan<KeyValuePair<TKey, TValue>[]> Values
+    {
+        get
+        {
+            if (cache is null)
+            {
+                var decoded = new KeyValuePair<TKey, TValue>[rowCount][];
+                for (int i = 0; i < rowCount; i++)
+                {
+                    decoded[i] = Materialize(i);
+                }
+
+                cache = decoded;
+            }
+
+            return cache.AsSpan(0, rowCount);
+        }
+    }
+
+    /// <inheritdoc/>
+    public KeyValuePair<TKey, TValue>[] this[int row] => cache is not null ? cache[row] : Materialize(row);
+
+    /// <inheritdoc/>
+    public object GetValue(int row) => this[row];
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        keys.Dispose();
+        values.Dispose();
+        if (pooledOffsets && offsets.Length != 0)
+        {
+            ArrayPool<int>.Shared.Return(offsets);
+        }
+
+        offsets = Array.Empty<int>();
+        cache = null;
+    }
+
+    /// <summary>Copies row <paramref name="row"/>'s slice of the key and value columns into a new pair array, preserving order and duplicate keys.</summary>
+    private KeyValuePair<TKey, TValue>[] Materialize(int row)
+    {
+        int start = offsets[row];
+        int length = offsets[row + 1] - start;
+        if (length == 0)
+        {
+            return Array.Empty<KeyValuePair<TKey, TValue>>();
+        }
+
+        var pairs = new KeyValuePair<TKey, TValue>[length];
+        for (int i = 0; i < length; i++)
+        {
+            pairs[i] = new KeyValuePair<TKey, TValue>(keys[start + i], values[start + i]);
+        }
+
+        return pairs;
+    }
+}

--- a/ClickHouse.Driver.Tcp/Types/MapColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/MapColumn.cs
@@ -29,7 +29,7 @@ namespace ClickHouse.Driver.Tcp.Types;
 /// </summary>
 /// <typeparam name="TKey">The key codec's CLR element type.</typeparam>
 /// <typeparam name="TValue">The value codec's CLR element type.</typeparam>
-internal sealed class MapColumn<TKey, TValue> : IColumn<KeyValuePair<TKey, TValue>[]>
+internal sealed class MapColumn<TKey, TValue> : IColumn<KeyValuePair<TKey, TValue>[]>, IMapColumn<TKey, TValue>
 {
     private readonly IColumn<TKey> keys;
     private readonly IColumn<TValue> values;
@@ -96,17 +96,14 @@ internal sealed class MapColumn<TKey, TValue> : IColumn<KeyValuePair<TKey, TValu
     /// <inheritdoc/>
     public int RowCount => rowCount;
 
-    /// <summary>The flat key column (every row's keys concatenated) — a zero-copy write source.</summary>
-    internal IColumn<TKey> KeyColumn => keys;
+    /// <inheritdoc/>
+    public IColumn<TKey> KeyColumn => keys;
 
-    /// <summary>The flat value column (every row's values concatenated, aligned with <see cref="KeyColumn"/>) — a zero-copy write source.</summary>
-    internal IColumn<TValue> ValueColumn => values;
+    /// <inheritdoc/>
+    public IColumn<TValue> ValueColumn => values;
 
-    /// <summary>
-    /// The per-row offsets, sliced to <see cref="RowCount"/> + 1 entries: <c>[0]</c> is 0 and <c>[i + 1]</c> is
-    /// the exclusive end of row <c>i</c>'s slice of the key/value columns — a zero-copy write source.
-    /// </summary>
-    internal ReadOnlySpan<int> Offsets => offsets.AsSpan(0, rowCount + 1);
+    /// <inheritdoc/>
+    public ReadOnlySpan<int> Offsets => offsets.AsSpan(0, rowCount + 1);
 
     /// <summary>
     /// The rows as key/value-pair arrays, materialized once and cached. Prefer the indexer when only some rows are

--- a/ClickHouse.Driver.Tcp/Types/MapColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/MapColumn.cs
@@ -51,6 +51,8 @@ internal sealed class MapColumn<TKey, TValue> : IColumn<KeyValuePair<TKey, TValu
     /// <param name="offsets">The per-row offsets: <c>offsets[0]</c> is 0 and <c>offsets[i + 1]</c> is the exclusive end of row <c>i</c>'s pairs; must have at least <paramref name="rowCount"/> + 1 entries.</param>
     /// <param name="rowCount">The number of rows.</param>
     /// <param name="pooledOffsets">Whether <paramref name="offsets"/> was rented and should be returned on dispose.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="keys"/>, <paramref name="values"/> or <paramref name="offsets"/> is null.</exception>
+    /// <exception cref="ArgumentException"><paramref name="offsets"/> holds fewer than <paramref name="rowCount"/> + 1 entries.</exception>
     public MapColumn(string name, string typeName, IColumn<TKey> keys, IColumn<TValue> values, int[] offsets, int rowCount, bool pooledOffsets)
     {
         Name = name;
@@ -60,6 +62,17 @@ internal sealed class MapColumn<TKey, TValue> : IColumn<KeyValuePair<TKey, TValu
         this.offsets = offsets ?? throw new ArgumentNullException(nameof(offsets));
         this.rowCount = rowCount;
         this.pooledOffsets = pooledOffsets;
+
+        // The row count cannot be derived here: the key and value columns are flat (one entry per pair across all
+        // rows, so their height is the pair total) and the offsets are typically a pooled buffer longer than the
+        // column. So the one input that can disagree is checked instead — a short offsets array would leave the row
+        // bounds reading past its end.
+        if (offsets.Length < rowCount + 1)
+        {
+            throw new ArgumentException(
+                $"The offsets for column '{name}' ({typeName}) hold {offsets.Length} entries, fewer than the {rowCount + 1} needed for {rowCount} rows.",
+                nameof(offsets));
+        }
     }
 
     /// <summary>
@@ -149,8 +162,12 @@ internal sealed class MapColumn<TKey, TValue> : IColumn<KeyValuePair<TKey, TValu
     /// <summary>Copies row <paramref name="row"/>'s slice of the key and value columns into a new pair array, preserving order and duplicate keys.</summary>
     private KeyValuePair<TKey, TValue>[] Materialize(int row)
     {
-        int start = offsets[row];
-        int length = offsets[row + 1] - start;
+        // Index through the RowCount-sliced offsets, not the raw buffer: the buffer is usually a pooled array longer
+        // than the column, and a stale offset pair left in it by a previous, larger read is still monotonic — so an
+        // out-of-range row would quietly hand back real-looking pairs instead of throwing.
+        ReadOnlySpan<int> bounds = Offsets;
+        int start = bounds[row];
+        int length = bounds[row + 1] - start;
         if (length == 0)
         {
             return Array.Empty<KeyValuePair<TKey, TValue>>();


### PR DESCRIPTION
## Summary

Adds `Map(K, V)` to the TCP/Native client (epic I4), stacked on the Tuple branch (I3).

On the wire, `Map(K, V)` is **byte-identical to `Array(Tuple(K, V))`**: the key then value codec's state prefix, a per-row `UInt64` offsets stream, then a flat keys stream and a flat values stream, positionally aligned (`pair i = (keys[i], values[i])`). The codec reuses Array's offset framing and Tuple's per-element streams.

## Design decision: `KeyValuePair<K, V>[]`, not `Dictionary<K, V>`

Each row surfaces as `KeyValuePair<K, V>[]` so that **duplicate keys and pair order — both meaningful on the wire — round-trip intact**. A `Dictionary` would silently collapse duplicates. This intentionally diverges from the HTTP driver's `Dictionary<K, V>` (the two clients are permitted to surface different CLR types), and is also more span/pool-friendly.

Also accepting dictionary rows on the *write* path was tried as an experiment and dropped as not worth it. Advertising `Dictionary<K, V>`/`IReadOnlyDictionary<K, V>` as extra writable element types meant a third specialized flatten path, plus a per-row size re-check with a throw on mismatch — unlike a pair array, a dictionary can change size between the flatten's measure and copy passes, and a stale trailing slot would be stored as real data. That is a lot of machinery to save a caller one enumeration into pairs, so a write column supplies `KeyValuePair<K, V>[]`.

- Map rows are non-nullable; the server rejects `Nullable(Map(...))`, so nullability composes inside the value as `Map(K, Nullable(V))`. Map keys are themselves non-nullable in ClickHouse.
- Nested composites recurse: `Map(String, Array(T))`, `Map(String, Tuple(...))`, `Array(Map(K, V))`.

## Changes

- **New** `Types/Codecs/MapColumnCodec.cs` — codec + `IMapShape`/`MapShape<K,V>`/`MapShapes` bridge (mirrors `ArrayColumnCodec`, carrying two child codecs over one offsets vector).
- **New** `Types/MapColumn.cs` — `IColumn<KeyValuePair<K,V>[]>` (mirrors `ArrayValueColumn`).
- `Types/ColumnCodecRegistry.cs` — register `AddFactory("Map", …)`.
- **New** `Tests/Types/MapColumnCodecTests.cs` and Map cases in `Tests/Utilities/InsertRoundTripCase.cs`.
- Repointed two tests (`ColumnCodecRegistryTests`, `NullableColumnCodecTests`) that used `Map(...)` as their "well-formed but unimplemented type" placeholder to `Nested(...)`, the next unimplemented composite.

## Testing

- **692/692** TCP tests pass (net9.0), including a new `MapColumnCodecTests` and **7 integration round-trip cases** proven against a real ClickHouse server (`Map(String, UInt32)`, `Map(UInt8, String)`, empty/all-empty, `Map(String, Nullable(UInt32))`, `Map(String, Array(Int32))`, `Map(String, Tuple(Int32, String))`, `Array(Map(String, UInt32))`).
- Builds clean across net6.0–net10.0.
- Coverage: `MapColumn.cs` 100%, `MapColumnCodec.cs` 92.9% (remainder = multi-GB overflow guards + cleanup catch-blocks, same as Array).
- A review pass found no Critical/Major issues; applied two Minor fixes (null-tolerant flatten guard for Array parity; pooled scratch buffers in `MeasureRow` so the common `Map(String, …)` path doesn't allocate per row).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
