### PR TITLE
TCP J1/J2: Add LowCardinality(T) and LowCardinality(Nullable(T)) support

### DIFF
--- a/ClickHouse.Driver.Tcp.Tests/Format/BlockWriterTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Format/BlockWriterTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using ClickHouse.Driver.Tcp.Format;
@@ -127,6 +128,50 @@ public class BlockWriterTests
         {
             Assert.That(stream.Length, Is.EqualTo(0), "a small block should stay buffered until the message-boundary flush");
             Assert.That(writer.BufferedBytes, Is.GreaterThan(0));
+        });
+    }
+
+    [Test]
+    public async Task WriteDataBlockAsync_ZeroRowsWithDictionaryBearingColumn_EmitsNoStatePrefix()
+    {
+        // A dictionary-bearing type (LowCardinality) is the one case where a zero-row block could plausibly still
+        // owe a serialization-state prefix, since that prefix is per-column state rather than per-row data. It does
+        // not: ClickHouse's own NativeWriter emits the prefix from inside writeData, which it calls only `if (rows)`,
+        // and NativeReader likewise skips readData for a zero-row block. So the header block that opens every result
+        // set — and the schema block the server sends for an INSERT — carry column names and types but no prefix and
+        // no body. Both of our halves are gated the same way; this pins it byte-exactly, because getting it wrong on
+        // either side makes the reader consume 8 bytes that were never written, desynchronizing the stream for every
+        // column that follows.
+        IColumn[] columns = { new ArrayColumn<string>("v", "LowCardinality(String)", Array.Empty<string>()) };
+
+        byte[] bytes = await WriteAsync(w => BlockWriter.WriteDataBlockAsync(
+            w, Negotiated, columns, rowCount: 0, ColumnCodecRegistry.Default, BlockWriter.DefaultFlushThresholdBytes, None));
+
+        // Empty block name, block info, num_columns = 1, num_rows = 0, then the column name, the type string and the
+        // has_custom_serialization byte — and nothing at all after it.
+        var expected = new List<byte> { 0x00, 0x01, 0x00, 0x02, 0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x01, 0x00, 0x01, (byte)'v', 0x16 };
+        expected.AddRange(Encoding.UTF8.GetBytes("LowCardinality(String)"));
+        expected.Add(0x00);
+
+        CollectionAssert.AreEqual(expected, bytes, "no Int64 version marker may follow the column header");
+
+        // Read it back with a sentinel appended: the block must consume its own bytes and not one more, so the
+        // sentinel has to survive intact. An over-reading reader would swallow it as a state prefix.
+        const ulong sentinel = 0xDEADBEEFCAFEF00DUL;
+        var framed = new List<byte>(bytes);
+        framed.AddRange(BitConverter.GetBytes(sentinel));
+
+        using var reader = new ClickHouseBinaryReader(new MemoryStream(framed.ToArray()));
+        using Block block = await BlockReader.ReadBlockAsync(reader, Negotiated, ColumnCodecRegistry.Default, default, None);
+        ulong trailing = await reader.ReadUInt64Async(None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(block.RowCount, Is.Zero);
+            Assert.That(block.ColumnCount, Is.EqualTo(1));
+            Assert.That(block[0].TypeName, Is.EqualTo("LowCardinality(String)"));
+            Assert.That(block[0].RowCount, Is.Zero);
+            Assert.That(trailing, Is.EqualTo(sentinel), "the reader consumed the block exactly, leaving the following bytes untouched");
         });
     }
 

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpConnectionQueryIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpConnectionQueryIntegrationTests.cs
@@ -212,6 +212,33 @@ public class ClickHouseTcpConnectionQueryIntegrationTests
     }
 
     [Test]
+    public async Task QueryAsync_EmptyResultOfDictionaryBearingType_ReadsTheZeroRowHeaderAndStaysReady()
+    {
+        // The empty-result case above uses a type with no serialization state. LowCardinality has some — a version
+        // marker that precedes the column body — which raises the question of whether the zero-row header block
+        // that opens every result set carries it. It does not: ClickHouse gates the whole of writeData, prefix
+        // included, on `if (rows)`. This is the server-agreement half of the invariant that BlockWriterTests pins
+        // between our own writer and reader, and it is the shape that would desync the stream if we read a prefix
+        // the server never sent — a failure that surfaces as a protocol error here rather than as wrong data.
+        await using var connection = await TcpServerFixture.ConnectAsync(None);
+
+        int blockCount = 0;
+        await foreach (Block block in connection.QueryAsync(
+            "SELECT CAST('x', 'LowCardinality(String)') AS v, CAST(NULL, 'LowCardinality(Nullable(String))') AS n WHERE 0",
+            cancellationToken: None))
+        {
+            _ = block;
+            blockCount++;
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(blockCount, Is.EqualTo(0), "the header block carries no rows, so nothing is yielded");
+            Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready), "reaching Ready proves the stream stayed in sync through end-of-stream");
+        });
+    }
+
+    [Test]
     public async Task QueryAsync_SessionTimezoneSetting_ResolvesTimezoneLessColumnAgainstSessionTimezone()
     {
         await using var connection = await TcpServerFixture.ConnectAsync(None);

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ColumnarReadSurfaceIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ColumnarReadSurfaceIntegrationTests.cs
@@ -4,16 +4,19 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using ClickHouse.Driver.Tcp.Format;
+using ClickHouse.Driver.Tcp.Protocol;
 using ClickHouse.Driver.Tcp.Types;
 
 namespace ClickHouse.Driver.Tcp.Tests.Integration;
 
 /// <summary>
-/// Covers the public columnar read surface of the composite column types against a real server. Every concrete
-/// column class is internal, so these interfaces — obtained by pattern-matching an <see cref="IColumn"/> — are the
-/// only way a consumer reaches the wire layout underneath a composite. These tests assert the shape a real decoded
-/// block presents: that the view is reachable at all, that its spans are sliced to the column's row count rather
-/// than to a pooled buffer's length, and that the raw columnar data it exposes agrees with the materialized rows.
+/// Covers the public columnar surface of the composite column types against a real server. Every concrete column
+/// class is internal, so these interfaces — obtained by pattern-matching an <see cref="IColumn"/> — are the only way
+/// a consumer reaches the wire layout underneath a composite. These tests assert the shape a real decoded block
+/// presents: that the view is reachable at all, that its spans are sliced to the column's row count rather than to a
+/// pooled buffer's length, and that the raw columnar data it exposes agrees with the materialized rows. Where the
+/// same data doubles as a zero-copy <em>write</em> source, the invariant deciding whether it may be re-emitted
+/// verbatim is pinned here too, alongside the layout rules it depends on.
 ///
 /// <para>
 /// A yielded <see cref="Block"/> is borrowed — valid only for its iteration — so every test reads or copies what it
@@ -461,5 +464,155 @@ public class ColumnarReadSurfaceIntegrationTests
             Assert.That(byNameMatchesByIndex, Is.True, "name lookup resolves to the same column as the index");
             Assert.That(recordsOfLastRow, Is.EqualTo(new[] { ((byte)0, "f0"), ((byte)1, "f1") }));
         });
+    }
+
+    [Test]
+    public async Task QueryAsync_LowCardinalityColumn_ExposesDictionaryAndKeysThroughILowCardinalityColumn()
+    {
+        // LowCardinality is the type with the widest gap between the two surfaces: the materialized one resolves
+        // every row to its dictionary entry, so N rows over a K-entry dictionary produce N values. Reading the
+        // dictionary and keys instead means touching each distinct value once — the whole reason the encoding exists.
+        // Here 12 rows collapse onto 3 distinct values.
+        await using var connection = await TcpServerFixture.ConnectAsync(None);
+
+        bool matched = false;
+        int rowCount = 0;
+        int keyCount = 0;
+        int dictionarySize = 0;
+        string[] dictionary = null;
+        string[] materialized = null;
+        var resolvedThroughKeys = new List<string>();
+
+        await foreach (Block block in connection.QueryAsync(
+            "SELECT CAST(concat('v', toString(number % 3)), 'LowCardinality(String)') FROM system.numbers LIMIT 12",
+            cancellationToken: None))
+        {
+            IColumn column = block[0];
+            matched = column is ILowCardinalityColumn<string>;
+
+            var lc = (ILowCardinalityColumn<string>)column;
+            rowCount = lc.RowCount;
+            keyCount = lc.Keys.Length;
+            dictionarySize = lc.Dictionary.RowCount;
+            dictionary = lc.Dictionary.Values.ToArray();
+            materialized = ((IColumn<string>)column).Values.ToArray();
+
+            for (int row = 0; row < lc.RowCount; row++)
+            {
+                resolvedThroughKeys.Add(lc.Dictionary[lc.Keys[row]]);
+            }
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(matched, Is.True);
+            Assert.That(rowCount, Is.EqualTo(12));
+            Assert.That(keyCount, Is.EqualTo(rowCount), "one key per row, sliced to the row count rather than the pooled buffer length");
+            Assert.That(dictionarySize, Is.EqualTo(4), "three distinct values plus the reserved default slot at [0]");
+            Assert.That(dictionary[0], Is.Empty, "a non-nullable inner reserves exactly one slot, holding the type default");
+            Assert.That(dictionary.Skip(1), Is.EquivalentTo(new[] { "v0", "v1", "v2" }));
+            Assert.That(resolvedThroughKeys, Is.EqualTo(materialized), "Dictionary[Keys[i]] reproduces the materialized rows");
+        });
+    }
+
+    [Test]
+    public async Task QueryAsync_LowCardinalityNullableColumn_ReservesTwoDictionarySlotsAndMarksNullWithKeyZero()
+    {
+        // LowCardinality(Nullable(T)) decodes to a different column class whose dictionary reserves *two* leading
+        // slots — [0] NULL, [1] the default — so real values start at [2] and a key of 0 means NULL. That shift is
+        // the one thing a consumer reading Keys directly has to know, and it is invisible from the materialized
+        // surface. Note the view is still spelled with the bare inner type, matching the non-nullable case.
+        await using var connection = await TcpServerFixture.ConnectAsync(None);
+
+        bool matched = false;
+        int dictionarySize = 0;
+        int[] keys = null;
+        string[] dictionary = null;
+        string[] materialized = null;
+
+        await foreach (Block block in connection.QueryAsync(
+            """
+            SELECT CAST(number = 1 ? NULL : concat('v', toString(number % 2)), 'LowCardinality(Nullable(String))')
+            FROM system.numbers LIMIT 4
+            """,
+            cancellationToken: None))
+        {
+            IColumn column = block[0];
+            matched = column is ILowCardinalityColumn<string>;
+
+            var lc = (ILowCardinalityColumn<string>)column;
+            dictionarySize = lc.Dictionary.RowCount;
+            keys = lc.Keys.ToArray();
+            dictionary = lc.Dictionary.Values.ToArray();
+            materialized = ((IColumn<string>)column).Values.ToArray();
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(matched, Is.True, "spelled with the bare inner type, as for the non-nullable column");
+            Assert.That(materialized, Is.EqualTo(new[] { "v0", null, "v0", "v1" }));
+            Assert.That(dictionarySize, Is.EqualTo(4), "two reserved slots plus the two distinct values");
+            Assert.That(keys[1], Is.Zero, "the null row's key is 0 — the reserved NULL slot");
+            Assert.That(keys.Where((_, i) => i != 1), Is.All.GreaterThanOrEqualTo(2), "real values start at slot 2, past NULL and the default");
+            Assert.That(dictionary.Skip(2), Is.EquivalentTo(new[] { "v0", "v1" }));
+        });
+    }
+
+    [Test]
+    public async Task InsertAsync_NonNullableLowCardinalityColumnIntoNullableTarget_RebuildsRatherThanReemitting()
+    {
+        // The reserved-slot difference the two tests above describe is not just a reading hazard: it decides whether
+        // a decoded column may be written back verbatim. Both low-cardinality shapes expose the dictionary/keys pair
+        // through ILowCardinalityColumn<T>, but only the nullable ones additionally claim IDenseLowCardinality<T> —
+        // the internal marker meaning "a nullable codec may re-emit this pair as-is". The non-nullable column must
+        // not claim it, because its dictionary reserves one leading slot where a nullable dictionary reserves two, so
+        // a verbatim re-emit shifts every key by one and makes the reader decode slot 0 as NULL.
+        //
+        // Conflating the two interfaces corrupts data silently, and nothing else covers it, so it is pinned here
+        // rather than in the insert fixture — this is where the slot semantics are documented.
+        await using var connection = await TcpServerFixture.ConnectAsync(None);
+        string table = $"tcp_lc_dense_exclusion_{Guid.NewGuid():N}";
+        try
+        {
+            await ExecuteAsync(connection, $"CREATE TABLE {table} (value LowCardinality(Nullable(String))) ENGINE = Memory");
+
+            // Row 0's key is 0 deliberately. To a non-nullable dictionary slot 0 is the type default — an ordinary
+            // value for a row to reference — while to a nullable dictionary it is the NULL marker. A row keyed at 0
+            // is therefore the only row that can distinguish the two paths: rows keyed above the reserve survive a
+            // verbatim re-emit unharmed, so a case without a slot-0 row passes whether or not the bug is present.
+            var dictionary = new ArrayColumn<string>("value", "String", new[] { string.Empty, "alpha", "beta" });
+            using var nonNullableDense = new LowCardinalityColumn<string>(
+                "value",
+                "LowCardinality(String)",
+                dictionary,
+                new[] { 0, 1, 2, 1 },
+                rowCount: 4,
+                pooledKeys: false);
+
+            Assert.That(nonNullableDense, Is.Not.InstanceOf<IDenseLowCardinality<string>>(), "the non-nullable column must not claim dense write eligibility");
+            Assert.That(nonNullableDense, Is.InstanceOf<ILowCardinalityColumn<string>>(), "though it still exposes the pair for reading");
+
+            await connection.InsertAsync($"INSERT INTO {table} (value) VALUES", new IColumn[] { nonNullableDense }, cancellationToken: None);
+
+            var readBack = new List<string>();
+            await foreach (Block block in connection.QueryAsync($"SELECT value FROM {table}", cancellationToken: None))
+            {
+                readBack.AddRange(((IColumn<string>)block[0]).Values.ToArray());
+            }
+
+            Assert.That(readBack, Is.EqualTo(new[] { string.Empty, "alpha", "beta", "alpha" }), "the slot-0 row stays the empty string rather than turning into NULL");
+        }
+        finally
+        {
+            await ExecuteAsync(connection, $"DROP TABLE IF EXISTS {table}");
+        }
+    }
+
+    private static async Task ExecuteAsync(ClickHouseTcpConnection connection, string sql)
+    {
+        await foreach (Block block in connection.QueryAsync(sql, cancellationToken: None))
+        {
+            _ = block;
+        }
     }
 }

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ColumnarReadSurfaceIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ColumnarReadSurfaceIntegrationTests.cs
@@ -479,6 +479,7 @@ public class ColumnarReadSurfaceIntegrationTests
         int rowCount = 0;
         int keyCount = 0;
         int dictionarySize = 0;
+        int reservedSlots = 0;
         string[] dictionary = null;
         string[] materialized = null;
         var resolvedThroughKeys = new List<string>();
@@ -494,6 +495,7 @@ public class ColumnarReadSurfaceIntegrationTests
             rowCount = lc.RowCount;
             keyCount = lc.Keys.Length;
             dictionarySize = lc.Dictionary.RowCount;
+            reservedSlots = lc.ReservedSlotCount;
             dictionary = lc.Dictionary.Values.ToArray();
             materialized = ((IColumn<string>)column).Values.ToArray();
 
@@ -509,7 +511,8 @@ public class ColumnarReadSurfaceIntegrationTests
             Assert.That(rowCount, Is.EqualTo(12));
             Assert.That(keyCount, Is.EqualTo(rowCount), "one key per row, sliced to the row count rather than the pooled buffer length");
             Assert.That(dictionarySize, Is.EqualTo(4), "three distinct values plus the reserved default slot at [0]");
-            Assert.That(dictionary[0], Is.Empty, "a non-nullable inner reserves exactly one slot, holding the type default");
+            Assert.That(reservedSlots, Is.EqualTo(1), "a non-nullable inner reserves exactly one slot, so key 0 is a value and not NULL");
+            Assert.That(dictionary[0], Is.Empty, "and that slot holds the type default");
             Assert.That(dictionary.Skip(1), Is.EquivalentTo(new[] { "v0", "v1", "v2" }));
             Assert.That(resolvedThroughKeys, Is.EqualTo(materialized), "Dictionary[Keys[i]] reproduces the materialized rows");
         });
@@ -526,9 +529,11 @@ public class ColumnarReadSurfaceIntegrationTests
 
         bool matched = false;
         int dictionarySize = 0;
+        int reservedSlots = 0;
         int[] keys = null;
         string[] dictionary = null;
         string[] materialized = null;
+        var nullRowsFromKeys = new List<int>();
 
         await foreach (Block block in connection.QueryAsync(
             """
@@ -542,19 +547,32 @@ public class ColumnarReadSurfaceIntegrationTests
 
             var lc = (ILowCardinalityColumn<string>)column;
             dictionarySize = lc.Dictionary.RowCount;
+            reservedSlots = lc.ReservedSlotCount;
             keys = lc.Keys.ToArray();
             dictionary = lc.Dictionary.Values.ToArray();
             materialized = ((IColumn<string>)column).Values.ToArray();
+
+            // Identify the null rows from the keys alone, the way a consumer should: ReservedSlotCount says whether
+            // slot 0 is a NULL marker, so nothing here parses the type string.
+            for (int row = 0; row < lc.RowCount; row++)
+            {
+                if (lc.ReservedSlotCount == 2 && lc.Keys[row] == 0)
+                {
+                    nullRowsFromKeys.Add(row);
+                }
+            }
         }
 
         Assert.Multiple(() =>
         {
             Assert.That(matched, Is.True, "spelled with the bare inner type, as for the non-nullable column");
             Assert.That(materialized, Is.EqualTo(new[] { "v0", null, "v0", "v1" }));
+            Assert.That(reservedSlots, Is.EqualTo(2), "a nullable inner reserves two slots — this is what makes key 0 mean NULL");
             Assert.That(dictionarySize, Is.EqualTo(4), "two reserved slots plus the two distinct values");
             Assert.That(keys[1], Is.Zero, "the null row's key is 0 — the reserved NULL slot");
-            Assert.That(keys.Where((_, i) => i != 1), Is.All.GreaterThanOrEqualTo(2), "real values start at slot 2, past NULL and the default");
-            Assert.That(dictionary.Skip(2), Is.EquivalentTo(new[] { "v0", "v1" }));
+            Assert.That(keys.Where((_, i) => i != 1), Is.All.GreaterThanOrEqualTo(reservedSlots), "real values start past the reserve");
+            Assert.That(dictionary.Skip(reservedSlots), Is.EquivalentTo(new[] { "v0", "v1" }));
+            Assert.That(nullRowsFromKeys, Is.EqualTo(new[] { 1 }), "the keys alone identify the null rows, with no type-string parsing");
         });
     }
 

--- a/ClickHouse.Driver.Tcp.Tests/Types/ColumnCodecRegistryTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/ColumnCodecRegistryTests.cs
@@ -34,7 +34,7 @@ public class ColumnCodecRegistryTests
 
     [Test]
     public void Resolve_UnsupportedButWellFormedType_ThrowsNotSupported()
-        => Assert.Throws<NotSupportedException>(() => ColumnCodecRegistry.Default.Resolve("LowCardinality(String)", default));
+        => Assert.Throws<NotSupportedException>(() => ColumnCodecRegistry.Default.Resolve("Variant(UInt8, String)", default));
 
     [Test]
     public void Resolve_MalformedType_ThrowsFormat()

--- a/ClickHouse.Driver.Tcp.Tests/Types/LowCardinalityColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/LowCardinalityColumnCodecTests.cs
@@ -20,7 +20,7 @@ public class LowCardinalityColumnCodecTests
 
         byte[] bytes = await CodecTestHarness.WriteAsync(w =>
         {
-            codec.WriteStatePrefix(w);
+            codec.WriteStatePrefix(w, column);
             codec.WriteColumn(w, column);
         });
 
@@ -127,7 +127,8 @@ public class LowCardinalityColumnCodecTests
     public async Task WriteThenReadStatePrefix_RoundTripsTheVersionMarker()
     {
         IColumnCodec codec = Resolve("LowCardinality(String)");
-        byte[] bytes = await CodecTestHarness.WriteAsync(w => codec.WriteStatePrefix(w));
+        var column = new ArrayColumn<string>("c", "LowCardinality(String)", new[] { "a" });
+        byte[] bytes = await CodecTestHarness.WriteAsync(w => codec.WriteStatePrefix(w, column));
 
         Assert.That(bytes, Is.EqualTo(new byte[] { 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }));
 
@@ -327,17 +328,6 @@ public class LowCardinalityColumnCodecTests
     }
 
     [Test]
-    public void MeasureRowBytes_DenseColumn_PricesKeyPlusInnerValue()
-    {
-        IColumnCodec codec = Resolve("LowCardinality(String)");
-        using var dictionary = new ArrayColumn<string>("c", "String", new[] { string.Empty, "abc" });
-        using var dense = new LowCardinalityColumn<string>("c", "LowCardinality(String)", dictionary, new[] { 1 }, rowCount: 1, pooledKeys: false);
-
-        // 8 bytes for the widest key, plus the inner String's encoding of "abc" (1-byte length prefix + 3 bytes).
-        Assert.That(codec.MeasureRowBytes(dense, 0), Is.EqualTo(8 + 1 + 3));
-    }
-
-    [Test]
     public void NullPlaceholder_NullableInner_IsNull()
         => Assert.That(Resolve("LowCardinality(Nullable(String))").NullPlaceholder, Is.Null);
 
@@ -430,16 +420,14 @@ public class LowCardinalityColumnCodecTests
     }
 
     [Test]
-    public async Task WriteColumn_NullableValueDenseColumn_RoundTripsAndMeasuresWithoutRebuilding()
+    public async Task WriteColumn_NullableValueDenseColumn_RoundTripsWithoutRebuilding()
     {
-        // The value-inner dense column (uint dictionary + keys, key 0 = NULL) is the zero-copy write source and is
-        // priced straight off the dictionary. dict [0, 0, 7, 42], keys [2, 0, 3, 1] → [7, NULL, 42, 0].
+        // The value-inner dense column (uint dictionary + keys, key 0 = NULL) is the zero-copy write source.
+        // dict [0, 0, 7, 42], keys [2, 0, 3, 1] → [7, NULL, 42, 0].
         IColumnCodec codec = Resolve("LowCardinality(Nullable(UInt32))");
         using var dictionary = PrimitiveColumn<uint>.FromValues("c", "UInt32", new uint[] { 0, 0, 7, 42 });
         using var dense = new NullableLowCardinalityValueColumn<uint>(
             "c", "LowCardinality(Nullable(UInt32))", dictionary, new[] { 2, 0, 3, 1 }, rowCount: 4, pooledKeys: false);
-
-        Assert.That(codec.MeasureRowBytes(dense, 0), Is.EqualTo(8 + 4), "8-byte widest key plus the fixed UInt32 width");
 
         using IColumn read = await CodecTestHarness.RoundTripAsync(codec, dense, "LowCardinality(Nullable(UInt32))", dense.RowCount);
         Assert.That(((IColumn<uint?>)read).Values.ToArray(), Is.EqualTo(new uint?[] { 7, null, 42, 0 }));

--- a/ClickHouse.Driver.Tcp.Tests/Types/LowCardinalityColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/LowCardinalityColumnCodecTests.cs
@@ -1,0 +1,475 @@
+using System;
+using System.Buffers.Binary;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Protocol;
+using ClickHouse.Driver.Tcp.Tests.Utilities;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Tests.Types;
+
+[TestFixture]
+public class LowCardinalityColumnCodecTests
+{
+    private static IColumnCodec Resolve(string type) => ColumnCodecRegistry.Default.Resolve(type, default);
+
+    [Test]
+    public async Task WriteStatePrefixAndColumn_NonNullableString_ProducesTheDocumentedBytes()
+    {
+        IColumnCodec codec = Resolve("LowCardinality(String)");
+        var column = new ArrayColumn<string>("c", "LowCardinality(String)", new[] { "a", "b", "a", "c", "b" });
+
+        byte[] bytes = await CodecTestHarness.WriteAsync(w =>
+        {
+            codec.WriteStatePrefix(w);
+            codec.WriteColumn(w, column);
+        });
+
+        // dict[0] is the reserved empty-string default; 'a','b','c' take slots 1..3; keys index them.
+        byte[] expected =
+        {
+            0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // state prefix Int64 = 1
+            0x00, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // metadata UInt64 = 0x600 (key code 0)
+            0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // dict_size = 4
+            0x00,                                           // dict[0] = ""
+            0x01, (byte)'a',                                // dict[1] = "a"
+            0x01, (byte)'b',                                // dict[2] = "b"
+            0x01, (byte)'c',                                // dict[3] = "c"
+            0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // keys_count = 5
+            0x01, 0x02, 0x01, 0x03, 0x02,                   // keys (UInt8): 1, 2, 1, 3, 2
+        };
+
+        CollectionAssert.AreEqual(expected, bytes);
+    }
+
+    [Test]
+    public async Task ReadColumn_WriteThenRead_StringRoundTrips()
+    {
+        IColumnCodec codec = Resolve("LowCardinality(String)");
+        var expected = new[] { "a", "b", "a", "c", "b" };
+        var column = new ArrayColumn<string>("c", "LowCardinality(String)", expected);
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "LowCardinality(String)", column.RowCount);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(read.RowCount, Is.EqualTo(5));
+            Assert.That(((IColumn<string>)read).Values.ToArray(), Is.EqualTo(expected));
+        });
+    }
+
+    [Test]
+    public async Task ReadColumn_WriteThenRead_FixedWidthInnerRoundTrips()
+    {
+        IColumnCodec codec = Resolve("LowCardinality(UInt32)");
+        var expected = new uint[] { 7, 7, 42, 7, 42 };
+        var column = new ArrayColumn<uint>("c", "LowCardinality(UInt32)", expected);
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "LowCardinality(UInt32)", column.RowCount);
+
+        Assert.That(((IColumn<uint>)read).Values.ToArray(), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public async Task WriteColumn_ValueEqualToInnerDefault_ReusesTheReservedSlotZero()
+    {
+        // The reserved dict[0] holds the inner default (""), so an actual empty-string row maps to key 0 rather
+        // than adding a duplicate slot — and still round-trips as an empty string.
+        IColumnCodec codec = Resolve("LowCardinality(String)");
+        var expected = new[] { string.Empty, "a", string.Empty };
+        var column = new ArrayColumn<string>("c", "LowCardinality(String)", expected);
+
+        byte[] bytes = await CodecTestHarness.WriteAsync(w => codec.WriteColumn(w, column));
+
+        // metadata (8) + dict_size (8) + dict ["" , "a"] (1 + 2) + keys_count (8) + keys [0,1,0] (3) = 30 bytes.
+        Assert.That(BinaryPrimitives.ReadUInt64LittleEndian(bytes.AsSpan(8, 8)), Is.EqualTo(2UL), "dict has the default plus 'a'");
+
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(bytes);
+        using IColumn read = await codec.ReadColumnAsync(reader, "c", "LowCardinality(String)", 3, CodecTestHarness.None);
+        Assert.That(((IColumn<string>)read).Values.ToArray(), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public async Task WriteThenRead_DictionaryPast255Entries_PromotesToUInt16Keys()
+    {
+        IColumnCodec codec = Resolve("LowCardinality(String)");
+        var values = new string[300];
+        for (int i = 0; i < values.Length; i++)
+        {
+            values[i] = "v" + i; // 300 distinct values → dict_size 301 → 2-byte keys
+        }
+
+        var column = new ArrayColumn<string>("c", "LowCardinality(String)", values);
+        byte[] bytes = await CodecTestHarness.WriteAsync(w => codec.WriteColumn(w, column));
+
+        ulong metadata = BinaryPrimitives.ReadUInt64LittleEndian(bytes.AsSpan(0, 8));
+        Assert.That(metadata & 0xFF, Is.EqualTo(1UL), "301 dictionary entries need a 2-byte key");
+
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(bytes);
+        using IColumn read = await codec.ReadColumnAsync(reader, "c", "LowCardinality(String)", values.Length, CodecTestHarness.None);
+        Assert.That(((IColumn<string>)read).Values.ToArray(), Is.EqualTo(values));
+    }
+
+    [Test]
+    public async Task WriteColumn_EmptySlice_WritesNothing()
+    {
+        IColumnCodec codec = Resolve("LowCardinality(String)");
+        var column = new ArrayColumn<string>("c", "LowCardinality(String)", Array.Empty<string>());
+
+        byte[] bytes = await CodecTestHarness.WriteAsync(w => codec.WriteColumn(w, column, 0, 0));
+        Assert.That(bytes, Is.Empty, "a zero-length low-cardinality slice writes no body");
+
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(bytes);
+        using IColumn read = await codec.ReadColumnAsync(reader, "c", "LowCardinality(String)", 0, CodecTestHarness.None);
+        Assert.That(read.RowCount, Is.Zero);
+    }
+
+    [Test]
+    public async Task WriteThenReadStatePrefix_RoundTripsTheVersionMarker()
+    {
+        IColumnCodec codec = Resolve("LowCardinality(String)");
+        byte[] bytes = await CodecTestHarness.WriteAsync(w => codec.WriteStatePrefix(w));
+
+        Assert.That(bytes, Is.EqualTo(new byte[] { 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }));
+
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(bytes);
+        Assert.DoesNotThrowAsync(async () => await codec.ReadStatePrefixAsync(reader, CodecTestHarness.None));
+    }
+
+    [Test]
+    public void ReadStatePrefix_UnknownVersion_Throws()
+    {
+        IColumnCodec codec = Resolve("LowCardinality(String)");
+        byte[] bytes = { 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }; // version 2
+
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(bytes);
+        Assert.ThrowsAsync<ClickHouseProtocolException>(async () => await codec.ReadStatePrefixAsync(reader, CodecTestHarness.None));
+    }
+
+    [Test]
+    public void ReadColumn_GlobalDictionaryBitSet_Throws()
+    {
+        IColumnCodec codec = Resolve("LowCardinality(String)");
+        byte[] metadata = new byte[8];
+        BinaryPrimitives.WriteUInt64LittleEndian(metadata, 0x600 | (1UL << 8)); // NeedGlobalDictionaryBit
+
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(metadata);
+        Assert.ThrowsAsync<ClickHouseProtocolException>(async () => await codec.ReadColumnAsync(reader, "c", "LowCardinality(String)", 1, CodecTestHarness.None));
+    }
+
+    [Test]
+    public void ReadColumn_AdditionalKeysBitMissing_Throws()
+    {
+        IColumnCodec codec = Resolve("LowCardinality(String)");
+        byte[] metadata = new byte[8];
+        BinaryPrimitives.WriteUInt64LittleEndian(metadata, 1UL << 10); // NeedUpdateDictionary only, no HasAdditionalKeys
+
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(metadata);
+        Assert.ThrowsAsync<ClickHouseProtocolException>(async () => await codec.ReadColumnAsync(reader, "c", "LowCardinality(String)", 1, CodecTestHarness.None));
+    }
+
+    [Test]
+    public void ReadColumn_UnknownKeyWidthCode_Throws()
+    {
+        IColumnCodec codec = Resolve("LowCardinality(String)");
+        byte[] metadata = new byte[8];
+        BinaryPrimitives.WriteUInt64LittleEndian(metadata, 0x600 | 4); // key code 4 is undefined
+
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(metadata);
+        Assert.ThrowsAsync<ClickHouseProtocolException>(async () => await codec.ReadColumnAsync(reader, "c", "LowCardinality(String)", 1, CodecTestHarness.None));
+    }
+
+    [Test]
+    public async Task ReadColumn_KeysCountDisagreesWithBlock_Throws()
+    {
+        IColumnCodec codec = Resolve("LowCardinality(String)");
+        var column = new ArrayColumn<string>("c", "LowCardinality(String)", new[] { "a", "b" });
+        byte[] bytes = await CodecTestHarness.WriteAsync(w => codec.WriteColumn(w, column)); // keys_count = 2
+
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(bytes);
+        Assert.ThrowsAsync<ClickHouseProtocolException>(async () => await codec.ReadColumnAsync(reader, "c", "LowCardinality(String)", 3, CodecTestHarness.None));
+    }
+
+    [Test]
+    public async Task ReadColumn_KeyOutsideDictionary_Throws()
+    {
+        IColumnCodec codec = Resolve("LowCardinality(String)");
+        // metadata 0x600 (code 0), dict_size 2, dict ["", "a"], keys_count 1, key = 5 (out of range).
+        byte[] bytes = await CodecTestHarness.WriteAsync(w =>
+        {
+            w.WriteUInt64(0x600);
+            w.WriteUInt64(2);
+            w.WriteString(string.Empty);
+            w.WriteString("a");
+            w.WriteUInt64(1);
+            w.WriteUInt8(5);
+        });
+
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(bytes);
+        Assert.ThrowsAsync<ClickHouseProtocolException>(async () => await codec.ReadColumnAsync(reader, "c", "LowCardinality(String)", 1, CodecTestHarness.None));
+    }
+
+    [Test]
+    public async Task WriteColumn_DenseLowCardinalityColumn_RoundTripsWithoutRebuilding()
+    {
+        IColumnCodec codec = Resolve("LowCardinality(String)");
+        using var dictionary = new ArrayColumn<string>("c", "String", new[] { string.Empty, "x", "y" });
+        using var dense = new LowCardinalityColumn<string>("c", "LowCardinality(String)", dictionary, new[] { 1, 2, 1 }, rowCount: 3, pooledKeys: false);
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, dense, "LowCardinality(String)", dense.RowCount);
+
+        Assert.That(((IColumn<string>)read).Values.ToArray(), Is.EqualTo(new[] { "x", "y", "x" }));
+    }
+
+    [Test]
+    public void CanWrite_AcceptsInnerElementTypeOnly()
+    {
+        IColumnCodec codec = Resolve("LowCardinality(String)");
+        Assert.Multiple(() =>
+        {
+            Assert.That(codec.CanWrite(new ArrayColumn<string>("c", "LowCardinality(String)", Array.Empty<string>())), Is.True);
+            Assert.That(codec.CanWrite(new ArrayColumn<int>("c", "LowCardinality(String)", Array.Empty<int>())), Is.False);
+        });
+    }
+
+    [TestCase("LowCardinality(UInt8, String)")]
+    [TestCase("LowCardinality()")]
+    [TestCase("LowCardinality(Nullable(Nullable(String)))")]
+    public void Create_WrongArgumentCount_ThrowsFormat(string type)
+        => Assert.Throws<FormatException>(() => Resolve(type));
+
+    [Test]
+    public void Create_NullableInner_ResolvesToNullableSurfaceType()
+        => Assert.Multiple(() =>
+        {
+            Assert.That(Resolve("LowCardinality(Nullable(String))").ElementType, Is.EqualTo(typeof(string)));
+            Assert.That(Resolve("LowCardinality(Nullable(UInt32))").ElementType, Is.EqualTo(typeof(uint?)));
+        });
+
+    [Test]
+    public void NullPlaceholder_DelegatesToInner()
+        => Assert.That(Resolve("LowCardinality(String)").NullPlaceholder, Is.EqualTo(string.Empty));
+
+    [Test]
+    public async Task WriteThenRead_DictionaryPast65534Entries_PromotesToUInt32Keys()
+    {
+        IColumnCodec codec = Resolve("LowCardinality(String)");
+        var values = new string[65_600]; // > ushort.MaxValue distinct values → dict_size forces 4-byte keys
+        for (int i = 0; i < values.Length; i++)
+        {
+            values[i] = "v" + i;
+        }
+
+        var column = new ArrayColumn<string>("c", "LowCardinality(String)", values);
+        byte[] bytes = await CodecTestHarness.WriteAsync(w => codec.WriteColumn(w, column));
+
+        Assert.That(BinaryPrimitives.ReadUInt64LittleEndian(bytes.AsSpan(0, 8)) & 0xFF, Is.EqualTo(2UL), "more than 65534 entries need a 4-byte key");
+
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(bytes);
+        using IColumn read = await codec.ReadColumnAsync(reader, "c", "LowCardinality(String)", values.Length, CodecTestHarness.None);
+        Assert.That(((IColumn<string>)read).Values.ToArray(), Is.EqualTo(values));
+    }
+
+    [Test]
+    public async Task ReadColumn_UInt64Keys_Decodes()
+    {
+        // A crafted stream with key-width code 3 (8-byte keys); the writer never selects this width, but a decoder
+        // must handle it. dict ["", "a", "b"], keys [2, 1] → ["b", "a"].
+        IColumnCodec codec = Resolve("LowCardinality(String)");
+        byte[] bytes = await CodecTestHarness.WriteAsync(w =>
+        {
+            w.WriteUInt64(0x600 | 3);
+            w.WriteUInt64(3);
+            w.WriteString(string.Empty);
+            w.WriteString("a");
+            w.WriteString("b");
+            w.WriteUInt64(2);
+            w.WriteUInt64(2);
+            w.WriteUInt64(1);
+        });
+
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(bytes);
+        using IColumn read = await codec.ReadColumnAsync(reader, "c", "LowCardinality(String)", 2, CodecTestHarness.None);
+        Assert.That(((IColumn<string>)read).Values.ToArray(), Is.EqualTo(new[] { "b", "a" }));
+    }
+
+    [Test]
+    public void ReadColumn_DictionarySizeExceedsInt32_Throws()
+    {
+        IColumnCodec codec = Resolve("LowCardinality(String)");
+        byte[] bytes = new byte[16];
+        BinaryPrimitives.WriteUInt64LittleEndian(bytes.AsSpan(0, 8), 0x600); // valid metadata
+        BinaryPrimitives.WriteUInt64LittleEndian(bytes.AsSpan(8, 8), (ulong)int.MaxValue + 1); // dict_size overflows int
+
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(bytes);
+        Assert.ThrowsAsync<ClickHouseProtocolException>(async () => await codec.ReadColumnAsync(reader, "c", "LowCardinality(String)", 1, CodecTestHarness.None));
+    }
+
+    [Test]
+    public async Task WriteColumn_FixedStringWithEqualValues_DeduplicatesByContent()
+    {
+        // byte[] defaults to reference equality; the codec must use structural equality so two distinct-but-equal
+        // FixedString values collapse to one dictionary slot (dict = ["", {1,2,3,4}] → dict_size 2), not two.
+        IColumnCodec codec = Resolve("LowCardinality(FixedString(4))");
+        var column = new ArrayColumn<byte[]>("c", "LowCardinality(FixedString(4))", new[]
+        {
+            new byte[] { 1, 2, 3, 4 },
+            new byte[] { 1, 2, 3, 4 },
+            new byte[] { 9, 9, 9, 9 },
+        });
+
+        byte[] bytes = await CodecTestHarness.WriteAsync(w => codec.WriteColumn(w, column));
+
+        Assert.That(BinaryPrimitives.ReadUInt64LittleEndian(bytes.AsSpan(8, 8)), Is.EqualTo(3UL), "the two equal values share one slot: default + {1,2,3,4} + {9,9,9,9}");
+
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(bytes);
+        using IColumn read = await codec.ReadColumnAsync(reader, "c", "LowCardinality(FixedString(4))", 3, CodecTestHarness.None);
+        Assert.That(((IColumn<byte[]>)read).Values.ToArray(), Is.EqualTo(new[] { new byte[] { 1, 2, 3, 4 }, new byte[] { 1, 2, 3, 4 }, new byte[] { 9, 9, 9, 9 } }));
+    }
+
+    [Test]
+    public void MeasureRowBytes_DenseColumn_PricesKeyPlusInnerValue()
+    {
+        IColumnCodec codec = Resolve("LowCardinality(String)");
+        using var dictionary = new ArrayColumn<string>("c", "String", new[] { string.Empty, "abc" });
+        using var dense = new LowCardinalityColumn<string>("c", "LowCardinality(String)", dictionary, new[] { 1 }, rowCount: 1, pooledKeys: false);
+
+        // 8 bytes for the widest key, plus the inner String's encoding of "abc" (1-byte length prefix + 3 bytes).
+        Assert.That(codec.MeasureRowBytes(dense, 0), Is.EqualTo(8 + 1 + 3));
+    }
+
+    [Test]
+    public void NullPlaceholder_NullableInner_IsNull()
+        => Assert.That(Resolve("LowCardinality(Nullable(String))").NullPlaceholder, Is.Null);
+
+    [Test]
+    public async Task WriteColumn_NullableString_ProducesTheDocumentedBytes()
+    {
+        // The dictionary is written as bare String (no null-map); two slots are reserved — dict[0] the NULL marker,
+        // dict[1] the "" default — so a NULL row's key is 0 and a present "" reuses slot 1. Values ['a', NULL, '', 'b'].
+        IColumnCodec codec = Resolve("LowCardinality(Nullable(String))");
+        var column = new ArrayColumn<string>("c", "LowCardinality(Nullable(String))", new[] { "a", null, string.Empty, "b" });
+
+        byte[] bytes = await CodecTestHarness.WriteAsync(w => codec.WriteColumn(w, column));
+
+        byte[] expected =
+        {
+            0x00, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // metadata UInt64 = 0x600 (key code 0)
+            0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // dict_size = 4
+            0x00,                                           // dict[0] = "" → NULL marker
+            0x00,                                           // dict[1] = "" → inner default
+            0x01, (byte)'a',                                // dict[2] = "a"
+            0x01, (byte)'b',                                // dict[3] = "b"
+            0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // keys_count = 4
+            0x02, 0x00, 0x01, 0x03,                         // keys (UInt8): 2, 0, 1, 3
+        };
+
+        CollectionAssert.AreEqual(expected, bytes);
+    }
+
+    [Test]
+    public async Task ReadColumn_WriteThenRead_NullableStringRoundTrips()
+    {
+        // A present "" must read back as "" (present), not NULL — it points at the reserved default slot 1, not slot 0.
+        IColumnCodec codec = Resolve("LowCardinality(Nullable(String))");
+        var expected = new[] { "a", null, string.Empty, "b", "a", null };
+        var column = new ArrayColumn<string>("c", "LowCardinality(Nullable(String))", expected);
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "LowCardinality(Nullable(String))", column.RowCount);
+
+        Assert.That(((IColumn<string>)read).Values.ToArray(), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public async Task ReadColumn_WriteThenRead_NullableValueTypeRoundTrips()
+    {
+        // A value-type inner surfaces uint?; a present 0 (the inner default) round-trips as 0, distinct from NULL.
+        IColumnCodec codec = Resolve("LowCardinality(Nullable(UInt32))");
+        var expected = new uint?[] { 7, null, 0, 7, null, 42 };
+        var column = new ArrayColumn<uint?>("c", "LowCardinality(Nullable(UInt32))", expected);
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "LowCardinality(Nullable(UInt32))", column.RowCount);
+
+        Assert.That(((IColumn<uint?>)read).Values.ToArray(), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public async Task WriteThenRead_NullableFixedString_DeduplicatesByContentAndKeepsNulls()
+    {
+        IColumnCodec codec = Resolve("LowCardinality(Nullable(FixedString(4)))");
+        var expected = new[]
+        {
+            new byte[] { 1, 2, 3, 4 },
+            null,
+            new byte[] { 1, 2, 3, 4 },
+            new byte[] { 9, 9, 9, 9 },
+        };
+        var column = new ArrayColumn<byte[]>("c", "LowCardinality(Nullable(FixedString(4)))", expected);
+
+        byte[] bytes = await CodecTestHarness.WriteAsync(w => codec.WriteColumn(w, column));
+
+        // dict = [NULL, default(0000), {1,2,3,4}, {9,9,9,9}] → the two equal values collapse to one slot: dict_size 4.
+        Assert.That(BinaryPrimitives.ReadUInt64LittleEndian(bytes.AsSpan(8, 8)), Is.EqualTo(4UL));
+
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(bytes);
+        using IColumn read = await codec.ReadColumnAsync(reader, "c", "LowCardinality(Nullable(FixedString(4)))", expected.Length, CodecTestHarness.None);
+        Assert.That(((IColumn<byte[]>)read).Values.ToArray(), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public async Task WriteColumn_NullableDenseColumn_RoundTripsWithoutRebuilding()
+    {
+        // A dense nullable column (dictionary + keys, key 0 = NULL) is the wire's own layout and re-emits directly.
+        IColumnCodec codec = Resolve("LowCardinality(Nullable(String))");
+        using var dictionary = new ArrayColumn<string>("c", "String", new[] { string.Empty, string.Empty, "x", "y" });
+        using var dense = new NullableLowCardinalityReferenceColumn<string>(
+            "c", "LowCardinality(Nullable(String))", dictionary, new[] { 2, 0, 3, 1 }, rowCount: 4, pooledKeys: false);
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, dense, "LowCardinality(Nullable(String))", dense.RowCount);
+
+        Assert.That(((IColumn<string>)read).Values.ToArray(), Is.EqualTo(new[] { "x", null, "y", string.Empty }));
+    }
+
+    [Test]
+    public async Task WriteColumn_NullableValueDenseColumn_RoundTripsAndMeasuresWithoutRebuilding()
+    {
+        // The value-inner dense column (uint dictionary + keys, key 0 = NULL) is the zero-copy write source and is
+        // priced straight off the dictionary. dict [0, 0, 7, 42], keys [2, 0, 3, 1] → [7, NULL, 42, 0].
+        IColumnCodec codec = Resolve("LowCardinality(Nullable(UInt32))");
+        using var dictionary = PrimitiveColumn<uint>.FromValues("c", "UInt32", new uint[] { 0, 0, 7, 42 });
+        using var dense = new NullableLowCardinalityValueColumn<uint>(
+            "c", "LowCardinality(Nullable(UInt32))", dictionary, new[] { 2, 0, 3, 1 }, rowCount: 4, pooledKeys: false);
+
+        Assert.That(codec.MeasureRowBytes(dense, 0), Is.EqualTo(8 + 4), "8-byte widest key plus the fixed UInt32 width");
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, dense, "LowCardinality(Nullable(UInt32))", dense.RowCount);
+        Assert.That(((IColumn<uint?>)read).Values.ToArray(), Is.EqualTo(new uint?[] { 7, null, 42, 0 }));
+    }
+
+    [Test]
+    public async Task WriteColumn_NullableEmptySlice_WritesNothing()
+    {
+        IColumnCodec codec = Resolve("LowCardinality(Nullable(String))");
+        var column = new ArrayColumn<string>("c", "LowCardinality(Nullable(String))", Array.Empty<string>());
+
+        byte[] bytes = await CodecTestHarness.WriteAsync(w => codec.WriteColumn(w, column, 0, 0));
+        Assert.That(bytes, Is.Empty, "a zero-length low-cardinality slice writes no body");
+
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(bytes);
+        using IColumn read = await codec.ReadColumnAsync(reader, "c", "LowCardinality(Nullable(String))", 0, CodecTestHarness.None);
+        Assert.That(read.RowCount, Is.Zero);
+    }
+
+    [Test]
+    public void CanWrite_NullableInner_AcceptsNullableElementTypeOnly()
+    {
+        Assert.Multiple(() =>
+        {
+            IColumnCodec reference = Resolve("LowCardinality(Nullable(String))");
+            Assert.That(reference.CanWrite(new ArrayColumn<string>("c", "LowCardinality(Nullable(String))", Array.Empty<string>())), Is.True);
+
+            IColumnCodec value = Resolve("LowCardinality(Nullable(UInt32))");
+            Assert.That(value.CanWrite(new ArrayColumn<uint?>("c", "LowCardinality(Nullable(UInt32))", Array.Empty<uint?>())), Is.True);
+            Assert.That(value.CanWrite(new ArrayColumn<uint>("c", "LowCardinality(Nullable(UInt32))", Array.Empty<uint>())), Is.False, "the bare (non-nullable) element type is not accepted");
+        });
+    }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Types/LowCardinalityColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/LowCardinalityColumnCodecTests.cs
@@ -42,31 +42,31 @@ public class LowCardinalityColumnCodecTests
     }
 
     [Test]
-    public async Task ReadColumn_WriteThenRead_StringRoundTrips()
+    public async Task Values_MaterializesTheDictionaryBackedCacheAndAgreesWithGetValue()
     {
+        // Row values are covered against a real server by the LowCardinality cases in InsertRoundTripCase. What
+        // those cannot reach is this accessor: GetValue routes to the indexer, which short-circuits on
+        // `cache is not null ? cache[row] : dictionary[keys[row]]`, and AssertColumnsEqual only ever calls
+        // GetValue -- so the lazily materialized ArrayPool-rented Values cache runs nowhere else. Reading Values
+        // twice pins the cache reuse, and reading GetValue afterwards pins the cached and uncached paths against
+        // each other; each test previously picked one or the other and never compared them.
         IColumnCodec codec = Resolve("LowCardinality(String)");
         var expected = new[] { "a", "b", "a", "c", "b" };
         var column = new ArrayColumn<string>("c", "LowCardinality(String)", expected);
 
         using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "LowCardinality(String)", column.RowCount);
+        var typed = (IColumn<string>)read;
 
         Assert.Multiple(() =>
         {
             Assert.That(read.RowCount, Is.EqualTo(5));
-            Assert.That(((IColumn<string>)read).Values.ToArray(), Is.EqualTo(expected));
+            Assert.That(typed.Values.ToArray(), Is.EqualTo(expected), "first access materializes the cache");
+            Assert.That(typed.Values.ToArray(), Is.EqualTo(expected), "second access reuses it");
+            for (int row = 0; row < expected.Length; row++)
+            {
+                Assert.That(read.GetValue(row), Is.EqualTo(expected[row]), $"row {row} through the warm cache");
+            }
         });
-    }
-
-    [Test]
-    public async Task ReadColumn_WriteThenRead_FixedWidthInnerRoundTrips()
-    {
-        IColumnCodec codec = Resolve("LowCardinality(UInt32)");
-        var expected = new uint[] { 7, 7, 42, 7, 42 };
-        var column = new ArrayColumn<uint>("c", "LowCardinality(UInt32)", expected);
-
-        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "LowCardinality(UInt32)", column.RowCount);
-
-        Assert.That(((IColumn<uint>)read).Values.ToArray(), Is.EqualTo(expected));
     }
 
     [Test]
@@ -354,32 +354,6 @@ public class LowCardinalityColumnCodecTests
         };
 
         CollectionAssert.AreEqual(expected, bytes);
-    }
-
-    [Test]
-    public async Task ReadColumn_WriteThenRead_NullableStringRoundTrips()
-    {
-        // A present "" must read back as "" (present), not NULL — it points at the reserved default slot 1, not slot 0.
-        IColumnCodec codec = Resolve("LowCardinality(Nullable(String))");
-        var expected = new[] { "a", null, string.Empty, "b", "a", null };
-        var column = new ArrayColumn<string>("c", "LowCardinality(Nullable(String))", expected);
-
-        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "LowCardinality(Nullable(String))", column.RowCount);
-
-        Assert.That(((IColumn<string>)read).Values.ToArray(), Is.EqualTo(expected));
-    }
-
-    [Test]
-    public async Task ReadColumn_WriteThenRead_NullableValueTypeRoundTrips()
-    {
-        // A value-type inner surfaces uint?; a present 0 (the inner default) round-trips as 0, distinct from NULL.
-        IColumnCodec codec = Resolve("LowCardinality(Nullable(UInt32))");
-        var expected = new uint?[] { 7, null, 0, 7, null, 42 };
-        var column = new ArrayColumn<uint?>("c", "LowCardinality(Nullable(UInt32))", expected);
-
-        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "LowCardinality(Nullable(UInt32))", column.RowCount);
-
-        Assert.That(((IColumn<uint?>)read).Values.ToArray(), Is.EqualTo(expected));
     }
 
     [Test]

--- a/ClickHouse.Driver.Tcp.Tests/Types/LowCardinalityColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/LowCardinalityColumnCodecTests.cs
@@ -422,6 +422,44 @@ public class LowCardinalityColumnCodecTests
     }
 
     [Test]
+    public void Indexer_RowPastRowCount_ThrowsRatherThanReadingStaleKeys()
+    {
+        // The keys buffer is normally a pooled array longer than the column, and a stale key left in its tail by a
+        // previous read is a perfectly valid dictionary index — so reading a row past RowCount through the raw buffer
+        // returned a real value from the dictionary instead of failing. Here row 0 is the whole column; the trailing
+        // 2 is the stale tail. All three shapes keep their own copy of the indexer, hence all three here.
+        using var dictionary = new ArrayColumn<string>("c", "String", new[] { string.Empty, "x", "y" });
+        using var bare = new LowCardinalityColumn<string>("c", "LowCardinality(String)", dictionary, new[] { 1, 2 }, rowCount: 1, pooledKeys: false);
+        using var nullableReference = new NullableLowCardinalityReferenceColumn<string>(
+            "c", "LowCardinality(Nullable(String))", dictionary, new[] { 1, 2 }, rowCount: 1, pooledKeys: false);
+        using var valueDictionary = new ArrayColumn<uint>("c", "UInt32", new uint[] { 0, 7, 9 });
+        using var nullableValue = new NullableLowCardinalityValueColumn<uint>(
+            "c", "LowCardinality(Nullable(UInt32))", valueDictionary, new[] { 1, 2 }, rowCount: 1, pooledKeys: false);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(bare[0], Is.EqualTo("x"));
+            Assert.That(() => bare[1], Throws.InstanceOf<IndexOutOfRangeException>());
+            Assert.That(nullableReference[0], Is.EqualTo("x"));
+            Assert.That(() => nullableReference[1], Throws.InstanceOf<IndexOutOfRangeException>());
+            Assert.That(nullableValue[0], Is.EqualTo(7u));
+            Assert.That(() => nullableValue[1], Throws.InstanceOf<IndexOutOfRangeException>());
+        });
+    }
+
+    [Test]
+    public void Constructor_KeysShorterThanRowCount_Throws()
+    {
+        // rowCount is load-bearing here — the dictionary holds one entry per distinct value, and the keys are pooled
+        // — so it is validated rather than derived.
+        using var dictionary = new ArrayColumn<string>("c", "String", new[] { string.Empty, "x" });
+
+        Assert.That(
+            () => new LowCardinalityColumn<string>("c", "LowCardinality(String)", dictionary, new[] { 1 }, rowCount: 2, pooledKeys: false),
+            Throws.ArgumentException.With.Message.Contains("fewer than"));
+    }
+
+    [Test]
     public void CanWrite_NullableInner_AcceptsNullableElementTypeOnly()
     {
         Assert.Multiple(() =>

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
@@ -783,6 +783,63 @@ public sealed class InsertRoundTripCase
                     ownsFields: false);
             },
             NestedSettings);
+
+        // LowCardinality(T): the inner values are replaced by a block-local dictionary plus per-row keys. Values
+        // repeat (and include the inner default) so the dedup and the reserved slot-0 default are both exercised.
+        // Like Array/Tuple/Map/Nested, LowCardinality is an exception to the "wrap every type in Nullable" rule —
+        // the server rejects Nullable(LowCardinality(T)); nullability composes the other way as
+        // LowCardinality(Nullable(T)), which is a separate (not-yet-supported) feature. A numeric inner is
+        // "suspicious" and needs allow_suspicious_low_cardinality_types; String/FixedString are allowed by default.
+        yield return Same(
+            "LowCardinality(String)",
+            "LowCardinality(String)",
+            name => new ArrayColumn<string>(name, "LowCardinality(String)", new[] { "a", "b", "a", "c", "b", string.Empty }));
+
+        yield return Same(
+            "LowCardinality(UInt32)",
+            "LowCardinality(UInt32)",
+            name => PrimitiveColumn<uint>.FromValues(name, "LowCardinality(UInt32)", new uint[] { 7, 7, 42, 7, 42, 0 }),
+            LowCardinalitySettings);
+
+        yield return Same(
+            "LowCardinality(FixedString(4))",
+            "LowCardinality(FixedString(4))",
+            name => new ArrayColumn<byte[]>(name, "LowCardinality(FixedString(4))", new[]
+            {
+                new byte[] { 1, 2, 3, 4 },
+                new byte[] { 1, 2, 3, 4 },
+                new byte[] { 0xFF, 0, 0xFF, 0 },
+            }));
+
+        // Array(LowCardinality(String)) flattens its jagged rows into one values stream handed to the
+        // low-cardinality codec; empty rows and repeated values ride along.
+        yield return Arrays("LowCardinality(String)", new[] { "a", "b" }, Array.Empty<string>(), new[] { "a", "a", "c" });
+
+        // LowCardinality(Nullable(T)): nullability is expressed by a reserved dictionary slot (key 0 = NULL), not a
+        // null-map — the dictionary is still bare T. This is the nullable coverage for LowCardinality (the server
+        // rejects Nullable(LowCardinality(T))). A present value equal to the inner default (empty string, 0) rides
+        // alongside NULL to prove the two are distinct on the wire.
+        yield return Same(
+            "LowCardinality(Nullable(String))",
+            "LowCardinality(Nullable(String))",
+            name => new ArrayColumn<string>(name, "LowCardinality(Nullable(String))", new[] { "a", null, string.Empty, "b", "a", null }));
+
+        yield return Same(
+            "LowCardinality(Nullable(UInt32))",
+            "LowCardinality(Nullable(UInt32))",
+            name => new ArrayColumn<uint?>(name, "LowCardinality(Nullable(UInt32))", new uint?[] { 7, null, 0, 7, 42, null }),
+            LowCardinalitySettings);
+
+        yield return Same(
+            "LowCardinality(Nullable(FixedString(4)))",
+            "LowCardinality(Nullable(FixedString(4)))",
+            name => new ArrayColumn<byte[]>(name, "LowCardinality(Nullable(FixedString(4)))", new[]
+            {
+                new byte[] { 1, 2, 3, 4 },
+                null,
+                new byte[] { 1, 2, 3, 4 },
+                new byte[] { 0xFF, 0, 0xFF, 0 },
+            }));
     }
 
     // Map(K, V) inserts and reads back the ergonomic jagged column of KeyValuePair arrays, which doubles as expected.
@@ -973,5 +1030,11 @@ public sealed class InsertRoundTripCase
     private static readonly IReadOnlyDictionary<string, string> NestedSettings = new Dictionary<string, string>(StringComparer.Ordinal)
     {
         ["flatten_nested"] = "0",
+    };
+
+    /// <summary>Allows a <c>LowCardinality</c> over a numeric inner, which the server otherwise rejects as suspicious.</summary>
+    private static readonly IReadOnlyDictionary<string, string> LowCardinalitySettings = new Dictionary<string, string>(StringComparer.Ordinal)
+    {
+        ["allow_suspicious_low_cardinality_types"] = "1",
     };
 }

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
@@ -596,6 +596,16 @@ public sealed class InsertRoundTripCase
         yield return Maps<string, int[]>("String", "Array(Int32)", Pairs<string, int[]>(("a", new[] { 1, 2, 3 }), ("b", Array.Empty<int>())), Pairs<string, int[]>(("c", new[] { -1 })));
         yield return Maps<string, (int, string)>("String", "Tuple(Int32, String)", Pairs<string, (int, string)>(("a", (1, "x")), ("b", (-5, string.Empty))), Array.Empty<KeyValuePair<string, (int, string)>>());
 
+        // A value that carries its own state prefix: the map has to emit LowCardinality's dictionary prefix for the
+        // value stream, which none of the value composites above have (Nullable, Array and Tuple of leaves emit no
+        // prefix of their own). Repeated values across rows exercise one dictionary spanning the whole value run.
+        yield return Maps<string, string>(
+            "String",
+            "LowCardinality(String)",
+            Pairs<string, string>(("a", "x"), ("b", "y")),
+            Array.Empty<KeyValuePair<string, string>>(),
+            Pairs<string, string>(("c", "x"), ("d", string.Empty)));
+
         // Both key and value fixed-width: the cases above pair a variable key with a fixed value or the reverse,
         // never both fixed.
         yield return Maps<byte, byte>("UInt8", "UInt8", Pairs<byte, byte>((1, 10), (2, 20)), Array.Empty<KeyValuePair<byte, byte>>(), Pairs<byte, byte>((3, 30)));

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
@@ -815,6 +815,19 @@ public sealed class InsertRoundTripCase
         // low-cardinality codec; empty rows and repeated values ride along.
         yield return Arrays("LowCardinality(String)", new[] { "a", "b" }, Array.Empty<string>(), new[] { "a", "a", "c" });
 
+        // A dictionary past 255 entries forces the client to widen the key stream from UInt8 to UInt16
+        // (SelectKeyWidthCode switches on dictSize < byte.MaxValue). Unit tests assert the client picks that
+        // width; no case had more than three distinct values, so nothing proved the server accepts a
+        // client-written wide key stream.
+        yield return Same(
+            "LowCardinality(String) [wide keys]",
+            "LowCardinality(String)",
+            name => new ArrayColumn<string>(name, "LowCardinality(String)", Enumerable.Range(0, 300).Select(i => $"v{i}").ToArray()));
+
+        // Array(LowCardinality(Nullable(String))) puts the reserved key-0-is-NULL dictionary underneath the array
+        // offsets — exactly where a reserved-slot off-by-one would surface. Neither half-case reaches it.
+        yield return Arrays("LowCardinality(Nullable(String))", new[] { "a", null }, Array.Empty<string>(), new[] { "a", null, "c" });
+
         // LowCardinality(Nullable(T)): nullability is expressed by a reserved dictionary slot (key 0 = NULL), not a
         // null-map — the dictionary is still bare T. This is the nullable coverage for LowCardinality (the server
         // rejects Nullable(LowCardinality(T))). A present value equal to the inner default (empty string, 0) rides

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
@@ -788,7 +788,7 @@ public sealed class InsertRoundTripCase
         // repeat (and include the inner default) so the dedup and the reserved slot-0 default are both exercised.
         // Like Array/Tuple/Map/Nested, LowCardinality is an exception to the "wrap every type in Nullable" rule —
         // the server rejects Nullable(LowCardinality(T)); nullability composes the other way as
-        // LowCardinality(Nullable(T)), which is a separate (not-yet-supported) feature. A numeric inner is
+        // LowCardinality(Nullable(T)), covered by its own cases further below. A numeric inner is
         // "suspicious" and needs allow_suspicious_low_cardinality_types; String/FixedString are allowed by default.
         yield return Same(
             "LowCardinality(String)",

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
@@ -821,6 +821,21 @@ public sealed class InsertRoundTripCase
                 new byte[] { 0xFF, 0, 0xFF, 0 },
             }));
 
+        // A DateTime inner is the first low-cardinality case whose inner type is *parameterized*: its codec is
+        // built from the type node plus the resolve context (the session timezone), so this is what proves
+        // LowCardinality forwards that context to the inner factory rather than resolving the inner in isolation.
+        // It also puts a different column class under the dictionary — DateTimeColumn casts a byte buffer, where
+        // every inner above is a primitive or object array — since the dictionary is read as a normal inner column.
+        // Values are the raw epoch seconds the column surfaces (see the plain DateTime cases): at this point the
+        // shape is keyed on the inner codec's canonical ElementType, so the write source is IColumn<uint>, not the
+        // DateTime/DateTimeOffset convenience types the bare DateTime codec also accepts. The epoch (0) rides along
+        // as the inner default, so slot-0 folding is exercised on a type whose CLR default is *not* its wire zero.
+        yield return Same(
+            "LowCardinality(DateTime)",
+            "LowCardinality(DateTime)",
+            name => new ArrayColumn<uint>(name, "LowCardinality(DateTime)", new uint[] { 1_700_000_000, 1_700_000_000, 599_916_153, 0, 1_700_000_000, 599_916_153 }),
+            LowCardinalitySettings);
+
         // Array(LowCardinality(String)) flattens its jagged rows into one values stream handed to the
         // low-cardinality codec; empty rows and repeated values ride along.
         yield return Arrays("LowCardinality(String)", new[] { "a", "b" }, Array.Empty<string>(), new[] { "a", "a", "c" });
@@ -863,6 +878,17 @@ public sealed class InsertRoundTripCase
                 new byte[] { 1, 2, 3, 4 },
                 new byte[] { 0xFF, 0, 0xFF, 0 },
             }));
+
+        // The nullable counterpart of the DateTime case above, and the one that actually needs the codec's
+        // NullPlaceholderAs override: the reserved default in slot 1 is asked for as the shape's element type
+        // (uint), and DateTime answers with its wire zero — the epoch — where the CLR default would be
+        // DateTime.MinValue, which the type cannot even represent. The epoch is *also* present as a real value
+        // (row 2) next to NULLs, so the reserved NULL slot and the reserved default slot must stay distinct.
+        yield return Same(
+            "LowCardinality(Nullable(DateTime))",
+            "LowCardinality(Nullable(DateTime))",
+            name => new ArrayColumn<uint?>(name, "LowCardinality(Nullable(DateTime))", new uint?[] { 1_700_000_000, null, 0, 1_700_000_000, 599_916_153, null }),
+            LowCardinalitySettings);
     }
 
     // Map(K, V) inserts and reads back the ergonomic jagged column of KeyValuePair arrays, which doubles as expected.

--- a/ClickHouse.Driver.Tcp/Format/BlockReader.cs
+++ b/ClickHouse.Driver.Tcp/Format/BlockReader.cs
@@ -53,10 +53,9 @@ internal static class BlockReader
 
                 IColumnCodec codec = registry.Resolve(columnType, in context);
 
-                // A zero-row block (a schema header, or an end-of-input marker) carries no state prefix and no body.
-                // TODO: this holds for every type with default serialization, but dictionary-bearing types
-                // (e.g. LowCardinality) write a serialization-state prefix even when empty. When such types are
-                // added, the reader and writer must emit their prefix regardless of row count or the stream desyncs.
+                // A zero-row block (a schema header, or an end-of-input marker) carries no state prefix and no
+                // body — this holds for dictionary-bearing types too: LowCardinality emits its version prefix only
+                // for a block whose row count is greater than zero, matching the writer.
                 if (rowCount != 0)
                 {
                     await codec.ReadStatePrefixAsync(reader, cancellationToken).ConfigureAwait(false);

--- a/ClickHouse.Driver.Tcp/Format/BlockReader.cs
+++ b/ClickHouse.Driver.Tcp/Format/BlockReader.cs
@@ -53,9 +53,14 @@ internal static class BlockReader
 
                 IColumnCodec codec = registry.Resolve(columnType, in context);
 
-                // A zero-row block (a schema header, or an end-of-input marker) carries no state prefix and no
-                // body — this holds for dictionary-bearing types too: LowCardinality emits its version prefix only
-                // for a block whose row count is greater than zero, matching the writer.
+                // A zero-row block (a schema header, or an end-of-input marker) carries no state prefix and no body.
+                // This holds for dictionary-bearing types too, which is not obvious: a serialization-state prefix is
+                // per-column state rather than per-row data, so a zero-row LowCardinality column could plausibly
+                // still owe its version marker. It does not, because ClickHouse writes that prefix from inside
+                // NativeWriter's writeData — which it calls only `if (rows)` — and NativeReader skips readData for a
+                // zero-row block symmetrically. BlockWriter gates both phases the same way, so the two halves agree.
+                // BlockWriterTests pins the byte layout and ClickHouseTcpConnectionQueryIntegrationTests pins the
+                // server's half; reading a prefix here that was never written desyncs every column after it.
                 if (rowCount != 0)
                 {
                     await codec.ReadStatePrefixAsync(reader, cancellationToken).ConfigureAwait(false);

--- a/ClickHouse.Driver.Tcp/Types/Codecs/ILowCardinalityShape.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/ILowCardinalityShape.cs
@@ -1,0 +1,48 @@
+using System;
+using ClickHouse.Driver.Tcp.Protocol;
+
+namespace ClickHouse.Driver.Tcp.Types.Codecs;
+
+/// <summary>
+/// The generic bridge for one low-cardinality element type: it knows how to build the typed
+/// <see cref="LowCardinalityColumn{T}"/>, test a writable column, build the dictionary and keys on write, and
+/// price a row. One implementation covers every element type; the concrete instance is chosen once per element
+/// type and cached.
+///
+/// <para>
+/// This exists because the codec pipeline is non-generic — the registry parses a type string at runtime and
+/// hands codecs back through <see cref="IColumnCodec"/>, so the element type <c>T</c> arrives only as a
+/// <see cref="Type"/>. The T-independent machinery (the version prefix, the metadata word, the keys stream)
+/// stays in <see cref="LowCardinalityColumnCodec"/>; the thin slice that genuinely needs <c>T</c> — building the
+/// typed column, the write-side casts, deduplicating values into a dictionary — lives here.
+/// </para>
+/// </summary>
+internal interface ILowCardinalityShape
+{
+    /// <summary>
+    /// The CLR element type the decoded column surfaces — the inner element type for a non-nullable
+    /// <c>LowCardinality(T)</c>, or that type made nullable for <c>LowCardinality(Nullable(T))</c>.
+    /// </summary>
+    Type SurfaceElementType { get; }
+
+    /// <summary>Wraps a decoded dictionary column and its per-row keys into the typed low-cardinality column.</summary>
+    IColumn Wrap(string name, string typeName, IColumn dictionary, int[] keys, int rowCount, bool pooledKeys);
+
+    /// <summary>Whether <paramref name="column"/> is a column of this element type, writable by the codec.</summary>
+    bool CanWrite(IColumn column);
+
+    /// <summary>Whether the inner codec can write an inner-typed column at all (e.g. <c>Nothing</c> cannot).</summary>
+    bool CanInnerWrite(IColumnCodec inner);
+
+    /// <summary>
+    /// Writes the low-cardinality body for rows [<paramref name="start"/>, start + length): the metadata word,
+    /// the dictionary size, the dictionary values, the keys count, then the keys. A dense
+    /// <see cref="LowCardinalityColumn{T}"/> re-emits its dictionary and keys with no rebuild; an ergonomic
+    /// <c>IColumn&lt;T&gt;</c> is deduplicated into a fresh block-local dictionary. Writes nothing when
+    /// <paramref name="length"/> is zero (the empty body a composite emits under its own state prefix).
+    /// </summary>
+    void WriteBody(IColumnCodec inner, ClickHouseBinaryWriter writer, IColumn column, int start, int length);
+
+    /// <summary>An upper-bound encoded byte length of row <paramref name="row"/>: a max-width key plus its inner value.</summary>
+    long MeasureRow(IColumnCodec inner, IColumn column, int row);
+}

--- a/ClickHouse.Driver.Tcp/Types/Codecs/ILowCardinalityShape.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/ILowCardinalityShape.cs
@@ -42,7 +42,4 @@ internal interface ILowCardinalityShape
     /// <paramref name="length"/> is zero (the empty body a composite emits under its own state prefix).
     /// </summary>
     void WriteBody(IColumnCodec inner, ClickHouseBinaryWriter writer, IColumn column, int start, int length);
-
-    /// <summary>An upper-bound encoded byte length of row <paramref name="row"/>: a max-width key plus its inner value.</summary>
-    long MeasureRow(IColumnCodec inner, IColumn column, int row);
 }

--- a/ClickHouse.Driver.Tcp/Types/Codecs/ILowCardinalityShape.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/ILowCardinalityShape.cs
@@ -36,8 +36,9 @@ internal interface ILowCardinalityShape
 
     /// <summary>
     /// Writes the low-cardinality body for rows [<paramref name="start"/>, start + length): the metadata word,
-    /// the dictionary size, the dictionary values, the keys count, then the keys. A dense
-    /// <see cref="LowCardinalityColumn{T}"/> re-emits its dictionary and keys with no rebuild; an ergonomic
+    /// the dictionary size, the dictionary values, the keys count, then the keys. A dense low-cardinality column —
+    /// the non-nullable <see cref="LowCardinalityColumn{T}"/> or a nullable one implementing
+    /// <see cref="IDenseLowCardinality{T}"/> — re-emits its dictionary and keys with no rebuild; an ergonomic
     /// <c>IColumn&lt;T&gt;</c> is deduplicated into a fresh block-local dictionary. Writes nothing when
     /// <paramref name="length"/> is zero (the empty body a composite emits under its own state prefix).
     /// </summary>

--- a/ClickHouse.Driver.Tcp/Types/Codecs/LowCardinalityColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/LowCardinalityColumnCodec.cs
@@ -338,13 +338,12 @@ internal sealed class LowCardinalityColumnCodec : IColumnCodec
     }
 
     /// <inheritdoc/>
-    public long MeasureRowBytes(IColumn column, int row) => shape.MeasureRow(inner, column, row);
-
-    /// <inheritdoc/>
     public bool CanWrite(IColumn column) => innerCanWrite && shape.CanWrite(column);
 
     /// <inheritdoc/>
-    public void WriteStatePrefix(ClickHouseBinaryWriter writer) => writer.WriteInt64(LowCardinalityWire.StatePrefixVersion);
+    // The prefix is a fixed version marker, independent of the data; the column/slice is unused.
+    public void WriteStatePrefix(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
+        => writer.WriteInt64(LowCardinalityWire.StatePrefixVersion);
 
     /// <inheritdoc/>
     public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length)

--- a/ClickHouse.Driver.Tcp/Types/Codecs/LowCardinalityColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/LowCardinalityColumnCodec.cs
@@ -1,0 +1,352 @@
+using System;
+using System.Buffers;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Protocol;
+
+namespace ClickHouse.Driver.Tcp.Types.Codecs;
+
+/// <summary>
+/// The wire constants and per-key encoding shared by the low-cardinality codec (read side) and its shape (write
+/// side). A <c>LowCardinality</c> column replaces <c>N</c> inner values with a block-local dictionary of the
+/// distinct values plus <c>N</c> keys indexing into it; the key width is the smallest unsigned integer that can
+/// index the dictionary.
+/// </summary>
+internal static class LowCardinalityWire
+{
+    /// <summary>The single defined serialization-state version (<c>sharedDictionariesWithAdditionalKeys</c>).</summary>
+    public const long StatePrefixVersion = 1;
+
+    /// <summary>The low byte of the metadata word carries the key-width code.</summary>
+    public const ulong IndexTypeMask = 0xFF;
+
+    /// <summary>Key-width codes: the key is <c>1 &lt;&lt; code</c> bytes wide.</summary>
+    public const int KeyUInt8 = 0;
+    public const int KeyUInt16 = 1;
+    public const int KeyUInt32 = 2;
+    public const int KeyUInt64 = 3;
+
+    /// <summary>A single dictionary shared across blocks — never set in the Native format (on-disk MergeTree only).</summary>
+    public const ulong NeedGlobalDictionaryBit = 1UL << 8;
+
+    /// <summary>Set when the block carries its own dictionary keys — always set for a non-empty Native block.</summary>
+    public const ulong HasAdditionalKeysBit = 1UL << 9;
+
+    /// <summary>Set when the block carries a dictionary update — always set for a non-empty Native block.</summary>
+    public const ulong NeedUpdateDictionaryBit = 1UL << 10;
+
+    /// <summary>The metadata flag bits a self-contained per-block dictionary carries (<c>0x600</c>).</summary>
+    public const ulong NativeFlags = HasAdditionalKeysBit | NeedUpdateDictionaryBit;
+
+    /// <summary>
+    /// The key-width code to encode a dictionary of <paramref name="dictSize"/> entries with. The thresholds
+    /// mirror the reference client (clickhouse-go) rather than the theoretical minimum: a strict <c>&lt;</c>
+    /// against each type's max value, so a dictionary of exactly 255 entries already promotes to a 2-byte key
+    /// even though index 254 would fit a byte. A wider-than-strictly-necessary key at the boundary is harmless —
+    /// the server reads keys at the width the metadata declares — and matching the reference keeps the write
+    /// output byte-compatible with what other clients and the server itself produce.
+    /// </summary>
+    /// <param name="dictSize">The number of dictionary entries.</param>
+    /// <returns>The key-width code (0..3).</returns>
+    public static int SelectKeyWidthCode(int dictSize)
+    {
+        // A dictionary never exceeds int.MaxValue entries, so the 8-byte key is never selected here.
+        if (dictSize < byte.MaxValue)
+        {
+            return KeyUInt8;
+        }
+
+        if (dictSize < ushort.MaxValue)
+        {
+            return KeyUInt16;
+        }
+
+        return KeyUInt32;
+    }
+
+    /// <summary>The byte width of a key encoded with <paramref name="code"/>.</summary>
+    /// <param name="code">The key-width code (0..3).</param>
+    /// <returns>The width in bytes (1, 2, 4, or 8).</returns>
+    public static int KeyByteWidth(int code) => 1 << code;
+
+    /// <summary>Writes a single dictionary key at the width selected by <paramref name="code"/>.</summary>
+    /// <param name="writer">The writer to encode into.</param>
+    /// <param name="code">The key-width code (0..3).</param>
+    /// <param name="key">The dictionary index to write.</param>
+    public static void WriteKey(ClickHouseBinaryWriter writer, int code, int key)
+    {
+        switch (code)
+        {
+            case KeyUInt8:
+                writer.WriteUInt8((byte)key);
+                break;
+            case KeyUInt16:
+                writer.WriteUInt16((ushort)key);
+                break;
+            case KeyUInt32:
+                writer.WriteUInt32((uint)key);
+                break;
+            default:
+                writer.WriteUInt64((ulong)key);
+                break;
+        }
+    }
+}
+
+/// <summary>
+/// A codec for the ClickHouse <c>LowCardinality(T)</c> column. Its serialization-state prefix is a single fixed
+/// version marker (an <c>Int64</c> = 1), written once per non-empty block; the dictionary and keys live in the
+/// column body. The body is a metadata word (the key-width code plus the block-local dictionary flags), the
+/// dictionary size, the dictionary values encoded with the inner codec, the key count, and the keys themselves —
+/// each key <c>1 &lt;&lt; code</c> bytes indexing the dictionary. The decoded column surfaces each row as the
+/// inner CLR value (<c>dict[keys[row]]</c>).
+///
+/// <para>
+/// Each Native block ships a self-contained, block-local dictionary — there is no cross-block dictionary state,
+/// so the codec instance holds none and stays a shared singleton. The codec is non-generic; the generic work —
+/// building the typed column and deduplicating values on write — is delegated to a cached, per-element-type
+/// <see cref="ILowCardinalityShape"/>.
+/// </para>
+/// </summary>
+internal sealed class LowCardinalityColumnCodec : IColumnCodec
+{
+    private readonly IColumnCodec inner;
+    private readonly ILowCardinalityShape shape;
+    private readonly bool nullable;
+    private readonly bool innerCanWrite;
+
+    private LowCardinalityColumnCodec(string typeName, IColumnCodec inner, bool nullable)
+    {
+        TypeName = typeName;
+        this.inner = inner;
+        this.nullable = nullable;
+        shape = LowCardinalityShapes.For(inner.ElementType, nullable);
+        innerCanWrite = shape.CanInnerWrite(inner);
+    }
+
+    /// <inheritdoc/>
+    public string TypeName { get; }
+
+    /// <inheritdoc/>
+    public Type ElementType => shape.SurfaceElementType;
+
+    /// <summary>
+    /// The placeholder for an absent value: for a nullable inner it is <see langword="null"/> itself (the reserved
+    /// NULL dictionary slot), otherwise the inner codec's placeholder. Relevant only if a composite nests a
+    /// <c>LowCardinality</c> and asks for its placeholder; the server rejects <c>Nullable(LowCardinality(...))</c>,
+    /// so this is not exercised by a nullable wrapper.
+    /// </summary>
+    public object NullPlaceholder => nullable ? null : inner.NullPlaceholder;
+
+    /// <summary>Builds a <c>LowCardinality(T)</c> codec, resolving the inner type <c>T</c> through the registry.</summary>
+    /// <param name="node">The parsed <c>LowCardinality</c> type node; its single argument is the inner type.</param>
+    /// <param name="context">The resolution context, forwarded to the inner codec's factory.</param>
+    /// <param name="registry">The registry used to resolve the inner type's codec.</param>
+    /// <returns>The codec.</returns>
+    /// <exception cref="FormatException">The type does not have exactly one inner type argument, or a <c>Nullable</c> inner is malformed or itself <c>Nullable</c>.</exception>
+    public static LowCardinalityColumnCodec Create(TypeNode node, in ResolveContext context, ColumnCodecRegistry registry)
+    {
+        if (node.Arguments.Count != 1)
+        {
+            throw new FormatException($"LowCardinality type '{node}' must have exactly one inner type argument.");
+        }
+
+        TypeNode innerNode = node.Arguments[0];
+        bool nullable = innerNode.Name == "Nullable";
+        if (nullable)
+        {
+            // The dictionary is serialized as the bare inner type (no null-map stream); nullability is expressed
+            // positionally by the reserved dict[0] slot that all NULL keys point at. So resolve the codec for the
+            // bare inner type, not the Nullable codec, which would frame a null-map inside the dictionary stream.
+            if (innerNode.Arguments.Count != 1)
+            {
+                throw new FormatException($"Nullable inner of '{node}' must have exactly one inner type argument.");
+            }
+
+            innerNode = innerNode.Arguments[0];
+            if (innerNode.Name == "Nullable")
+            {
+                throw new FormatException($"Nullable cannot be nested inside '{node}'.");
+            }
+        }
+
+        IColumnCodec inner = registry.ResolveNode(innerNode, in context);
+        return new LowCardinalityColumnCodec(node.ToString(), inner, nullable);
+    }
+
+    /// <inheritdoc/>
+    public ValueTask ReadStatePrefixAsync(ClickHouseBinaryReader reader, CancellationToken cancellationToken)
+        => ReadAndValidateVersionAsync(reader, cancellationToken);
+
+    private static async ValueTask ReadAndValidateVersionAsync(ClickHouseBinaryReader reader, CancellationToken cancellationToken)
+    {
+        long version = await reader.ReadInt64Async(cancellationToken).ConfigureAwait(false);
+        if (version != LowCardinalityWire.StatePrefixVersion)
+        {
+            throw new ClickHouseProtocolException(
+                $"LowCardinality serialization version {version} is not supported (expected {LowCardinalityWire.StatePrefixVersion}).");
+        }
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask<IColumn> ReadColumnAsync(ClickHouseBinaryReader reader, string columnName, string columnType, int rowCount, CancellationToken cancellationToken)
+    {
+        if (rowCount == 0)
+        {
+            // An empty (or empty-flattened) column writes no body — no metadata, dictionary, or keys. Wrap a
+            // zero-row dictionary (which reads nothing) with an empty key array.
+            IColumn emptyDict = await inner.ReadColumnAsync(reader, columnName, inner.TypeName, 0, cancellationToken).ConfigureAwait(false);
+            return shape.Wrap(columnName, columnType, emptyDict, Array.Empty<int>(), rowCount: 0, pooledKeys: false);
+        }
+
+        ulong metadata = await reader.ReadUInt64Async(cancellationToken).ConfigureAwait(false);
+        int code = (int)(metadata & LowCardinalityWire.IndexTypeMask);
+        if (code is < LowCardinalityWire.KeyUInt8 or > LowCardinalityWire.KeyUInt64)
+        {
+            throw new ClickHouseProtocolException(
+                $"LowCardinality column '{columnName}' declares an unknown key-width code {code}.");
+        }
+
+        if ((metadata & LowCardinalityWire.NeedGlobalDictionaryBit) != 0)
+        {
+            throw new ClickHouseProtocolException(
+                $"LowCardinality column '{columnName}' requests a global dictionary, which the Native format does not use.");
+        }
+
+        if ((metadata & LowCardinalityWire.HasAdditionalKeysBit) == 0)
+        {
+            throw new ClickHouseProtocolException(
+                $"LowCardinality column '{columnName}' carries no additional keys; a non-empty Native block must.");
+        }
+
+        // NeedUpdateDictionaryBit is expected to be set (each block ships a fresh dictionary), but it is not
+        // required on read: a self-contained block-local dictionary is what the following bytes describe either
+        // way, and being lenient here avoids rejecting a stream that merely differs in this advisory bit.
+        ulong dictSizeRaw = await reader.ReadUInt64Async(cancellationToken).ConfigureAwait(false);
+        if (dictSizeRaw > int.MaxValue)
+        {
+            throw new ClickHouseProtocolException(
+                $"LowCardinality column '{columnName}' declares {dictSizeRaw} dictionary entries, exceeding the maximum this client can address.");
+        }
+
+        int dictSize = (int)dictSizeRaw;
+        IColumn dictionary = await inner.ReadColumnAsync(reader, columnName, inner.TypeName, dictSize, cancellationToken).ConfigureAwait(false);
+
+        int[] keys = null;
+        try
+        {
+            ulong keysCount = await reader.ReadUInt64Async(cancellationToken).ConfigureAwait(false);
+            if (keysCount != (ulong)rowCount)
+            {
+                throw new ClickHouseProtocolException(
+                    $"LowCardinality column '{columnName}' declares {keysCount} keys but the block expects {rowCount}.");
+            }
+
+            keys = ArrayPool<int>.Shared.Rent(rowCount);
+            await ReadKeysAsync(reader, keys, rowCount, code, dictSize, columnName, cancellationToken).ConfigureAwait(false);
+
+            // Wrap inside the try: only a successful Wrap takes ownership of the rented keys and the dictionary
+            // column, so a throw leaks neither.
+            return shape.Wrap(columnName, columnType, dictionary, keys, rowCount, pooledKeys: true);
+        }
+        catch
+        {
+            if (keys is not null)
+            {
+                ArrayPool<int>.Shared.Return(keys);
+            }
+
+            dictionary.Dispose();
+            throw;
+        }
+    }
+
+    // Bulk-reads rowCount keys of (1 << code) bytes each into a scratch buffer, decodes them into keys, and
+    // validates each index is within the dictionary.
+    private static async ValueTask ReadKeysAsync(
+        ClickHouseBinaryReader reader, int[] keys, int rowCount, int code, int dictSize, string columnName, CancellationToken cancellationToken)
+    {
+        int width = LowCardinalityWire.KeyByteWidth(code);
+        long keyBytes = (long)rowCount * width;
+        if (keyBytes > Array.MaxLength)
+        {
+            throw new ClickHouseProtocolException(
+                $"LowCardinality column '{columnName}' declares {rowCount} keys, whose stream exceeds the maximum this client can buffer.");
+        }
+
+        byte[] scratch = ArrayPool<byte>.Shared.Rent((int)keyBytes);
+        try
+        {
+            await reader.ReadBytesAsync(scratch.AsMemory(0, (int)keyBytes), cancellationToken).ConfigureAwait(false);
+            DecodeKeys(scratch.AsSpan(0, (int)keyBytes), keys.AsSpan(0, rowCount), code, dictSize, columnName);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(scratch);
+        }
+    }
+
+    // Decodes the raw little-endian keys stream at the given width into int indices, validating each is in range.
+    private static void DecodeKeys(ReadOnlySpan<byte> source, Span<int> keys, int code, int dictSize, string columnName)
+    {
+        switch (code)
+        {
+            case LowCardinalityWire.KeyUInt8:
+                for (int i = 0; i < keys.Length; i++)
+                {
+                    keys[i] = ValidateKey(source[i], dictSize, columnName);
+                }
+
+                break;
+            case LowCardinalityWire.KeyUInt16:
+                ReadOnlySpan<ushort> u16 = MemoryMarshal.Cast<byte, ushort>(source);
+                for (int i = 0; i < keys.Length; i++)
+                {
+                    keys[i] = ValidateKey(u16[i], dictSize, columnName);
+                }
+
+                break;
+            case LowCardinalityWire.KeyUInt32:
+                ReadOnlySpan<uint> u32 = MemoryMarshal.Cast<byte, uint>(source);
+                for (int i = 0; i < keys.Length; i++)
+                {
+                    keys[i] = ValidateKey(u32[i], dictSize, columnName);
+                }
+
+                break;
+            default:
+                ReadOnlySpan<ulong> u64 = MemoryMarshal.Cast<byte, ulong>(source);
+                for (int i = 0; i < keys.Length; i++)
+                {
+                    keys[i] = ValidateKey(u64[i], dictSize, columnName);
+                }
+
+                break;
+        }
+    }
+
+    private static int ValidateKey(ulong key, int dictSize, string columnName)
+    {
+        if (key >= (ulong)dictSize)
+        {
+            throw new ClickHouseProtocolException(
+                $"LowCardinality column '{columnName}' has a key {key} outside its {dictSize}-entry dictionary; the stream is corrupt.");
+        }
+
+        return (int)key;
+    }
+
+    /// <inheritdoc/>
+    public long MeasureRowBytes(IColumn column, int row) => shape.MeasureRow(inner, column, row);
+
+    /// <inheritdoc/>
+    public bool CanWrite(IColumn column) => innerCanWrite && shape.CanWrite(column);
+
+    /// <inheritdoc/>
+    public void WriteStatePrefix(ClickHouseBinaryWriter writer) => writer.WriteInt64(LowCardinalityWire.StatePrefixVersion);
+
+    /// <inheritdoc/>
+    public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
+        => shape.WriteBody(inner, writer, column, start, length);
+}

--- a/ClickHouse.Driver.Tcp/Types/Codecs/LowCardinalityShape.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/LowCardinalityShape.cs
@@ -112,31 +112,6 @@ internal sealed class LowCardinalityShape<T> : ILowCardinalityShape
             ArrayPool<int>.Shared.Return(keys);
         }
     }
-
-    /// <inheritdoc/>
-    public long MeasureRow(IColumnCodec inner, IColumn column, int row)
-    {
-        // A conservative upper bound: the widest key plus this row's full inner value, ignoring the dictionary's
-        // deduplication (which only ever makes the true size smaller). The block splitter tolerates an
-        // over-estimate — it just closes blocks a little earlier.
-        const long maxKeyBytes = sizeof(ulong);
-
-        if (column is LowCardinalityColumn<T> dense)
-        {
-            // The value lives in the dictionary at this row's key, so it can be priced in place with no allocation.
-            return maxKeyBytes + inner.MeasureRowBytes(dense.Dictionary, dense.Keys[row]);
-        }
-
-        if (inner.FixedRowByteSize is int width)
-        {
-            return maxKeyBytes + width;
-        }
-
-        // A variable-width inner must measure the value; wrap the single row so the inner codec can price it.
-        T value = ((IColumn<T>)column)[row];
-        var wrapped = ArrayColumn<T>.OverBuffer(column.Name, inner.TypeName, new[] { value }, 1);
-        return maxKeyBytes + inner.MeasureRowBytes(wrapped, 0);
-    }
 }
 
 /// <summary>Structural (content) equality for <see cref="byte"/> arrays, so equal FixedString values deduplicate.</summary>

--- a/ClickHouse.Driver.Tcp/Types/Codecs/LowCardinalityShape.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/LowCardinalityShape.cs
@@ -1,0 +1,170 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using ClickHouse.Driver.Tcp.Protocol;
+
+namespace ClickHouse.Driver.Tcp.Types.Codecs;
+
+/// <summary>The bridge for an inner element type <typeparamref name="T"/>: the low-cardinality column surfaces <c>T</c>.</summary>
+/// <typeparam name="T">The inner codec's element type.</typeparam>
+internal sealed class LowCardinalityShape<T> : ILowCardinalityShape
+{
+    // The comparer used to deduplicate values into the block-local dictionary. Reference types generally carry
+    // value equality (String, IPAddress), but byte[] — the element type of FixedString — defaults to reference
+    // equality, which would give every equal-valued row its own dictionary slot; use a structural comparer so
+    // FixedString values actually collapse to one entry.
+    private static readonly IEqualityComparer<T> DictionaryComparer = typeof(T) == typeof(byte[])
+        ? (IEqualityComparer<T>)(object)ByteArrayEqualityComparer.Instance
+        : EqualityComparer<T>.Default;
+
+    /// <inheritdoc/>
+    public Type SurfaceElementType => typeof(T);
+
+    /// <inheritdoc/>
+    public IColumn Wrap(string name, string typeName, IColumn dictionary, int[] keys, int rowCount, bool pooledKeys)
+        => new LowCardinalityColumn<T>(name, typeName, (IColumn<T>)dictionary, keys, rowCount, pooledKeys);
+
+    /// <inheritdoc/>
+    public bool CanWrite(IColumn column) => column is IColumn<T>;
+
+    /// <inheritdoc/>
+    public bool CanInnerWrite(IColumnCodec inner) => inner.CanWrite(new ArrayColumn<T>(string.Empty, inner.TypeName, Array.Empty<T>()));
+
+    /// <inheritdoc/>
+    public void WriteBody(IColumnCodec inner, ClickHouseBinaryWriter writer, IColumn column, int start, int length)
+    {
+        // A zero-length slice writes no body at all: only the state prefix (emitted by the block layer, or by a
+        // composite's prefix phase) precedes it. Metadata, dictionary, and keys are all absent.
+        if (length == 0)
+        {
+            return;
+        }
+
+        if (column is LowCardinalityColumn<T> dense)
+        {
+            // Dense form (the wire's own layout): the dictionary and keys already exist, so re-emit both directly.
+            // The whole dictionary is written even for a slice — unused entries are harmless, and the key width is
+            // fixed by the dictionary size, so a slice's keys keep the same encoding.
+            IColumn<T> dictionary = dense.Dictionary;
+            int dictSize = dictionary.RowCount;
+            int code = LowCardinalityWire.SelectKeyWidthCode(dictSize);
+
+            writer.WriteUInt64(LowCardinalityWire.NativeFlags | (ulong)code);
+            writer.WriteUInt64((ulong)dictSize);
+            inner.WriteColumn(writer, dictionary, 0, dictSize);
+            writer.WriteUInt64((ulong)length);
+
+            ReadOnlySpan<int> keys = dense.Keys;
+            for (int i = 0; i < length; i++)
+            {
+                LowCardinalityWire.WriteKey(writer, code, keys[start + i]);
+            }
+
+            return;
+        }
+
+        WriteErgonomic(inner, writer, (IColumn<T>)column, start, length);
+    }
+
+    // Ergonomic form: deduplicate the sliced values into a fresh block-local dictionary (slot 0 reserved for the
+    // inner type's default, so a value equal to the default reuses it), then write the dictionary and the keys.
+    private static void WriteErgonomic(IColumnCodec inner, ClickHouseBinaryWriter writer, IColumn<T> source, int start, int length)
+    {
+        var defaultValue = (T)inner.NullPlaceholderAs(typeof(T));
+        var indexByValue = new Dictionary<T, int>(DictionaryComparer) { [defaultValue] = 0 };
+
+        // The dictionary can grow to length + 1 (every value distinct, plus the reserved default). Rent both
+        // buffers up front; the dictionary is filled as new values are discovered.
+        T[] dict = ArrayPool<T>.Shared.Rent(length + 1);
+        int[] keys = ArrayPool<int>.Shared.Rent(length);
+        try
+        {
+            dict[0] = defaultValue;
+            int dictSize = 1;
+            for (int i = 0; i < length; i++)
+            {
+                T value = source[start + i];
+                if (!indexByValue.TryGetValue(value, out int index))
+                {
+                    index = dictSize;
+                    dict[dictSize++] = value;
+                    indexByValue[value] = index;
+                }
+
+                keys[i] = index;
+            }
+
+            int code = LowCardinalityWire.SelectKeyWidthCode(dictSize);
+            writer.WriteUInt64(LowCardinalityWire.NativeFlags | (ulong)code);
+            writer.WriteUInt64((ulong)dictSize);
+            inner.WriteColumn(writer, ArrayColumn<T>.OverBuffer(source.Name, inner.TypeName, dict, dictSize), 0, dictSize);
+            writer.WriteUInt64((ulong)length);
+
+            for (int i = 0; i < length; i++)
+            {
+                LowCardinalityWire.WriteKey(writer, code, keys[i]);
+            }
+        }
+        finally
+        {
+            ArrayPool<T>.Shared.Return(dict, clearArray: RuntimeHelpers.IsReferenceOrContainsReferences<T>());
+            ArrayPool<int>.Shared.Return(keys);
+        }
+    }
+
+    /// <inheritdoc/>
+    public long MeasureRow(IColumnCodec inner, IColumn column, int row)
+    {
+        // A conservative upper bound: the widest key plus this row's full inner value, ignoring the dictionary's
+        // deduplication (which only ever makes the true size smaller). The block splitter tolerates an
+        // over-estimate — it just closes blocks a little earlier.
+        const long maxKeyBytes = sizeof(ulong);
+
+        if (column is LowCardinalityColumn<T> dense)
+        {
+            // The value lives in the dictionary at this row's key, so it can be priced in place with no allocation.
+            return maxKeyBytes + inner.MeasureRowBytes(dense.Dictionary, dense.Keys[row]);
+        }
+
+        if (inner.FixedRowByteSize is int width)
+        {
+            return maxKeyBytes + width;
+        }
+
+        // A variable-width inner must measure the value; wrap the single row so the inner codec can price it.
+        T value = ((IColumn<T>)column)[row];
+        var wrapped = ArrayColumn<T>.OverBuffer(column.Name, inner.TypeName, new[] { value }, 1);
+        return maxKeyBytes + inner.MeasureRowBytes(wrapped, 0);
+    }
+}
+
+/// <summary>Structural (content) equality for <see cref="byte"/> arrays, so equal FixedString values deduplicate.</summary>
+internal sealed class ByteArrayEqualityComparer : IEqualityComparer<byte[]>
+{
+    /// <summary>The shared instance.</summary>
+    public static readonly ByteArrayEqualityComparer Instance = new();
+
+    private ByteArrayEqualityComparer()
+    {
+    }
+
+    /// <inheritdoc/>
+    public bool Equals(byte[] x, byte[] y)
+    {
+        if (ReferenceEquals(x, y))
+        {
+            return true;
+        }
+
+        return x is not null && y is not null && x.AsSpan().SequenceEqual(y);
+    }
+
+    /// <inheritdoc/>
+    public int GetHashCode(byte[] obj)
+    {
+        var hash = new HashCode();
+        hash.AddBytes(obj);
+        return hash.ToHashCode();
+    }
+}

--- a/ClickHouse.Driver.Tcp/Types/Codecs/LowCardinalityShape.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/LowCardinalityShape.cs
@@ -138,6 +138,13 @@ internal sealed class ByteArrayEqualityComparer : IEqualityComparer<byte[]>
     /// <inheritdoc/>
     public int GetHashCode(byte[] obj)
     {
+        // A null key hashes deterministically to zero (like EqualityComparer<byte[]>.Default) rather than
+        // throwing inside HashCode.AddBytes, so a stray null element never faults the dictionary build.
+        if (obj is null)
+        {
+            return 0;
+        }
+
         var hash = new HashCode();
         hash.AddBytes(obj);
         return hash.ToHashCode();

--- a/ClickHouse.Driver.Tcp/Types/Codecs/LowCardinalityShapes.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/LowCardinalityShapes.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Concurrent;
+
+namespace ClickHouse.Driver.Tcp.Types.Codecs;
+
+/// <summary>Resolves and caches the <see cref="ILowCardinalityShape"/> for a given inner element type.</summary>
+internal static class LowCardinalityShapes
+{
+    private static readonly ConcurrentDictionary<(Type ElementType, bool Nullable), ILowCardinalityShape> Cache = new();
+
+    /// <summary>Returns the shape for <paramref name="elementType"/>, building it once and caching it.</summary>
+    /// <param name="elementType">The inner (bare) codec's CLR element type.</param>
+    /// <param name="nullable">Whether the inner is <c>Nullable</c> — the surfaced element type is then made nullable and the dictionary reserves a NULL slot.</param>
+    /// <returns>The shape.</returns>
+    public static ILowCardinalityShape For(Type elementType, bool nullable) => Cache.GetOrAdd((elementType, nullable), Build);
+
+    // nonPublic: true so the shape's (implicit, but internal-assembly) constructor is always reachable here.
+    private static ILowCardinalityShape Build((Type ElementType, bool Nullable) key)
+    {
+        Type shapeType = key.Nullable
+            ? (key.ElementType.IsValueType ? typeof(ValueLowCardinalityShape<>) : typeof(ReferenceLowCardinalityShape<>))
+            : typeof(LowCardinalityShape<>);
+
+        return (ILowCardinalityShape)Activator.CreateInstance(shapeType.MakeGenericType(key.ElementType), nonPublic: true);
+    }
+}

--- a/ClickHouse.Driver.Tcp/Types/Codecs/NullableLowCardinalityShape.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/NullableLowCardinalityShape.cs
@@ -137,30 +137,6 @@ internal abstract class NullableLowCardinalityShape<T> : ILowCardinalityShape
             ArrayPool<int>.Shared.Return(keys);
         }
     }
-
-    /// <inheritdoc/>
-    public long MeasureRow(IColumnCodec inner, IColumn column, int row)
-    {
-        // A conservative upper bound: the widest key plus this row's inner value, ignoring the dictionary's
-        // deduplication (which only ever makes the true size smaller). A NULL row prices as the inner default, the
-        // bytes written into the reserved slot 0.
-        const long maxKeyBytes = sizeof(ulong);
-
-        if (column is IDenseLowCardinality<T> dense)
-        {
-            return maxKeyBytes + inner.MeasureRowBytes(dense.Dictionary, dense.Keys[row]);
-        }
-
-        if (inner.FixedRowByteSize is int width)
-        {
-            return maxKeyBytes + width;
-        }
-
-        // A variable-width inner must measure the value; a NULL row measures the inner default it reserves.
-        T value = IsNull(column, row) ? (T)inner.NullPlaceholderAs(typeof(T)) : Value(column, row);
-        var wrapped = ArrayColumn<T>.OverBuffer(column.Name, inner.TypeName, new[] { value }, 1);
-        return maxKeyBytes + inner.MeasureRowBytes(wrapped, 0);
-    }
 }
 
 /// <summary>The nullable bridge for a value-type inner: the column surfaces <c>T?</c>.</summary>

--- a/ClickHouse.Driver.Tcp/Types/Codecs/NullableLowCardinalityShape.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/NullableLowCardinalityShape.cs
@@ -1,0 +1,208 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using ClickHouse.Driver.Tcp.Protocol;
+
+namespace ClickHouse.Driver.Tcp.Types.Codecs;
+
+/// <summary>
+/// The generic bridge for one <c>LowCardinality(Nullable(T))</c> element type. The dictionary is still serialized
+/// with the <em>bare</em> inner codec (no null-map); nullability is expressed positionally by two reserved leading
+/// dictionary slots — <c>dict[0]</c> is the NULL marker and <c>dict[1]</c> the inner default — with a NULL row's key
+/// pointing at <c>dict[0]</c>. This base owns the T-independent parts of that (the dedup-with-two-reserved-slots
+/// write, the dense re-emit, row pricing); the value/reference subclasses supply the null test, the value
+/// extraction, and the typed column the reader surfaces.
+/// </summary>
+/// <typeparam name="T">The inner (bare) codec's element type; the surfaced element type is this made nullable.</typeparam>
+internal abstract class NullableLowCardinalityShape<T> : ILowCardinalityShape
+{
+    // The comparer used to deduplicate present values into the block-local dictionary. Reference types generally
+    // carry value equality (String), but byte[] — the element type of FixedString — defaults to reference equality;
+    // use a structural comparer so equal FixedString values collapse to one entry. NULL is handled positionally
+    // (slot 0), never through this comparer.
+    private static readonly IEqualityComparer<T> DictionaryComparer = typeof(T) == typeof(byte[])
+        ? (IEqualityComparer<T>)(object)ByteArrayEqualityComparer.Instance
+        : EqualityComparer<T>.Default;
+
+    /// <inheritdoc/>
+    public abstract Type SurfaceElementType { get; }
+
+    /// <inheritdoc/>
+    public abstract IColumn Wrap(string name, string typeName, IColumn dictionary, int[] keys, int rowCount, bool pooledKeys);
+
+    /// <inheritdoc/>
+    public abstract bool CanWrite(IColumn column);
+
+    /// <summary>Whether row <paramref name="row"/> of <paramref name="column"/> is NULL (maps to the reserved slot 0).</summary>
+    protected abstract bool IsNull(IColumn column, int row);
+
+    /// <summary>The present (non-NULL) value at row <paramref name="row"/> of <paramref name="column"/>.</summary>
+    protected abstract T Value(IColumn column, int row);
+
+    /// <inheritdoc/>
+    public bool CanInnerWrite(IColumnCodec inner) => inner.CanWrite(new ArrayColumn<T>(string.Empty, inner.TypeName, Array.Empty<T>()));
+
+    /// <inheritdoc/>
+    public void WriteBody(IColumnCodec inner, ClickHouseBinaryWriter writer, IColumn column, int start, int length)
+    {
+        // A zero-length slice writes no body at all: only the state prefix (emitted by the block layer, or by a
+        // composite's prefix phase) precedes it. Metadata, dictionary, and keys are all absent.
+        if (length == 0)
+        {
+            return;
+        }
+
+        if (column is IDenseLowCardinality<T> dense)
+        {
+            // Dense form (the wire's own layout): the dictionary already carries the two reserved slots and the keys
+            // already point correctly (NULL rows at slot 0), so re-emit both directly with no rebuild.
+            WriteDense(inner, writer, dense, start, length);
+            return;
+        }
+
+        WriteErgonomic(inner, writer, column, start, length);
+    }
+
+    private static void WriteDense(IColumnCodec inner, ClickHouseBinaryWriter writer, IDenseLowCardinality<T> dense, int start, int length)
+    {
+        IColumn<T> dictionary = dense.Dictionary;
+        int dictSize = dictionary.RowCount;
+        int code = LowCardinalityWire.SelectKeyWidthCode(dictSize);
+
+        writer.WriteUInt64(LowCardinalityWire.NativeFlags | (ulong)code);
+        writer.WriteUInt64((ulong)dictSize);
+        inner.WriteColumn(writer, dictionary, 0, dictSize);
+        writer.WriteUInt64((ulong)length);
+
+        ReadOnlySpan<int> keys = dense.Keys;
+        for (int i = 0; i < length; i++)
+        {
+            LowCardinalityWire.WriteKey(writer, code, keys[start + i]);
+        }
+    }
+
+    // Ergonomic form: deduplicate the sliced present values into a fresh block-local dictionary. Two slots are
+    // reserved up front — dict[0] the NULL marker and dict[1] the inner default — so real distinct values start at
+    // index 2. A NULL row maps to key 0; a present value equal to the inner default reuses the reserved default
+    // slot 1 (so it reads back as that default value, present rather than NULL) rather than adding a duplicate.
+    private void WriteErgonomic(IColumnCodec inner, ClickHouseBinaryWriter writer, IColumn source, int start, int length)
+    {
+        var defaultValue = (T)inner.NullPlaceholderAs(typeof(T));
+        var indexByValue = new Dictionary<T, int>(DictionaryComparer) { [defaultValue] = 1 };
+
+        // The dictionary can grow to length + 2 (every value distinct, plus the two reserved slots). Rent both
+        // buffers up front; the dictionary is filled as new values are discovered.
+        T[] dict = ArrayPool<T>.Shared.Rent(length + 2);
+        int[] keys = ArrayPool<int>.Shared.Rent(length);
+        try
+        {
+            dict[0] = defaultValue;
+            dict[1] = defaultValue;
+            int dictSize = 2;
+            for (int i = 0; i < length; i++)
+            {
+                int row = start + i;
+                if (IsNull(source, row))
+                {
+                    keys[i] = 0;
+                    continue;
+                }
+
+                T value = Value(source, row);
+                if (!indexByValue.TryGetValue(value, out int index))
+                {
+                    index = dictSize;
+                    dict[dictSize++] = value;
+                    indexByValue[value] = index;
+                }
+
+                keys[i] = index;
+            }
+
+            int code = LowCardinalityWire.SelectKeyWidthCode(dictSize);
+            writer.WriteUInt64(LowCardinalityWire.NativeFlags | (ulong)code);
+            writer.WriteUInt64((ulong)dictSize);
+            inner.WriteColumn(writer, ArrayColumn<T>.OverBuffer(source.Name, inner.TypeName, dict, dictSize), 0, dictSize);
+            writer.WriteUInt64((ulong)length);
+
+            for (int i = 0; i < length; i++)
+            {
+                LowCardinalityWire.WriteKey(writer, code, keys[i]);
+            }
+        }
+        finally
+        {
+            ArrayPool<T>.Shared.Return(dict, clearArray: RuntimeHelpers.IsReferenceOrContainsReferences<T>());
+            ArrayPool<int>.Shared.Return(keys);
+        }
+    }
+
+    /// <inheritdoc/>
+    public long MeasureRow(IColumnCodec inner, IColumn column, int row)
+    {
+        // A conservative upper bound: the widest key plus this row's inner value, ignoring the dictionary's
+        // deduplication (which only ever makes the true size smaller). A NULL row prices as the inner default, the
+        // bytes written into the reserved slot 0.
+        const long maxKeyBytes = sizeof(ulong);
+
+        if (column is IDenseLowCardinality<T> dense)
+        {
+            return maxKeyBytes + inner.MeasureRowBytes(dense.Dictionary, dense.Keys[row]);
+        }
+
+        if (inner.FixedRowByteSize is int width)
+        {
+            return maxKeyBytes + width;
+        }
+
+        // A variable-width inner must measure the value; a NULL row measures the inner default it reserves.
+        T value = IsNull(column, row) ? (T)inner.NullPlaceholderAs(typeof(T)) : Value(column, row);
+        var wrapped = ArrayColumn<T>.OverBuffer(column.Name, inner.TypeName, new[] { value }, 1);
+        return maxKeyBytes + inner.MeasureRowBytes(wrapped, 0);
+    }
+}
+
+/// <summary>The nullable bridge for a value-type inner: the column surfaces <c>T?</c>.</summary>
+/// <typeparam name="T">The inner value type.</typeparam>
+internal sealed class ValueLowCardinalityShape<T> : NullableLowCardinalityShape<T>
+    where T : struct
+{
+    /// <inheritdoc/>
+    public override Type SurfaceElementType => typeof(T?);
+
+    /// <inheritdoc/>
+    public override IColumn Wrap(string name, string typeName, IColumn dictionary, int[] keys, int rowCount, bool pooledKeys)
+        => new NullableLowCardinalityValueColumn<T>(name, typeName, (IColumn<T>)dictionary, keys, rowCount, pooledKeys);
+
+    /// <inheritdoc/>
+    public override bool CanWrite(IColumn column) => column is IColumn<T?>;
+
+    /// <inheritdoc/>
+    protected override bool IsNull(IColumn column, int row) => !((IColumn<T?>)column)[row].HasValue;
+
+    /// <inheritdoc/>
+    protected override T Value(IColumn column, int row) => ((IColumn<T?>)column)[row].GetValueOrDefault();
+}
+
+/// <summary>The nullable bridge for a reference-type inner: the column surfaces the nullable reference.</summary>
+/// <typeparam name="T">The inner reference type.</typeparam>
+internal sealed class ReferenceLowCardinalityShape<T> : NullableLowCardinalityShape<T>
+    where T : class
+{
+    /// <inheritdoc/>
+    public override Type SurfaceElementType => typeof(T);
+
+    /// <inheritdoc/>
+    public override IColumn Wrap(string name, string typeName, IColumn dictionary, int[] keys, int rowCount, bool pooledKeys)
+        => new NullableLowCardinalityReferenceColumn<T>(name, typeName, (IColumn<T>)dictionary, keys, rowCount, pooledKeys);
+
+    /// <inheritdoc/>
+    public override bool CanWrite(IColumn column) => column is IColumn<T>;
+
+    /// <inheritdoc/>
+    protected override bool IsNull(IColumn column, int row) => ((IColumn<T>)column)[row] is null;
+
+    /// <inheritdoc/>
+    protected override T Value(IColumn column, int row) => ((IColumn<T>)column)[row];
+}

--- a/ClickHouse.Driver.Tcp/Types/ColumnCodecRegistry.cs
+++ b/ClickHouse.Driver.Tcp/Types/ColumnCodecRegistry.cs
@@ -139,6 +139,11 @@ internal sealed class ColumnCodecRegistry
         // and value codecs are resolved recursively; each row surfaces as a KeyValuePair<K, V>[].
         AddFactory("Map", static (TypeNode node, in ResolveContext context, ColumnCodecRegistry registry) => MapColumnCodec.Create(node, context, registry));
 
+        // LowCardinality(T) replaces the inner values with a block-local dictionary plus indices; the inner codec
+        // is resolved recursively. Its serialization-state prefix is a fixed version marker; the dictionary and
+        // keys live in the column body.
+        AddFactory("LowCardinality", static (TypeNode node, in ResolveContext context, ColumnCodecRegistry registry) => LowCardinalityColumnCodec.Create(node, context, registry));
+
         // Nested(...) as a single wire column (flatten_nested = 0) is byte-identical to Array(Tuple(...)): the same
         // offsets stream plus each field's flattened stream, differing only in the type string, which keeps the
         // field names. It has a dedicated arity-agnostic codec (not Array(Tuple) reuse) surfacing a columnar

--- a/ClickHouse.Driver.Tcp/Types/IDenseLowCardinality.cs
+++ b/ClickHouse.Driver.Tcp/Types/IDenseLowCardinality.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace ClickHouse.Driver.Tcp.Types;
+
+/// <summary>
+/// The dense wire shape of a <c>LowCardinality</c> column — a dictionary column plus per-row keys — exposed so the
+/// codec can re-emit a decoded column with no rebuild. Implemented only by the nullable low-cardinality columns:
+/// the non-nullable <see cref="LowCardinalityColumn{T}"/> is deliberately <em>not</em> a dense source under a
+/// nullable codec, because its dictionary reserves a single default slot rather than the two slots
+/// (NULL + default) a <c>LowCardinality(Nullable(T))</c> dictionary requires — re-emitting it verbatim would make
+/// the reader read slot 0 back as NULL.
+/// </summary>
+/// <typeparam name="T">The dictionary's CLR element type (the bare inner type; never made nullable).</typeparam>
+internal interface IDenseLowCardinality<T>
+{
+    /// <summary>The dictionary of distinct values, including the reserved leading slots.</summary>
+    IColumn<T> Dictionary { get; }
+
+    /// <summary>The per-row keys, sliced to the column's row count — indices into <see cref="Dictionary"/>.</summary>
+    ReadOnlySpan<int> Keys { get; }
+}

--- a/ClickHouse.Driver.Tcp/Types/IDenseLowCardinality.cs
+++ b/ClickHouse.Driver.Tcp/Types/IDenseLowCardinality.cs
@@ -1,21 +1,19 @@
-using System;
-
 namespace ClickHouse.Driver.Tcp.Types;
 
 /// <summary>
-/// The dense wire shape of a <c>LowCardinality</c> column — a dictionary column plus per-row keys — exposed so the
-/// codec can re-emit a decoded column with no rebuild. Implemented only by the nullable low-cardinality columns:
-/// the non-nullable <see cref="LowCardinalityColumn{T}"/> is deliberately <em>not</em> a dense source under a
-/// nullable codec, because its dictionary reserves a single default slot rather than the two slots
+/// Marks a <c>LowCardinality</c> column whose dictionary and keys a <em>nullable</em> low-cardinality codec may
+/// re-emit verbatim, with no rebuild. Carries no members of its own — the dictionary and keys come from
+/// <see cref="ILowCardinalityColumn{T}"/>; this interface adds only the write-eligibility claim.
+///
+/// <para>
+/// Implemented solely by the nullable low-cardinality columns. The non-nullable
+/// <see cref="LowCardinalityColumn{T}"/> exposes the same pair for reading but is deliberately <em>not</em> a dense
+/// source under a nullable codec, because its dictionary reserves a single default slot rather than the two slots
 /// (NULL + default) a <c>LowCardinality(Nullable(T))</c> dictionary requires — re-emitting it verbatim would make
 /// the reader read slot 0 back as NULL.
+/// </para>
 /// </summary>
 /// <typeparam name="T">The dictionary's CLR element type (the bare inner type; never made nullable).</typeparam>
-internal interface IDenseLowCardinality<T>
+internal interface IDenseLowCardinality<T> : ILowCardinalityColumn<T>
 {
-    /// <summary>The dictionary of distinct values, including the reserved leading slots.</summary>
-    IColumn<T> Dictionary { get; }
-
-    /// <summary>The per-row keys, sliced to the column's row count — indices into <see cref="Dictionary"/>.</summary>
-    ReadOnlySpan<int> Keys { get; }
 }

--- a/ClickHouse.Driver.Tcp/Types/ILowCardinalityColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/ILowCardinalityColumn.cs
@@ -3,7 +3,7 @@ using System;
 namespace ClickHouse.Driver.Tcp.Types;
 
 /// <summary>
-/// The zero-copy read surface of a decoded <c>LowCardinality(T)</c> or <c>LowCardinality(Nullable(T))</c> column:
+/// The columnar read surface of a decoded <c>LowCardinality(T)</c> or <c>LowCardinality(Nullable(T))</c> column:
 /// a dictionary of distinct values plus one key per row indexing into it. That is exactly the wire layout, and it
 /// is what makes the type worth reading columnar — the materialized <c>Values</c>/indexer surface resolves every
 /// row to its dictionary entry, so a column of a million rows over a five-entry dictionary materializes a million
@@ -14,9 +14,10 @@ namespace ClickHouse.Driver.Tcp.Types;
 /// Row <c>i</c>'s value is <c>Dictionary[Keys[i]]</c>. The dictionary carries reserved leading slots that never
 /// appear as data, and <em>how many</em> depends on nullability: for a non-nullable inner, <c>Dictionary[0]</c>
 /// holds the inner type's default and real values start at <c>[1]</c>; for a nullable inner, <c>[0]</c> is the NULL
-/// marker and <c>[1]</c> the default, so real values start at <c>[2]</c>. So a key of <c>0</c> means NULL only for
-/// a <c>LowCardinality(Nullable(T))</c> column — check the column's <see cref="IColumn.TypeName"/>, or compare
-/// against the materialized value, before reading a key as a null marker.
+/// marker and <c>[1]</c> the default, so real values start at <c>[2]</c>. A key of <c>0</c> therefore means NULL for
+/// one shape and an ordinary default value for the other — read <see cref="ReservedSlotCount"/> rather than
+/// inferring it from the type string, so the distinction never rests on parsing
+/// <see cref="IColumn.TypeName"/>.
 /// </para>
 ///
 /// <para>
@@ -34,7 +35,7 @@ public interface ILowCardinalityColumn<T> : IColumn
     /// <summary>
     /// The dictionary of distinct values, including the reserved leading slots described on this interface. Its row
     /// count is the dictionary size, not the column's row count. A borrowed view valid only while the owning block
-    /// is alive.
+    /// is alive — it is the block's to dispose, never the caller's.
     /// </summary>
     IColumn<T> Dictionary { get; }
 
@@ -43,4 +44,12 @@ public interface ILowCardinalityColumn<T> : IColumn
     /// is alive.
     /// </summary>
     ReadOnlySpan<int> Keys { get; }
+
+    /// <summary>
+    /// How many leading <see cref="Dictionary"/> slots are reserved rather than data: <c>1</c> for a non-nullable
+    /// inner (slot 0 is the inner type's default) and <c>2</c> for a nullable one (slot 0 is the NULL marker, slot 1
+    /// the default). So real distinct values begin at this index, and a row is NULL exactly when this is <c>2</c>
+    /// and its key is <c>0</c>.
+    /// </summary>
+    int ReservedSlotCount { get; }
 }

--- a/ClickHouse.Driver.Tcp/Types/ILowCardinalityColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/ILowCardinalityColumn.cs
@@ -1,0 +1,46 @@
+using System;
+
+namespace ClickHouse.Driver.Tcp.Types;
+
+/// <summary>
+/// The zero-copy read surface of a decoded <c>LowCardinality(T)</c> or <c>LowCardinality(Nullable(T))</c> column:
+/// a dictionary of distinct values plus one key per row indexing into it. That is exactly the wire layout, and it
+/// is what makes the type worth reading columnar — the materialized <c>Values</c>/indexer surface resolves every
+/// row to its dictionary entry, so a column of a million rows over a five-entry dictionary materializes a million
+/// values. Reading the dictionary and the keys instead lets a caller group, count, or filter on the keys and touch
+/// each distinct value once.
+///
+/// <para>
+/// Row <c>i</c>'s value is <c>Dictionary[Keys[i]]</c>. The dictionary carries reserved leading slots that never
+/// appear as data, and <em>how many</em> depends on nullability: for a non-nullable inner, <c>Dictionary[0]</c>
+/// holds the inner type's default and real values start at <c>[1]</c>; for a nullable inner, <c>[0]</c> is the NULL
+/// marker and <c>[1]</c> the default, so real values start at <c>[2]</c>. So a key of <c>0</c> means NULL only for
+/// a <c>LowCardinality(Nullable(T))</c> column — check the column's <see cref="IColumn.TypeName"/>, or compare
+/// against the materialized value, before reading a key as a null marker.
+/// </para>
+///
+/// <para>
+/// The type parameter is the dictionary's element type — the bare inner type, never made nullable — so both
+/// <c>LowCardinality(Int32)</c> and <c>LowCardinality(Nullable(Int32))</c> present as
+/// <c>ILowCardinalityColumn&lt;int&gt;</c> even though their <see cref="IColumn{T}"/> surfaces differ
+/// (<c>IColumn&lt;int&gt;</c> and <c>IColumn&lt;int?&gt;</c> respectively). Both the dictionary column and the keys
+/// are borrowed views over the owning block's storage: read them in place, and copy out only what must outlive the
+/// block. Obtain this view by pattern-matching a column, e.g. <c>if (column is ILowCardinalityColumn&lt;int&gt; lc)</c>.
+/// </para>
+/// </summary>
+/// <typeparam name="T">The dictionary's CLR element type (the bare inner type; never made nullable).</typeparam>
+public interface ILowCardinalityColumn<T> : IColumn
+{
+    /// <summary>
+    /// The dictionary of distinct values, including the reserved leading slots described on this interface. Its row
+    /// count is the dictionary size, not the column's row count. A borrowed view valid only while the owning block
+    /// is alive.
+    /// </summary>
+    IColumn<T> Dictionary { get; }
+
+    /// <summary>
+    /// One key per row — an index into <see cref="Dictionary"/>. A borrowed span valid only while the owning block
+    /// is alive.
+    /// </summary>
+    ReadOnlySpan<int> Keys { get; }
+}

--- a/ClickHouse.Driver.Tcp/Types/LowCardinalityColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/LowCardinalityColumn.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Buffers;
+
+namespace ClickHouse.Driver.Tcp.Types;
+
+/// <summary>
+/// A ClickHouse <c>LowCardinality(T)</c> column: it pairs a small dictionary of distinct inner values with a
+/// per-row array of keys (indices into the dictionary), and surfaces each row as the inner CLR value
+/// <c>dict[keys[row]]</c>. This is the dense shape the wire uses (a dictionary stream plus a keys stream), so it
+/// is also the zero-copy source for writing — handed back to the <c>LowCardinality(T)</c> codec it re-emits the
+/// dictionary and keys without rebuilding anything.
+///
+/// <para>
+/// The dictionary reserves leading slots the server never surfaces as data: for a non-nullable inner,
+/// <c>dict[0]</c> holds the inner type's default value and real values start at <c>dict[1]</c>. Those reserved
+/// slots are ordinary dictionary entries here — a row's key simply never points at an unused reserve.
+/// </para>
+///
+/// <para>
+/// The dictionary column's storage and the keys are borrowed for this column's lifetime; the dictionary is
+/// disposed and the keys returned (when pooled) on <see cref="Dispose"/>. Read the column only while the owning
+/// block is alive.
+/// </para>
+/// </summary>
+/// <typeparam name="T">The inner codec's CLR element type; each row surfaces as <typeparamref name="T"/>.</typeparam>
+internal sealed class LowCardinalityColumn<T> : IColumn<T>
+{
+    private readonly IColumn<T> dictionary;
+    private readonly int rowCount;
+    private readonly bool pooledKeys;
+    private int[] keys;
+    private T[] cache;
+
+    /// <summary>Initializes a low-cardinality column over a dictionary column and its per-row keys.</summary>
+    /// <param name="name">The column name.</param>
+    /// <param name="typeName">The full <c>LowCardinality(...)</c> type string.</param>
+    /// <param name="dictionary">The dictionary column holding the distinct values (including any reserved slots).</param>
+    /// <param name="keys">The per-row indices into <paramref name="dictionary"/>; must have at least <paramref name="rowCount"/> entries.</param>
+    /// <param name="rowCount">The number of rows.</param>
+    /// <param name="pooledKeys">Whether <paramref name="keys"/> was rented and should be returned on dispose.</param>
+    public LowCardinalityColumn(string name, string typeName, IColumn<T> dictionary, int[] keys, int rowCount, bool pooledKeys)
+    {
+        Name = name;
+        TypeName = typeName;
+        this.dictionary = dictionary ?? throw new ArgumentNullException(nameof(dictionary));
+        this.keys = keys ?? throw new ArgumentNullException(nameof(keys));
+        this.rowCount = rowCount;
+        this.pooledKeys = pooledKeys;
+    }
+
+    /// <inheritdoc/>
+    public string Name { get; }
+
+    /// <inheritdoc/>
+    public string TypeName { get; }
+
+    /// <inheritdoc/>
+    public int RowCount => rowCount;
+
+    /// <summary>The dictionary of distinct values (including reserved slots) — the zero-copy write source.</summary>
+    internal IColumn<T> Dictionary => dictionary;
+
+    /// <summary>The per-row keys, sliced to <see cref="RowCount"/> entries — the zero-copy write source.</summary>
+    internal ReadOnlySpan<int> Keys => keys.AsSpan(0, rowCount);
+
+    /// <summary>
+    /// The rows as values, materialized once and cached. Prefer the indexer when only some rows are needed, to
+    /// avoid reconstructing the whole column.
+    /// </summary>
+    public ReadOnlySpan<T> Values
+    {
+        get
+        {
+            if (cache is null)
+            {
+                var decoded = new T[rowCount];
+                ReadOnlySpan<T> dict = dictionary.Values;
+                for (int i = 0; i < rowCount; i++)
+                {
+                    decoded[i] = dict[keys[i]];
+                }
+
+                cache = decoded;
+            }
+
+            return cache.AsSpan(0, rowCount);
+        }
+    }
+
+    /// <inheritdoc/>
+    public T this[int row] => cache is not null ? cache[row] : dictionary[keys[row]];
+
+    /// <inheritdoc/>
+    public object GetValue(int row) => this[row];
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        dictionary.Dispose();
+        if (pooledKeys && keys.Length != 0)
+        {
+            ArrayPool<int>.Shared.Return(keys);
+        }
+
+        keys = Array.Empty<int>();
+        cache = null;
+    }
+}

--- a/ClickHouse.Driver.Tcp/Types/LowCardinalityColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/LowCardinalityColumn.cs
@@ -75,6 +75,11 @@ internal sealed class LowCardinalityColumn<T> : IColumn<T>, ILowCardinalityColum
     /// <inheritdoc/>
     public ReadOnlySpan<int> Keys => keys.AsSpan(0, rowCount);
 
+    /// <inheritdoc/>
+    // One reserved slot: the inner type's default at slot 0. A non-nullable dictionary has no NULL marker, so a key
+    // of 0 here is an ordinary default value, not an absent one.
+    public int ReservedSlotCount => 1;
+
     /// <summary>
     /// The rows as values, materialized once and cached. Prefer the indexer when only some rows are needed, to
     /// avoid reconstructing the whole column.

--- a/ClickHouse.Driver.Tcp/Types/LowCardinalityColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/LowCardinalityColumn.cs
@@ -38,6 +38,8 @@ internal sealed class LowCardinalityColumn<T> : IColumn<T>
     /// <param name="keys">The per-row indices into <paramref name="dictionary"/>; must have at least <paramref name="rowCount"/> entries.</param>
     /// <param name="rowCount">The number of rows.</param>
     /// <param name="pooledKeys">Whether <paramref name="keys"/> was rented and should be returned on dispose.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="dictionary"/> or <paramref name="keys"/> is null.</exception>
+    /// <exception cref="ArgumentException"><paramref name="keys"/> holds fewer than <paramref name="rowCount"/> entries.</exception>
     public LowCardinalityColumn(string name, string typeName, IColumn<T> dictionary, int[] keys, int rowCount, bool pooledKeys)
     {
         Name = name;
@@ -46,6 +48,16 @@ internal sealed class LowCardinalityColumn<T> : IColumn<T>
         this.keys = keys ?? throw new ArgumentNullException(nameof(keys));
         this.rowCount = rowCount;
         this.pooledKeys = pooledKeys;
+
+        // The row count cannot be derived here: the dictionary holds one entry per distinct value (plus any reserved
+        // slots), and the keys are typically a pooled buffer longer than the column. So the one input that can
+        // disagree is checked instead — with a short keys array the per-row lookup would read past its end.
+        if (keys.Length < rowCount)
+        {
+            throw new ArgumentException(
+                $"The keys for column '{name}' ({typeName}) hold {keys.Length} entries, fewer than the {rowCount} rows.",
+                nameof(keys));
+        }
     }
 
     /// <inheritdoc/>
@@ -88,7 +100,10 @@ internal sealed class LowCardinalityColumn<T> : IColumn<T>
     }
 
     /// <inheritdoc/>
-    public T this[int row] => cache is not null ? cache[row] : dictionary[keys[row]];
+    // Index through the RowCount-sliced keys, not the raw buffer: the buffer is usually a pooled array longer than
+    // the column, and a stale key left in its tail by a previous read is a perfectly valid dictionary index — so an
+    // out-of-range row would quietly return a real value from the dictionary instead of throwing.
+    public T this[int row] => cache is not null ? cache[row] : dictionary[Keys[row]];
 
     /// <inheritdoc/>
     public object GetValue(int row) => this[row];

--- a/ClickHouse.Driver.Tcp/Types/LowCardinalityColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/LowCardinalityColumn.cs
@@ -23,7 +23,7 @@ namespace ClickHouse.Driver.Tcp.Types;
 /// </para>
 /// </summary>
 /// <typeparam name="T">The inner codec's CLR element type; each row surfaces as <typeparamref name="T"/>.</typeparam>
-internal sealed class LowCardinalityColumn<T> : IColumn<T>
+internal sealed class LowCardinalityColumn<T> : IColumn<T>, ILowCardinalityColumn<T>
 {
     private readonly IColumn<T> dictionary;
     private readonly int rowCount;
@@ -69,11 +69,11 @@ internal sealed class LowCardinalityColumn<T> : IColumn<T>
     /// <inheritdoc/>
     public int RowCount => rowCount;
 
-    /// <summary>The dictionary of distinct values (including reserved slots) — the zero-copy write source.</summary>
-    internal IColumn<T> Dictionary => dictionary;
+    /// <inheritdoc/>
+    public IColumn<T> Dictionary => dictionary;
 
-    /// <summary>The per-row keys, sliced to <see cref="RowCount"/> entries — the zero-copy write source.</summary>
-    internal ReadOnlySpan<int> Keys => keys.AsSpan(0, rowCount);
+    /// <inheritdoc/>
+    public ReadOnlySpan<int> Keys => keys.AsSpan(0, rowCount);
 
     /// <summary>
     /// The rows as values, materialized once and cached. Prefer the indexer when only some rows are needed, to

--- a/ClickHouse.Driver.Tcp/Types/NullableLowCardinalityReferenceColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/NullableLowCardinalityReferenceColumn.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Buffers;
+
+namespace ClickHouse.Driver.Tcp.Types;
+
+/// <summary>
+/// A ClickHouse <c>LowCardinality(Nullable(T))</c> column for a reference-type inner (e.g.
+/// <c>LowCardinality(Nullable(String))</c>): it pairs a dictionary of distinct inner values with a per-row array of
+/// keys, and surfaces each row as the inner value <c>dict[keys[row]]</c>, or <see langword="null"/> where the key
+/// points at the reserved NULL slot (<c>key 0</c>).
+///
+/// <para>
+/// The dictionary is the bare inner type <typeparamref name="T"/> (there is no null-map in the dictionary stream);
+/// nullability is expressed positionally through the reserved slot 0. The dictionary reserves two leading slots —
+/// <c>dict[0]</c> is the NULL marker and <c>dict[1]</c> the inner default — so real distinct values start at
+/// <c>dict[2]</c>. This is the dense shape the wire uses, so it is also the zero-copy source for writing.
+/// </para>
+///
+/// <para>
+/// The dictionary column's storage and the keys are borrowed for this column's lifetime; the dictionary is disposed
+/// and the keys returned (when pooled) on <see cref="Dispose"/>. Read the column only while the owning block is alive.
+/// </para>
+/// </summary>
+/// <typeparam name="T">The inner reference type; each row surfaces as <typeparamref name="T"/> or <see langword="null"/>.</typeparam>
+internal sealed class NullableLowCardinalityReferenceColumn<T> : IColumn<T>, IDenseLowCardinality<T>
+    where T : class
+{
+    private readonly IColumn<T> dictionary;
+    private readonly int rowCount;
+    private readonly bool pooledKeys;
+    private int[] keys;
+    private T[] cache;
+
+    /// <summary>Initializes a nullable low-cardinality column over a dictionary column and its per-row keys.</summary>
+    /// <param name="name">The column name.</param>
+    /// <param name="typeName">The full <c>LowCardinality(Nullable(...))</c> type string.</param>
+    /// <param name="dictionary">The dictionary column holding the distinct values (including the reserved slots).</param>
+    /// <param name="keys">The per-row indices into <paramref name="dictionary"/>; must have at least <paramref name="rowCount"/> entries.</param>
+    /// <param name="rowCount">The number of rows.</param>
+    /// <param name="pooledKeys">Whether <paramref name="keys"/> was rented and should be returned on dispose.</param>
+    public NullableLowCardinalityReferenceColumn(string name, string typeName, IColumn<T> dictionary, int[] keys, int rowCount, bool pooledKeys)
+    {
+        Name = name;
+        TypeName = typeName;
+        this.dictionary = dictionary ?? throw new ArgumentNullException(nameof(dictionary));
+        this.keys = keys ?? throw new ArgumentNullException(nameof(keys));
+        this.rowCount = rowCount;
+        this.pooledKeys = pooledKeys;
+    }
+
+    /// <inheritdoc/>
+    public string Name { get; }
+
+    /// <inheritdoc/>
+    public string TypeName { get; }
+
+    /// <inheritdoc/>
+    public int RowCount => rowCount;
+
+    /// <inheritdoc/>
+    public IColumn<T> Dictionary => dictionary;
+
+    /// <inheritdoc/>
+    public ReadOnlySpan<int> Keys => keys.AsSpan(0, rowCount);
+
+    /// <summary>The rows, materialized once and cached, with <see langword="null"/> at the reserved-NULL-slot rows.</summary>
+    public ReadOnlySpan<T> Values
+    {
+        get
+        {
+            if (cache is null)
+            {
+                var decoded = new T[rowCount];
+                ReadOnlySpan<T> dict = dictionary.Values;
+                for (int i = 0; i < rowCount; i++)
+                {
+                    int key = keys[i];
+                    decoded[i] = key == 0 ? null : dict[key];
+                }
+
+                cache = decoded;
+            }
+
+            return cache.AsSpan(0, rowCount);
+        }
+    }
+
+    /// <inheritdoc/>
+    public T this[int row] => cache is not null ? cache[row] : keys[row] == 0 ? null : dictionary[keys[row]];
+
+    /// <inheritdoc/>
+    public object GetValue(int row) => this[row];
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        dictionary.Dispose();
+        if (pooledKeys && keys.Length != 0)
+        {
+            ArrayPool<int>.Shared.Return(keys);
+        }
+
+        keys = Array.Empty<int>();
+        cache = null;
+    }
+}

--- a/ClickHouse.Driver.Tcp/Types/NullableLowCardinalityReferenceColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/NullableLowCardinalityReferenceColumn.cs
@@ -75,6 +75,10 @@ internal sealed class NullableLowCardinalityReferenceColumn<T> : IColumn<T>, IDe
     /// <inheritdoc/>
     public ReadOnlySpan<int> Keys => keys.AsSpan(0, rowCount);
 
+    /// <inheritdoc/>
+    // Two reserved slots: the NULL marker at 0 and the inner default at 1, so real values start at 2.
+    public int ReservedSlotCount => 2;
+
     /// <summary>The rows, materialized once and cached, with <see langword="null"/> at the reserved-NULL-slot rows.</summary>
     public ReadOnlySpan<T> Values
     {

--- a/ClickHouse.Driver.Tcp/Types/NullableLowCardinalityReferenceColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/NullableLowCardinalityReferenceColumn.cs
@@ -38,6 +38,8 @@ internal sealed class NullableLowCardinalityReferenceColumn<T> : IColumn<T>, IDe
     /// <param name="keys">The per-row indices into <paramref name="dictionary"/>; must have at least <paramref name="rowCount"/> entries.</param>
     /// <param name="rowCount">The number of rows.</param>
     /// <param name="pooledKeys">Whether <paramref name="keys"/> was rented and should be returned on dispose.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="dictionary"/> or <paramref name="keys"/> is null.</exception>
+    /// <exception cref="ArgumentException"><paramref name="keys"/> holds fewer than <paramref name="rowCount"/> entries.</exception>
     public NullableLowCardinalityReferenceColumn(string name, string typeName, IColumn<T> dictionary, int[] keys, int rowCount, bool pooledKeys)
     {
         Name = name;
@@ -46,6 +48,16 @@ internal sealed class NullableLowCardinalityReferenceColumn<T> : IColumn<T>, IDe
         this.keys = keys ?? throw new ArgumentNullException(nameof(keys));
         this.rowCount = rowCount;
         this.pooledKeys = pooledKeys;
+
+        // The row count cannot be derived here: the dictionary holds one entry per distinct value (plus any reserved
+        // slots), and the keys are typically a pooled buffer longer than the column. So the one input that can
+        // disagree is checked instead — with a short keys array the per-row lookup would read past its end.
+        if (keys.Length < rowCount)
+        {
+            throw new ArgumentException(
+                $"The keys for column '{name}' ({typeName}) hold {keys.Length} entries, fewer than the {rowCount} rows.",
+                nameof(keys));
+        }
     }
 
     /// <inheritdoc/>
@@ -86,7 +98,22 @@ internal sealed class NullableLowCardinalityReferenceColumn<T> : IColumn<T>, IDe
     }
 
     /// <inheritdoc/>
-    public T this[int row] => cache is not null ? cache[row] : keys[row] == 0 ? null : dictionary[keys[row]];
+    // Index through the RowCount-sliced keys, not the raw buffer: the buffer is usually a pooled array longer than
+    // the column, and a stale key left in its tail by a previous read is a perfectly valid dictionary index — so an
+    // out-of-range row would quietly return a real value from the dictionary instead of throwing.
+    public T this[int row]
+    {
+        get
+        {
+            if (cache is not null)
+            {
+                return cache[row];
+            }
+
+            int key = Keys[row];
+            return key == 0 ? null : dictionary[key];
+        }
+    }
 
     /// <inheritdoc/>
     public object GetValue(int row) => this[row];

--- a/ClickHouse.Driver.Tcp/Types/NullableLowCardinalityValueColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/NullableLowCardinalityValueColumn.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Buffers;
+
+namespace ClickHouse.Driver.Tcp.Types;
+
+/// <summary>
+/// A ClickHouse <c>LowCardinality(Nullable(T))</c> column for a value-type inner: it pairs a dictionary of distinct
+/// inner values with a per-row array of keys, and surfaces each row as a <see cref="Nullable{T}"/> — the value
+/// <c>dict[keys[row]]</c>, or <see langword="null"/> where the key points at the reserved NULL slot (<c>key 0</c>).
+///
+/// <para>
+/// The dictionary is the bare inner type <typeparamref name="T"/> (there is no null-map in the dictionary stream);
+/// nullability is expressed positionally through the reserved slot 0. The dictionary reserves two leading slots —
+/// <c>dict[0]</c> is the NULL marker and <c>dict[1]</c> the inner default — so real distinct values start at
+/// <c>dict[2]</c>. This is the dense shape the wire uses, so it is also the zero-copy source for writing.
+/// </para>
+///
+/// <para>
+/// The dictionary column's storage and the keys are borrowed for this column's lifetime; the dictionary is disposed
+/// and the keys returned (when pooled) on <see cref="Dispose"/>. Read the column only while the owning block is alive.
+/// </para>
+/// </summary>
+/// <typeparam name="T">The inner value type; each row surfaces as <c>T?</c>.</typeparam>
+internal sealed class NullableLowCardinalityValueColumn<T> : IColumn<T?>, IDenseLowCardinality<T>
+    where T : struct
+{
+    private readonly IColumn<T> dictionary;
+    private readonly int rowCount;
+    private readonly bool pooledKeys;
+    private int[] keys;
+    private T?[] cache;
+
+    /// <summary>Initializes a nullable low-cardinality column over a dictionary column and its per-row keys.</summary>
+    /// <param name="name">The column name.</param>
+    /// <param name="typeName">The full <c>LowCardinality(Nullable(...))</c> type string.</param>
+    /// <param name="dictionary">The dictionary column holding the distinct values (including the reserved slots).</param>
+    /// <param name="keys">The per-row indices into <paramref name="dictionary"/>; must have at least <paramref name="rowCount"/> entries.</param>
+    /// <param name="rowCount">The number of rows.</param>
+    /// <param name="pooledKeys">Whether <paramref name="keys"/> was rented and should be returned on dispose.</param>
+    public NullableLowCardinalityValueColumn(string name, string typeName, IColumn<T> dictionary, int[] keys, int rowCount, bool pooledKeys)
+    {
+        Name = name;
+        TypeName = typeName;
+        this.dictionary = dictionary ?? throw new ArgumentNullException(nameof(dictionary));
+        this.keys = keys ?? throw new ArgumentNullException(nameof(keys));
+        this.rowCount = rowCount;
+        this.pooledKeys = pooledKeys;
+    }
+
+    /// <inheritdoc/>
+    public string Name { get; }
+
+    /// <inheritdoc/>
+    public string TypeName { get; }
+
+    /// <inheritdoc/>
+    public int RowCount => rowCount;
+
+    /// <inheritdoc/>
+    public IColumn<T> Dictionary => dictionary;
+
+    /// <inheritdoc/>
+    public ReadOnlySpan<int> Keys => keys.AsSpan(0, rowCount);
+
+    /// <summary>
+    /// The rows as <see cref="Nullable{T}"/>, materialized once and cached. Prefer the indexer when only some rows
+    /// are needed, to avoid reconstructing the whole column.
+    /// </summary>
+    public ReadOnlySpan<T?> Values
+    {
+        get
+        {
+            if (cache is null)
+            {
+                var decoded = new T?[rowCount];
+                ReadOnlySpan<T> dict = dictionary.Values;
+                for (int i = 0; i < rowCount; i++)
+                {
+                    int key = keys[i];
+                    decoded[i] = key == 0 ? null : dict[key];
+                }
+
+                cache = decoded;
+            }
+
+            return cache.AsSpan(0, rowCount);
+        }
+    }
+
+    /// <inheritdoc/>
+    public T? this[int row] => cache is not null ? cache[row] : keys[row] == 0 ? null : dictionary[keys[row]];
+
+    /// <inheritdoc/>
+    public object GetValue(int row)
+    {
+        T? value = this[row];
+        return value.HasValue ? value.Value : null;
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        dictionary.Dispose();
+        if (pooledKeys && keys.Length != 0)
+        {
+            ArrayPool<int>.Shared.Return(keys);
+        }
+
+        keys = Array.Empty<int>();
+        cache = null;
+    }
+}

--- a/ClickHouse.Driver.Tcp/Types/NullableLowCardinalityValueColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/NullableLowCardinalityValueColumn.cs
@@ -74,6 +74,10 @@ internal sealed class NullableLowCardinalityValueColumn<T> : IColumn<T?>, IDense
     /// <inheritdoc/>
     public ReadOnlySpan<int> Keys => keys.AsSpan(0, rowCount);
 
+    /// <inheritdoc/>
+    // Two reserved slots: the NULL marker at 0 and the inner default at 1, so real values start at 2.
+    public int ReservedSlotCount => 2;
+
     /// <summary>
     /// The rows as <see cref="Nullable{T}"/>, materialized once and cached. Prefer the indexer when only some rows
     /// are needed, to avoid reconstructing the whole column.

--- a/ClickHouse.Driver.Tcp/Types/NullableLowCardinalityValueColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/NullableLowCardinalityValueColumn.cs
@@ -37,6 +37,8 @@ internal sealed class NullableLowCardinalityValueColumn<T> : IColumn<T?>, IDense
     /// <param name="keys">The per-row indices into <paramref name="dictionary"/>; must have at least <paramref name="rowCount"/> entries.</param>
     /// <param name="rowCount">The number of rows.</param>
     /// <param name="pooledKeys">Whether <paramref name="keys"/> was rented and should be returned on dispose.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="dictionary"/> or <paramref name="keys"/> is null.</exception>
+    /// <exception cref="ArgumentException"><paramref name="keys"/> holds fewer than <paramref name="rowCount"/> entries.</exception>
     public NullableLowCardinalityValueColumn(string name, string typeName, IColumn<T> dictionary, int[] keys, int rowCount, bool pooledKeys)
     {
         Name = name;
@@ -45,6 +47,16 @@ internal sealed class NullableLowCardinalityValueColumn<T> : IColumn<T?>, IDense
         this.keys = keys ?? throw new ArgumentNullException(nameof(keys));
         this.rowCount = rowCount;
         this.pooledKeys = pooledKeys;
+
+        // The row count cannot be derived here: the dictionary holds one entry per distinct value (plus any reserved
+        // slots), and the keys are typically a pooled buffer longer than the column. So the one input that can
+        // disagree is checked instead — with a short keys array the per-row lookup would read past its end.
+        if (keys.Length < rowCount)
+        {
+            throw new ArgumentException(
+                $"The keys for column '{name}' ({typeName}) hold {keys.Length} entries, fewer than the {rowCount} rows.",
+                nameof(keys));
+        }
     }
 
     /// <inheritdoc/>
@@ -88,7 +100,22 @@ internal sealed class NullableLowCardinalityValueColumn<T> : IColumn<T?>, IDense
     }
 
     /// <inheritdoc/>
-    public T? this[int row] => cache is not null ? cache[row] : keys[row] == 0 ? null : dictionary[keys[row]];
+    // Index through the RowCount-sliced keys, not the raw buffer: the buffer is usually a pooled array longer than
+    // the column, and a stale key left in its tail by a previous read is a perfectly valid dictionary index — so an
+    // out-of-range row would quietly return a real value from the dictionary instead of throwing.
+    public T? this[int row]
+    {
+        get
+        {
+            if (cache is not null)
+            {
+                return cache[row];
+            }
+
+            int key = Keys[row];
+            return key == 0 ? null : dictionary[key];
+        }
+    }
 
     /// <inheritdoc/>
     public object GetValue(int row)


### PR DESCRIPTION
## What

Implements **`LowCardinality(T)`** for the TCP/Native client (Epic J1), for **both non-nullable and nullable inner types**. A `LowCardinality` column replaces a run of inner values with a block-local dictionary of the distinct values plus one key per row indexing into it.

Works both top-level and under composites (`Array(LowCardinality(String))` verified).

## Design

- **Wire body:** metadata `UInt64` (key-width code in the low byte + `HasAdditionalKeys | NeedUpdateDictionary` = `0x600`), `dict_size`, dictionary values via the inner codec, `keys_count`, then keys at `1 << code` bytes. Key width is the smallest that indexes the dictionary (UInt8/16/32). An empty (or empty-flattened) column writes no body.
- **Column surface:** dense `LowCardinalityColumn<T>` (dictionary column + `int[]` keys) reconstructs `dict[keys[row]]` and is the zero-copy write source; the ergonomic write source is a plain `IColumn<T>`, deduplicated into a fresh block-local dictionary on write. Follows the existing `Array`/`Nullable` shape-bridge pattern (`ILowCardinalityShape` + reflection-cached per-element-type shape). Each Native block ships a self-contained dictionary, so the codec stays a shared singleton.
- **`byte[]` dedup:** `FixedString` element type (`byte[]`) uses a structural comparer so equal values collapse to one dictionary slot rather than defaulting to reference equality.
- **Hostile-stream validation:** unknown key-width code, global-dictionary bit, missing additional-keys bit, `dict_size`/key-stream overflow, `keys_count` mismatch, and out-of-range keys are all rejected.

### `LowCardinality(Nullable(T))`

The composability gap the non-nullable path left open: the codec's single `inner` field was serving as **both** the dictionary's wire serializer **and** the element-type/null authority. `Nullable` inner forces those apart.

- **The dictionary stays bare `T` — no null-map.** Nullability is expressed *positionally* by two reserved leading slots: `dict[0]` is the NULL marker and `dict[1]` the inner default, so real distinct values start at `dict[2]`. Every NULL row's key points at `dict[0]`.
- **Resolve the bare inner, not the `Nullable` codec.** `Create` detects a `Nullable` inner and resolves the codec for the *unwrapped* type (`registry.ResolveNode(innerNode.Arguments[0])`), carrying a `nullable` flag. Resolving the `Nullable` codec would frame a null-map inside the dictionary stream and desynchronize the reader.
- **Surface type diverges from the dictionary type.** For a value inner, the dictionary decodes as `IColumn<T>` but the column surfaces `T?` (`NullableLowCardinalityValueColumn<T>`); for a reference inner it surfaces the nullable reference (`NullableLowCardinalityReferenceColumn<T>`). Both read a `key == 0` row back as NULL. Selected via a value/reference shape split mirroring `Nullable`'s.
- **Write dedup, inverted default folding.** A NULL row maps to key 0; a present value equal to the inner default reuses the reserved default **slot 1** (so it round-trips as a present default, distinct from NULL) rather than folding into slot 0 as the non-nullable path does.
- **Dense re-emit safety.** The dense nullable columns are the zero-copy re-emit source via a new `IDenseLowCardinality<T>` marker. The non-nullable `LowCardinalityColumn<T>` deliberately does **not** implement it — its single reserved slot would be misread as NULL if re-emitted verbatim under a nullable codec.

Like Array/Tuple/Map/Nested, the server rejects `Nullable(LowCardinality(T))`, so nullability composes inside as `LowCardinality(Nullable(T))`.

## Testing

Codec unit tests cover the documented wire bytes, key-width promotion, hostile streams, dense re-emit, and the nullable-specific paths (present-default-vs-NULL, value/reference/FixedString, empty slice). Verified end-to-end against **ClickHouse 26.6**: `LowCardinality(T)` and `LowCardinality(Nullable(T))` round-trips for `String`, `UInt32`, and `FixedString(4)`, interleaving NULLs with present values (including a present inner-default value). New/changed codec files are ~98% line / 100% method covered.