### PR TITLE
TCP I5: Add Nested(...) support

### DIFF
--- a/ClickHouse.Driver.Tcp.Tests/Integration/ColumnarReadSurfaceIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ColumnarReadSurfaceIntegrationTests.cs
@@ -391,4 +391,75 @@ public class ColumnarReadSurfaceIntegrationTests
             Assert.That(flatValues, Is.EqualTo(new[] { 1, 2, 3 }), "in wire order, so both entries stay addressable");
         });
     }
+
+    [Test]
+    public async Task QueryAsync_NestedColumn_ExposesPerFieldColumnsAndSharedOffsetsThroughINestedColumn()
+    {
+        // Nested is the case where the columnar view is the *primary* access path rather than an optimization: a
+        // Nested can carry any number of fields, so there is no generic per-row value type for it and the
+        // IColumn<T> surface has to degrade to object[][] — a boxed object[] per record, per row. INestedColumn is
+        // how a consumer reads it typed. One offsets array is shared by every field, since within a row all fields
+        // have the same element count.
+        await using var connection = await TcpServerFixture.ConnectAsync(None);
+
+        bool matched = false;
+        int rowCount = 0;
+        int fieldCount = 0;
+        string[] fieldNames = null;
+        int[] offsets = null;
+        byte[] fieldA = null;
+        string[] fieldB = null;
+        bool byNameMatchesByIndex = false;
+        int[] fieldRowCounts = null;
+        var recordsOfLastRow = new List<(byte A, string B)>();
+
+        // Rows: [], [(0, 'f0')], [(0, 'f0'), (1, 'f1')].
+        await foreach (Block block in connection.QueryAsync(
+            """
+            SELECT CAST(
+                arrayMap(i -> (toUInt8(i), concat('f', toString(i))), range(number)),
+                'Nested(a UInt8, b String)')
+            FROM system.numbers LIMIT 3
+            """,
+            cancellationToken: None))
+        {
+            IColumn column = block[0];
+            matched = column is INestedColumn;
+
+            var nested = (INestedColumn)column;
+            rowCount = nested.RowCount;
+            fieldCount = nested.FieldCount;
+            fieldNames = nested.FieldNames.ToArray();
+            offsets = nested.Offsets.ToArray();
+            fieldA = ((IColumn<byte>)nested.GetField(0)).Values.ToArray();
+            fieldB = ((IColumn<string>)nested.GetField(1)).Values.ToArray();
+            byNameMatchesByIndex = ReferenceEquals(nested.GetField("b"), nested.GetField(1));
+            fieldRowCounts = new[] { nested.GetField(0).RowCount, nested.GetField(1).RowCount };
+
+            // Reassemble the last row's records by walking the shared offsets across both field columns — the
+            // typed, allocation-free equivalent of what the object[][] surface would box.
+            int last = nested.RowCount - 1;
+            var a = (IColumn<byte>)nested.GetField(0);
+            var b = (IColumn<string>)nested.GetField(1);
+            for (int i = nested.Offsets[last]; i < nested.Offsets[last + 1]; i++)
+            {
+                recordsOfLastRow.Add((a[i], b[i]));
+            }
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(matched, Is.True);
+            Assert.That(rowCount, Is.EqualTo(3));
+            Assert.That(fieldCount, Is.EqualTo(2));
+            Assert.That(fieldNames, Is.EqualTo(new[] { "a", "b" }));
+            Assert.That(offsets, Is.EqualTo(new[] { 0, 0, 1, 3 }), "one shared offsets array, one more entry than rows");
+            Assert.That(offsets.Length, Is.EqualTo(rowCount + 1), "sliced to the row count, not the pooled buffer length");
+            Assert.That(fieldA, Is.EqualTo(new byte[] { 0, 0, 1 }), "field-major: every row's 'a' elements end-to-end");
+            Assert.That(fieldB, Is.EqualTo(new[] { "f0", "f0", "f1" }), "and every row's 'b', aligned with 'a'");
+            Assert.That(fieldRowCounts, Is.EqualTo(new[] { 3, 3 }), "every field holds the same total element count");
+            Assert.That(byNameMatchesByIndex, Is.True, "name lookup resolves to the same column as the index");
+            Assert.That(recordsOfLastRow, Is.EqualTo(new[] { ((byte)0, "f0"), ((byte)1, "f1") }));
+        });
+    }
 }

--- a/ClickHouse.Driver.Tcp.Tests/Types/ArrayColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/ArrayColumnCodecTests.cs
@@ -95,6 +95,30 @@ public class ArrayColumnCodecTests
     }
 
     [Test]
+    public void CanWrite_NestedInnerWithoutDenseNamedFieldColumn_ReturnsFalse()
+    {
+        const string type = "Array(Nested(a UInt8))";
+        const string nestedType = "Nested(a UInt8)";
+        IColumnCodec codec = Resolve(type);
+
+        // Flattening the ergonomic rows would leave only object[][] values, not Nested's named field columns.
+        var ergonomic = new ArrayColumn<object[][][]>("c", type, Array.Empty<object[][][]>());
+        var wrongDense = new ArrayValueColumn<object[][]>(
+            "c",
+            type,
+            new ArrayColumn<object[][]>("c", nestedType, Array.Empty<object[][]>()),
+            new[] { 0 },
+            rowCount: 0,
+            pooledOffsets: false);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(codec.CanWrite(ergonomic), Is.False, "the row-oriented projection has lost the named fields");
+            Assert.That(codec.CanWrite(wrongDense), Is.False, "a dense outer column still needs a real NestedColumn inner");
+        });
+    }
+
+    [Test]
     public void ElementType_IsInnerElementTypeArray()
     {
         Assert.Multiple(() =>

--- a/ClickHouse.Driver.Tcp.Tests/Types/ColumnCodecRegistryTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/ColumnCodecRegistryTests.cs
@@ -34,7 +34,7 @@ public class ColumnCodecRegistryTests
 
     [Test]
     public void Resolve_UnsupportedButWellFormedType_ThrowsNotSupported()
-        => Assert.Throws<NotSupportedException>(() => ColumnCodecRegistry.Default.Resolve("Nested(a Int32, b String)", default));
+        => Assert.Throws<NotSupportedException>(() => ColumnCodecRegistry.Default.Resolve("LowCardinality(String)", default));
 
     [Test]
     public void Resolve_MalformedType_ThrowsFormat()

--- a/ClickHouse.Driver.Tcp.Tests/Types/MapColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/MapColumnCodecTests.cs
@@ -143,6 +143,34 @@ public class MapColumnCodecTests
     }
 
     [Test]
+    public void CanWrite_NestedValueWithoutDenseNamedFieldColumn_ReturnsFalse()
+    {
+        const string type = "Map(String, Nested(a UInt8))";
+        const string nestedType = "Nested(a UInt8)";
+        IColumnCodec codec = Resolve(type);
+
+        // Flattening the ergonomic pairs would leave object[][] values, not Nested's named field columns.
+        var ergonomic = new ArrayColumn<KeyValuePair<string, object[][]>[]>(
+            "c",
+            type,
+            Array.Empty<KeyValuePair<string, object[][]>[]>());
+        var wrongDense = new MapColumn<string, object[][]>(
+            "c",
+            type,
+            new ArrayColumn<string>("c", "String", Array.Empty<string>()),
+            new ArrayColumn<object[][]>("c", nestedType, Array.Empty<object[][]>()),
+            new[] { 0 },
+            rowCount: 0,
+            pooledOffsets: false);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(codec.CanWrite(ergonomic), Is.False, "the row-oriented projection has lost the named fields");
+            Assert.That(codec.CanWrite(wrongDense), Is.False, "a dense map still needs a real NestedColumn value");
+        });
+    }
+
+    [Test]
     public void ElementType_IsKeyValuePairArray()
     {
         Assert.Multiple(() =>

--- a/ClickHouse.Driver.Tcp.Tests/Types/NestedColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/NestedColumnCodecTests.cs
@@ -1,0 +1,327 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Protocol;
+using ClickHouse.Driver.Tcp.Tests.Utilities;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Tests.Types;
+
+[TestFixture]
+public class NestedColumnCodecTests
+{
+    private static IColumnCodec Resolve(string type) => ColumnCodecRegistry.Default.Resolve(type, default);
+
+    // Builds a dense NestedColumn (the wire's own columnar shape) from field columns and per-row offsets.
+    private static NestedColumn Nested(string typeName, string[] fieldNames, IColumn[] fields, int[] offsets)
+        => new("c", typeName, fieldNames, fields, offsets, rowCount: offsets.Length - 1, pooledOffsets: false, ownsFields: false);
+
+    private static IColumn Field<T>(string typeName, params T[] values) => new ArrayColumn<T>("c", typeName, values);
+
+    [Test]
+    public async Task ReadColumn_WriteThenRead_FixedAndStringFieldsRoundTripWithEmptyRows()
+    {
+        // Rows: [(1,'a'),(2,'b')], [], [(3,'c')] — three rows, the middle one empty.
+        const string type = "Nested(a UInt8, b String)";
+        IColumnCodec codec = Resolve(type);
+        var column = Nested(
+            type,
+            new[] { "a", "b" },
+            new[] { Field<byte>("UInt8", 1, 2, 3), Field<string>("String", "a", "b", "c") },
+            new[] { 0, 2, 2, 3 });
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, type, column.RowCount);
+        var nested = (NestedColumn)read;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(nested.TypeName, Is.EqualTo(type));
+            Assert.That(nested.RowCount, Is.EqualTo(3));
+            Assert.That(nested.FieldNames, Is.EqualTo(new[] { "a", "b" }));
+            Assert.That(nested.Offsets.ToArray(), Is.EqualTo(new[] { 0, 2, 2, 3 }));
+
+            // Columnar access: each field is a flat column of every row's elements concatenated.
+            Assert.That(((IColumn<byte>)nested.GetField("a")).Values.ToArray(), Is.EqualTo(new byte[] { 1, 2, 3 }));
+            Assert.That(((IColumn<string>)nested.GetField("b")).Values.ToArray(), Is.EqualTo(new[] { "a", "b", "c" }));
+
+            // Row (boxed array-of-records) access.
+            Assert.That(nested.GetValue(0), Is.EqualTo(new[] { new object[] { (byte)1, "a" }, new object[] { (byte)2, "b" } }));
+            Assert.That(nested.GetValue(1), Is.EqualTo(Array.Empty<object[]>()));
+            Assert.That(nested.GetValue(2), Is.EqualTo(new[] { new object[] { (byte)3, "c" } }));
+        });
+    }
+
+    [Test]
+    public async Task WriteColumn_Nested_IsByteIdenticalToArrayOfTuple()
+    {
+        // The flatten_nested = 0 form is byte-for-byte the same as Array(Tuple(...)); only the type-string text
+        // (which keeps the field names) differs. Proven by writing the same data through both and comparing bytes.
+        var nested = Nested(
+            "Nested(a UInt8, b String)",
+            new[] { "a", "b" },
+            new[] { Field<byte>("UInt8", 10, 20, 30), Field<string>("String", "x", "y", "z") },
+            new[] { 0, 2, 3 });
+        var arrayOfTuple = new ArrayColumn<(byte, string)[]>("c", "Array(Tuple(a UInt8, b String))", new[]
+        {
+            new[] { ((byte)10, "x"), ((byte)20, "y") },
+            new[] { ((byte)30, "z") },
+        });
+
+        byte[] nestedBytes = await CodecTestHarness.WriteAsync(w => Resolve("Nested(a UInt8, b String)").WriteColumn(w, nested));
+        byte[] arrayBytes = await CodecTestHarness.WriteAsync(w => Resolve("Array(Tuple(a UInt8, b String))").WriteColumn(w, arrayOfTuple));
+
+        Assert.That(nestedBytes, Is.EqualTo(arrayBytes));
+    }
+
+    [Test]
+    public async Task ReadColumn_MoreThanSevenFields_RoundTrips()
+    {
+        // The whole point of the dedicated codec: a Nested is not bound by the tuple's 7-element cap. Eight fields.
+        const string type = "Nested(a UInt8, b UInt8, c UInt8, d UInt8, e UInt8, f UInt8, g UInt8, h UInt8)";
+        IColumnCodec codec = Resolve(type);
+        var names = new[] { "a", "b", "c", "d", "e", "f", "g", "h" };
+        var fields = new IColumn[8];
+        for (int i = 0; i < 8; i++)
+        {
+            fields[i] = Field<byte>("UInt8", (byte)(i * 10), (byte)(i * 10 + 1), (byte)(i * 10 + 2));
+        }
+
+        var column = Nested(type, names, fields, new[] { 0, 2, 3 });
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, type, column.RowCount);
+        var nested = (NestedColumn)read;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(nested.FieldCount, Is.EqualTo(8));
+            Assert.That(nested.RowCount, Is.EqualTo(2));
+            Assert.That(((IColumn<byte>)nested.GetField(0)).Values.ToArray(), Is.EqualTo(new byte[] { 0, 1, 2 }));
+            Assert.That(((IColumn<byte>)nested.GetField("h")).Values.ToArray(), Is.EqualTo(new byte[] { 70, 71, 72 }));
+        });
+    }
+
+    [Test]
+    public async Task ReadColumn_CompositeFields_RoundTrip()
+    {
+        // Fields recurse through the registry, so a nullable field, an array field, and a tuple field compose.
+        const string type = "Nested(a Nullable(Int32), b Array(String), c Tuple(UInt8, String))";
+        IColumnCodec codec = Resolve(type);
+        var column = Nested(
+            type,
+            new[] { "a", "b", "c" },
+            new[]
+            {
+                Field<int?>("Nullable(Int32)", 1, null, -5),
+                Field<string[]>("Array(String)", new[] { "x", "y" }, Array.Empty<string>(), new[] { "z" }),
+                Field<(byte, string)>("Tuple(UInt8, String)", ((byte)1, "p"), ((byte)2, "q"), ((byte)3, "r")),
+            },
+            new[] { 0, 2, 3 });
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, type, column.RowCount);
+        var nested = (NestedColumn)read;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(((IColumn<int?>)nested.GetField("a")).Values.ToArray(), Is.EqualTo(new int?[] { 1, null, -5 }));
+            Assert.That(((IColumn<string[]>)nested.GetField("b")).Values.ToArray(), Is.EqualTo(new[] { new[] { "x", "y" }, Array.Empty<string>(), new[] { "z" } }));
+            Assert.That(((IColumn<(byte, string)>)nested.GetField("c")).Values.ToArray(), Is.EqualTo(new[] { ((byte)1, "p"), ((byte)2, "q"), ((byte)3, "r") }));
+        });
+    }
+
+    [Test]
+    public async Task ReadColumn_EmptyColumn_ReadsZeroRowsWithoutConsumingBytes()
+    {
+        const string type = "Nested(a UInt8, b String)";
+        IColumnCodec codec = Resolve(type);
+        var column = Nested(type, new[] { "a", "b" }, new[] { Field<byte>("UInt8"), Field<string>("String") }, new[] { 0 });
+
+        byte[] bytes = await CodecTestHarness.WriteAsync(w => codec.WriteColumn(w, column, 0, 0));
+        Assert.That(bytes, Is.Empty, "an empty Nested column writes no offsets and no field streams");
+
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(bytes);
+        using IColumn read = await codec.ReadColumnAsync(reader, "c", type, 0, CodecTestHarness.None);
+        Assert.That(read.RowCount, Is.Zero);
+    }
+
+    [Test]
+    public async Task WriteColumn_SlicedRange_WritesOffsetsRelativeToTheSlice()
+    {
+        // Writing only rows [1, 3) of a four-row column (the insert splitter's per-block path) must emit offsets
+        // relative to that block's own field streams, not the full column.
+        const string type = "Nested(a UInt8, b String)";
+        IColumnCodec codec = Resolve(type);
+        var full = Nested(
+            type,
+            new[] { "a", "b" },
+            new[] { Field<byte>("UInt8", 1, 2, 3, 4, 5, 6), Field<string>("String", "a", "b", "c", "d", "e", "f") },
+            new[] { 0, 1, 3, 3, 6 }); // rows: [a], [b,c], [], [d,e,f]
+
+        byte[] bytes = await CodecTestHarness.WriteAsync(w => codec.WriteColumn(w, full, start: 1, length: 2));
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(bytes);
+        using IColumn read = await codec.ReadColumnAsync(reader, "c", type, 2, CodecTestHarness.None);
+        var nested = (NestedColumn)read;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(nested.Offsets.ToArray(), Is.EqualTo(new[] { 0, 2, 2 }));
+            Assert.That(((IColumn<byte>)nested.GetField("a")).Values.ToArray(), Is.EqualTo(new byte[] { 2, 3 }));
+            Assert.That(((IColumn<string>)nested.GetField("b")).Values.ToArray(), Is.EqualTo(new[] { "b", "c" }));
+        });
+    }
+
+    [Test]
+    public void MeasureRowBytes_CountsOneOffsetPlusEachFieldsElements()
+    {
+        const string type = "Nested(a UInt8, b String)";
+        IColumnCodec codec = Resolve(type);
+        var column = Nested(
+            type,
+            new[] { "a", "b" },
+            new[] { Field<byte>("UInt8", 1, 2, 3), Field<string>("String", "x", "yy", "z") },
+            new[] { 0, 2, 3 });
+
+        Assert.Multiple(() =>
+        {
+            // row 0 has 2 elements: offset(8) + 2 UInt8 + ("x"=1+1) + ("yy"=1+2)
+            Assert.That(codec.MeasureRowBytes(column, 0), Is.EqualTo(8 + 2 + (1 + 1) + (1 + 2)));
+            // row 1 has 1 element: offset(8) + 1 UInt8 + ("z"=1+1)
+            Assert.That(codec.MeasureRowBytes(column, 1), Is.EqualTo(8 + 1 + (1 + 1)));
+            Assert.That(codec.FixedRowByteSize, Is.Null);
+        });
+    }
+
+    [Test]
+    public void CanWrite_AcceptsMatchingNestedColumnOnly()
+    {
+        IColumnCodec codec = Resolve("Nested(a UInt8, b String)");
+        var matching = Nested("Nested(a UInt8, b String)", new[] { "a", "b" }, new[] { Field<byte>("UInt8", 1), Field<string>("String", "x") }, new[] { 0, 1 });
+        var wrongFieldType = Nested("Nested(a UInt8, b UInt8)", new[] { "a", "b" }, new[] { Field<byte>("UInt8", 1), Field<byte>("UInt8", 2) }, new[] { 0, 1 });
+        var wrongFieldCount = Nested("Nested(a UInt8)", new[] { "a" }, new[] { Field<byte>("UInt8", 1) }, new[] { 0, 1 });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(codec.CanWrite(matching), Is.True);
+            Assert.That(codec.CanWrite(wrongFieldType), Is.False);
+            Assert.That(codec.CanWrite(wrongFieldCount), Is.False);
+            Assert.That(codec.CanWrite(new ArrayColumn<byte>("c", "UInt8", new byte[] { 1 })), Is.False);
+        });
+    }
+
+    [Test]
+    public async Task Values_MaterializesEveryRowAsArrayOfRecords()
+    {
+        const string type = "Nested(a UInt8, b String)";
+        IColumnCodec codec = Resolve(type);
+        var column = Nested(
+            type,
+            new[] { "a", "b" },
+            new[] { Field<byte>("UInt8", 1, 2, 3), Field<string>("String", "a", "b", "c") },
+            new[] { 0, 2, 2, 3 });
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, type, column.RowCount);
+
+        Assert.That(((IColumn<object[][]>)read).Values.ToArray(), Is.EqualTo(new[]
+        {
+            new[] { new object[] { (byte)1, "a" }, new object[] { (byte)2, "b" } },
+            Array.Empty<object[]>(),
+            new[] { new object[] { (byte)3, "c" } },
+        }));
+    }
+
+    [Test]
+    public void Constructor_EmptyFields_ThrowsArgument()
+        => Assert.Throws<ArgumentException>(() => new NestedColumn("c", "Nested()", Array.Empty<string>(), Array.Empty<IColumn>(), new[] { 0 }, 0, false, false));
+
+    [Test]
+    public void Constructor_FieldNameCountMismatch_ThrowsArgument()
+        => Assert.Throws<ArgumentException>(() => new NestedColumn("c", "Nested(a UInt8)", new[] { "a", "b" }, new[] { Field<byte>("UInt8", 1) }, new[] { 0, 1 }, 1, false, false));
+
+    [Test]
+    public void WriteColumn_NonNestedColumn_ThrowsArgument()
+    {
+        IColumnCodec codec = Resolve("Nested(a UInt8, b String)");
+        var wrong = new ArrayColumn<byte>("c", "UInt8", new byte[] { 1 });
+        Assert.ThrowsAsync<ArgumentException>(() => CodecTestHarness.WriteAsync(w => codec.WriteColumn(w, wrong, 0, 1)));
+    }
+
+    [Test]
+    public void ReadColumn_TruncatedFieldStream_ThrowsAndDisposesAlreadyReadFields()
+    {
+        // Valid offsets declaring one element and a full first field, but the second field's stream is truncated:
+        // the read fails after field 'a' is already read, exercising the cleanup path (dispose the fields read so
+        // far, then the caller returns the pooled offsets — the offsets must be returned exactly once).
+        IColumnCodec codec = Resolve("Nested(a UInt8, b UInt8)");
+        byte[] wire = new byte[9];
+        BitConverter.TryWriteBytes(wire.AsSpan(0, 8), 1UL); // offsets[0] = 1 → one element expected per field
+        wire[8] = 42;                                        // field 'a' value; field 'b' stream is missing
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(wire);
+
+        Assert.CatchAsync(async () => await codec.ReadColumnAsync(reader, "c", "Nested(a UInt8, b UInt8)", 1, CodecTestHarness.None));
+    }
+
+    [Test]
+    public void ReadColumn_OffsetBeyondInt32_ThrowsProtocol()
+    {
+        // An offset larger than int.MaxValue cannot be addressed by this client and is rejected up front.
+        IColumnCodec codec = Resolve("Nested(a UInt8)");
+        byte[] wire = new byte[8];
+        BitConverter.TryWriteBytes(wire.AsSpan(0, 8), (ulong)int.MaxValue + 1);
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(wire);
+
+        Assert.ThrowsAsync<ClickHouseProtocolException>(async () =>
+            await codec.ReadColumnAsync(reader, "c", "Nested(a UInt8)", 1, CodecTestHarness.None));
+    }
+
+    [Test]
+    public void ElementType_IsArrayOfRecords()
+        => Assert.That(Resolve("Nested(a UInt8, b String)").ElementType, Is.EqualTo(typeof(object[][])));
+
+    [Test]
+    public void NullPlaceholder_IsEmptyRow()
+        => Assert.That(Resolve("Nested(a UInt8, b String)").NullPlaceholder, Is.EqualTo(Array.Empty<object[]>()));
+
+    [Test]
+    public void GetField_UnknownName_ThrowsKeyNotFound()
+    {
+        var column = Nested("Nested(a UInt8, b String)", new[] { "a", "b" }, new[] { Field<byte>("UInt8", 1), Field<string>("String", "x") }, new[] { 0, 1 });
+        Assert.Throws<KeyNotFoundException>(() => column.GetField("nope"));
+    }
+
+    [Test]
+    public void Resolve_Nested_StampsFullTypeNameWithFieldNames()
+        => Assert.That(Resolve("Nested(a UInt8, b String)").TypeName, Is.EqualTo("Nested(a UInt8, b String)"));
+
+    [TestCase("Nested")]  // no parens: zero fields reaches the codec's own guard
+    [TestCase("Nested()")] // empty parens: rejected by the parser before the codec
+    public void Resolve_NoFields_ThrowsFormat(string type)
+        => Assert.Throws<FormatException>(() => Resolve(type));
+
+    [Test]
+    public void Resolve_UnnamedField_ThrowsFormat()
+    {
+        // Every Nested field must be named; an unnamed field is malformed (unlike a Tuple, where names are optional).
+        Assert.Multiple(() =>
+        {
+            Assert.Throws<FormatException>(() => Resolve("Nested(UInt8, b String)"));
+            Assert.Throws<FormatException>(() => Resolve("Nested(a UInt8, String)"));
+        });
+    }
+
+    [Test]
+    public void Resolve_UnsupportedField_ThrowsNotSupported()
+        => Assert.Throws<NotSupportedException>(() => Resolve("Nested(a NoSuchType, b String)"));
+
+    [Test]
+    public async Task ReadColumn_NonMonotonicOffsets_ThrowsProtocol()
+    {
+        // Offsets must be non-decreasing; a decrease is corruption. Wire: two UInt64 offsets [2, 1].
+        IColumnCodec codec = Resolve("Nested(a UInt8, b UInt8)");
+        byte[] wire = new byte[16];
+        BitConverter.TryWriteBytes(wire.AsSpan(0, 8), 2UL);
+        BitConverter.TryWriteBytes(wire.AsSpan(8, 8), 1UL);
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(wire);
+
+        Assert.ThrowsAsync<ClickHouseProtocolException>(async () =>
+            await codec.ReadColumnAsync(reader, "c", "Nested(a UInt8, b UInt8)", 2, CodecTestHarness.None));
+    }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Types/NestedColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/NestedColumnCodecTests.cs
@@ -67,8 +67,10 @@ public class NestedColumnCodecTests
             new[] { ((byte)30, "z") },
         });
 
-        byte[] nestedBytes = await CodecTestHarness.WriteAsync(w => Resolve("Nested(a UInt8, b String)").WriteColumn(w, nested));
-        byte[] arrayBytes = await CodecTestHarness.WriteAsync(w => Resolve("Array(Tuple(a UInt8, b String))").WriteColumn(w, arrayOfTuple));
+        IColumnCodec nestedCodec = Resolve("Nested(a UInt8, b String)");
+        IColumnCodec arrayCodec = Resolve("Array(Tuple(a UInt8, b String))");
+        byte[] nestedBytes = await CodecTestHarness.WriteAsync(w => nestedCodec.WriteColumn(w, nestedCodec.TryDensify(nested, out _)));
+        byte[] arrayBytes = await CodecTestHarness.WriteAsync(w => arrayCodec.WriteColumn(w, arrayCodec.TryDensify(arrayOfTuple, out _)));
 
         Assert.That(nestedBytes, Is.EqualTo(arrayBytes));
     }
@@ -323,5 +325,47 @@ public class NestedColumnCodecTests
 
         Assert.ThrowsAsync<ClickHouseProtocolException>(async () =>
             await codec.ReadColumnAsync(reader, "c", "Nested(a UInt8, b UInt8)", 2, CodecTestHarness.None));
+    }
+
+    [Test]
+    public void TryDensify_NestedWithOneErgonomicField_DisposesOnlyRebuiltFieldNotBorrowed()
+    {
+        // A Nested whose field 'a' is still ergonomic (a jagged Nullable column) while field 'b' is already dense (a
+        // leaf): TryDensify rebuilds only field 'a' and keeps field 'b' by reference. Disposing the rebuilt wrapper must
+        // free the freshly built field 'a' but leave the borrowed field 'b' alone — it is still owned by the source
+        // column, so disposing it here would double-dispose it.
+        IColumnCodec codec = Resolve("Nested(a Nullable(Int32), b UInt32)");
+        var ergonomicField = Field<int?>("Nullable(Int32)", 1, null, 3);
+        var borrowedField = new DisposeSpyColumn<uint>("c", "UInt32", new uint[] { 9, 8, 7 });
+        var source = Nested("Nested(a Nullable(Int32), b UInt32)", new[] { "a", "b" }, new IColumn[] { ergonomicField, borrowedField }, new[] { 0, 3 });
+
+        IColumn densified = codec.TryDensify(source, out bool built);
+        Assert.That(built, Is.True, "field 'a' was ergonomic, so a rebuild is expected");
+        Assert.That(densified, Is.Not.SameAs(source));
+        densified.Dispose();
+
+        Assert.That(borrowedField.DisposeCount, Is.EqualTo(0), "the borrowed, already-dense field must not be disposed by the rebuilt wrapper");
+
+        ergonomicField.Dispose();
+        borrowedField.Dispose();
+    }
+
+    [Test]
+    public void RestrictOwnership_DisposesOnlyFlaggedFields()
+    {
+        // The mechanism the partial densify rebuild relies on: after RestrictOwnership, Dispose frees exactly the
+        // fields flagged true (the freshly built ones) and leaves the rest (borrowed) untouched.
+        var owned = new DisposeSpyColumn<byte>("c", "UInt8", new byte[] { 1 });
+        var borrowed = new DisposeSpyColumn<string>("c", "String", new[] { "x" });
+        var nested = Nested("Nested(a UInt8, b String)", new[] { "a", "b" }, new IColumn[] { owned, borrowed }, new[] { 0, 1 });
+
+        nested.RestrictOwnership(new[] { true, false });
+        nested.Dispose();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(owned.DisposeCount, Is.EqualTo(1), "a flagged (freshly built) field must be disposed exactly once");
+            Assert.That(borrowed.DisposeCount, Is.EqualTo(0), "an unflagged (borrowed) field must not be disposed");
+        });
     }
 }

--- a/ClickHouse.Driver.Tcp.Tests/Types/NestedColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/NestedColumnCodecTests.cs
@@ -52,30 +52,6 @@ public class NestedColumnCodecTests
     }
 
     [Test]
-    public async Task WriteColumn_Nested_IsByteIdenticalToArrayOfTuple()
-    {
-        // The flatten_nested = 0 form is byte-for-byte the same as Array(Tuple(...)); only the type-string text
-        // (which keeps the field names) differs. Proven by writing the same data through both and comparing bytes.
-        var nested = Nested(
-            "Nested(a UInt8, b String)",
-            new[] { "a", "b" },
-            new[] { Field<byte>("UInt8", 10, 20, 30), Field<string>("String", "x", "y", "z") },
-            new[] { 0, 2, 3 });
-        var arrayOfTuple = new ArrayColumn<(byte, string)[]>("c", "Array(Tuple(a UInt8, b String))", new[]
-        {
-            new[] { ((byte)10, "x"), ((byte)20, "y") },
-            new[] { ((byte)30, "z") },
-        });
-
-        IColumnCodec nestedCodec = Resolve("Nested(a UInt8, b String)");
-        IColumnCodec arrayCodec = Resolve("Array(Tuple(a UInt8, b String))");
-        byte[] nestedBytes = await CodecTestHarness.WriteAsync(w => nestedCodec.WriteColumn(w, nestedCodec.TryDensify(nested, out _)));
-        byte[] arrayBytes = await CodecTestHarness.WriteAsync(w => arrayCodec.WriteColumn(w, arrayCodec.TryDensify(arrayOfTuple, out _)));
-
-        Assert.That(nestedBytes, Is.EqualTo(arrayBytes));
-    }
-
-    [Test]
     public async Task ReadColumn_MoreThanSevenFields_RoundTrips()
     {
         // The whole point of the dedicated codec: a Nested is not bound by the tuple's 7-element cap. Eight fields.
@@ -168,27 +144,6 @@ public class NestedColumnCodecTests
             Assert.That(nested.Offsets.ToArray(), Is.EqualTo(new[] { 0, 2, 2 }));
             Assert.That(((IColumn<byte>)nested.GetField("a")).Values.ToArray(), Is.EqualTo(new byte[] { 2, 3 }));
             Assert.That(((IColumn<string>)nested.GetField("b")).Values.ToArray(), Is.EqualTo(new[] { "b", "c" }));
-        });
-    }
-
-    [Test]
-    public void MeasureRowBytes_CountsOneOffsetPlusEachFieldsElements()
-    {
-        const string type = "Nested(a UInt8, b String)";
-        IColumnCodec codec = Resolve(type);
-        var column = Nested(
-            type,
-            new[] { "a", "b" },
-            new[] { Field<byte>("UInt8", 1, 2, 3), Field<string>("String", "x", "yy", "z") },
-            new[] { 0, 2, 3 });
-
-        Assert.Multiple(() =>
-        {
-            // row 0 has 2 elements: offset(8) + 2 UInt8 + ("x"=1+1) + ("yy"=1+2)
-            Assert.That(codec.MeasureRowBytes(column, 0), Is.EqualTo(8 + 2 + (1 + 1) + (1 + 2)));
-            // row 1 has 1 element: offset(8) + 1 UInt8 + ("z"=1+1)
-            Assert.That(codec.MeasureRowBytes(column, 1), Is.EqualTo(8 + 1 + (1 + 1)));
-            Assert.That(codec.FixedRowByteSize, Is.Null);
         });
     }
 
@@ -325,29 +280,6 @@ public class NestedColumnCodecTests
 
         Assert.ThrowsAsync<ClickHouseProtocolException>(async () =>
             await codec.ReadColumnAsync(reader, "c", "Nested(a UInt8, b UInt8)", 2, CodecTestHarness.None));
-    }
-
-    [Test]
-    public void TryDensify_NestedWithOneErgonomicField_DisposesOnlyRebuiltFieldNotBorrowed()
-    {
-        // A Nested whose field 'a' is still ergonomic (a jagged Nullable column) while field 'b' is already dense (a
-        // leaf): TryDensify rebuilds only field 'a' and keeps field 'b' by reference. Disposing the rebuilt wrapper must
-        // free the freshly built field 'a' but leave the borrowed field 'b' alone — it is still owned by the source
-        // column, so disposing it here would double-dispose it.
-        IColumnCodec codec = Resolve("Nested(a Nullable(Int32), b UInt32)");
-        var ergonomicField = Field<int?>("Nullable(Int32)", 1, null, 3);
-        var borrowedField = new DisposeSpyColumn<uint>("c", "UInt32", new uint[] { 9, 8, 7 });
-        var source = Nested("Nested(a Nullable(Int32), b UInt32)", new[] { "a", "b" }, new IColumn[] { ergonomicField, borrowedField }, new[] { 0, 3 });
-
-        IColumn densified = codec.TryDensify(source, out bool built);
-        Assert.That(built, Is.True, "field 'a' was ergonomic, so a rebuild is expected");
-        Assert.That(densified, Is.Not.SameAs(source));
-        densified.Dispose();
-
-        Assert.That(borrowedField.DisposeCount, Is.EqualTo(0), "the borrowed, already-dense field must not be disposed by the rebuilt wrapper");
-
-        ergonomicField.Dispose();
-        borrowedField.Dispose();
     }
 
     [Test]

--- a/ClickHouse.Driver.Tcp.Tests/Types/NestedColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/NestedColumnCodecTests.cs
@@ -43,45 +43,15 @@ public class NestedColumnCodecTests
             // Columnar access: each field is a flat column of every row's elements concatenated.
             Assert.That(((IColumn<byte>)nested.GetField("a")).Values.ToArray(), Is.EqualTo(new byte[] { 1, 2, 3 }));
             Assert.That(((IColumn<string>)nested.GetField("b")).Values.ToArray(), Is.EqualTo(new[] { "a", "b", "c" }));
-
-            // Row (boxed array-of-records) access.
-            Assert.That(nested.GetValue(0), Is.EqualTo(new[] { new object[] { (byte)1, "a" }, new object[] { (byte)2, "b" } }));
-            Assert.That(nested.GetValue(1), Is.EqualTo(Array.Empty<object[]>()));
-            Assert.That(nested.GetValue(2), Is.EqualTo(new[] { new object[] { (byte)3, "c" } }));
-        });
-    }
-
-    [Test]
-    public async Task ReadColumn_MoreThanSevenFields_RoundTrips()
-    {
-        // The whole point of the dedicated codec: a Nested is not bound by the tuple's 7-element cap. Eight fields.
-        const string type = "Nested(a UInt8, b UInt8, c UInt8, d UInt8, e UInt8, f UInt8, g UInt8, h UInt8)";
-        IColumnCodec codec = Resolve(type);
-        var names = new[] { "a", "b", "c", "d", "e", "f", "g", "h" };
-        var fields = new IColumn[8];
-        for (int i = 0; i < 8; i++)
-        {
-            fields[i] = Field<byte>("UInt8", (byte)(i * 10), (byte)(i * 10 + 1), (byte)(i * 10 + 2));
-        }
-
-        var column = Nested(type, names, fields, new[] { 0, 2, 3 });
-
-        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, type, column.RowCount);
-        var nested = (NestedColumn)read;
-
-        Assert.Multiple(() =>
-        {
-            Assert.That(nested.FieldCount, Is.EqualTo(8));
-            Assert.That(nested.RowCount, Is.EqualTo(2));
-            Assert.That(((IColumn<byte>)nested.GetField(0)).Values.ToArray(), Is.EqualTo(new byte[] { 0, 1, 2 }));
-            Assert.That(((IColumn<byte>)nested.GetField("h")).Values.ToArray(), Is.EqualTo(new byte[] { 70, 71, 72 }));
         });
     }
 
     [Test]
     public async Task ReadColumn_CompositeFields_RoundTrip()
     {
-        // Fields recurse through the registry, so a nullable field, an array field, and a tuple field compose.
+        // Fields recurse through the registry. The Nullable and Array field compositions are covered against a
+        // real server by the "Nested(a Nullable(Int32), b Array(String))" case; a Tuple field has no integration
+        // case, so only that assertion remains here.
         const string type = "Nested(a Nullable(Int32), b Array(String), c Tuple(UInt8, String))";
         IColumnCodec codec = Resolve(type);
         var column = Nested(
@@ -100,8 +70,6 @@ public class NestedColumnCodecTests
 
         Assert.Multiple(() =>
         {
-            Assert.That(((IColumn<int?>)nested.GetField("a")).Values.ToArray(), Is.EqualTo(new int?[] { 1, null, -5 }));
-            Assert.That(((IColumn<string[]>)nested.GetField("b")).Values.ToArray(), Is.EqualTo(new[] { new[] { "x", "y" }, Array.Empty<string>(), new[] { "z" } }));
             Assert.That(((IColumn<(byte, string)>)nested.GetField("c")).Values.ToArray(), Is.EqualTo(new[] { ((byte)1, "p"), ((byte)2, "q"), ((byte)3, "r") }));
         });
     }

--- a/ClickHouse.Driver.Tcp.Tests/Types/NestedColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/NestedColumnCodecTests.cs
@@ -49,9 +49,9 @@ public class NestedColumnCodecTests
     [Test]
     public async Task ReadColumn_CompositeFields_RoundTrip()
     {
-        // Fields recurse through the registry. The Nullable and Array field compositions are covered against a
-        // real server by the "Nested(a Nullable(Int32), b Array(String))" case; a Tuple field has no integration
-        // case, so only that assertion remains here.
+        // Fields recurse through the registry. The live-server insert matrix covers each supported composite
+        // category in both legal directions; this direct codec round-trip keeps representative child layouts
+        // aligned in one Nested body.
         const string type = "Nested(a Nullable(Int32), b Array(String), c Tuple(UInt8, String))";
         IColumnCodec codec = Resolve(type);
         var column = Nested(
@@ -160,6 +160,18 @@ public class NestedColumnCodecTests
     [Test]
     public void Constructor_FieldNameCountMismatch_ThrowsArgument()
         => Assert.Throws<ArgumentException>(() => new NestedColumn("c", "Nested(a UInt8)", new[] { "a", "b" }, new[] { Field<byte>("UInt8", 1) }, new[] { 0, 1 }, 1, false, false));
+
+    [Test]
+    public void Constructor_OffsetsShorterThanRowCountPlusOne_Throws()
+    {
+        // rowCount is load-bearing here — every field column is flat and the offsets may be pooled — so it is
+        // validated rather than derived. One offset per row plus the leading zero is the minimum.
+        IColumn[] fields = { Field<byte>("UInt8", 1, 2, 3) };
+
+        Assert.That(
+            () => new NestedColumn("c", "Nested(a UInt8)", new[] { "a" }, fields, new[] { 0, 3 }, rowCount: 2, pooledOffsets: false, ownsFields: false),
+            Throws.ArgumentException.With.Message.Contains("fewer than"));
+    }
 
     [Test]
     public void WriteColumn_NonNestedColumn_ThrowsArgument()

--- a/ClickHouse.Driver.Tcp.Tests/Types/TupleColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/TupleColumnCodecTests.cs
@@ -104,6 +104,33 @@ public class TupleColumnCodecTests
     }
 
     [Test]
+    public void CanWrite_NestedChildWithoutDenseNamedFieldColumn_ReturnsFalse()
+    {
+        const string type = "Tuple(Nested(a UInt8), String)";
+        const string nestedType = "Nested(a UInt8)";
+        IColumnCodec codec = Resolve(type);
+
+        // Both forms expose the right CLR ValueTuple, but neither retains Nested's named field column.
+        var ergonomic = new ArrayColumn<(object[][], string)>("c", type, Array.Empty<(object[][], string)>());
+        var wrongDense = new TupleColumn<object[][], string>(
+            "c",
+            type,
+            new IColumn[]
+            {
+                new ArrayColumn<object[][]>("c", nestedType, Array.Empty<object[][]>()),
+                new ArrayColumn<string>("c", "String", Array.Empty<string>()),
+            },
+            fieldNames: null,
+            ownsChildren: false);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(codec.CanWrite(ergonomic), Is.False, "the row-oriented projection has lost the named fields");
+            Assert.That(codec.CanWrite(wrongDense), Is.False, "a dense tuple still needs a real NestedColumn child");
+        });
+    }
+
+    [Test]
     public void ElementType_IsTheValueTupleOfElementTypes()
     {
         Assert.Multiple(() =>

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
@@ -639,7 +639,8 @@ public sealed class InsertRoundTripCase
                 ownsFields: false),
             NestedSettings);
 
-        // Composite fields recurse: a nullable field and an array field. Rows: [(1,['x','y']),(null,[])], [], [(-5,['z'])].
+        // Composite fields recurse: a nullable field and an array field. The inner array lengths [1, 2, 0]
+        // deliberately differ from the Nested row lengths [2, 0, 1], so the two offsets streams cannot be mixed up.
         yield return Same(
             "Nested(a Nullable(Int32), b Array(String)) [nullable + array fields]",
             "Nested(a Nullable(Int32), b Array(String))",
@@ -650,12 +651,112 @@ public sealed class InsertRoundTripCase
                 new IColumn[]
                 {
                     new ArrayColumn<int?>(name, "Nullable(Int32)", new int?[] { 1, null, -5 }),
-                    new ArrayColumn<string[]>(name, "Array(String)", new[] { new[] { "x", "y" }, Array.Empty<string>(), new[] { "z" } }),
+                    new ArrayColumn<string[]>(name, "Array(String)", new[] { new[] { "x" }, new[] { "y", "z" }, Array.Empty<string>() }),
                 },
                 new[] { 0, 2, 2, 3 },
                 rowCount: 3,
                 pooledOffsets: false,
                 ownsFields: false),
+            NestedSettings);
+
+        // The remaining previously implemented composites as fields: Tuple contributes side-by-side child
+        // streams, while Map contributes its own offsets plus key/value streams. Together with the nullable +
+        // array case above, every older composite is exercised inside Nested against a real server.
+        yield return Same(
+            "Nested(a Tuple(UInt8, String), b Map(String, UInt32)) [tuple + map fields]",
+            "Nested(a Tuple(UInt8, String), b Map(String, UInt32))",
+            name => new NestedColumn(
+                name,
+                "Nested(a Tuple(UInt8, String), b Map(String, UInt32))",
+                new[] { "a", "b" },
+                new IColumn[]
+                {
+                    new ArrayColumn<(byte, string)>(name, "Tuple(UInt8, String)", new[] { ((byte)1, "p"), ((byte)2, "q"), ((byte)3, "r") }),
+                    new ArrayColumn<KeyValuePair<string, uint>[]>(name, "Map(String, UInt32)", new[]
+                    {
+                        Pairs<string, uint>(("x", 1)),
+                        Pairs<string, uint>(("y", 2), ("z", uint.MaxValue)),
+                        Array.Empty<KeyValuePair<string, uint>>(),
+                    }),
+                },
+                new[] { 0, 2, 2, 3 },
+                rowCount: 3,
+                pooledOffsets: false,
+                ownsFields: false),
+            NestedSettings);
+
+        // flatten_nested = 0 permits arbitrary nesting, including a Nested field inside another Nested. The outer
+        // offsets delimit three records; the child Nested has one value per record and its own independent shape.
+        yield return Same(
+            "Nested(a Nested(b UInt8)) [nested field]",
+            "Nested(a Nested(b UInt8))",
+            name => new NestedColumn(
+                name,
+                "Nested(a Nested(b UInt8))",
+                new[] { "a" },
+                new IColumn[] { ByteNested(name, "b", new byte[] { 1, 2, 3, 4, 5, 6 }, new[] { 0, 2, 2, 3, 6 }) },
+                new[] { 0, 1, 3, 4 },
+                rowCount: 3,
+                pooledOffsets: false,
+                ownsFields: false),
+            NestedSettings);
+
+        // The inverse composite directions are legal too. These use dense wire-shaped outer columns because a
+        // Nested has deliberately no row-oriented write form: each outer codec forwards the actual NestedColumn
+        // child rather than attempting to flatten object[][] values back into named field columns.
+        yield return Same(
+            "Array(Nested(a UInt8)) [dense nested inner]",
+            "Array(Nested(a UInt8))",
+            name => new ArrayValueColumn<object[][]>(
+                name,
+                "Array(Nested(a UInt8))",
+                ByteNested(name, "a", new byte[] { 1, 2, 3, 4, 5, 6 }, new[] { 0, 1, 3, 3, 6 }),
+                new[] { 0, 2, 2, 4 },
+                rowCount: 3,
+                pooledOffsets: false),
+            NestedSettings);
+
+        yield return Same(
+            "Tuple(Nested(a UInt8), String) [dense nested child]",
+            "Tuple(Nested(a UInt8), String)",
+            name => new TupleColumn<object[][], string>(
+                name,
+                "Tuple(Nested(a UInt8), String)",
+                new IColumn[]
+                {
+                    ByteNested(name, "a", new byte[] { 1, 2, 3, 4, 5 }, new[] { 0, 2, 2, 5 }),
+                    new ArrayColumn<string>(name, "String", new[] { "first", "empty", "last" }),
+                },
+                fieldNames: null,
+                ownsChildren: false),
+            NestedSettings);
+
+        yield return Same(
+            "Map(String, Nested(a UInt8)) [dense nested value]",
+            "Map(String, Nested(a UInt8))",
+            name => new MapColumn<string, object[][]>(
+                name,
+                "Map(String, Nested(a UInt8))",
+                new ArrayColumn<string>(name, "String", new[] { "w", "x", "y", "z" }),
+                ByteNested(name, "a", new byte[] { 1, 2, 3, 4, 5, 6 }, new[] { 0, 1, 3, 3, 6 }),
+                new[] { 0, 2, 2, 4 },
+                rowCount: 3,
+                pooledOffsets: false),
+            NestedSettings);
+
+        // Map drives its key and value codecs independently, so cover Nested in the key position too. The map row
+        // lengths [1, 2, 0] deliberately differ from the Nested key lengths [2, 0, 3].
+        yield return Same(
+            "Map(Nested(a UInt8), UInt32) [dense nested key]",
+            "Map(Nested(a UInt8), UInt32)",
+            name => new MapColumn<object[][], uint>(
+                name,
+                "Map(Nested(a UInt8), UInt32)",
+                ByteNested(name, "a", new byte[] { 1, 2, 3, 4, 5 }, new[] { 0, 2, 2, 5 }),
+                new ArrayColumn<uint>(name, "UInt32", new uint[] { 7, 8, uint.MaxValue }),
+                new[] { 0, 1, 3, 3 },
+                rowCount: 3,
+                pooledOffsets: false),
             NestedSettings);
 
         // Eight fields: proves the dedicated codec is not bound by the tuple's 7-element cap. Rows of 2 and 1 elements.
@@ -701,6 +802,21 @@ public sealed class InsertRoundTripCase
         }
 
         return result;
+    }
+
+    // Builds the dense single-field Nested used as a child by the recursive composition cases above.
+    private static NestedColumn ByteNested(string name, string fieldName, byte[] values, int[] offsets)
+    {
+        string type = $"Nested({fieldName} UInt8)";
+        return new NestedColumn(
+            name,
+            type,
+            new[] { fieldName },
+            new IColumn[] { new ArrayColumn<byte>(name, "UInt8", values) },
+            offsets,
+            rowCount: offsets.Length - 1,
+            pooledOffsets: false,
+            ownsFields: false);
     }
 
     // Array(T) inserts and reads back the inner element arrays; the ergonomic jagged column doubles as expected.

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
@@ -608,12 +608,80 @@ public sealed class InsertRoundTripCase
             Pairs<string, KeyValuePair<string, uint>[]>(("outer", Pairs<string, uint>(("x", 1), ("y", 2)))),
             Array.Empty<KeyValuePair<string, KeyValuePair<string, uint>[]>>());
 
-        // Nested: Array(Map(...)) recurses the offsets-plus-streams shape one level up through the array codec.
+        // Array(Map(...)) recurses the offsets-plus-streams shape one level up through the array codec.
         yield return Arrays<KeyValuePair<string, uint>[]>("Map(String, UInt32)", new[]
         {
             new[] { Pairs<string, uint>(("a", 1)), Pairs<string, uint>(("b", 2), ("c", 3)) },
             Array.Empty<KeyValuePair<string, uint>[]>(),
         });
+
+        // Nested(...) at flatten_nested = 0: a single wire column laid out byte-identically to Array(Tuple(...)),
+        // surfaced as a columnar NestedColumn (flat field columns + shared offsets), arity-agnostic. The insert
+        // source is the dense NestedColumn itself. flatten_nested = 0 must apply at CREATE so the column is stored
+        // as one Nested column rather than flattened into parallel dotted Array columns. Like Array/Tuple/Map, the
+        // server rejects Nullable(Nested), so nullability composes inside a field.
+        // Rows: [(1,'a'),(2,'b')], [], [(3,'c')].
+        yield return Same(
+            "Nested(a UInt8, b String)",
+            "Nested(a UInt8, b String)",
+            name => new NestedColumn(
+                name,
+                "Nested(a UInt8, b String)",
+                new[] { "a", "b" },
+                new IColumn[]
+                {
+                    new ArrayColumn<byte>(name, "UInt8", new byte[] { 1, 2, 3 }),
+                    new ArrayColumn<string>(name, "String", new[] { "a", "b", "c" }),
+                },
+                new[] { 0, 2, 2, 3 },
+                rowCount: 3,
+                pooledOffsets: false,
+                ownsFields: false),
+            NestedSettings);
+
+        // Composite fields recurse: a nullable field and an array field. Rows: [(1,['x','y']),(null,[])], [], [(-5,['z'])].
+        yield return Same(
+            "Nested(a Nullable(Int32), b Array(String)) [nullable + array fields]",
+            "Nested(a Nullable(Int32), b Array(String))",
+            name => new NestedColumn(
+                name,
+                "Nested(a Nullable(Int32), b Array(String))",
+                new[] { "a", "b" },
+                new IColumn[]
+                {
+                    new ArrayColumn<int?>(name, "Nullable(Int32)", new int?[] { 1, null, -5 }),
+                    new ArrayColumn<string[]>(name, "Array(String)", new[] { new[] { "x", "y" }, Array.Empty<string>(), new[] { "z" } }),
+                },
+                new[] { 0, 2, 2, 3 },
+                rowCount: 3,
+                pooledOffsets: false,
+                ownsFields: false),
+            NestedSettings);
+
+        // Eight fields: proves the dedicated codec is not bound by the tuple's 7-element cap. Rows of 2 and 1 elements.
+        yield return Same(
+            "Nested(8 fields) [uncapped]",
+            "Nested(a UInt8, b UInt8, c UInt8, d UInt8, e UInt8, f UInt8, g UInt8, h UInt8)",
+            name =>
+            {
+                var names = new[] { "a", "b", "c", "d", "e", "f", "g", "h" };
+                var fields = new IColumn[8];
+                for (int i = 0; i < 8; i++)
+                {
+                    fields[i] = new ArrayColumn<byte>(name, "UInt8", new byte[] { (byte)i, (byte)(i + 10), (byte)(i + 20) });
+                }
+
+                return new NestedColumn(
+                    name,
+                    "Nested(a UInt8, b UInt8, c UInt8, d UInt8, e UInt8, f UInt8, g UInt8, h UInt8)",
+                    names,
+                    fields,
+                    new[] { 0, 2, 3 },
+                    rowCount: 2,
+                    pooledOffsets: false,
+                    ownsFields: false);
+            },
+            NestedSettings);
     }
 
     // Map(K, V) inserts and reads back the ergonomic jagged column of KeyValuePair arrays, which doubles as expected.
@@ -780,5 +848,14 @@ public sealed class InsertRoundTripCase
     {
         ["enable_time_time64_type"] = "1",
         ["allow_experimental_time_time64_type"] = "1",
+    };
+
+    /// <summary>
+    /// Keeps a <c>Nested</c> column as a single wire column instead of flattening it into parallel dotted
+    /// <c>Array</c> columns; must apply at CREATE for the column to be stored as one <c>Nested(...)</c> column.
+    /// </summary>
+    private static readonly IReadOnlyDictionary<string, string> NestedSettings = new Dictionary<string, string>(StringComparer.Ordinal)
+    {
+        ["flatten_nested"] = "0",
     };
 }

--- a/ClickHouse.Driver.Tcp/Types/Codecs/ArrayColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/ArrayColumnCodec.cs
@@ -66,23 +66,25 @@ internal static class ArrayColumnCodec
 /// once at the read boundary. The write path takes either shape as it comes: the dense
 /// <see cref="ArrayValueColumn{TElement}"/> is the wire's own layout and is written with no copy, while the
 /// ergonomic jagged form (<c>TElement[]</c> per row) is written from its rows without its elements being copied
-/// into a flat buffer first.
+/// into a flat buffer first when the inner codec accepts that projected shape. An inner such as <c>Nested</c>,
+/// whose only write source is its dense named-field column, therefore requires the dense outer form too.
 /// </para>
 /// </summary>
 /// <typeparam name="TElement">The inner codec's CLR element type; each row surfaces as <typeparamref name="TElement"/>[].</typeparam>
 internal sealed class ArrayColumnCodec<TElement> : IColumnCodec
 {
     private readonly IColumnCodec inner;
-    private readonly bool innerCanWrite;
+    private readonly bool projectedInnerCanWrite;
 
     internal ArrayColumnCodec(string typeName, IColumnCodec inner)
     {
         TypeName = typeName;
         this.inner = inner;
 
-        // Whether the inner codec can write at all (e.g. Nothing cannot). Computed once so CanWrite can reject an
-        // Array(non-writable) column up front rather than letting the write fail mid-stream.
-        innerCanWrite = inner.CanWrite(new ArrayColumn<TElement>(string.Empty, inner.TypeName, Array.Empty<TElement>()));
+        // Whether the ergonomic jagged path can project its flattened values through the inner codec (e.g.
+        // Nothing cannot, and Nested requires its dense NestedColumn). A dense ArrayValueColumn is checked against
+        // its actual inner column instead, so Array(Nested(...)) can re-insert the wire-shaped column a read yields.
+        projectedInnerCanWrite = inner.CanWrite(new ArrayColumn<TElement>(string.Empty, inner.TypeName, Array.Empty<TElement>()));
     }
 
     /// <inheritdoc/>
@@ -194,7 +196,10 @@ internal sealed class ArrayColumnCodec<TElement> : IColumnCodec
     }
 
     /// <inheritdoc/>
-    public bool CanWrite(IColumn column) => innerCanWrite && column is IColumn<TElement[]>;
+    public bool CanWrite(IColumn column)
+        => column is ArrayValueColumn<TElement> dense
+            ? inner.CanWrite(dense.Inner)
+            : projectedInnerCanWrite && column is IColumn<TElement[]>;
 
     /// <inheritdoc/>
     // Computed once per slice and handed to both the prefix and body phases; see BuildState for what it holds.

--- a/ClickHouse.Driver.Tcp/Types/Codecs/MapColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/MapColumnCodec.cs
@@ -23,7 +23,8 @@ namespace ClickHouse.Driver.Tcp.Types.Codecs;
 /// The generic bridge from the non-generic key/value codecs to the right typed <see cref="MapColumn{TKey, TValue}"/>
 /// lives in the cached per-type-pair <see cref="IMapShape"/>; the codec itself stays non-generic. On the write
 /// path it accepts a column of <c>KeyValuePair&lt;K, V&gt;[]</c> (the dense <see cref="MapColumn{TKey, TValue}"/>,
-/// written with no copy, or the ergonomic jagged form, flattened through pooled key/value buffers).
+/// written with no copy, or the ergonomic jagged form when both children accept columns flattened through pooled
+/// key/value buffers). A shape-only child such as <c>Nested</c> requires the dense map form.
 /// </para>
 /// </summary>
 internal sealed class MapColumnCodec : IColumnCodec
@@ -31,7 +32,7 @@ internal sealed class MapColumnCodec : IColumnCodec
     private readonly IColumnCodec keyCodec;
     private readonly IColumnCodec valueCodec;
     private readonly IMapShape shape;
-    private readonly bool childrenCanWrite;
+    private readonly bool projectedChildrenCanWrite;
 
     private MapColumnCodec(string typeName, IColumnCodec keyCodec, IColumnCodec valueCodec)
     {
@@ -40,9 +41,10 @@ internal sealed class MapColumnCodec : IColumnCodec
         this.valueCodec = valueCodec;
         shape = MapShapes.For(keyCodec.ElementType, valueCodec.ElementType);
 
-        // Whether both the key and value codecs can write at all (e.g. Nothing cannot). Computed once so CanWrite
-        // can reject a Map(non-writable, ...) column up front rather than letting the write fail mid-stream.
-        childrenCanWrite = shape.CanInnerWrite(keyCodec, valueCodec);
+        // Whether the ergonomic jagged path can project its flattened key/value buffers through both codecs. A
+        // dense MapColumn is checked against its actual key/value columns instead, so Map(K, Nested(...)) can
+        // re-insert the wire-shaped NestedColumn value child a read yields.
+        projectedChildrenCanWrite = shape.CanInnerWrite(keyCodec, valueCodec);
     }
 
     /// <inheritdoc/>
@@ -175,7 +177,7 @@ internal sealed class MapColumnCodec : IColumnCodec
     }
 
     /// <inheritdoc/>
-    public bool CanWrite(IColumn column) => childrenCanWrite && shape.CanWrite(column);
+    public bool CanWrite(IColumn column) => shape.CanWrite(keyCodec, valueCodec, column, projectedChildrenCanWrite);
 
     /// <inheritdoc/>
     // Flatten the slice's keys and values once and create the key/value codecs' own write states over them, so a
@@ -228,10 +230,14 @@ internal interface IMapShape
     /// <summary>Wraps decoded flat key/value columns and their shared offsets into the typed map column.</summary>
     IColumn Wrap(string name, string typeName, IColumn keys, IColumn values, int[] offsets, int rowCount, bool pooledOffsets);
 
-    /// <summary>Whether <paramref name="column"/> is a map column of this key/value type pair, writable by the codec.</summary>
-    bool CanWrite(IColumn column);
+    /// <summary>
+    /// Whether <paramref name="column"/> is a writable map column of this key/value type pair. A dense column is
+    /// checked against its actual key/value children; an ergonomic jagged column relies on the flattened child
+    /// probe supplied in <paramref name="projectedChildrenCanWrite"/>.
+    /// </summary>
+    bool CanWrite(IColumnCodec keyCodec, IColumnCodec valueCodec, IColumn column, bool projectedChildrenCanWrite);
 
-    /// <summary>Whether both the key and value codecs can write their typed column at all (e.g. <c>Nothing</c> cannot).</summary>
+    /// <summary>Whether both codecs accept the flat typed columns projected by the ergonomic jagged write path.</summary>
     bool CanInnerWrite(IColumnCodec keyCodec, IColumnCodec valueCodec);
 
     /// <summary>
@@ -285,7 +291,15 @@ internal sealed class MapShape<TKey, TValue> : IMapShape
         => new MapColumn<TKey, TValue>(name, typeName, (IColumn<TKey>)keys, (IColumn<TValue>)values, offsets, rowCount, pooledOffsets);
 
     /// <inheritdoc/>
-    public bool CanWrite(IColumn column) => column is IColumn<KeyValuePair<TKey, TValue>[]>;
+    public bool CanWrite(IColumnCodec keyCodec, IColumnCodec valueCodec, IColumn column, bool projectedChildrenCanWrite)
+    {
+        if (column is MapColumn<TKey, TValue> dense)
+        {
+            return keyCodec.CanWrite(dense.KeyColumn) && valueCodec.CanWrite(dense.ValueColumn);
+        }
+
+        return projectedChildrenCanWrite && column is IColumn<KeyValuePair<TKey, TValue>[]>;
+    }
 
     /// <inheritdoc/>
     public bool CanInnerWrite(IColumnCodec keyCodec, IColumnCodec valueCodec)

--- a/ClickHouse.Driver.Tcp/Types/Codecs/NestedColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/NestedColumnCodec.cs
@@ -1,0 +1,296 @@
+using System;
+using System.Buffers;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Protocol;
+
+namespace ClickHouse.Driver.Tcp.Types.Codecs;
+
+/// <summary>
+/// A codec for a ClickHouse <c>Nested(name1 T1, ..., namen Tn)</c> column carried as a single wire column — the
+/// case a table declares under <c>flatten_nested = 0</c>. Its layout after the type string is byte-identical to
+/// <c>Array(Tuple(T1, ..., Tn))</c>: the fields' serialization-state prefixes in order, then a per-row offsets
+/// stream (<c>num_rows</c> little-endian <c>UInt64</c>, each the cumulative element end after that row), then each
+/// field's encoding for every element concatenated end-to-end. Within a row every field carries the same element
+/// count (the server enforces it), so the single offsets stream delimits all fields.
+///
+/// <para>
+/// Unlike the other composites this codec is arity-agnostic and does not route through the tuple codec, so it is
+/// not bound by the tuple's element-count cap — a <c>Nested</c> commonly has many fields. It owns one child codec
+/// per field and loops them for every phase; the decoded <see cref="NestedColumn"/> keeps the fields as flat
+/// columns plus offsets (the columnar, zero-copy shape), which is also the write source.
+/// </para>
+///
+/// <para>
+/// Under the server-default <c>flatten_nested = 1</c> there is no <c>Nested</c> wire type at all: the server
+/// presents the column as N parallel <c>Array(T_i)</c> columns with dotted names, each a plain array handled by
+/// the array codec. Only the single-column form reaches this codec.
+/// </para>
+/// </summary>
+internal sealed class NestedColumnCodec : IColumnCodec
+{
+    private readonly IColumnCodec[] children;
+    private readonly string[] fieldNames;
+
+    private NestedColumnCodec(string typeName, IColumnCodec[] children, string[] fieldNames)
+    {
+        TypeName = typeName;
+        this.children = children;
+        this.fieldNames = fieldNames;
+    }
+
+    /// <inheritdoc/>
+    public string TypeName { get; }
+
+    /// <summary>
+    /// A <c>Nested</c> column surfaces as an array of records (<c>object[][]</c>). This is never consumed
+    /// compositionally — ClickHouse does not allow <c>Nested</c> as an inner type of another type — but the
+    /// interface requires an element type.
+    /// </summary>
+    public Type ElementType => typeof(object[][]);
+
+    /// <summary>
+    /// The placeholder for an absent <c>Nested</c> value is the empty row (no elements). A <c>Nested</c> is never
+    /// wrapped in <c>Nullable</c> (the server rejects it), so this is a formality the interface requires.
+    /// </summary>
+    public object NullPlaceholder => Array.Empty<object[]>();
+
+    /// <summary>A nested row is variable-width (its element count and each field's values vary), so it has no fixed byte size.</summary>
+    public int? FixedRowByteSize => null;
+
+    /// <summary>Builds a <c>Nested(...)</c> codec, resolving each field's codec through the registry.</summary>
+    /// <param name="node">The parsed <c>Nested</c> node; each argument is a named field (<c>name Type</c>).</param>
+    /// <param name="context">The resolution context, forwarded to each field codec's factory.</param>
+    /// <param name="registry">The registry used to resolve the field codecs.</param>
+    /// <returns>The codec.</returns>
+    /// <exception cref="FormatException">The type has no fields, or a field is unnamed.</exception>
+    /// <exception cref="NotSupportedException">A field type is unsupported.</exception>
+    public static NestedColumnCodec Create(TypeNode node, in ResolveContext context, ColumnCodecRegistry registry)
+    {
+        if (node.Arguments.Count == 0)
+        {
+            throw new FormatException($"Nested type '{node}' must have at least one field.");
+        }
+
+        // Every Nested field is named — an unnamed field is malformed (the server never emits one, and it could
+        // not have created the column). NamedElementParser handles the shared 'name Type' element syntax: the
+        // field name is glued to the type by the first whitespace, since the tokenizer only breaks on ',()'.
+        (string Name, TypeNode Type)[] elements = NamedElementParser.Split(node);
+        var childCodecs = new IColumnCodec[elements.Length];
+        var names = new string[elements.Length];
+        for (int i = 0; i < elements.Length; i++)
+        {
+            if (elements[i].Name is null)
+            {
+                throw new FormatException($"Nested type '{node}' has an unnamed field; every Nested field must be named.");
+            }
+
+            childCodecs[i] = registry.ResolveNode(elements[i].Type, in context);
+            names[i] = elements[i].Name;
+        }
+
+        return new NestedColumnCodec(node.ToString(), childCodecs, names);
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask ReadStatePrefixAsync(ClickHouseBinaryReader reader, CancellationToken cancellationToken)
+    {
+        // A Nested has no prefix of its own; it delegates the prefix phase to each field's serialization, in order,
+        // matching the inner Tuple(...) it is byte-compatible with. Empty unless a field type is versioned.
+        foreach (IColumnCodec child in children)
+        {
+            await child.ReadStatePrefixAsync(reader, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask<IColumn> ReadColumnAsync(ClickHouseBinaryReader reader, string columnName, string columnType, int rowCount, CancellationToken cancellationToken)
+    {
+        if (rowCount == 0)
+        {
+            // An empty column writes no offsets and no field streams: read zero-row field columns and wrap them
+            // with the single sentinel offset (offsets[0] = 0) every nested column carries.
+            return await ReadFieldsAndWrapAsync(reader, columnName, columnType, new int[1], rowCount: 0, totalElements: 0, pooledOffsets: false, cancellationToken).ConfigureAwait(false);
+        }
+
+        long offsetBytes = (long)rowCount * sizeof(ulong);
+        if (offsetBytes > Array.MaxLength)
+        {
+            throw new ClickHouseProtocolException(
+                $"Nested column '{columnName}' declares {rowCount} rows, whose offsets stream exceeds the maximum this client can buffer.");
+        }
+
+        int[] offsets = ArrayPool<int>.Shared.Rent(rowCount + 1);
+        byte[] scratch = ArrayPool<byte>.Shared.Rent((int)offsetBytes);
+        try
+        {
+            await reader.ReadBytesAsync(scratch.AsMemory(0, (int)offsetBytes), cancellationToken).ConfigureAwait(false);
+            DecodeOffsets(scratch.AsSpan(0, (int)offsetBytes), offsets, rowCount, columnName);
+            return await ReadFieldsAndWrapAsync(reader, columnName, columnType, offsets, rowCount, offsets[rowCount], pooledOffsets: true, cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            ArrayPool<int>.Shared.Return(offsets);
+            throw;
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(scratch);
+        }
+    }
+
+    /// <summary>
+    /// Reads every field's flat column (each holding <paramref name="totalElements"/> values) and wraps them with
+    /// <paramref name="offsets"/> into a <see cref="NestedColumn"/>. On any failure disposes whatever fields were
+    /// read and rethrows; the <paramref name="offsets"/> lifetime is owned by the caller (returned by the caller's
+    /// own failure handler when pooled, or by the constructed column on success), so this method never touches it.
+    /// </summary>
+    private async ValueTask<IColumn> ReadFieldsAndWrapAsync(ClickHouseBinaryReader reader, string columnName, string columnType, int[] offsets, int rowCount, int totalElements, bool pooledOffsets, CancellationToken cancellationToken)
+    {
+        var fieldColumns = new IColumn[children.Length];
+        int read = 0;
+        try
+        {
+            for (int i = 0; i < children.Length; i++)
+            {
+                fieldColumns[i] = await children[i].ReadColumnAsync(reader, columnName, children[i].TypeName, totalElements, cancellationToken).ConfigureAwait(false);
+                read = i + 1;
+            }
+
+            // The constructed column takes ownership of the field columns and the offsets.
+            return new NestedColumn(columnName, columnType, fieldNames, fieldColumns, offsets, rowCount, pooledOffsets, ownsFields: true);
+        }
+        catch
+        {
+            for (int i = 0; i < read; i++)
+            {
+                fieldColumns[i].Dispose();
+            }
+
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Decodes the per-row offsets stream — the <paramref name="rowCount"/> little-endian <c>UInt64</c> cumulative
+    /// element ends — into <paramref name="offsets"/>, prepending the <c>offsets[0] = 0</c> sentinel. Validates
+    /// that the stream never runs backwards and never declares more elements than this client can address.
+    /// </summary>
+    private static void DecodeOffsets(ReadOnlySpan<byte> offsetBytes, Span<int> offsets, int rowCount, string columnName)
+    {
+        // Offsets are little-endian UInt64 (this client is little-endian only, like every fixed-width codec).
+        ReadOnlySpan<ulong> wire = MemoryMarshal.Cast<byte, ulong>(offsetBytes);
+        offsets[0] = 0;
+        ulong previous = 0;
+        for (int i = 0; i < rowCount; i++)
+        {
+            ulong end = wire[i];
+            if (end < previous)
+            {
+                throw new ClickHouseProtocolException(
+                    $"Nested column '{columnName}' has a non-monotonic offset at row {i} ({end} < {previous}); the stream is corrupt.");
+            }
+
+            if (end > int.MaxValue)
+            {
+                throw new ClickHouseProtocolException(
+                    $"Nested column '{columnName}' declares {end} total elements, exceeding the maximum this client can address.");
+            }
+
+            offsets[i + 1] = (int)end;
+            previous = end;
+        }
+    }
+
+    /// <inheritdoc/>
+    public long MeasureRowBytes(IColumn column, int row)
+    {
+        var nested = AsNested(column);
+        ReadOnlySpan<int> offsets = nested.Offsets;
+        int start = offsets[row];
+        int end = offsets[row + 1];
+
+        long total = sizeof(ulong); // this row's single offset entry
+        for (int f = 0; f < children.Length; f++)
+        {
+            // A fixed-width field prices its slice in O(1); only a variable-width field is walked per element.
+            if (children[f].FixedRowByteSize is int width)
+            {
+                total += (long)(end - start) * width;
+                continue;
+            }
+
+            IColumn field = nested.GetField(f);
+            for (int e = start; e < end; e++)
+            {
+                total += children[f].MeasureRowBytes(field, e);
+            }
+        }
+
+        return total;
+    }
+
+    /// <inheritdoc/>
+    public bool CanWrite(IColumn column)
+    {
+        if (column is not NestedColumn nested || nested.FieldCount != children.Length)
+        {
+            return false;
+        }
+
+        for (int i = 0; i < children.Length; i++)
+        {
+            if (!children[i].CanWrite(nested.GetField(i)))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <inheritdoc/>
+    public void WriteStatePrefix(ClickHouseBinaryWriter writer)
+    {
+        foreach (IColumnCodec child in children)
+        {
+            child.WriteStatePrefix(writer);
+        }
+    }
+
+    /// <inheritdoc/>
+    public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
+    {
+        var nested = AsNested(column);
+        ReadOnlySpan<int> offsets = nested.Offsets;
+
+        // The wire offsets are relative to this slice's own field streams, so subtract the slice's first element
+        // index from each cumulative end.
+        int elementBase = offsets[start];
+        for (int i = 0; i < length; i++)
+        {
+            writer.WriteUInt64((ulong)(offsets[start + i + 1] - elementBase));
+        }
+
+        int elementCount = offsets[start + length] - elementBase;
+        for (int f = 0; f < children.Length; f++)
+        {
+            children[f].WriteColumn(writer, nested.GetField(f), elementBase, elementCount);
+        }
+    }
+
+    // A Nested column has no jagged/row-oriented write form (that would need a per-row record type and reintroduce
+    // an arity cap); the dense NestedColumn is the only write source, so anything else is a caller error.
+    private NestedColumn AsNested(IColumn column)
+    {
+        if (column is NestedColumn nested && nested.FieldCount == children.Length)
+        {
+            return nested;
+        }
+
+        throw new ArgumentException(
+            $"The '{TypeName}' codec writes a NestedColumn with {children.Length} field(s); got '{column?.GetType().Name ?? "null"}'.",
+            nameof(column));
+    }
+}

--- a/ClickHouse.Driver.Tcp/Types/Codecs/NestedColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/NestedColumnCodec.cs
@@ -251,6 +251,54 @@ internal sealed class NestedColumnCodec : IColumnCodec
     }
 
     /// <inheritdoc/>
+    // A Nested column is only ever the dense NestedColumn (there is no ergonomic write form), so TryDensify just
+    // recurses each field codec's own TryDensify over its field column — turning e.g. a Nested with an Array or
+    // Nullable field dense all the way down. The wrapper is rebuilt only when some field densified to a new column;
+    // otherwise the input is returned unchanged (built = false).
+    public IColumn TryDensify(IColumn column, out bool built)
+    {
+        var nested = AsNested(column);
+        IColumn[] densified = null;
+        bool[] owned = null;
+        for (int f = 0; f < children.Length; f++)
+        {
+            IColumn original = nested.GetField(f);
+            IColumn field = children[f].TryDensify(original, out bool fieldBuilt);
+            if (densified is null && fieldBuilt)
+            {
+                densified = new IColumn[children.Length];
+                owned = new bool[children.Length];
+                for (int j = 0; j < f; j++)
+                {
+                    densified[j] = nested.GetField(j);
+                }
+            }
+
+            if (densified is not null)
+            {
+                densified[f] = field;
+                owned[f] = fieldBuilt;
+            }
+        }
+
+        if (densified is null)
+        {
+            built = false;
+            return column;
+        }
+
+        // The rebuilt wrapper mixes fields: the freshly densified ones are new columns it must dispose, while the
+        // unchanged ones are borrowed by reference and stay owned by the source column. Build it borrowing everything
+        // (ownsFields: false), then restrict disposal to exactly the fields we built — the per-field `owned` flags
+        // come straight from each field's `built` signal — so disposing the wrapper frees the new columns without
+        // double-disposing the borrowed ones.
+        var rebuilt = new NestedColumn(nested.Name, nested.TypeName, fieldNames, densified, nested.Offsets.ToArray(), nested.RowCount, pooledOffsets: false, ownsFields: false);
+        rebuilt.RestrictOwnership(owned);
+        built = true;
+        return rebuilt;
+    }
+
+    /// <inheritdoc/>
     public void WriteStatePrefix(ClickHouseBinaryWriter writer)
     {
         foreach (IColumnCodec child in children)

--- a/ClickHouse.Driver.Tcp/Types/Codecs/NestedColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/NestedColumnCodec.cs
@@ -56,9 +56,6 @@ internal sealed class NestedColumnCodec : IColumnCodec
     /// </summary>
     public object NullPlaceholder => Array.Empty<object[]>();
 
-    /// <summary>A nested row is variable-width (its element count and each field's values vary), so it has no fixed byte size.</summary>
-    public int? FixedRowByteSize => null;
-
     /// <summary>Builds a <c>Nested(...)</c> codec, resolving each field's codec through the registry.</summary>
     /// <param name="node">The parsed <c>Nested</c> node; each argument is a named field (<c>name Type</c>).</param>
     /// <param name="context">The resolution context, forwarded to each field codec's factory.</param>
@@ -204,34 +201,6 @@ internal sealed class NestedColumnCodec : IColumnCodec
     }
 
     /// <inheritdoc/>
-    public long MeasureRowBytes(IColumn column, int row)
-    {
-        var nested = AsNested(column);
-        ReadOnlySpan<int> offsets = nested.Offsets;
-        int start = offsets[row];
-        int end = offsets[row + 1];
-
-        long total = sizeof(ulong); // this row's single offset entry
-        for (int f = 0; f < children.Length; f++)
-        {
-            // A fixed-width field prices its slice in O(1); only a variable-width field is walked per element.
-            if (children[f].FixedRowByteSize is int width)
-            {
-                total += (long)(end - start) * width;
-                continue;
-            }
-
-            IColumn field = nested.GetField(f);
-            for (int e = start; e < end; e++)
-            {
-                total += children[f].MeasureRowBytes(field, e);
-            }
-        }
-
-        return total;
-    }
-
-    /// <inheritdoc/>
     public bool CanWrite(IColumn column)
     {
         if (column is not NestedColumn nested || nested.FieldCount != children.Length)
@@ -251,64 +220,57 @@ internal sealed class NestedColumnCodec : IColumnCodec
     }
 
     /// <inheritdoc/>
-    // A Nested column is only ever the dense NestedColumn (there is no ergonomic write form), so TryDensify just
-    // recurses each field codec's own TryDensify over its field column — turning e.g. a Nested with an Array or
-    // Nullable field dense all the way down. The wrapper is rebuilt only when some field densified to a new column;
-    // otherwise the input is returned unchanged (built = false).
-    public IColumn TryDensify(IColumn column, out bool built)
+    // Project each field's flat column and slice once and create each field codec's own write state over it, so a
+    // data-dependent field (Dynamic) sees its real values at prefix time and the projection spans both phases.
+    public IColumnWriteState BeginWrite(IColumn column, int start, int length) => BuildState(column, start, length);
+
+    /// <inheritdoc/>
+    public void WriteStatePrefix(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
     {
-        var nested = AsNested(column);
-        IColumn[] densified = null;
-        bool[] owned = null;
-        for (int f = 0; f < children.Length; f++)
-        {
-            IColumn original = nested.GetField(f);
-            IColumn field = children[f].TryDensify(original, out bool fieldBuilt);
-            if (densified is null && fieldBuilt)
-            {
-                densified = new IColumn[children.Length];
-                owned = new bool[children.Length];
-                for (int j = 0; j < f; j++)
-                {
-                    densified[j] = nested.GetField(j);
-                }
-            }
-
-            if (densified is not null)
-            {
-                densified[f] = field;
-                owned[f] = fieldBuilt;
-            }
-        }
-
-        if (densified is null)
-        {
-            built = false;
-            return column;
-        }
-
-        // The rebuilt wrapper mixes fields: the freshly densified ones are new columns it must dispose, while the
-        // unchanged ones are borrowed by reference and stay owned by the source column. Build it borrowing everything
-        // (ownsFields: false), then restrict disposal to exactly the fields we built — the per-field `owned` flags
-        // come straight from each field's `built` signal — so disposing the wrapper frees the new columns without
-        // double-disposing the borrowed ones.
-        var rebuilt = new NestedColumn(nested.Name, nested.TypeName, fieldNames, densified, nested.Offsets.ToArray(), nested.RowCount, pooledOffsets: false, ownsFields: false);
-        rebuilt.RestrictOwnership(owned);
-        built = true;
-        return rebuilt;
+        using NestedWriteState state = BuildState(column, start, length);
+        WriteStatePrefixCore(writer, state);
     }
 
     /// <inheritdoc/>
-    public void WriteStatePrefix(ClickHouseBinaryWriter writer)
+    public void WriteStatePrefix(ClickHouseBinaryWriter writer, IColumn column, int start, int length, IColumnWriteState state)
     {
-        foreach (IColumnCodec child in children)
+        if (state is NestedWriteState nestedState)
         {
-            child.WriteStatePrefix(writer);
+            WriteStatePrefixCore(writer, nestedState);
+            return;
         }
+
+        WriteStatePrefix(writer, column, start, length);
     }
 
     /// <inheritdoc/>
     public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
+    {
+        using NestedWriteState state = BuildState(column, start, length);
+        WriteBodyCore(writer, column, start, length, state);
+    }
+
+    /// <inheritdoc/>
+    public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length, IColumnWriteState state)
+    {
+        if (state is NestedWriteState nestedState)
+        {
+            WriteBodyCore(writer, column, start, length, nestedState);
+            return;
+        }
+
+        WriteColumn(writer, column, start, length);
+    }
+
+    private void WriteStatePrefixCore(ClickHouseBinaryWriter writer, NestedWriteState state)
+    {
+        for (int f = 0; f < children.Length; f++)
+        {
+            children[f].WriteStatePrefix(writer, state.FieldColumns[f], state.ElementBase, state.ElementCount, state.FieldStates[f]);
+        }
+    }
+
+    private void WriteBodyCore(ClickHouseBinaryWriter writer, IColumn column, int start, int length, NestedWriteState state)
     {
         var nested = AsNested(column);
         ReadOnlySpan<int> offsets = nested.Offsets;
@@ -321,11 +283,46 @@ internal sealed class NestedColumnCodec : IColumnCodec
             writer.WriteUInt64((ulong)(offsets[start + i + 1] - elementBase));
         }
 
-        int elementCount = offsets[start + length] - elementBase;
         for (int f = 0; f < children.Length; f++)
         {
-            children[f].WriteColumn(writer, nested.GetField(f), elementBase, elementCount);
+            children[f].WriteColumn(writer, state.FieldColumns[f], state.ElementBase, state.ElementCount, state.FieldStates[f]);
         }
+    }
+
+    // Builds the per-field projection state for a slice: each field's flat column with the slice's element range,
+    // plus each field codec's own write state over it.
+    private NestedWriteState BuildState(IColumn column, int start, int length)
+    {
+        var nested = AsNested(column);
+        ReadOnlySpan<int> offsets = nested.Offsets;
+        int elementBase = offsets[start];
+        int elementCount = offsets[start + length] - elementBase;
+
+        var fieldColumns = new IColumn[children.Length];
+        var fieldStates = new IColumnWriteState[children.Length];
+        int built = 0;
+        try
+        {
+            for (int f = 0; f < children.Length; f++)
+            {
+                fieldColumns[f] = nested.GetField(f);
+                fieldStates[f] = children[f].BeginWrite(fieldColumns[f], elementBase, elementCount);
+                built = f + 1;
+            }
+        }
+        catch
+        {
+            // A later field's BeginWrite throwing must not leak the field states already built (each may hold
+            // rented buffers).
+            for (int f = 0; f < built; f++)
+            {
+                fieldStates[f]?.Dispose();
+            }
+
+            throw;
+        }
+
+        return new NestedWriteState { FieldColumns = fieldColumns, ElementBase = elementBase, ElementCount = elementCount, FieldStates = fieldStates };
     }
 
     // A Nested column has no jagged/row-oriented write form (that would need a per-row record type and reintroduce
@@ -340,5 +337,26 @@ internal sealed class NestedColumnCodec : IColumnCodec
         throw new ArgumentException(
             $"The '{TypeName}' codec writes a NestedColumn with {children.Length} field(s); got '{column?.GetType().Name ?? "null"}'.",
             nameof(column));
+    }
+
+    // The per-field projection of one slice, shared across the prefix and body phases: each field's (borrowed)
+    // flat column, the shared element range, and each field codec's own state.
+    private sealed class NestedWriteState : IColumnWriteState
+    {
+        public IColumn[] FieldColumns;
+        public int ElementBase;
+        public int ElementCount;
+        public IColumnWriteState[] FieldStates;
+
+        public void Dispose()
+        {
+            if (FieldStates is not null)
+            {
+                foreach (IColumnWriteState state in FieldStates)
+                {
+                    state?.Dispose();
+                }
+            }
+        }
     }
 }

--- a/ClickHouse.Driver.Tcp/Types/Codecs/NestedColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/NestedColumnCodec.cs
@@ -234,13 +234,14 @@ internal sealed class NestedColumnCodec : IColumnCodec
     /// <inheritdoc/>
     public void WriteStatePrefix(ClickHouseBinaryWriter writer, IColumn column, int start, int length, IColumnWriteState state)
     {
-        if (state is NestedWriteState nestedState)
+        // A null state is the caller saying it has none to share, so build one for this call alone.
+        if (state is null)
         {
-            WriteStatePrefixCore(writer, nestedState);
+            WriteStatePrefix(writer, column, start, length);
             return;
         }
 
-        WriteStatePrefix(writer, column, start, length);
+        WriteStatePrefixCore(writer, state.Expect<NestedWriteState>(TypeName));
     }
 
     /// <inheritdoc/>
@@ -253,13 +254,13 @@ internal sealed class NestedColumnCodec : IColumnCodec
     /// <inheritdoc/>
     public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length, IColumnWriteState state)
     {
-        if (state is NestedWriteState nestedState)
+        if (state is null)
         {
-            WriteBodyCore(writer, column, start, length, nestedState);
+            WriteColumn(writer, column, start, length);
             return;
         }
 
-        WriteColumn(writer, column, start, length);
+        WriteBodyCore(writer, column, start, length, state.Expect<NestedWriteState>(TypeName));
     }
 
     private void WriteStatePrefixCore(ClickHouseBinaryWriter writer, NestedWriteState state)

--- a/ClickHouse.Driver.Tcp/Types/Codecs/NestedColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/NestedColumnCodec.cs
@@ -234,13 +234,6 @@ internal sealed class NestedColumnCodec : IColumnCodec
     /// <inheritdoc/>
     public void WriteStatePrefix(ClickHouseBinaryWriter writer, IColumn column, int start, int length, IColumnWriteState state)
     {
-        // A null state is the caller saying it has none to share, so build one for this call alone.
-        if (state is null)
-        {
-            WriteStatePrefix(writer, column, start, length);
-            return;
-        }
-
         WriteStatePrefixCore(writer, state.Expect<NestedWriteState>(TypeName));
     }
 
@@ -254,12 +247,6 @@ internal sealed class NestedColumnCodec : IColumnCodec
     /// <inheritdoc/>
     public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length, IColumnWriteState state)
     {
-        if (state is null)
-        {
-            WriteColumn(writer, column, start, length);
-            return;
-        }
-
         WriteBodyCore(writer, column, start, length, state.Expect<NestedWriteState>(TypeName));
     }
 

--- a/ClickHouse.Driver.Tcp/Types/Codecs/NestedColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/NestedColumnCodec.cs
@@ -44,9 +44,9 @@ internal sealed class NestedColumnCodec : IColumnCodec
     public string TypeName { get; }
 
     /// <summary>
-    /// A <c>Nested</c> column surfaces as an array of records (<c>object[][]</c>). This is never consumed
-    /// compositionally — ClickHouse does not allow <c>Nested</c> as an inner type of another type — but the
-    /// interface requires an element type.
+    /// A <c>Nested</c> column surfaces as an array of records (<c>object[][]</c>). With
+    /// <c>flatten_nested = 0</c>, ClickHouse supports arbitrary nesting, so another composite can use this as its
+    /// element type while retaining the dense <see cref="NestedColumn"/> as the write source.
     /// </summary>
     public Type ElementType => typeof(object[][]);
 

--- a/ClickHouse.Driver.Tcp/Types/Codecs/TupleColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/TupleColumnCodec.cs
@@ -22,10 +22,11 @@ namespace ClickHouse.Driver.Tcp.Types.Codecs;
 /// </para>
 ///
 /// <para>
-/// On the write path the column is always the dense <c>TupleColumn</c> (whose child columns already exist),
-/// serialized straight from those children with no copy. A flat column of <c>ValueTuple</c> values — the buffer
+/// On the write path a dense <c>TupleColumn</c> (whose child columns already exist) is serialized straight from
+/// those children with no copy. A flat column of <c>ValueTuple</c> values — the buffer
 /// an <c>Array(Tuple(...))</c> flattens into, or one a caller builds directly — is un-transposed into the
-/// per-child columns before the write.
+/// per-child columns before the write when every child codec accepts that projection. A shape-only child such as
+/// <c>Nested</c> requires the dense tuple form so its named field columns remain available.
 /// </para>
 /// </summary>
 internal sealed class TupleColumnCodec : IColumnCodec
@@ -63,7 +64,7 @@ internal sealed class TupleColumnCodec : IColumnCodec
     private readonly ConstructorInfo columnConstructor;
     private readonly Type icolumnOfTupleType;
     private readonly Func<string, IColumn, int, IColumn>[] childProjectionBuilders;
-    private readonly bool allChildrenWritable;
+    private readonly bool projectedChildrenWritable;
 
     private TupleColumnCodec(string typeName, IColumnCodec[] children, string[] fieldNames)
     {
@@ -114,15 +115,16 @@ internal sealed class TupleColumnCodec : IColumnCodec
                 .MakeGenericMethod(elementTypes[i])
                 .CreateDelegate(typeof(Func<string, IColumn, int, IColumn>));
 
-            // Probe writability with an empty child column so a Tuple over a non-writable element (e.g. Nothing)
-            // is rejected up front rather than mid-write.
+            // Probe the flat ValueTuple path with the projected child shape it will actually hand the codec. A
+            // dense TupleColumn is checked against its real child columns in CanWrite instead, which lets a
+            // Tuple(Nested(...)) re-insert its wire-shaped NestedColumn child.
             var emptyBuilder = (Func<string, IColumn>)emptyTemplate
                 .MakeGenericMethod(elementTypes[i])
                 .CreateDelegate(typeof(Func<string, IColumn>));
             writable &= children[i].CanWrite(emptyBuilder(children[i].TypeName));
         }
 
-        allChildrenWritable = writable;
+        projectedChildrenWritable = writable;
     }
 
     /// <inheritdoc/>
@@ -218,7 +220,33 @@ internal sealed class TupleColumnCodec : IColumnCodec
     }
 
     /// <inheritdoc/>
-    public bool CanWrite(IColumn column) => allChildrenWritable && icolumnOfTupleType.IsInstanceOfType(column);
+    public bool CanWrite(IColumn column)
+    {
+        if (!icolumnOfTupleType.IsInstanceOfType(column))
+        {
+            return false;
+        }
+
+        if (column is not ITupleColumn dense)
+        {
+            return projectedChildrenWritable;
+        }
+
+        if (dense.Children.Count != children.Length)
+        {
+            return false;
+        }
+
+        for (int i = 0; i < children.Length; i++)
+        {
+            if (!children[i].CanWrite(dense.Children[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
 
     /// <inheritdoc/>
     // Project each element position into its own child column once (dense children as-is, a flat tuple column

--- a/ClickHouse.Driver.Tcp/Types/ColumnCodecRegistry.cs
+++ b/ClickHouse.Driver.Tcp/Types/ColumnCodecRegistry.cs
@@ -139,6 +139,12 @@ internal sealed class ColumnCodecRegistry
         // and value codecs are resolved recursively; each row surfaces as a KeyValuePair<K, V>[].
         AddFactory("Map", static (TypeNode node, in ResolveContext context, ColumnCodecRegistry registry) => MapColumnCodec.Create(node, context, registry));
 
+        // Nested(...) as a single wire column (flatten_nested = 0) is byte-identical to Array(Tuple(...)): the same
+        // offsets stream plus each field's flattened stream, differing only in the type string, which keeps the
+        // field names. It has a dedicated arity-agnostic codec (not Array(Tuple) reuse) surfacing a columnar
+        // NestedColumn, so it is not bound by the tuple's element-count cap.
+        AddFactory("Nested", static (TypeNode node, in ResolveContext context, ColumnCodecRegistry registry) => NestedColumnCodec.Create(node, context, registry));
+
         return new ColumnCodecRegistry(byName);
     }
 }

--- a/ClickHouse.Driver.Tcp/Types/INestedColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/INestedColumn.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+
+namespace ClickHouse.Driver.Tcp.Types;
+
+/// <summary>
+/// The zero-copy read surface of a decoded <c>Nested(name1 T1, ..., namen Tn)</c> column carried as one wire column
+/// (the <c>flatten_nested = 0</c> form). A nested column is a table-within-a-row: each row holds a variable number
+/// of records, and each record has one value per named field. On the wire — and here — that is stored field-major:
+/// one flat column per field holding every row's elements for that field concatenated end-to-end, plus a single
+/// per-row offsets array shared by all fields (within a row every field has the same element count, so one set of
+/// row boundaries delimits them all). It is byte-identical to <c>Array(Tuple(T1, ..., Tn))</c>.
+///
+/// <para>
+/// This interface is the primary access path, not merely a fast one. Because a <c>Nested</c> can carry any number
+/// of fields, there is no single generic per-row value type for it, so the <see cref="IColumn{T}"/> surface has to
+/// fall back to <c>object[][]</c> — one boxed <c>object[]</c> of field values per record, per row. Reading through
+/// <see cref="GetField(int)"/> and <see cref="Offsets"/> instead is both typed and allocation-free.
+/// </para>
+///
+/// <para>
+/// Row <c>i</c>'s elements for a field are that field's column sliced from <c>Offsets[i]</c> (inclusive) to
+/// <c>Offsets[i + 1]</c> (exclusive); the same range applies to every field, so element <c>j</c> of that range
+/// across all fields makes up one record. Field columns and <see cref="Offsets"/> are borrowed views over the
+/// owning block's storage: read them in place, and copy out only what must outlive the block. Obtain this view by
+/// pattern-matching a column, e.g. <c>if (column is INestedColumn nested)</c>.
+/// </para>
+/// </summary>
+public interface INestedColumn : IColumn
+{
+    /// <summary>The number of named fields.</summary>
+    int FieldCount { get; }
+
+    /// <summary>The field names, in declaration order, aligned with the field columns.</summary>
+    IReadOnlyList<string> FieldNames { get; }
+
+    /// <summary>
+    /// The per-row offsets, shared by every field: <c>[0]</c> is 0 and <c>[i + 1]</c> is the exclusive end of row
+    /// <c>i</c>'s elements in <em>every</em> field column; the span has one more entry than the column has rows. A
+    /// borrowed span valid only while the owning block is alive.
+    /// </summary>
+    ReadOnlySpan<int> Offsets { get; }
+
+    /// <summary>
+    /// The flat column for the field at <paramref name="index"/>: every row's elements for that field concatenated
+    /// end-to-end. Its row count is the total element count across all rows — the same for every field — not the
+    /// nested column's row count. A field whose type is itself a composite pattern-matches to that type's own
+    /// columnar view. A borrowed view valid only while the owning block is alive.
+    /// </summary>
+    /// <param name="index">The zero-based field index.</param>
+    /// <returns>That field's flat column.</returns>
+    IColumn GetField(int index);
+
+    /// <summary>The flat column for the field named <paramref name="name"/>, matched ordinally.</summary>
+    /// <param name="name">The field name.</param>
+    /// <returns>That field's flat column.</returns>
+    /// <exception cref="KeyNotFoundException">No field has that name.</exception>
+    IColumn GetField(string name);
+}

--- a/ClickHouse.Driver.Tcp/Types/INestedColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/INestedColumn.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 namespace ClickHouse.Driver.Tcp.Types;
 
 /// <summary>
-/// The zero-copy read surface of a decoded <c>Nested(name1 T1, ..., namen Tn)</c> column carried as one wire column
+/// The columnar read surface of a decoded <c>Nested(name1 T1, ..., namen Tn)</c> column carried as one wire column
 /// (the <c>flatten_nested = 0</c> form). A nested column is a table-within-a-row: each row holds a variable number
 /// of records, and each record has one value per named field. On the wire — and here — that is stored field-major:
 /// one flat column per field holding every row's elements for that field concatenated end-to-end, plus a single
@@ -45,10 +45,12 @@ public interface INestedColumn : IColumn
     /// The flat column for the field at <paramref name="index"/>: every row's elements for that field concatenated
     /// end-to-end. Its row count is the total element count across all rows — the same for every field — not the
     /// nested column's row count. A field whose type is itself a composite pattern-matches to that type's own
-    /// columnar view. A borrowed view valid only while the owning block is alive.
+    /// columnar view. A borrowed view valid only while the owning block is alive — it is the block's to dispose,
+    /// never the caller's.
     /// </summary>
     /// <param name="index">The zero-based field index.</param>
     /// <returns>That field's flat column.</returns>
+    /// <exception cref="IndexOutOfRangeException"><paramref name="index"/> is negative or not less than <see cref="FieldCount"/>.</exception>
     IColumn GetField(int index);
 
     /// <summary>The flat column for the field named <paramref name="name"/>, matched ordinally.</summary>

--- a/ClickHouse.Driver.Tcp/Types/NestedColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/NestedColumn.cs
@@ -1,0 +1,192 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+
+namespace ClickHouse.Driver.Tcp.Types;
+
+/// <summary>
+/// A ClickHouse <c>Nested(name1 T1, ..., namen Tn)</c> column carried as a single wire column (the
+/// <c>flatten_nested = 0</c> form). It is columnar and arity-agnostic: it holds one flat field column per named
+/// field — every row's elements for that field concatenated end-to-end — plus a per-row offsets array shared by
+/// all fields (within a row every field has the same element count, so one set of row boundaries delimits them
+/// all). This is the dense shape the wire uses (offsets + one stream per field, byte-identical to
+/// <c>Array(Tuple(T1, ..., Tn))</c>), so it is also the zero-copy source for writing — handed back to the
+/// <c>Nested(...)</c> codec it serializes straight from the field columns and offsets without rebuilding anything.
+///
+/// <para>
+/// The primary, allocation-free access is columnar: <see cref="GetField(int)"/> / <see cref="GetField(string)"/>
+/// return a field's flat column (each holding <em>total elements</em> values, aligned across fields), and
+/// <see cref="Offsets"/> maps a row to its element range in those columns. Because a <c>Nested</c> can carry any
+/// number of fields, there is deliberately no single generic per-row value type; the <see cref="IColumn{T}"/>
+/// surface materializes each row as an array of records (<c>object[][]</c> — one <c>object[]</c> of field values
+/// per element), a boxed convenience for generic consumers rather than the fast path.
+/// </para>
+///
+/// <para>
+/// The field columns' storage and the offsets are borrowed for this column's lifetime; the field columns are
+/// disposed (when owned) and the offsets returned (when pooled) on <see cref="Dispose"/>. Each row access copies
+/// that row's slice into fresh arrays, so retain those freely, but read the column itself only while the owning
+/// block is alive.
+/// </para>
+/// </summary>
+internal sealed class NestedColumn : IColumn<object[][]>
+{
+    private readonly IColumn[] fields;
+    private readonly string[] fieldNames;
+    private readonly int rowCount;
+    private readonly bool pooledOffsets;
+    private readonly bool ownsFields;
+    private int[] offsets;
+    private object[][][] cache;
+
+    /// <summary>Initializes a nested column over its flat field columns and their shared per-row offsets.</summary>
+    /// <param name="name">The column name.</param>
+    /// <param name="typeName">The full <c>Nested(...)</c> type string.</param>
+    /// <param name="fieldNames">The field names, in declaration order; must align with <paramref name="fields"/>.</param>
+    /// <param name="fields">One flat column per field, each holding every row's elements for that field concatenated end-to-end.</param>
+    /// <param name="offsets">The per-row offsets: <c>offsets[0]</c> is 0 and <c>offsets[i + 1]</c> is the exclusive end of row <c>i</c>'s elements; must have at least <paramref name="rowCount"/> + 1 entries.</param>
+    /// <param name="rowCount">The number of rows.</param>
+    /// <param name="pooledOffsets">Whether <paramref name="offsets"/> was rented and should be returned on dispose.</param>
+    /// <param name="ownsFields">Whether this column owns and disposes <paramref name="fields"/> (false when a caller retains them).</param>
+    /// <exception cref="ArgumentException"><paramref name="fieldNames"/> and <paramref name="fields"/> differ in length, or <paramref name="fields"/> is empty.</exception>
+    public NestedColumn(string name, string typeName, string[] fieldNames, IColumn[] fields, int[] offsets, int rowCount, bool pooledOffsets, bool ownsFields)
+    {
+        this.fieldNames = fieldNames ?? throw new ArgumentNullException(nameof(fieldNames));
+        this.fields = fields ?? throw new ArgumentNullException(nameof(fields));
+        if (fields.Length == 0)
+        {
+            throw new ArgumentException("A Nested column must have at least one field.", nameof(fields));
+        }
+
+        if (fieldNames.Length != fields.Length)
+        {
+            throw new ArgumentException($"Field name count ({fieldNames.Length}) does not match field column count ({fields.Length}).", nameof(fieldNames));
+        }
+
+        Name = name;
+        TypeName = typeName;
+        this.offsets = offsets ?? throw new ArgumentNullException(nameof(offsets));
+        this.rowCount = rowCount;
+        this.pooledOffsets = pooledOffsets;
+        this.ownsFields = ownsFields;
+    }
+
+    /// <inheritdoc/>
+    public string Name { get; }
+
+    /// <inheritdoc/>
+    public string TypeName { get; }
+
+    /// <inheritdoc/>
+    public int RowCount => rowCount;
+
+    /// <summary>The number of fields.</summary>
+    public int FieldCount => fields.Length;
+
+    /// <summary>The field names, in declaration order.</summary>
+    public IReadOnlyList<string> FieldNames => fieldNames;
+
+    /// <summary>
+    /// The per-row offsets, sliced to <see cref="RowCount"/> + 1 entries: <c>[0]</c> is 0 and <c>[i + 1]</c> is
+    /// the exclusive end of row <c>i</c>'s slice of every field column — a zero-copy write source and the way to
+    /// address a single row's elements within the flat field columns from <see cref="GetField(int)"/>.
+    /// </summary>
+    internal ReadOnlySpan<int> Offsets => offsets.AsSpan(0, rowCount + 1);
+
+    /// <summary>The flat column for field <paramref name="index"/> (every row's elements concatenated) — a zero-copy access.</summary>
+    /// <param name="index">The zero-based field index.</param>
+    /// <returns>The field's flat column, holding the same total-element count as every other field.</returns>
+    public IColumn GetField(int index) => fields[index];
+
+    /// <summary>The flat column for the field named <paramref name="name"/> (ordinal match) — a zero-copy access.</summary>
+    /// <param name="name">The field name.</param>
+    /// <returns>The field's flat column.</returns>
+    /// <exception cref="KeyNotFoundException">No field has that name.</exception>
+    public IColumn GetField(string name)
+    {
+        for (int i = 0; i < fieldNames.Length; i++)
+        {
+            if (string.Equals(fieldNames[i], name, StringComparison.Ordinal))
+            {
+                return fields[i];
+            }
+        }
+
+        throw new KeyNotFoundException($"Nested column '{Name}' ({TypeName}) has no field named '{name}'.");
+    }
+
+    /// <summary>
+    /// The rows as arrays of records, materialized once and cached — each row is an <c>object[][]</c> of its
+    /// elements, and each element an <c>object[]</c> of the fields' values in declaration order (boxed). Prefer
+    /// <see cref="GetField(int)"/> plus <see cref="Offsets"/> for the allocation-free columnar path.
+    /// </summary>
+    public ReadOnlySpan<object[][]> Values
+    {
+        get
+        {
+            if (cache is null)
+            {
+                var decoded = new object[rowCount][][];
+                for (int i = 0; i < rowCount; i++)
+                {
+                    decoded[i] = Materialize(i);
+                }
+
+                cache = decoded;
+            }
+
+            return cache.AsSpan(0, rowCount);
+        }
+    }
+
+    /// <inheritdoc/>
+    public object[][] this[int row] => cache is not null ? cache[row] : Materialize(row);
+
+    /// <inheritdoc/>
+    public object GetValue(int row) => this[row];
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        if (ownsFields)
+        {
+            foreach (IColumn field in fields)
+            {
+                field.Dispose();
+            }
+        }
+
+        if (pooledOffsets && offsets.Length != 0)
+        {
+            ArrayPool<int>.Shared.Return(offsets);
+        }
+
+        offsets = Array.Empty<int>();
+        cache = null;
+    }
+
+    /// <summary>Copies row <paramref name="row"/>'s elements into an array of records, boxing each field value.</summary>
+    private object[][] Materialize(int row)
+    {
+        int start = offsets[row];
+        int length = offsets[row + 1] - start;
+        if (length == 0)
+        {
+            return Array.Empty<object[]>();
+        }
+
+        var records = new object[length][];
+        for (int e = 0; e < length; e++)
+        {
+            var record = new object[fields.Length];
+            for (int f = 0; f < fields.Length; f++)
+            {
+                record[f] = fields[f].GetValue(start + e);
+            }
+
+            records[e] = record;
+        }
+
+        return records;
+    }
+}

--- a/ClickHouse.Driver.Tcp/Types/NestedColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/NestedColumn.cs
@@ -39,6 +39,11 @@ internal sealed class NestedColumn : IColumn<object[][]>
     private int[] offsets;
     private object[][][] cache;
 
+    // When non-null, overrides ownsFields per field: Dispose disposes field i only when fieldOwnership[i] is true.
+    // Set once by RestrictOwnership immediately after construction so a densified wrapper that mixes freshly built
+    // field columns with fields borrowed from another column disposes only the ones it created.
+    private bool[] fieldOwnership;
+
     /// <summary>Initializes a nested column over its flat field columns and their shared per-row offsets.</summary>
     /// <param name="name">The column name.</param>
     /// <param name="typeName">The full <c>Nested(...)</c> type string.</param>
@@ -69,6 +74,22 @@ internal sealed class NestedColumn : IColumn<object[][]>
         this.rowCount = rowCount;
         this.pooledOffsets = pooledOffsets;
         this.ownsFields = ownsFields;
+    }
+
+    /// <summary>
+    /// Restricts disposal to the fields flagged in <paramref name="owned"/> (one entry per field), overriding the
+    /// all-or-nothing <c>ownsFields</c> passed at construction. Used when rebuilding a densified nested column that
+    /// keeps some field columns by reference (owned by the source column) and replaces others with freshly built
+    /// ones, so disposing this wrapper frees only the columns it created. Must be called before the column is observed.
+    /// </summary>
+    internal void RestrictOwnership(bool[] owned)
+    {
+        if (owned is null || owned.Length != fields.Length)
+        {
+            throw new ArgumentException("Ownership mask must have one entry per field column.", nameof(owned));
+        }
+
+        fieldOwnership = owned;
     }
 
     /// <inheritdoc/>
@@ -148,7 +169,17 @@ internal sealed class NestedColumn : IColumn<object[][]>
     /// <inheritdoc/>
     public void Dispose()
     {
-        if (ownsFields)
+        if (fieldOwnership is not null)
+        {
+            for (int i = 0; i < fields.Length; i++)
+            {
+                if (fieldOwnership[i])
+                {
+                    fields[i].Dispose();
+                }
+            }
+        }
+        else if (ownsFields)
         {
             foreach (IColumn field in fields)
             {

--- a/ClickHouse.Driver.Tcp/Types/NestedColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/NestedColumn.cs
@@ -53,7 +53,7 @@ internal sealed class NestedColumn : IColumn<object[][]>, INestedColumn
     /// <param name="rowCount">The number of rows.</param>
     /// <param name="pooledOffsets">Whether <paramref name="offsets"/> was rented and should be returned on dispose.</param>
     /// <param name="ownsFields">Whether this column owns and disposes <paramref name="fields"/> (false when a caller retains them).</param>
-    /// <exception cref="ArgumentException"><paramref name="fieldNames"/> and <paramref name="fields"/> differ in length, or <paramref name="fields"/> is empty.</exception>
+    /// <exception cref="ArgumentException"><paramref name="fieldNames"/> and <paramref name="fields"/> differ in length, <paramref name="fields"/> is empty, or <paramref name="offsets"/> holds fewer than <paramref name="rowCount"/> + 1 entries.</exception>
     public NestedColumn(string name, string typeName, string[] fieldNames, IColumn[] fields, int[] offsets, int rowCount, bool pooledOffsets, bool ownsFields)
     {
         this.fieldNames = fieldNames ?? throw new ArgumentNullException(nameof(fieldNames));
@@ -74,6 +74,16 @@ internal sealed class NestedColumn : IColumn<object[][]>, INestedColumn
         this.rowCount = rowCount;
         this.pooledOffsets = pooledOffsets;
         this.ownsFields = ownsFields;
+
+        // The row count cannot be derived here: every field column is flat (one entry per element across all rows,
+        // so its height is the element total) and the offsets are typically a pooled buffer longer than the column.
+        // A short offsets array would leave the row bounds reading past its end.
+        if (offsets.Length < rowCount + 1)
+        {
+            throw new ArgumentException(
+                $"The offsets for column '{name}' ({typeName}) hold {offsets.Length} entries, fewer than the {rowCount + 1} needed for {rowCount} rows.",
+                nameof(offsets));
+        }
     }
 
     /// <summary>

--- a/ClickHouse.Driver.Tcp/Types/NestedColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/NestedColumn.cs
@@ -199,8 +199,11 @@ internal sealed class NestedColumn : IColumn<object[][]>
     /// <summary>Copies row <paramref name="row"/>'s elements into an array of records, boxing each field value.</summary>
     private object[][] Materialize(int row)
     {
-        int start = offsets[row];
-        int length = offsets[row + 1] - start;
+        // Index through the RowCount-sliced offsets so an out-of-range row throws rather than reading a stale
+        // slot of the pooled offsets array, which can be longer than RowCount + 1.
+        ReadOnlySpan<int> rowOffsets = Offsets;
+        int start = rowOffsets[row];
+        int length = rowOffsets[row + 1] - start;
         if (length == 0)
         {
             return Array.Empty<object[]>();

--- a/ClickHouse.Driver.Tcp/Types/NestedColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/NestedColumn.cs
@@ -29,7 +29,7 @@ namespace ClickHouse.Driver.Tcp.Types;
 /// block is alive.
 /// </para>
 /// </summary>
-internal sealed class NestedColumn : IColumn<object[][]>
+internal sealed class NestedColumn : IColumn<object[][]>, INestedColumn
 {
     private readonly IColumn[] fields;
     private readonly string[] fieldNames;
@@ -101,28 +101,19 @@ internal sealed class NestedColumn : IColumn<object[][]>
     /// <inheritdoc/>
     public int RowCount => rowCount;
 
-    /// <summary>The number of fields.</summary>
+    /// <inheritdoc/>
     public int FieldCount => fields.Length;
 
-    /// <summary>The field names, in declaration order.</summary>
+    /// <inheritdoc/>
     public IReadOnlyList<string> FieldNames => fieldNames;
 
-    /// <summary>
-    /// The per-row offsets, sliced to <see cref="RowCount"/> + 1 entries: <c>[0]</c> is 0 and <c>[i + 1]</c> is
-    /// the exclusive end of row <c>i</c>'s slice of every field column — a zero-copy write source and the way to
-    /// address a single row's elements within the flat field columns from <see cref="GetField(int)"/>.
-    /// </summary>
-    internal ReadOnlySpan<int> Offsets => offsets.AsSpan(0, rowCount + 1);
+    /// <inheritdoc/>
+    public ReadOnlySpan<int> Offsets => offsets.AsSpan(0, rowCount + 1);
 
-    /// <summary>The flat column for field <paramref name="index"/> (every row's elements concatenated) — a zero-copy access.</summary>
-    /// <param name="index">The zero-based field index.</param>
-    /// <returns>The field's flat column, holding the same total-element count as every other field.</returns>
+    /// <inheritdoc/>
     public IColumn GetField(int index) => fields[index];
 
-    /// <summary>The flat column for the field named <paramref name="name"/> (ordinal match) — a zero-copy access.</summary>
-    /// <param name="name">The field name.</param>
-    /// <returns>The field's flat column.</returns>
-    /// <exception cref="KeyNotFoundException">No field has that name.</exception>
+    /// <inheritdoc/>
     public IColumn GetField(string name)
     {
         for (int i = 0; i < fieldNames.Length; i++)


### PR DESCRIPTION
Adds `Nested(...)` support (I5) for the TCP/Native client, stacked on top of FixedString (#452).

## What

`Nested(name1 T1, …)` carried as a **single wire column** (the `flatten_nested = 0` form) is laid out byte-identically to `Array(Tuple(T1, …))`. Under the server-default `flatten_nested = 1` there is no `Nested` wire type — the server presents N parallel dotted `Array(T_i)` columns, already handled as plain arrays — so only the single-column form needs a codec.

## Design: dedicated columnar representation (not `Array(Tuple)` reuse)

Reusing the Array+Tuple codecs would inherit the tuple's **7-element cap** — a limit a real `Nested` routinely exceeds — and expose named fields as positional `.ItemN` access. Instead:

- **`NestedColumn : IColumn<object[][]>`** — one flat field column per field + a shared per-row offsets array (the wire's own shape). Fast path is columnar and allocation-free: `GetField(index/name)`, `Offsets`, `FieldNames`. The `IColumn<object[][]>` surface (each row = array-of-records, boxed) is a convenience for generic consumers.
- **`NestedColumnCodec`** — owns one child codec per field; reads offsets + each field stream into a `NestedColumn`; writes sliced offsets + each sliced field stream. Fixed-width fields priced O(1) by the insert splitter. The dense `NestedColumn` is the only write source (no row-oriented insert form — that would reintroduce an arity cap).

Fields must be named. Nested composes inside a field (`Nested(a Nullable(T), b Array(T), c Tuple(...))`); the server rejects `Nullable(Nested(...))`, so nullability composes inside a field, like Array/Tuple/Map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)