### PR TITLE
TCP J3: Add Variant(...) support

### DIFF
--- a/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpConnectionInsertIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpConnectionInsertIntegrationTests.cs
@@ -474,6 +474,55 @@ public class ClickHouseTcpConnectionInsertIntegrationTests
         }
     }
 
+    [Test]
+    public async Task InsertAsync_DenseVariantColumnSplitAcrossBlocks_RoundTripsEveryRow()
+    {
+        var settings = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["allow_experimental_variant_type"] = "1",
+            ["allow_suspicious_variant_types"] = "1",
+        };
+        await using var connection = await TcpServerFixture.ConnectAsync(None);
+        string table = UniqueTableName();
+        try
+        {
+            await ExecuteAsync(connection, $"CREATE TABLE {table} (id UInt32, value Variant(String, UInt64)) ENGINE = Memory", settings);
+
+            // Discriminator 0 = String, 1 = UInt64, 255 = NULL. Interleaving the two alternatives (and a NULL) so
+            // that the maxRowsPerBlock: 2 split lands mid-run for both types — every block after the first then
+            // starts at a non-zero per-type offset, exercising the dense write path's before-slice offset
+            // derivation (the O(length) LocalIndices pass, not the old [0, start) rescan). Each type column holds
+            // its rows' values in row order: String rows 1,4,6; UInt64 rows 0,3,5.
+            object[] expected = { 100UL, "a", null, 200UL, "b", 300UL, "c" };
+            var discriminators = new byte[] { 1, 0, 255, 1, 0, 1, 0 };
+            IColumn[] typeColumns =
+            {
+                new ArrayColumn<string>("value", "String", new[] { "a", "b", "c" }),
+                PrimitiveColumn<ulong>.FromValues("value", "UInt64", new ulong[] { 100, 200, 300 }),
+            };
+            var dense = new VariantColumn("value", "Variant(String, UInt64)", discriminators, typeColumns, expected.Length, pooledDiscriminators: false, ownsColumns: false);
+
+            IColumn[] columns = { PrimitiveColumn<uint>.FromValues("id", "UInt32", RowIds(expected.Length)), dense };
+            await connection.InsertAsync($"INSERT INTO {table} (id, value) VALUES", columns, maxRowsPerBlock: 2, settings: settings, cancellationToken: None);
+
+            var readBack = new List<object>(expected.Length);
+            await foreach (Block block in connection.QueryAsync($"SELECT value FROM {table} ORDER BY id", settings: settings, cancellationToken: None))
+            {
+                for (int row = 0; row < block[0].RowCount; row++)
+                {
+                    readBack.Add(block[0].GetValue(row));
+                }
+            }
+
+            Assert.That(readBack, Is.EqualTo(expected));
+            Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+        }
+        finally
+        {
+            await ExecuteAsync(connection, $"DROP TABLE IF EXISTS {table}");
+        }
+    }
+
     private static uint[] RowIds(int count)
     {
         var ids = new uint[count];

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ColumnarReadSurfaceIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ColumnarReadSurfaceIntegrationTests.cs
@@ -626,6 +626,92 @@ public class ColumnarReadSurfaceIntegrationTests
         }
     }
 
+    [Test]
+    public async Task QueryAsync_VariantColumn_ExposesDiscriminatorsAndPerTypeChildColumnsThroughIVariantColumn()
+    {
+        // Variant is the composite with no useful materialized element type: its IColumn<T> surface is
+        // IColumn<object>, so every row read through it is boxed. The columnar view is the only typed way in —
+        // dispatch on the discriminator, then read the selected type's child column, which is typed. Each child holds
+        // only its own rows, contiguously, so the per-row position within a child is not the row index; LocalIndices
+        // carries that mapping, precomputed by one walk of the discriminators.
+        var settings = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["allow_experimental_variant_type"] = "1",
+            ["allow_suspicious_variant_types"] = "1",
+        };
+        await using var connection = await TcpServerFixture.ConnectAsync(None);
+
+        bool matched = false;
+        int typeCount = 0;
+        int rowCount = 0;
+        byte[] discriminators = null;
+        int discriminatorLength = 0;
+        int[] localIndices = null;
+        string[] stringChild = null;
+        ulong[] intChild = null;
+        var typedReads = new List<object>();
+        var materialized = new List<object>();
+
+        // Rows: 100, 'a', NULL, 400, 'b' — interleaved so neither child's rows are contiguous by row index.
+        await foreach (Block block in connection.QueryAsync(
+            """
+            SELECT CAST(multiIf(number = 1, CAST('a', 'Variant(String, UInt64)'),
+                                number = 2, CAST(NULL, 'Variant(String, UInt64)'),
+                                number = 4, CAST('b', 'Variant(String, UInt64)'),
+                                CAST(toUInt64((number + 1) * 100), 'Variant(String, UInt64)')), 'Variant(String, UInt64)')
+            FROM system.numbers LIMIT 5
+            """,
+            settings: settings,
+            cancellationToken: None))
+        {
+            IColumn column = block[0];
+            matched = column is IVariantColumn;
+
+            var variant = (IVariantColumn)column;
+            typeCount = variant.TypeCount;
+            rowCount = variant.RowCount;
+            discriminators = variant.Discriminators.ToArray();
+            discriminatorLength = variant.Discriminators.Length;
+            localIndices = variant.LocalIndices.ToArray();
+            stringChild = ((IColumn<string>)variant.GetTypeColumn(0)).Values.ToArray();
+            intChild = ((IColumn<ulong>)variant.GetTypeColumn(1)).Values.ToArray();
+
+            // The typed dispatch the interface exists for: no boxing except what we do here to compare.
+            for (int row = 0; row < variant.RowCount; row++)
+            {
+                byte d = variant.Discriminators[row];
+                if (d == IVariantColumn.NullDiscriminator)
+                {
+                    typedReads.Add(null);
+                }
+                else if (d == 0)
+                {
+                    typedReads.Add(((IColumn<string>)variant.GetTypeColumn(0))[variant.LocalIndices[row]]);
+                }
+                else
+                {
+                    typedReads.Add(((IColumn<ulong>)variant.GetTypeColumn(1))[variant.LocalIndices[row]]);
+                }
+
+                materialized.Add(column.GetValue(row));
+            }
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(matched, Is.True);
+            Assert.That(typeCount, Is.EqualTo(2));
+            Assert.That(rowCount, Is.EqualTo(5));
+            Assert.That(discriminatorLength, Is.EqualTo(rowCount), "sliced to the row count, not the pooled buffer length");
+            Assert.That(discriminators, Is.EqualTo(new byte[] { 1, 0, IVariantColumn.NullDiscriminator, 1, 0 }), "0 = String, 1 = UInt64, 255 = NULL");
+            Assert.That(localIndices, Is.EqualTo(new[] { 0, 0, -1, 1, 1 }), "per-type running position; a NULL row addresses no child, so -1");
+            Assert.That(stringChild, Is.EqualTo(new[] { "a", "b" }), "each child holds only its own rows, contiguously");
+            Assert.That(intChild, Is.EqualTo(new ulong[] { 100, 400 }));
+            Assert.That(typedReads, Is.EqualTo(materialized), "the typed columnar dispatch agrees with the boxed surface");
+            Assert.That(materialized, Is.EqualTo(new object[] { 100UL, "a", null, 400UL, "b" }));
+        });
+    }
+
     private static async Task ExecuteAsync(ClickHouseTcpConnection connection, string sql)
     {
         await foreach (Block block in connection.QueryAsync(sql, cancellationToken: None))

--- a/ClickHouse.Driver.Tcp.Tests/Types/ColumnCodecRegistryTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/ColumnCodecRegistryTests.cs
@@ -34,7 +34,7 @@ public class ColumnCodecRegistryTests
 
     [Test]
     public void Resolve_UnsupportedButWellFormedType_ThrowsNotSupported()
-        => Assert.Throws<NotSupportedException>(() => ColumnCodecRegistry.Default.Resolve("Variant(UInt8, String)", default));
+        => Assert.Throws<NotSupportedException>(() => ColumnCodecRegistry.Default.Resolve("Point", default));
 
     [Test]
     public void Resolve_MalformedType_ThrowsFormat()

--- a/ClickHouse.Driver.Tcp.Tests/Types/VariantColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/VariantColumnCodecTests.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Protocol;
+using ClickHouse.Driver.Tcp.Tests.Utilities;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Tests.Types;
+
+[TestFixture]
+public class VariantColumnCodecTests
+{
+    private const string StringUInt64 = "Variant(String, UInt64)";
+
+    private static IColumnCodec Resolve(string type) => ColumnCodecRegistry.Default.Resolve(type, default);
+
+    // The canonical example from the native-format notes: Variant(String, UInt64) with [42, 'hi', NULL]. String
+    // sorts before UInt64, so discriminator 0 = String, 1 = UInt64.
+    private static readonly byte[] DocumentedBytes =
+    {
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // state prefix: discriminators mode = 0 (BASIC)
+        0x01, 0x00, 0xFF,                               // discriminators: 1 (UInt64), 0 (String), 255 (NULL)
+        0x02, 0x68, 0x69,                               // String run (1 value): len = 2, "hi"
+        0x2A, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // UInt64 run (1 value): 42
+    };
+
+    [Test]
+    public async Task WriteStatePrefixAndColumn_DocumentedExample_ProducesTheDocumentedBytes()
+    {
+        IColumnCodec codec = Resolve(StringUInt64);
+        var column = new ArrayColumn<object>("v", StringUInt64, new object[] { 42UL, "hi", null });
+
+        byte[] bytes = await CodecTestHarness.WriteAsync(w =>
+        {
+            codec.WriteStatePrefix(w, column);
+            codec.WriteColumn(w, column);
+        });
+
+        CollectionAssert.AreEqual(DocumentedBytes, bytes);
+    }
+
+    [Test]
+    public async Task ReadColumn_DocumentedBytes_ReconstructsValuesAndNull()
+    {
+        IColumnCodec codec = Resolve(StringUInt64);
+
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(DocumentedBytes);
+        await codec.ReadStatePrefixAsync(reader, CodecTestHarness.None);
+        using IColumn column = await codec.ReadColumnAsync(reader, "v", StringUInt64, 3, CodecTestHarness.None);
+
+        Assert.That(column.RowCount, Is.EqualTo(3));
+        Assert.That(column.GetValue(0), Is.EqualTo(42UL));
+        Assert.That(column.GetValue(1), Is.EqualTo("hi"));
+        Assert.That(column.GetValue(2), Is.Null);
+    }
+
+    [Test]
+    public async Task WriteColumn_DenseColumnReadBack_RoundTripsToIdenticalBytes()
+    {
+        IColumnCodec codec = Resolve(StringUInt64);
+
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(DocumentedBytes);
+        await codec.ReadStatePrefixAsync(reader, CodecTestHarness.None);
+        using IColumn dense = await codec.ReadColumnAsync(reader, "v", StringUInt64, 3, CodecTestHarness.None);
+
+        // The read-back VariantColumn is the zero-copy write source: writing it must reproduce the exact bytes.
+        byte[] bytes = await CodecTestHarness.WriteAsync(w =>
+        {
+            codec.WriteStatePrefix(w, dense);
+            codec.WriteColumn(w, dense);
+        });
+
+        CollectionAssert.AreEqual(DocumentedBytes, bytes);
+    }
+
+    [Test]
+    public void ReadStatePrefix_CompactDiscriminatorsMode_Throws()
+    {
+        IColumnCodec codec = Resolve(StringUInt64);
+
+        // Mode 1 = COMPACT, which this client does not implement.
+        byte[] compactPrefix = { 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(compactPrefix);
+
+        Assert.ThrowsAsync<NotSupportedException>(async () => await codec.ReadStatePrefixAsync(reader, CodecTestHarness.None));
+    }
+
+    [Test]
+    public void ReadColumn_DiscriminatorPastAlternativeCount_Throws()
+    {
+        IColumnCodec codec = Resolve(StringUInt64);
+
+        // Discriminator 5 selects no declared alternative (only 0 and 1 exist).
+        byte[] bytes = { 0x05 };
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(bytes);
+
+        Assert.ThrowsAsync<FormatException>(async () => await codec.ReadColumnAsync(reader, "v", StringUInt64, 1, CodecTestHarness.None));
+    }
+
+    [Test]
+    public void Create_NullableAlternative_Throws()
+        => Assert.Throws<FormatException>(() => Resolve("Variant(String, Nullable(UInt64))"));
+
+    [Test]
+    public void Create_NoArguments_Throws()
+        => Assert.Throws<FormatException>(() => Resolve("Variant()"));
+
+    [Test]
+    public void Create_DynamicAlternative_Throws()
+        => Assert.Throws<FormatException>(() => Resolve("Variant(String, Dynamic)"));
+
+    [Test]
+    public void WriteColumn_ValueWithNoMatchingAlternative_Throws()
+    {
+        IColumnCodec codec = Resolve(StringUInt64);
+        var column = new ArrayColumn<object>("v", StringUInt64, new object[] { 3.14 }); // double matches neither String nor UInt64
+
+        Assert.ThrowsAsync<ArgumentException>(async () => await CodecTestHarness.WriteAsync(w => codec.WriteColumn(w, column)));
+    }
+
+    [Test]
+    public async Task WriteColumn_DenseColumnSlice_WritesOnlyTheSlicedRowsAndTheirValues()
+    {
+        IColumnCodec codec = Resolve(StringUInt64);
+
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(DocumentedBytes);
+        await codec.ReadStatePrefixAsync(reader, CodecTestHarness.None);
+        using IColumn dense = await codec.ReadColumnAsync(reader, "v", StringUInt64, 3, CodecTestHarness.None);
+
+        // Slice rows [1, 3): "hi" (String) and NULL. The discriminators are 00 FF; only the String run carries a
+        // value ("hi"), and the UInt64 run is empty because row 0 (the only UInt64) is before the slice.
+        byte[] bytes = await CodecTestHarness.WriteAsync(w => codec.WriteColumn(w, dense, 1, 2));
+
+        byte[] expected = { 0x00, 0xFF, 0x02, 0x68, 0x69 };
+        CollectionAssert.AreEqual(expected, bytes);
+    }
+
+    [Test]
+    public async Task ReadColumn_ZeroRows_ReturnsEmptyColumn()
+    {
+        IColumnCodec codec = Resolve(StringUInt64);
+
+        // A zero-row block carries no prefix and no body, so read straight from an empty buffer.
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(Array.Empty<byte>());
+        using IColumn column = await codec.ReadColumnAsync(reader, "v", StringUInt64, 0, CodecTestHarness.None);
+
+        Assert.That(column.RowCount, Is.Zero);
+    }
+
+    [Test]
+    public void RestrictOwnership_DisposesOnlyFlaggedTypeColumns()
+    {
+        // The mechanism the partial densify rebuild relies on: after RestrictOwnership, Dispose frees exactly the
+        // alternative columns flagged true (the freshly built ones) and leaves the rest (borrowed) untouched.
+        var owned = new DisposeSpyColumn<uint>("v", "UInt32", new uint[] { 1 });
+        var borrowed = new DisposeSpyColumn<int>("v", "Int32", new[] { 2 });
+        var variant = new VariantColumn("v", "Variant(UInt32, Int32)", new byte[] { 0, 1 }, new IColumn[] { owned, borrowed }, rowCount: 2, pooledDiscriminators: false, ownsColumns: false);
+
+        variant.RestrictOwnership(new[] { true, false });
+        variant.Dispose();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(owned.DisposeCount, Is.EqualTo(1), "a flagged (freshly built) alternative column must be disposed exactly once");
+            Assert.That(borrowed.DisposeCount, Is.EqualTo(0), "an unflagged (borrowed) alternative column must not be disposed");
+        });
+    }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Types/VariantColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/VariantColumnCodecTests.cs
@@ -147,6 +147,38 @@ public class VariantColumnCodecTests
     }
 
     [Test]
+    public void Indexer_RowPastRowCount_ThrowsRatherThanReadingStaleDiscriminators()
+    {
+        // The discriminator buffer is normally a pooled array longer than the column, so a row past RowCount read a
+        // stale byte from its tail — and the outcome depended on the leftover value: a stale 255 (the NULL
+        // discriminator) reported the row as an existing NULL, while any other value fell through to the
+        // exactly-sized local-index array and threw. Both spellings must be a bounds failure.
+        using var alternative = new ArrayColumn<uint>("v", "UInt32", new uint[] { 7 });
+        var discriminators = new byte[] { 0, VariantColumn.NullDiscriminator, 0 };
+        using var variant = new VariantColumn(
+            "v", "Variant(UInt32)", discriminators, new IColumn[] { alternative }, rowCount: 1, pooledDiscriminators: false, ownsColumns: false);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(variant[0], Is.EqualTo(7u));
+            Assert.That(() => variant[1], Throws.InstanceOf<IndexOutOfRangeException>(), "a stale NULL discriminator must not read as an existing NULL row");
+            Assert.That(() => variant[2], Throws.InstanceOf<IndexOutOfRangeException>());
+        });
+    }
+
+    [Test]
+    public void Constructor_DiscriminatorsShorterThanRowCount_Throws()
+    {
+        // rowCount is load-bearing here — each child holds only the rows that selected it, and a NULL row takes a slot
+        // in none of them — so it is validated rather than derived.
+        using var alternative = new ArrayColumn<uint>("v", "UInt32", new uint[] { 7 });
+
+        Assert.That(
+            () => new VariantColumn("v", "Variant(UInt32)", new byte[] { 0 }, new IColumn[] { alternative }, rowCount: 2, pooledDiscriminators: false, ownsColumns: false),
+            Throws.ArgumentException.With.Message.Contains("fewer than"));
+    }
+
+    [Test]
     public void RestrictOwnership_DisposesOnlyFlaggedTypeColumns()
     {
         // The mechanism the partial densify rebuild relies on: after RestrictOwnership, Dispose frees exactly the

--- a/ClickHouse.Driver.Tcp.Tests/Types/VariantColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/VariantColumnCodecTests.cs
@@ -154,7 +154,7 @@ public class VariantColumnCodecTests
         // discriminator) reported the row as an existing NULL, while any other value fell through to the
         // exactly-sized local-index array and threw. Both spellings must be a bounds failure.
         using var alternative = new ArrayColumn<uint>("v", "UInt32", new uint[] { 7 });
-        var discriminators = new byte[] { 0, VariantColumn.NullDiscriminator, 0 };
+        var discriminators = new byte[] { 0, IVariantColumn.NullDiscriminator, 0 };
         using var variant = new VariantColumn(
             "v", "Variant(UInt32)", discriminators, new IColumn[] { alternative }, rowCount: 1, pooledDiscriminators: false, ownsColumns: false);
 

--- a/ClickHouse.Driver.Tcp.Tests/Types/VariantColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/VariantColumnCodecTests.cs
@@ -13,21 +13,24 @@ public class VariantColumnCodecTests
 
     private static IColumnCodec Resolve(string type) => ColumnCodecRegistry.Default.Resolve(type, default);
 
-    // The canonical example from the native-format notes: Variant(String, UInt64) with [42, 'hi', NULL]. String
-    // sorts before UInt64, so discriminator 0 = String, 1 = UInt64.
+    // The example documented on VariantColumnCodec: Variant(String, UInt64) with [42, 'hi', NULL, 7, 'yo']. String
+    // sorts before UInt64, so discriminator 0 = String, 1 = UInt64. Each run holds its own rows in row order, so a
+    // multi-value run also pins that ordering. Verified against a ClickHouse 26.6 SELECT ... FORMAT Native.
     private static readonly byte[] DocumentedBytes =
     {
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // state prefix: discriminators mode = 0 (BASIC)
-        0x01, 0x00, 0xFF,                               // discriminators: 1 (UInt64), 0 (String), 255 (NULL)
-        0x02, 0x68, 0x69,                               // String run (1 value): len = 2, "hi"
-        0x2A, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // UInt64 run (1 value): 42
+        0x01, 0x00, 0xFF, 0x01, 0x00,                   // discriminators: UInt64, String, NULL, UInt64, String
+        0x02, 0x68, 0x69,                               // String run, rows 1 and 4: len = 2, "hi"
+        0x02, 0x79, 0x6F,                               //                          len = 2, "yo"
+        0x2A, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // UInt64 run, rows 0 and 3: 42
+        0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, //                           7
     };
 
     [Test]
     public async Task WriteStatePrefixAndColumn_DocumentedExample_ProducesTheDocumentedBytes()
     {
         IColumnCodec codec = Resolve(StringUInt64);
-        var column = new ArrayColumn<object>("v", StringUInt64, new object[] { 42UL, "hi", null });
+        var column = new ArrayColumn<object>("v", StringUInt64, new object[] { 42UL, "hi", null, 7UL, "yo" });
 
         byte[] bytes = await CodecTestHarness.WriteAsync(w =>
         {
@@ -45,12 +48,16 @@ public class VariantColumnCodecTests
 
         using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(DocumentedBytes);
         await codec.ReadStatePrefixAsync(reader, CodecTestHarness.None);
-        using IColumn column = await codec.ReadColumnAsync(reader, "v", StringUInt64, 3, CodecTestHarness.None);
+        using IColumn column = await codec.ReadColumnAsync(reader, "v", StringUInt64, 5, CodecTestHarness.None);
 
-        Assert.That(column.RowCount, Is.EqualTo(3));
+        Assert.That(column.RowCount, Is.EqualTo(5));
         Assert.That(column.GetValue(0), Is.EqualTo(42UL));
         Assert.That(column.GetValue(1), Is.EqualTo("hi"));
         Assert.That(column.GetValue(2), Is.Null);
+
+        // Rows past the NULL: each addresses the second value of its run, so these also pin the per-row local index.
+        Assert.That(column.GetValue(3), Is.EqualTo(7UL));
+        Assert.That(column.GetValue(4), Is.EqualTo("yo"));
     }
 
     [Test]
@@ -60,7 +67,7 @@ public class VariantColumnCodecTests
 
         using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(DocumentedBytes);
         await codec.ReadStatePrefixAsync(reader, CodecTestHarness.None);
-        using IColumn dense = await codec.ReadColumnAsync(reader, "v", StringUInt64, 3, CodecTestHarness.None);
+        using IColumn dense = await codec.ReadColumnAsync(reader, "v", StringUInt64, 5, CodecTestHarness.None);
 
         // The read-back VariantColumn is the zero-copy write source: writing it must reproduce the exact bytes.
         byte[] bytes = await CodecTestHarness.WriteAsync(w =>
@@ -124,13 +131,36 @@ public class VariantColumnCodecTests
 
         using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(DocumentedBytes);
         await codec.ReadStatePrefixAsync(reader, CodecTestHarness.None);
-        using IColumn dense = await codec.ReadColumnAsync(reader, "v", StringUInt64, 3, CodecTestHarness.None);
+        using IColumn dense = await codec.ReadColumnAsync(reader, "v", StringUInt64, 5, CodecTestHarness.None);
 
-        // Slice rows [1, 3): "hi" (String) and NULL. The discriminators are 00 FF; only the String run carries a
-        // value ("hi"), and the UInt64 run is empty because row 0 (the only UInt64) is before the slice.
+        // Slice rows [1, 3): "hi" (String) and NULL. The discriminators are 00 FF; the String run is cut to just
+        // the in-slice value ("hi", leaving out "yo" at row 4), and the UInt64 run is empty because both its rows
+        // (0 and 3) fall outside the slice.
         byte[] bytes = await CodecTestHarness.WriteAsync(w => codec.WriteColumn(w, dense, 1, 2));
 
         byte[] expected = { 0x00, 0xFF, 0x02, 0x68, 0x69 };
+        CollectionAssert.AreEqual(expected, bytes);
+    }
+
+    [Test]
+    public async Task WriteColumn_DenseColumnSliceAfterEarlierValues_StartsEachRunAtItsSliceOffset()
+    {
+        IColumnCodec codec = Resolve(StringUInt64);
+
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(DocumentedBytes);
+        await codec.ReadStatePrefixAsync(reader, CodecTestHarness.None);
+        using IColumn dense = await codec.ReadColumnAsync(reader, "v", StringUInt64, 5, CodecTestHarness.None);
+
+        // Slice rows [3, 5): 7 (UInt64) and "yo" (String). Both rows are the *second* value of their run, so each
+        // run must be written from offset 1 — the case a slice starting at row 0 cannot catch.
+        byte[] bytes = await CodecTestHarness.WriteAsync(w => codec.WriteColumn(w, dense, 3, 2));
+
+        byte[] expected =
+        {
+            0x01, 0x00,                                     // discriminators: UInt64, String
+            0x02, 0x79, 0x6F,                               // String run from offset 1: "yo"
+            0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // UInt64 run from offset 1: 7
+        };
         CollectionAssert.AreEqual(expected, bytes);
     }
 

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
@@ -942,6 +942,30 @@ public sealed class InsertRoundTripCase
                 new object[] { "hi", ("lc", (byte)7), null, (string.Empty, (byte)0) }),
             VariantSettings);
 
+        // An alternative that carries a state prefix but is selected by no row in the block. The variant's
+        // alternatives are fixed by its type, not by the data, so every alternative's prefix belongs on the wire
+        // whether or not any row picks it — here LowCardinality's dictionary prefix, with every row a UInt64 or
+        // NULL. Omitting it desyncs the block, so the server rejects the insert rather than storing bad data.
+        yield return Same(
+            "Variant(LowCardinality(String), UInt64) [absent alternative]",
+            "Variant(LowCardinality(String), UInt64)",
+            name => new ArrayColumn<object>(
+                name,
+                "Variant(LowCardinality(String), UInt64)",
+                new object[] { 1UL, null, 2UL, null }),
+            VariantSettings);
+
+        // The same, one level deeper: the absent alternative is a Tuple whose own element carries the prefix, so the
+        // tuple's children have to be walked over an empty slice for that prefix to be emitted at all.
+        yield return Same(
+            "Variant(Tuple(LowCardinality(String), UInt8), UInt64) [absent alternative]",
+            "Variant(Tuple(LowCardinality(String), UInt8), UInt64)",
+            name => new ArrayColumn<object>(
+                name,
+                "Variant(Tuple(LowCardinality(String), UInt8), UInt64)",
+                new object[] { 7UL, null, 9UL }),
+            VariantSettings);
+
         // Array(Variant(...)) composition: the array flattens its elements into one Variant value stream, so each
         // element is a variant value (or NULL) and empty rows ride along.
         yield return Arrays(

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
@@ -918,9 +918,8 @@ public sealed class InsertRoundTripCase
             name => new ArrayColumn<object>(name, "Variant(Array(UInt64), String)", new object[] { "hello", new ulong[] { 1, 2, 3 }, null, Array.Empty<ulong>() }),
             VariantSettings);
 
-        // A Tuple alternative. Worth a case of its own because the variant has no per-slice write state: it forwards
-        // its own column to every alternative's prefix phase, so the tuple codec is handed a column it cannot project
-        // into per-element children and has to walk its children instead. A row selecting it carries the ValueTuple.
+        // A Tuple alternative: the variant projects the rows that selected it into a column of its own, which the
+        // tuple codec then distributes across its per-element children. A row selecting it carries the ValueTuple.
         yield return Same(
             "Variant(String, Tuple(UInt8, String))",
             "Variant(String, Tuple(UInt8, String))",
@@ -930,9 +929,9 @@ public sealed class InsertRoundTripCase
                 new object[] { "hi", ((byte)1, "x"), null, ((byte)0, string.Empty) }),
             VariantSettings);
 
-        // The same shape, but with an element inside the tuple that carries its own state prefix. LowCardinality's
-        // dictionary prefix has to reach the wire through that forwarded column, so losing the forwarding walk
-        // desyncs the block mid-stream instead of failing cleanly.
+        // The same shape, but with an element inside the tuple that carries its own state prefix, so LowCardinality's
+        // dictionary prefix has to travel two composites down to reach the wire. Losing it desyncs the block
+        // mid-stream instead of failing cleanly.
         yield return Same(
             "Variant(String, Tuple(LowCardinality(String), UInt8))",
             "Variant(String, Tuple(LowCardinality(String), UInt8))",
@@ -940,6 +939,25 @@ public sealed class InsertRoundTripCase
                 name,
                 "Variant(String, Tuple(LowCardinality(String), UInt8))",
                 new object[] { "hi", ("lc", (byte)7), null, (string.Empty, (byte)0) }),
+            VariantSettings);
+
+        // A Map alternative, whose value in turn carries a state prefix. The map is the composite whose own write
+        // state is most easily bypassed — it reaches its key and value codecs through a shape object rather than
+        // directly — so this pins that a map nested in a variant still emits its offsets, keys, and the value
+        // stream's dictionary prefix.
+        yield return Same(
+            "Variant(Map(String, LowCardinality(String)), UInt64)",
+            "Variant(Map(String, LowCardinality(String)), UInt64)",
+            name => new ArrayColumn<object>(
+                name,
+                "Variant(Map(String, LowCardinality(String)), UInt64)",
+                new object[]
+                {
+                    1UL,
+                    Pairs<string, string>(("a", "x"), ("b", "x")),
+                    null,
+                    Array.Empty<KeyValuePair<string, string>>(),
+                }),
             VariantSettings);
 
         // An alternative that carries a state prefix but is selected by no row in the block. The variant's

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
@@ -889,6 +889,43 @@ public sealed class InsertRoundTripCase
             "LowCardinality(Nullable(DateTime))",
             name => new ArrayColumn<uint?>(name, "LowCardinality(Nullable(DateTime))", new uint?[] { 1_700_000_000, null, 0, 1_700_000_000, 599_916_153, null }),
             LowCardinalitySettings);
+
+        // Variant(...): a discriminated union — each row is a value of one alternative or NULL. The ergonomic
+        // insert source is a flat IColumn<object>; each value's runtime CLR type picks its alternative, and null
+        // marks a NULL row. Like Array/Tuple/Map/Nested, the server rejects Nullable(Variant(...)) — NULL is the
+        // discriminator's job — so there is no Nullable(...) case; NULL rides inside the variant instead. The
+        // alternatives arrive server-canonicalized (sorted by name), so the type strings here are already in
+        // discriminator order. A present value equal to a type's default (0, empty string) rides alongside NULL to
+        // prove the two are distinct.
+        yield return Same(
+            "Variant(String, UInt64)",
+            "Variant(String, UInt64)",
+            name => new ArrayColumn<object>(name, "Variant(String, UInt64)", new object[] { 42UL, "hi", null, 0UL, string.Empty, null }),
+            VariantSettings);
+
+        // Three alternatives, exercising more than one non-null discriminator interleaved with NULL.
+        yield return Same(
+            "Variant(Bool, Int32, String)",
+            "Variant(Bool, Int32, String)",
+            name => new ArrayColumn<object>(name, "Variant(Bool, Int32, String)", new object[] { true, 42, "x", null, false, -1 }),
+            VariantSettings);
+
+        // A composite alternative: an Array as one of the variant types. A row selecting it carries the inner
+        // element array (ulong[]); the other rows carry a String or NULL.
+        yield return Same(
+            "Variant(Array(UInt64), String)",
+            "Variant(Array(UInt64), String)",
+            name => new ArrayColumn<object>(name, "Variant(Array(UInt64), String)", new object[] { "hello", new ulong[] { 1, 2, 3 }, null, Array.Empty<ulong>() }),
+            VariantSettings);
+
+        // Array(Variant(...)) composition: the array flattens its elements into one Variant value stream, so each
+        // element is a variant value (or NULL) and empty rows ride along.
+        yield return Arrays(
+            "Variant(String, UInt64)",
+            VariantSettings,
+            new object[] { 1UL, "a" },
+            Array.Empty<object>(),
+            new object[] { "b", 2UL, null });
     }
 
     // Map(K, V) inserts and reads back the ergonomic jagged column of KeyValuePair arrays, which doubles as expected.
@@ -1085,5 +1122,12 @@ public sealed class InsertRoundTripCase
     private static readonly IReadOnlyDictionary<string, string> LowCardinalitySettings = new Dictionary<string, string>(StringComparer.Ordinal)
     {
         ["allow_suspicious_low_cardinality_types"] = "1",
+    };
+
+    /// <summary>Enables the experimental <c>Variant</c> type (and allows the suspicious combinations the tests use).</summary>
+    private static readonly IReadOnlyDictionary<string, string> VariantSettings = new Dictionary<string, string>(StringComparer.Ordinal)
+    {
+        ["allow_experimental_variant_type"] = "1",
+        ["allow_suspicious_variant_types"] = "1",
     };
 }

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
@@ -918,6 +918,30 @@ public sealed class InsertRoundTripCase
             name => new ArrayColumn<object>(name, "Variant(Array(UInt64), String)", new object[] { "hello", new ulong[] { 1, 2, 3 }, null, Array.Empty<ulong>() }),
             VariantSettings);
 
+        // A Tuple alternative. Worth a case of its own because the variant has no per-slice write state: it forwards
+        // its own column to every alternative's prefix phase, so the tuple codec is handed a column it cannot project
+        // into per-element children and has to walk its children instead. A row selecting it carries the ValueTuple.
+        yield return Same(
+            "Variant(String, Tuple(UInt8, String))",
+            "Variant(String, Tuple(UInt8, String))",
+            name => new ArrayColumn<object>(
+                name,
+                "Variant(String, Tuple(UInt8, String))",
+                new object[] { "hi", ((byte)1, "x"), null, ((byte)0, string.Empty) }),
+            VariantSettings);
+
+        // The same shape, but with an element inside the tuple that carries its own state prefix. LowCardinality's
+        // dictionary prefix has to reach the wire through that forwarded column, so losing the forwarding walk
+        // desyncs the block mid-stream instead of failing cleanly.
+        yield return Same(
+            "Variant(String, Tuple(LowCardinality(String), UInt8))",
+            "Variant(String, Tuple(LowCardinality(String), UInt8))",
+            name => new ArrayColumn<object>(
+                name,
+                "Variant(String, Tuple(LowCardinality(String), UInt8))",
+                new object[] { "hi", ("lc", (byte)7), null, (string.Empty, (byte)0) }),
+            VariantSettings);
+
         // Array(Variant(...)) composition: the array flattens its elements into one Variant value stream, so each
         // element is a variant value (or NULL) and empty rows ride along.
         yield return Arrays(

--- a/ClickHouse.Driver.Tcp/Types/Codecs/VariantColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/VariantColumnCodec.cs
@@ -1,0 +1,387 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Protocol;
+
+namespace ClickHouse.Driver.Tcp.Types.Codecs;
+
+/// <summary>The wire constants for the variant serialization-state prefix.</summary>
+internal static class VariantWire
+{
+    /// <summary>
+    /// The discriminators-mode value in the state prefix selecting the BASIC layout, where every row's
+    /// discriminator is written literally (as opposed to COMPACT run-length granules).
+    /// </summary>
+    public const ulong BasicDiscriminatorsMode = 0;
+}
+
+/// <summary>
+/// A codec for the ClickHouse <c>Variant(T1, ..., Tn)</c> column — a discriminated union where each row holds a
+/// value of exactly one alternative type, or NULL. The wire layout is columnar: a serialization-state prefix
+/// (a <c>UInt64</c> discriminators mode), then one <c>UInt8</c> discriminator per row, then a dense run per
+/// alternative type holding the values of the rows that selected it (in row order). NULL is the reserved
+/// discriminator <c>255</c> and consumes no value from any run; the alternatives are therefore never themselves
+/// <c>Nullable</c>. The server canonicalizes the alternatives (sorted by name) before sending the type string,
+/// so the declared order already is the discriminator order — this codec does not reorder it.
+///
+/// <para>
+/// Only the BASIC discriminators mode (every row's discriminator written literally) is supported; the server
+/// uses it by default over the native protocol. A COMPACT (run-length) prefix is rejected.
+/// </para>
+///
+/// <para>
+/// On the write path a dense <see cref="VariantColumn"/> is serialized straight from its discriminator stream and
+/// per-type child columns with no copy. A flat <c>IColumn&lt;object&gt;</c> — a caller's column or what an
+/// <c>Array(Variant(...))</c> flattens into — is scattered by each value's runtime CLR type into per-type
+/// buffers, which boxes; this is the ergonomic, not the hot, path.
+/// </para>
+/// </summary>
+internal sealed class VariantColumnCodec : IColumnCodec
+{
+    // The discriminator is a single byte and 255 marks NULL, so at most 255 alternatives (indices 0..254) can be
+    // addressed under the BASIC layout.
+    private const int MaxTypes = 255;
+
+    private readonly IColumnCodec[] children;
+    private readonly Func<string, string, object[], int, IColumn>[] childFlatBuilders;
+    private readonly Dictionary<Type, int> discriminatorByClrType;
+    private readonly bool allChildrenWritable;
+
+    private VariantColumnCodec(string typeName, IColumnCodec[] children)
+    {
+        TypeName = typeName;
+        this.children = children;
+
+        int typeCount = children.Length;
+        childFlatBuilders = new Func<string, string, object[], int, IColumn>[typeCount];
+        MethodInfo builderTemplate = typeof(VariantColumnCodec).GetMethod(nameof(BuildFlatColumn), BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException($"Method '{nameof(BuildFlatColumn)}' was not found.");
+
+        // Map each alternative's writable CLR types to its discriminator, so the ergonomic write path can pick a
+        // row's alternative from the runtime type of its value. The canonical element type is registered first;
+        // if two alternatives claim the same CLR type the lower discriminator wins (the server does not allow
+        // duplicate alternative types, so this is only a defensive tie-break).
+        discriminatorByClrType = new Dictionary<Type, int>();
+        bool writable = true;
+        for (int i = 0; i < typeCount; i++)
+        {
+            childFlatBuilders[i] = (Func<string, string, object[], int, IColumn>)builderTemplate
+                .MakeGenericMethod(children[i].ElementType)
+                .CreateDelegate(typeof(Func<string, string, object[], int, IColumn>));
+
+            discriminatorByClrType.TryAdd(children[i].ElementType, i);
+            foreach (Type writeType in children[i].WritableElementTypes)
+            {
+                discriminatorByClrType.TryAdd(writeType, i);
+            }
+
+            // Probe writability with an empty child column so a Variant over a non-writable alternative (e.g.
+            // Nothing) is rejected up front rather than mid-write.
+            IColumn probe = childFlatBuilders[i](string.Empty, children[i].TypeName, Array.Empty<object>(), 0);
+            writable &= children[i].CanWrite(probe);
+        }
+
+        allChildrenWritable = writable;
+    }
+
+    /// <inheritdoc/>
+    public string TypeName { get; }
+
+    /// <inheritdoc/>
+    public Type ElementType => typeof(object);
+
+    // A Variant is never nested inside Nullable (the server rejects Nullable(Variant(...))), so this placeholder
+    // is a formality the interface requires and is never written.
+    /// <inheritdoc/>
+    public object NullPlaceholder => null;
+
+    /// <summary>Builds a <c>Variant(...)</c> codec, resolving each alternative's codec through the registry.</summary>
+    /// <param name="node">The parsed <c>Variant</c> node; its arguments are the alternative types in discriminator order.</param>
+    /// <param name="context">The resolution context, forwarded to each alternative codec's factory.</param>
+    /// <param name="registry">The registry used to resolve the alternative codecs.</param>
+    /// <returns>The codec.</returns>
+    /// <exception cref="FormatException">The variant has no alternatives, or an alternative is <c>Nullable</c>.</exception>
+    /// <exception cref="NotSupportedException">The variant has more alternatives than the BASIC layout can address.</exception>
+    public static VariantColumnCodec Create(TypeNode node, in ResolveContext context, ColumnCodecRegistry registry)
+    {
+        if (node.Arguments.Count == 0)
+        {
+            throw new FormatException($"Variant type '{node}' must have at least one alternative type argument.");
+        }
+
+        if (node.Arguments.Count > MaxTypes)
+        {
+            throw new NotSupportedException(
+                $"Variant type '{node}' has {node.Arguments.Count} alternatives; the discriminator is one byte, so at most {MaxTypes} are addressable.");
+        }
+
+        var childCodecs = new IColumnCodec[node.Arguments.Count];
+        for (int i = 0; i < childCodecs.Length; i++)
+        {
+            TypeNode argument = node.Arguments[i];
+            if (string.Equals(argument.Name, "Nullable", StringComparison.Ordinal))
+            {
+                throw new FormatException(
+                    $"Variant alternative '{argument}' must not be Nullable; a Variant carries NULL through its discriminator, not a nullable alternative.");
+            }
+
+            // The server rejects Dynamic inside Variant (Dynamic is a superset of Variant). Reject it client-side
+            // too: a Variant does not thread the per-operation write state a data-dependent alternative needs, so a
+            // Dynamic alternative would desynchronize its type-list prefix from its body.
+            if (string.Equals(argument.Name, "Dynamic", StringComparison.Ordinal))
+            {
+                throw new FormatException(
+                    $"Variant alternative '{argument}' must not be Dynamic; the server does not allow a Dynamic type inside a Variant.");
+            }
+
+            childCodecs[i] = registry.ResolveNode(argument, in context);
+        }
+
+        return new VariantColumnCodec(node.ToString(), childCodecs);
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask ReadStatePrefixAsync(ClickHouseBinaryReader reader, CancellationToken cancellationToken)
+    {
+        ulong mode = await reader.ReadUInt64Async(cancellationToken).ConfigureAwait(false);
+        if (mode != VariantWire.BasicDiscriminatorsMode)
+        {
+            throw new NotSupportedException(
+                $"Variant column '{TypeName}' uses discriminators mode {mode}; this client only supports BASIC (0).");
+        }
+
+        foreach (IColumnCodec child in children)
+        {
+            await child.ReadStatePrefixAsync(reader, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask<IColumn> ReadColumnAsync(ClickHouseBinaryReader reader, string columnName, string columnType, int rowCount, CancellationToken cancellationToken)
+    {
+        if (rowCount == 0)
+        {
+            // A zero-row block carries no discriminators and no per-type values; still read each child at zero
+            // rows so a codec that expects the call sees it, and surface an empty column.
+            var emptyChildren = new IColumn[children.Length];
+            int built = 0;
+            try
+            {
+                for (int i = 0; i < children.Length; i++)
+                {
+                    emptyChildren[i] = await children[i].ReadColumnAsync(reader, columnName, children[i].TypeName, 0, cancellationToken).ConfigureAwait(false);
+                    built = i + 1;
+                }
+            }
+            catch
+            {
+                for (int i = 0; i < built; i++)
+                {
+                    emptyChildren[i].Dispose();
+                }
+
+                throw;
+            }
+
+            return new VariantColumn(columnName, columnType, Array.Empty<byte>(), emptyChildren, 0, pooledDiscriminators: false, ownsColumns: true);
+        }
+
+        byte[] discriminators = ArrayPool<byte>.Shared.Rent(rowCount);
+        var typeColumns = new IColumn[children.Length];
+        int read = 0;
+        try
+        {
+            await reader.ReadBytesAsync(discriminators.AsMemory(0, rowCount), cancellationToken).ConfigureAwait(false);
+
+            var counts = new int[children.Length];
+            for (int row = 0; row < rowCount; row++)
+            {
+                byte d = discriminators[row];
+                if (d == VariantColumn.NullDiscriminator)
+                {
+                    continue;
+                }
+
+                if (d >= children.Length)
+                {
+                    throw new FormatException(
+                        $"Variant column '{columnName}' ({columnType}) has discriminator {d} at row {row}, but the type declares only {children.Length} alternative(s).");
+                }
+
+                counts[d]++;
+            }
+
+            for (int i = 0; i < children.Length; i++)
+            {
+                typeColumns[i] = await children[i].ReadColumnAsync(reader, columnName, children[i].TypeName, counts[i], cancellationToken).ConfigureAwait(false);
+                read = i + 1;
+            }
+
+            return new VariantColumn(columnName, columnType, discriminators, typeColumns, rowCount, pooledDiscriminators: true, ownsColumns: true);
+        }
+        catch
+        {
+            ArrayPool<byte>.Shared.Return(discriminators);
+            for (int i = 0; i < read; i++)
+            {
+                typeColumns[i].Dispose();
+            }
+
+            throw;
+        }
+    }
+
+    /// <inheritdoc/>
+    // A dense variant column is only writable when its alternatives match this codec's; a bare IColumn<object> is
+    // scattered by runtime CLR type. A variant column of a different arity is rejected here rather than silently
+    // re-scattered (which could reorder its discriminators).
+    public bool CanWrite(IColumn column)
+        => allChildrenWritable && (column is IVariantColumn dense ? dense.TypeCount == children.Length : column is IColumn<object>);
+
+    /// <inheritdoc/>
+    // The prefix is a fixed mode word followed by the alternatives' own prefixes; every alternative supported
+    // today has a data-independent prefix, so the outer column/slice is forwarded unchanged and ignored.
+    public void WriteStatePrefix(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
+    {
+        writer.WriteUInt64(VariantWire.BasicDiscriminatorsMode);
+        foreach (IColumnCodec child in children)
+        {
+            child.WriteStatePrefix(writer, column, start, length);
+        }
+    }
+
+    /// <inheritdoc/>
+    public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
+    {
+        if (column is IVariantColumn dense && dense.TypeCount == children.Length)
+        {
+            WriteDense(writer, dense, start, length);
+            return;
+        }
+
+        WriteScattered(writer, column, start, length);
+    }
+
+    // The dense path: the discriminators and per-type child columns already exist, so write the slice's
+    // discriminators verbatim, then each child's slice. A child's slice is the contiguous run of its values whose
+    // originating rows fall in [start, start + length) — found by counting that type's discriminators before and
+    // within the slice, since values are stored in row order.
+    private void WriteDense(ClickHouseBinaryWriter writer, IVariantColumn dense, int start, int length)
+    {
+        ReadOnlySpan<byte> discriminators = dense.Discriminators;
+        writer.WriteBytes(discriminators.Slice(start, length));
+
+        // Each type's values sit contiguously in its child column in row order, so writing this slice needs, per
+        // type, the count of its values before the slice (the child-column start offset) and within it (the length
+        // to write). Both come from a single pass over the slice: the precomputed LocalIndices give each row its
+        // index within its type's child column, so the first in-slice row of a given discriminator already carries
+        // that type's before-slice count. This avoids rescanning [0, start) per slice, which would make a
+        // multi-block insert quadratic. within[d] == 0 flags the first in-slice occurrence, and an absent type
+        // keeps before/within 0 (writing nothing) — so both spans must start zeroed.
+        ReadOnlySpan<int> localIndices = dense.LocalIndices;
+        Span<int> before = stackalloc int[children.Length];
+        Span<int> within = stackalloc int[children.Length];
+
+        // Explicitly zero the stack spans. stackalloc is zeroed today only because the compiler emits `.locals
+        // init`; a future `[SkipLocalsInit]` would silently drop that and leave the counters holding garbage, so
+        // do not depend on it — the Clear is a cheap memset that keeps this correct regardless.
+        before.Clear();
+        within.Clear();
+
+        for (int i = start; i < start + length; i++)
+        {
+            byte d = discriminators[i];
+            if (d == VariantColumn.NullDiscriminator)
+            {
+                continue;
+            }
+
+            if (within[d] == 0)
+            {
+                before[d] = localIndices[i];
+            }
+
+            within[d]++;
+        }
+
+        for (int i = 0; i < children.Length; i++)
+        {
+            children[i].WriteColumn(writer, dense.GetTypeColumn(i), before[i], within[i]);
+        }
+    }
+
+    // The ergonomic path: scatter a flat column of boxed values into per-type buffers by each value's runtime CLR
+    // type, writing the discriminator stream as it goes, then hand each type's bucket to its child codec. Mirrors
+    // the tuple codec's flat write, bucketing by discriminator instead of distributing across parallel columns.
+    private void WriteScattered(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
+    {
+        int typeCount = children.Length;
+        byte[] discriminators = ArrayPool<byte>.Shared.Rent(length);
+        var buckets = new object[typeCount][];
+        var filled = new int[typeCount];
+        for (int i = 0; i < typeCount; i++)
+        {
+            buckets[i] = ArrayPool<object>.Shared.Rent(length);
+        }
+
+        try
+        {
+            for (int row = 0; row < length; row++)
+            {
+                object value = column.GetValue(start + row);
+                if (value is null)
+                {
+                    discriminators[row] = VariantColumn.NullDiscriminator;
+                    continue;
+                }
+
+                int discriminator = DiscriminatorFor(value.GetType());
+                discriminators[row] = (byte)discriminator;
+                buckets[discriminator][filled[discriminator]++] = value;
+            }
+
+            writer.WriteBytes(discriminators.AsSpan(0, length));
+
+            for (int i = 0; i < typeCount; i++)
+            {
+                IColumn childColumn = childFlatBuilders[i](column.Name, children[i].TypeName, buckets[i], filled[i]);
+                children[i].WriteColumn(writer, childColumn, 0, filled[i]);
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(discriminators);
+            for (int i = 0; i < typeCount; i++)
+            {
+                ArrayPool<object>.Shared.Return(buckets[i], clearArray: true);
+            }
+        }
+    }
+
+    // Resolves the discriminator for a value's runtime CLR type, or throws if no alternative accepts it.
+    private int DiscriminatorFor(Type clrType)
+    {
+        if (discriminatorByClrType.TryGetValue(clrType, out int discriminator))
+        {
+            return discriminator;
+        }
+
+        throw new ArgumentException(
+            $"Variant '{TypeName}' has no alternative for a value of CLR type '{clrType}'. Supported CLR types: {string.Join(", ", discriminatorByClrType.Keys)}.");
+    }
+
+    // Builds a flat typed column from boxed values — the ergonomic write path's per-type projection.
+    private static IColumn BuildFlatColumn<T>(string name, string typeName, object[] boxed, int count)
+    {
+        var values = new T[count];
+        for (int i = 0; i < count; i++)
+        {
+            values[i] = (T)boxed[i];
+        }
+
+        return new ArrayColumn<T>(name, typeName, values);
+    }
+}

--- a/ClickHouse.Driver.Tcp/Types/Codecs/VariantColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/VariantColumnCodec.cs
@@ -161,74 +161,33 @@ internal sealed class VariantColumnCodec : IColumnCodec
     /// <inheritdoc/>
     public async ValueTask<IColumn> ReadColumnAsync(ClickHouseBinaryReader reader, string columnName, string columnType, int rowCount, CancellationToken cancellationToken)
     {
+        // A zero-row block puts neither discriminators nor values on the wire, so there is nothing to count and
+        // every run is empty.
         if (rowCount == 0)
         {
-            // A zero-row block carries no discriminators and no per-type values; still read each child at zero
-            // rows so a codec that expects the call sees it, and surface an empty column.
-            var emptyChildren = new IColumn[children.Length];
-            int built = 0;
-            try
-            {
-                for (int i = 0; i < children.Length; i++)
-                {
-                    emptyChildren[i] = await children[i].ReadColumnAsync(reader, columnName, children[i].TypeName, 0, cancellationToken).ConfigureAwait(false);
-                    built = i + 1;
-                }
-            }
-            catch
-            {
-                for (int i = 0; i < built; i++)
-                {
-                    emptyChildren[i].Dispose();
-                }
-
-                throw;
-            }
-
-            return new VariantColumn(columnName, columnType, Array.Empty<byte>(), emptyChildren, 0, pooledDiscriminators: false, ownsColumns: true);
+            IColumn[] emptyRuns = await ReadTypeColumnsAsync(reader, columnName, new int[children.Length], cancellationToken).ConfigureAwait(false);
+            return new VariantColumn(columnName, columnType, Array.Empty<byte>(), emptyRuns, 0, pooledDiscriminators: false, ownsColumns: true);
         }
 
         byte[] discriminators = ArrayPool<byte>.Shared.Rent(rowCount);
-        var typeColumns = new IColumn[children.Length];
-        int read = 0;
+        IColumn[] typeColumns = null;
         try
         {
             await reader.ReadBytesAsync(discriminators.AsMemory(0, rowCount), cancellationToken).ConfigureAwait(false);
 
-            var counts = new int[children.Length];
-            for (int row = 0; row < rowCount; row++)
-            {
-                byte d = discriminators[row];
-                if (d == IVariantColumn.NullDiscriminator)
-                {
-                    continue;
-                }
-
-                if (d >= children.Length)
-                {
-                    throw new FormatException(
-                        $"Variant column '{columnName}' ({columnType}) has discriminator {d} at row {row}, but the type declares only {children.Length} alternative(s).");
-                }
-
-                counts[d]++;
-            }
-
-            for (int i = 0; i < children.Length; i++)
-            {
-                typeColumns[i] = await children[i].ReadColumnAsync(reader, columnName, children[i].TypeName, counts[i], cancellationToken).ConfigureAwait(false);
-                read = i + 1;
-            }
+            // No run states its own length on the wire, so the whole discriminator stream has to be counted before
+            // a single run can be read.
+            int[] rowsPerType = CountRowsPerType(discriminators, rowCount, columnName, columnType);
+            typeColumns = await ReadTypeColumnsAsync(reader, columnName, rowsPerType, cancellationToken).ConfigureAwait(false);
 
             return new VariantColumn(columnName, columnType, discriminators, typeColumns, rowCount, pooledDiscriminators: true, ownsColumns: true);
         }
         catch
         {
+            // The column that would have taken over the rented buffer and the runs was never constructed.
+            // typeColumns stays null when ReadTypeColumnsAsync fails, having already disposed its own partial read.
             ArrayPool<byte>.Shared.Return(discriminators);
-            for (int i = 0; i < read; i++)
-            {
-                typeColumns[i].Dispose();
-            }
-
+            DisposeColumns(typeColumns, typeColumns?.Length ?? 0);
             throw;
         }
     }
@@ -295,6 +254,59 @@ internal sealed class VariantColumnCodec : IColumnCodec
         }
 
         WriteBodyCore(writer, state.Expect<VariantWriteState>(TypeName));
+    }
+
+    // How many rows chose each alternative — the length of every run that follows the discriminators.
+    private int[] CountRowsPerType(ReadOnlySpan<byte> discriminators, int rowCount, string columnName, string columnType)
+    {
+        var rowsPerType = new int[children.Length];
+        for (int row = 0; row < rowCount; row++)
+        {
+            byte d = discriminators[row];
+
+            // A NULL row takes a slot in no run.
+            if (d == IVariantColumn.NullDiscriminator)
+            {
+                continue;
+            }
+
+            // Rejected here, and not left to VariantColumn: its constructor indexes per-type counters by
+            // discriminator, so an out-of-range one would surface there as an IndexOutOfRangeException naming
+            // neither the column nor the row.
+            if (d >= children.Length)
+            {
+                throw new FormatException(
+                    $"Variant column '{columnName}' ({columnType}) has discriminator {d} at row {row}, but the type declares only {children.Length} alternative(s).");
+            }
+
+            rowsPerType[d]++;
+        }
+
+        return rowsPerType;
+    }
+
+    // One dense run per alternative, in declared order. A run of zero rows is still read, so an alternative no row
+    // selected still gets the call its codec may expect.
+    private async ValueTask<IColumn[]> ReadTypeColumnsAsync(ClickHouseBinaryReader reader, string columnName, int[] rowsPerType, CancellationToken cancellationToken)
+    {
+        var typeColumns = new IColumn[children.Length];
+        int read = 0;
+        try
+        {
+            for (int i = 0; i < children.Length; i++)
+            {
+                typeColumns[i] = await children[i].ReadColumnAsync(reader, columnName, children[i].TypeName, rowsPerType[i], cancellationToken).ConfigureAwait(false);
+                read = i + 1;
+            }
+        }
+        catch
+        {
+            // No variant column owns these yet.
+            DisposeColumns(typeColumns, read);
+            throw;
+        }
+
+        return typeColumns;
     }
 
     // A fixed mode word, then every alternative's own prefix over its projected column — including the alternatives
@@ -515,6 +527,15 @@ internal sealed class VariantColumnCodec : IColumnCodec
                 ArrayPool<byte>.Shared.Return(Discriminators);
                 Discriminators = null;
             }
+        }
+    }
+
+    // Disposes the first count entries of a partially read run array.
+    private static void DisposeColumns(IColumn[] columns, int count)
+    {
+        for (int i = 0; i < count; i++)
+        {
+            columns[i]?.Dispose();
         }
     }
 

--- a/ClickHouse.Driver.Tcp/Types/Codecs/VariantColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/VariantColumnCodec.cs
@@ -199,7 +199,7 @@ internal sealed class VariantColumnCodec : IColumnCodec
             for (int row = 0; row < rowCount; row++)
             {
                 byte d = discriminators[row];
-                if (d == VariantColumn.NullDiscriminator)
+                if (d == IVariantColumn.NullDiscriminator)
                 {
                     continue;
                 }
@@ -293,7 +293,7 @@ internal sealed class VariantColumnCodec : IColumnCodec
         for (int i = start; i < start + length; i++)
         {
             byte d = discriminators[i];
-            if (d == VariantColumn.NullDiscriminator)
+            if (d == IVariantColumn.NullDiscriminator)
             {
                 continue;
             }
@@ -333,7 +333,7 @@ internal sealed class VariantColumnCodec : IColumnCodec
                 object value = column.GetValue(start + row);
                 if (value is null)
                 {
-                    discriminators[row] = VariantColumn.NullDiscriminator;
+                    discriminators[row] = IVariantColumn.NullDiscriminator;
                     continue;
                 }
 

--- a/ClickHouse.Driver.Tcp/Types/Codecs/VariantColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/VariantColumnCodec.cs
@@ -249,55 +249,100 @@ internal sealed class VariantColumnCodec : IColumnCodec
         => allChildrenWritable && (column is VariantColumn dense ? dense.TypeCount == children.Length : column is IColumn<object>);
 
     /// <inheritdoc/>
-    // The prefix is a fixed mode word followed by the alternatives' own prefixes; every alternative supported
-    // today has a data-independent prefix, so the outer column/slice is forwarded unchanged and ignored.
+    // Project the slice into one column per alternative once, and open each alternative's own write state over it,
+    // so the prefix and body phases share a single projection and a child never sees the variant's own column.
+    // Every alternative gets a column and a state even when no row selects it: the alternative set is fixed by the
+    // type rather than by the data, so each one's prefix belongs on the wire regardless of which rows arrived.
+    public IColumnWriteState BeginWrite(IColumn column, int start, int length)
+        => column is VariantColumn dense && dense.TypeCount == children.Length
+            ? BuildDenseState(dense, start, length)
+            : BuildScatteredState(column, start, length);
+
+    /// <inheritdoc/>
     public void WriteStatePrefix(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
     {
-        writer.WriteUInt64(VariantWire.BasicDiscriminatorsMode);
-        foreach (IColumnCodec child in children)
+        using VariantWriteState state = BeginWriteCore(column, start, length);
+        WriteStatePrefixCore(writer, state);
+    }
+
+    /// <inheritdoc/>
+    public void WriteStatePrefix(ClickHouseBinaryWriter writer, IColumn column, int start, int length, IColumnWriteState state)
+    {
+        if (state is VariantWriteState variantState)
         {
-            child.WriteStatePrefix(writer, column, start, length);
+            WriteStatePrefixCore(writer, variantState);
+            return;
         }
+
+        WriteStatePrefix(writer, column, start, length);
     }
 
     /// <inheritdoc/>
     public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
     {
-        if (column is VariantColumn dense && dense.TypeCount == children.Length)
+        using VariantWriteState state = BeginWriteCore(column, start, length);
+        WriteBodyCore(writer, state);
+    }
+
+    /// <inheritdoc/>
+    public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length, IColumnWriteState state)
+    {
+        if (state is VariantWriteState variantState)
         {
-            WriteDense(writer, dense, start, length);
+            WriteBodyCore(writer, variantState);
             return;
         }
 
-        WriteScattered(writer, column, start, length);
+        WriteColumn(writer, column, start, length);
     }
 
-    // The dense path: the discriminators and per-type child columns already exist, so write the slice's
-    // discriminators verbatim, then each child's slice. A child's slice is the contiguous run of its values whose
-    // originating rows fall in [start, start + length) — found by counting that type's discriminators before and
-    // within the slice, since values are stored in row order.
-    private void WriteDense(ClickHouseBinaryWriter writer, VariantColumn dense, int start, int length)
+    // A fixed mode word, then every alternative's own prefix over its projected column — including the alternatives
+    // no row selected, whose column is simply empty.
+    private void WriteStatePrefixCore(ClickHouseBinaryWriter writer, VariantWriteState state)
     {
-        ReadOnlySpan<byte> discriminators = dense.Discriminators;
-        writer.WriteBytes(discriminators.Slice(start, length));
+        writer.WriteUInt64(VariantWire.BasicDiscriminatorsMode);
+        for (int i = 0; i < children.Length; i++)
+        {
+            children[i].WriteStatePrefix(writer, state.ChildColumns[i], state.ChildStart[i], state.ChildLength[i], state.ChildStates[i]);
+        }
+    }
+
+    // The row-order discriminator stream, then each alternative's values in alternative order.
+    private void WriteBodyCore(ClickHouseBinaryWriter writer, VariantWriteState state)
+    {
+        writer.WriteBytes(state.Discriminators is not null
+            ? state.Discriminators.AsSpan(0, state.Length)
+            : state.Dense.Discriminators.Slice(state.Start, state.Length));
+
+        for (int i = 0; i < children.Length; i++)
+        {
+            children[i].WriteColumn(writer, state.ChildColumns[i], state.ChildStart[i], state.ChildLength[i], state.ChildStates[i]);
+        }
+    }
+
+    private VariantWriteState BeginWriteCore(IColumn column, int start, int length)
+        => (VariantWriteState)BeginWrite(column, start, length);
+
+    // The dense path: the discriminators and per-type child columns already exist, so each alternative's slice is
+    // the contiguous run of its values whose originating rows fall in [start, start + length) — found by counting
+    // that type's discriminators before and within the slice, since values are stored in row order. The child
+    // columns are borrowed from the dense column, so nothing is copied and the state owns none of them.
+    private VariantWriteState BuildDenseState(VariantColumn dense, int start, int length)
+    {
+        int typeCount = children.Length;
+        var childColumns = new IColumn[typeCount];
 
         // Each type's values sit contiguously in its child column in row order, so writing this slice needs, per
         // type, the count of its values before the slice (the child-column start offset) and within it (the length
         // to write). Both come from a single pass over the slice: the precomputed LocalIndices give each row its
         // index within its type's child column, so the first in-slice row of a given discriminator already carries
         // that type's before-slice count. This avoids rescanning [0, start) per slice, which would make a
-        // multi-block insert quadratic. within[d] == 0 flags the first in-slice occurrence, and an absent type
-        // keeps before/within 0 (writing nothing) — so both spans must start zeroed.
+        // multi-block insert quadratic. A length of 0 flags the first in-slice occurrence, and an absent type keeps
+        // start/length 0 — an empty slice its codec still writes a prefix for.
+        var childStart = new int[typeCount];
+        var childLength = new int[typeCount];
+        ReadOnlySpan<byte> discriminators = dense.Discriminators;
         ReadOnlySpan<int> localIndices = dense.LocalIndices;
-        Span<int> before = stackalloc int[children.Length];
-        Span<int> within = stackalloc int[children.Length];
-
-        // Explicitly zero the stack spans. stackalloc is zeroed today only because the compiler emits `.locals
-        // init`; a future `[SkipLocalsInit]` would silently drop that and leave the counters holding garbage, so
-        // do not depend on it — the Clear is a cheap memset that keeps this correct regardless.
-        before.Clear();
-        within.Clear();
-
         for (int i = start; i < start + length; i++)
         {
             byte d = discriminators[i];
@@ -306,24 +351,28 @@ internal sealed class VariantColumnCodec : IColumnCodec
                 continue;
             }
 
-            if (within[d] == 0)
+            if (childLength[d] == 0)
             {
-                before[d] = localIndices[i];
+                childStart[d] = localIndices[i];
             }
 
-            within[d]++;
+            childLength[d]++;
         }
 
-        for (int i = 0; i < children.Length; i++)
+        for (int i = 0; i < typeCount; i++)
         {
-            children[i].WriteColumn(writer, dense.GetTypeColumn(i), before[i], within[i]);
+            childColumns[i] = dense.GetTypeColumn(i);
         }
+
+        return OpenChildStates(childColumns, childStart, childLength, dense, start, length, discriminators: null);
     }
 
-    // The ergonomic path: scatter a flat column of boxed values into per-type buffers by each value's runtime CLR
-    // type, writing the discriminator stream as it goes, then hand each type's bucket to its child codec. Mirrors
-    // the tuple codec's flat write, bucketing by discriminator instead of distributing across parallel columns.
-    private void WriteScattered(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
+    // The ergonomic path: scatter a flat column of boxed values into per-type buckets by each value's runtime CLR
+    // type, building the discriminator stream as it goes, then project each bucket into its alternative's own typed
+    // column. Mirrors the tuple codec's flat write, bucketing by discriminator instead of distributing across
+    // parallel columns. The buckets are pooled scratch for the projection only, so they go back before returning;
+    // the discriminator buffer outlives this call because the body phase writes it, so the state owns it.
+    private VariantWriteState BuildScatteredState(IColumn column, int start, int length)
     {
         int typeCount = children.Length;
         byte[] discriminators = ArrayPool<byte>.Shared.Rent(length);
@@ -350,22 +399,76 @@ internal sealed class VariantColumnCodec : IColumnCodec
                 buckets[discriminator][filled[discriminator]++] = value;
             }
 
-            writer.WriteBytes(discriminators.AsSpan(0, length));
-
+            var childColumns = new IColumn[typeCount];
             for (int i = 0; i < typeCount; i++)
             {
-                IColumn childColumn = childFlatBuilders[i](column.Name, children[i].TypeName, buckets[i], filled[i]);
-                children[i].WriteColumn(writer, childColumn, 0, filled[i]);
+                childColumns[i] = childFlatBuilders[i](column.Name, children[i].TypeName, buckets[i], filled[i]);
             }
+
+            // Each projected column starts at 0 and runs for the rows that selected that alternative.
+            return OpenChildStates(childColumns, new int[typeCount], filled, dense: null, start, length, discriminators);
+        }
+        catch
+        {
+            ArrayPool<byte>.Shared.Return(discriminators);
+            throw;
         }
         finally
         {
-            ArrayPool<byte>.Shared.Return(discriminators);
             for (int i = 0; i < typeCount; i++)
             {
                 ArrayPool<object>.Shared.Return(buckets[i], clearArray: true);
             }
         }
+    }
+
+    // Opens each alternative's own write state over its projected column and assembles the slice's state. A later
+    // alternative's BeginWrite throwing must not leak the states already opened, nor the rented discriminators.
+    private VariantWriteState OpenChildStates(
+        IColumn[] childColumns,
+        int[] childStart,
+        int[] childLength,
+        VariantColumn dense,
+        int start,
+        int length,
+        byte[] discriminators)
+    {
+        var childStates = new IColumnWriteState[children.Length];
+        int opened = 0;
+        try
+        {
+            for (int i = 0; i < children.Length; i++)
+            {
+                childStates[i] = children[i].BeginWrite(childColumns[i], childStart[i], childLength[i]);
+                opened = i + 1;
+            }
+        }
+        catch
+        {
+            for (int i = 0; i < opened; i++)
+            {
+                childStates[i]?.Dispose();
+            }
+
+            if (discriminators is not null)
+            {
+                ArrayPool<byte>.Shared.Return(discriminators);
+            }
+
+            throw;
+        }
+
+        return new VariantWriteState
+        {
+            ChildColumns = childColumns,
+            ChildStart = childStart,
+            ChildLength = childLength,
+            ChildStates = childStates,
+            Dense = dense,
+            Start = start,
+            Length = length,
+            Discriminators = discriminators,
+        };
     }
 
     // Resolves the discriminator for a value's runtime CLR type, or throws if no alternative accepts it.
@@ -378,6 +481,40 @@ internal sealed class VariantColumnCodec : IColumnCodec
 
         throw new ArgumentException(
             $"Variant '{TypeName}' has no alternative for a value of CLR type '{clrType}'. Supported CLR types: {string.Join(", ", discriminatorByClrType.Keys)}.");
+    }
+
+    // The write scratch of one slice, shared across the prefix and body phases. ChildColumns holds one column per
+    // alternative — borrowed from the dense column, or projected out of the boxed values — with the slice of it that
+    // alternative occupies and its own codec's state; an alternative no row selected carries an empty slice rather
+    // than being absent, so its prefix is still written. Discriminators is the scattered path's own row-order stream,
+    // rented and returned on dispose; for a dense column it is null and Dense supplies the stream instead.
+    private sealed class VariantWriteState : IColumnWriteState
+    {
+        public IColumn[] ChildColumns;
+        public int[] ChildStart;
+        public int[] ChildLength;
+        public IColumnWriteState[] ChildStates;
+        public VariantColumn Dense;
+        public int Start;
+        public int Length;
+        public byte[] Discriminators;
+
+        public void Dispose()
+        {
+            if (ChildStates is not null)
+            {
+                foreach (IColumnWriteState state in ChildStates)
+                {
+                    state?.Dispose();
+                }
+            }
+
+            if (Discriminators is not null)
+            {
+                ArrayPool<byte>.Shared.Return(Discriminators);
+                Discriminators = null;
+            }
+        }
     }
 
     // Builds a flat typed column from boxed values — the ergonomic write path's per-type projection.

--- a/ClickHouse.Driver.Tcp/Types/Codecs/VariantColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/VariantColumnCodec.cs
@@ -237,8 +237,16 @@ internal sealed class VariantColumnCodec : IColumnCodec
     // A dense variant column is only writable when its alternatives match this codec's; a bare IColumn<object> is
     // scattered by runtime CLR type. A variant column of a different arity is rejected here rather than silently
     // re-scattered (which could reorder its discriminators).
+    //
+    // The dense test is the concrete VariantColumn, not the public IVariantColumn: the dense writer trusts
+    // invariants only that class's constructor establishes (every discriminator is either a valid alternative index
+    // or the NULL marker, and LocalIndices is exactly as long as the column with a correct per-type running index).
+    // Matching on the public interface would let a caller-supplied implementation reach the writer with none of
+    // that checked, and the first thing the writer does is put the discriminators on the wire — so a bad value
+    // would desync the block mid-stream rather than fail cleanly. Anything else writable arrives as IColumn<object>
+    // and goes down the scattered path, which validates as it goes.
     public bool CanWrite(IColumn column)
-        => allChildrenWritable && (column is IVariantColumn dense ? dense.TypeCount == children.Length : column is IColumn<object>);
+        => allChildrenWritable && (column is VariantColumn dense ? dense.TypeCount == children.Length : column is IColumn<object>);
 
     /// <inheritdoc/>
     // The prefix is a fixed mode word followed by the alternatives' own prefixes; every alternative supported
@@ -255,7 +263,7 @@ internal sealed class VariantColumnCodec : IColumnCodec
     /// <inheritdoc/>
     public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
     {
-        if (column is IVariantColumn dense && dense.TypeCount == children.Length)
+        if (column is VariantColumn dense && dense.TypeCount == children.Length)
         {
             WriteDense(writer, dense, start, length);
             return;
@@ -268,7 +276,7 @@ internal sealed class VariantColumnCodec : IColumnCodec
     // discriminators verbatim, then each child's slice. A child's slice is the contiguous run of its values whose
     // originating rows fall in [start, start + length) — found by counting that type's discriminators before and
     // within the slice, since values are stored in row order.
-    private void WriteDense(ClickHouseBinaryWriter writer, IVariantColumn dense, int start, int length)
+    private void WriteDense(ClickHouseBinaryWriter writer, VariantColumn dense, int start, int length)
     {
         ReadOnlySpan<byte> discriminators = dense.Discriminators;
         writer.WriteBytes(discriminators.Slice(start, length));

--- a/ClickHouse.Driver.Tcp/Types/Codecs/VariantColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/VariantColumnCodec.cs
@@ -268,13 +268,14 @@ internal sealed class VariantColumnCodec : IColumnCodec
     /// <inheritdoc/>
     public void WriteStatePrefix(ClickHouseBinaryWriter writer, IColumn column, int start, int length, IColumnWriteState state)
     {
-        if (state is VariantWriteState variantState)
+        // A null state is the caller saying it has none to share, so build one for this call alone.
+        if (state is null)
         {
-            WriteStatePrefixCore(writer, variantState);
+            WriteStatePrefix(writer, column, start, length);
             return;
         }
 
-        WriteStatePrefix(writer, column, start, length);
+        WriteStatePrefixCore(writer, state.Expect<VariantWriteState>(TypeName));
     }
 
     /// <inheritdoc/>
@@ -287,13 +288,13 @@ internal sealed class VariantColumnCodec : IColumnCodec
     /// <inheritdoc/>
     public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length, IColumnWriteState state)
     {
-        if (state is VariantWriteState variantState)
+        if (state is null)
         {
-            WriteBodyCore(writer, variantState);
+            WriteColumn(writer, column, start, length);
             return;
         }
 
-        WriteColumn(writer, column, start, length);
+        WriteBodyCore(writer, state.Expect<VariantWriteState>(TypeName));
     }
 
     // A fixed mode word, then every alternative's own prefix over its projected column — including the alternatives

--- a/ClickHouse.Driver.Tcp/Types/Codecs/VariantColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/VariantColumnCodec.cs
@@ -28,8 +28,27 @@ internal static class VariantWire
 /// so the declared order already is the discriminator order — this codec does not reorder it.
 ///
 /// <para>
-/// Only the BASIC discriminators mode (every row's discriminator written literally) is supported; the server
-/// uses it by default over the native protocol. A COMPACT (run-length) prefix is rejected.
+/// The column data for <c>Variant(String, UInt64)</c> holding <c>[42, 'hi', NULL, 7, 'yo']</c>. <c>String</c> sorts
+/// before <c>UInt64</c>, so discriminator <c>0</c> is the string alternative. Each run holds only its own rows, in
+/// row order, and no run states its own length — a length is recoverable only by counting the discriminators.
+/// <code>
+/// 00 00 00 00 00 00 00 00  discriminators mode = 0 (BASIC)
+///                          then one state prefix per alternative (both empty here)
+/// 01 00 FF 01 00           one discriminator per row: UInt64, String, NULL, UInt64, String
+/// 02 68 69                 String run, rows 1 and 4: len 2, "hi"
+/// 02 79 6F                                           len 2, "yo"
+/// 2A 00 00 00 00 00 00 00  UInt64 run, rows 0 and 3: 42
+/// 07 00 00 00 00 00 00 00                            7
+/// </code>
+/// Reading row 4 therefore takes two steps: its discriminator says the string alternative, and the number of
+/// earlier rows that also chose it says which value in that run — index 1, <c>"yo"</c>.
+/// </para>
+///
+/// <para>
+/// Only the BASIC discriminators mode (every row's discriminator written literally) is supported. COMPACT exists
+/// for MergeTree part serialization, chosen by the table-level
+/// <c>use_compact_variant_discriminators_serialization</c> setting; the native protocol's writer leaves that
+/// setting at its default, so a server never sends COMPACT over the wire. A COMPACT prefix is rejected.
 /// </para>
 ///
 /// <para>

--- a/ClickHouse.Driver.Tcp/Types/Codecs/VariantColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/VariantColumnCodec.cs
@@ -60,10 +60,13 @@ internal sealed class VariantColumnCodec : IColumnCodec
         MethodInfo builderTemplate = typeof(VariantColumnCodec).GetMethod(nameof(BuildFlatColumn), BindingFlags.NonPublic | BindingFlags.Static)
             ?? throw new InvalidOperationException($"Method '{nameof(BuildFlatColumn)}' was not found.");
 
-        // Map each alternative's writable CLR types to its discriminator, so the ergonomic write path can pick a
-        // row's alternative from the runtime type of its value. The canonical element type is registered first;
-        // if two alternatives claim the same CLR type the lower discriminator wins (the server does not allow
-        // duplicate alternative types, so this is only a defensive tie-break).
+        // Map each alternative's canonical element type to its discriminator, so the ergonomic write path can
+        // pick a row's alternative from the runtime type of its value. Only the canonical element type is keyed
+        // here — not a codec's extra convenience write types (e.g. DateTime alongside DateTimeOffset): the
+        // per-alternative bucket is materialized as that exact element type (BuildFlatColumn<ElementType>), so a
+        // convenience-typed value would fail the bucket cast. Rejecting it up front with a clear "no alternative"
+        // error beats a deep InvalidCastException. If two alternatives claimed the same CLR type the lower
+        // discriminator would win (the server forbids duplicate alternative types, so this is only a tie-break).
         discriminatorByClrType = new Dictionary<Type, int>();
         bool writable = true;
         for (int i = 0; i < typeCount; i++)
@@ -73,10 +76,6 @@ internal sealed class VariantColumnCodec : IColumnCodec
                 .CreateDelegate(typeof(Func<string, string, object[], int, IColumn>));
 
             discriminatorByClrType.TryAdd(children[i].ElementType, i);
-            foreach (Type writeType in children[i].WritableElementTypes)
-            {
-                discriminatorByClrType.TryAdd(writeType, i);
-            }
 
             // Probe writability with an empty child column so a Variant over a non-writable alternative (e.g.
             // Nothing) is rejected up front rather than mid-write.

--- a/ClickHouse.Driver.Tcp/Types/Codecs/VariantColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/VariantColumnCodec.cs
@@ -246,13 +246,6 @@ internal sealed class VariantColumnCodec : IColumnCodec
     /// <inheritdoc/>
     public void WriteStatePrefix(ClickHouseBinaryWriter writer, IColumn column, int start, int length, IColumnWriteState state)
     {
-        // A null state is the caller saying it has none to share, so build one for this call alone.
-        if (state is null)
-        {
-            WriteStatePrefix(writer, column, start, length);
-            return;
-        }
-
         WriteStatePrefixCore(writer, state.Expect<VariantWriteState>(TypeName));
     }
 
@@ -266,12 +259,6 @@ internal sealed class VariantColumnCodec : IColumnCodec
     /// <inheritdoc/>
     public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length, IColumnWriteState state)
     {
-        if (state is null)
-        {
-            WriteColumn(writer, column, start, length);
-            return;
-        }
-
         WriteBodyCore(writer, state.Expect<VariantWriteState>(TypeName));
     }
 

--- a/ClickHouse.Driver.Tcp/Types/ColumnCodecRegistry.cs
+++ b/ClickHouse.Driver.Tcp/Types/ColumnCodecRegistry.cs
@@ -150,6 +150,11 @@ internal sealed class ColumnCodecRegistry
         // NestedColumn, so it is not bound by the tuple's element-count cap.
         AddFactory("Nested", static (TypeNode node, in ResolveContext context, ColumnCodecRegistry registry) => NestedColumnCodec.Create(node, context, registry));
 
+        // Variant(T1, ..., Tn) is a discriminated union: a per-row discriminator picks one alternative (or NULL),
+        // and the alternatives' values are stored one dense run per type. Each alternative codec is resolved
+        // recursively; the declared order is the discriminator order (the server sends it canonicalized).
+        AddFactory("Variant", static (TypeNode node, in ResolveContext context, ColumnCodecRegistry registry) => VariantColumnCodec.Create(node, context, registry));
+
         return new ColumnCodecRegistry(byName);
     }
 }

--- a/ClickHouse.Driver.Tcp/Types/VariantColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/VariantColumn.cs
@@ -1,0 +1,207 @@
+using System;
+using System.Buffers;
+
+namespace ClickHouse.Driver.Tcp.Types;
+
+/// <summary>
+/// The dense shape of a ClickHouse <c>Variant(T1, ..., Tn)</c> column: a per-row discriminator stream plus one
+/// child column per alternative type, each holding only the values of the rows that selected it (in row order).
+/// This is exactly how the type is laid out on the wire — a discriminator array followed by a contiguous run per
+/// type — so a <see cref="VariantColumn"/> is both what a read produces and the zero-copy source for a write.
+///
+/// <para>
+/// A row's discriminator is an index into the alternative types (<c>0</c> = the first type, and so on), or
+/// <see cref="NullDiscriminator"/> (<c>255</c>) for a NULL row, which consumes no value from any child column.
+/// Random access maps a row to its value through a per-row index into the selected type's child column,
+/// precomputed once by a single walk of the discriminators.
+/// </para>
+///
+/// <para>
+/// The child columns and the discriminator buffer are borrowed for this column's lifetime: the child columns are
+/// disposed (when owned) and the discriminator buffer returned (when pooled) on <see cref="Dispose"/>. Read the
+/// column only while the owning block is alive; copy values out to retain them.
+/// </para>
+/// </summary>
+internal sealed class VariantColumn : IColumn<object>, IVariantColumn
+{
+    /// <summary>The discriminator value marking a NULL row; it selects no alternative type.</summary>
+    internal const byte NullDiscriminator = 255;
+
+    private readonly IColumn[] typeColumns;
+    private readonly int rowCount;
+    private readonly bool ownsColumns;
+    private readonly bool pooledDiscriminators;
+    private readonly int[] localIndex;
+    private byte[] discriminators;
+    private object[] cache;
+
+    // When non-null, overrides ownsColumns per type column: Dispose disposes type column i only when
+    // columnOwnership[i] is true. Set once by RestrictOwnership immediately after construction so a densified
+    // wrapper that mixes freshly built type columns with columns borrowed from another column disposes only the
+    // ones it created.
+    private bool[] columnOwnership;
+
+    /// <summary>Initializes a variant column over its discriminator stream and per-type child columns.</summary>
+    /// <param name="name">The column name.</param>
+    /// <param name="typeName">The full <c>Variant(...)</c> type string.</param>
+    /// <param name="discriminators">One discriminator per row; <see cref="NullDiscriminator"/> marks a NULL row.</param>
+    /// <param name="typeColumns">One child column per alternative type, in declared (discriminator) order; each holds the values of the rows that selected it, in row order.</param>
+    /// <param name="rowCount">The number of rows.</param>
+    /// <param name="pooledDiscriminators">Whether <paramref name="discriminators"/> was rented and should be returned on dispose.</param>
+    /// <param name="ownsColumns">Whether this column owns and disposes <paramref name="typeColumns"/> (false when a caller retains them).</param>
+    public VariantColumn(string name, string typeName, byte[] discriminators, IColumn[] typeColumns, int rowCount, bool pooledDiscriminators, bool ownsColumns)
+    {
+        Name = name;
+        TypeName = typeName;
+        this.discriminators = discriminators ?? throw new ArgumentNullException(nameof(discriminators));
+        this.typeColumns = typeColumns ?? throw new ArgumentNullException(nameof(typeColumns));
+        this.rowCount = rowCount;
+        this.pooledDiscriminators = pooledDiscriminators;
+        this.ownsColumns = ownsColumns;
+
+        // Precompute each row's index into its selected type's child column: walk the discriminators once,
+        // keeping a per-type running counter. A NULL row gets -1 (it addresses no child value).
+        localIndex = rowCount == 0 ? Array.Empty<int>() : new int[rowCount];
+
+        // Zero the stack counters explicitly rather than trusting the compiler's `.locals init` — a future
+        // `[SkipLocalsInit]` would drop that guarantee and leave garbage counts, silently corrupting the local
+        // indices. The Clear is a cheap memset.
+        Span<int> counters = stackalloc int[typeColumns.Length];
+        counters.Clear();
+        for (int row = 0; row < rowCount; row++)
+        {
+            byte d = discriminators[row];
+            localIndex[row] = d == NullDiscriminator ? -1 : counters[d]++;
+        }
+    }
+
+    /// <summary>
+    /// Restricts disposal to the type columns flagged in <paramref name="owned"/> (one entry per alternative),
+    /// overriding the all-or-nothing <c>ownsColumns</c> passed at construction. Used when rebuilding a densified
+    /// variant that keeps some type columns by reference (owned by the source column) and replaces others with
+    /// freshly built ones, so disposing this wrapper frees only the columns it created. Must be called before the
+    /// column is observed.
+    /// </summary>
+    internal void RestrictOwnership(bool[] owned)
+    {
+        if (owned is null || owned.Length != typeColumns.Length)
+        {
+            throw new ArgumentException("Ownership mask must have one entry per type column.", nameof(owned));
+        }
+
+        columnOwnership = owned;
+    }
+
+    /// <inheritdoc/>
+    public string Name { get; }
+
+    /// <inheritdoc/>
+    public string TypeName { get; }
+
+    /// <inheritdoc/>
+    public int RowCount => rowCount;
+
+    /// <inheritdoc/>
+    public int TypeCount => typeColumns.Length;
+
+    /// <inheritdoc/>
+    public ReadOnlySpan<byte> Discriminators => discriminators.AsSpan(0, rowCount);
+
+    /// <inheritdoc/>
+    public ReadOnlySpan<int> LocalIndices => localIndex.AsSpan(0, rowCount);
+
+    /// <summary>
+    /// The rows as boxed values, materialized once and cached — each row is the selected alternative's value, or
+    /// <see langword="null"/> for a NULL row. Prefer <see cref="Discriminators"/> plus
+    /// <see cref="GetTypeColumn(int)"/> for the allocation-free columnar path.
+    /// </summary>
+    public ReadOnlySpan<object> Values
+    {
+        get
+        {
+            if (cache is null)
+            {
+                var decoded = new object[rowCount];
+                for (int row = 0; row < rowCount; row++)
+                {
+                    decoded[row] = this[row];
+                }
+
+                cache = decoded;
+            }
+
+            return cache.AsSpan(0, rowCount);
+        }
+    }
+
+    /// <inheritdoc/>
+    public object this[int row]
+    {
+        get
+        {
+            byte d = discriminators[row];
+            return d == NullDiscriminator ? null : typeColumns[d].GetValue(localIndex[row]);
+        }
+    }
+
+    /// <inheritdoc/>
+    public object GetValue(int row) => this[row];
+
+    /// <inheritdoc/>
+    public IColumn GetTypeColumn(int discriminator) => typeColumns[discriminator];
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        if (columnOwnership is not null)
+        {
+            for (int i = 0; i < typeColumns.Length; i++)
+            {
+                if (columnOwnership[i])
+                {
+                    typeColumns[i].Dispose();
+                }
+            }
+        }
+        else if (ownsColumns)
+        {
+            foreach (IColumn column in typeColumns)
+            {
+                column.Dispose();
+            }
+        }
+
+        if (pooledDiscriminators && discriminators.Length != 0)
+        {
+            ArrayPool<byte>.Shared.Return(discriminators);
+        }
+
+        discriminators = Array.Empty<byte>();
+        cache = null;
+    }
+}
+
+/// <summary>
+/// The dense-column contract a <c>Variant(...)</c> codec writes from without copying: the per-row discriminator
+/// stream and the per-type child columns. Implemented by <see cref="VariantColumn"/>.
+/// </summary>
+internal interface IVariantColumn : IColumn
+{
+    /// <summary>The number of alternative types.</summary>
+    int TypeCount { get; }
+
+    /// <summary>One discriminator per row; <see cref="VariantColumn.NullDiscriminator"/> marks a NULL row.</summary>
+    ReadOnlySpan<byte> Discriminators { get; }
+
+    /// <summary>
+    /// Each row's index into its selected type's child column (the count of that discriminator in the rows before
+    /// it), precomputed once; a NULL row's entry is <c>-1</c>. Lets a caller price or address a row in O(1)
+    /// rather than rescanning the discriminators.
+    /// </summary>
+    ReadOnlySpan<int> LocalIndices { get; }
+
+    /// <summary>The child column for the given discriminator (holding the values of the rows that selected it).</summary>
+    /// <param name="discriminator">The alternative-type index.</param>
+    /// <returns>That type's child column.</returns>
+    IColumn GetTypeColumn(int discriminator);
+}

--- a/ClickHouse.Driver.Tcp/Types/VariantColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/VariantColumn.cs
@@ -197,9 +197,10 @@ internal sealed class VariantColumn : IColumn<object>, IVariantColumn
 }
 
 /// <summary>
-/// The zero-copy read surface of a decoded <c>Variant(T1, ..., Tn)</c> column, and the shape its codec writes from
-/// without copying: a per-row discriminator stream plus one child column per alternative type, each holding only the
-/// values of the rows that selected it, in row order. That is exactly the wire layout.
+/// The columnar read surface of a decoded <c>Variant(T1, ..., Tn)</c> column: a per-row discriminator stream plus one
+/// child column per alternative type, each holding only the values of the rows that selected it, in row order. That
+/// is exactly the wire layout. It is a read view only — implementing it does not make a column insertable, because
+/// the codec's zero-copy write path accepts only columns this driver decoded, whose invariants it has checked.
 ///
 /// <para>
 /// Unlike the other composites, a <c>Variant</c> has no useful materialized element type — the

--- a/ClickHouse.Driver.Tcp/Types/VariantColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/VariantColumn.cs
@@ -49,6 +49,8 @@ internal sealed class VariantColumn : IColumn<object>, IVariantColumn
     /// <param name="rowCount">The number of rows.</param>
     /// <param name="pooledDiscriminators">Whether <paramref name="discriminators"/> was rented and should be returned on dispose.</param>
     /// <param name="ownsColumns">Whether this column owns and disposes <paramref name="typeColumns"/> (false when a caller retains them).</param>
+    /// <exception cref="ArgumentNullException"><paramref name="discriminators"/> or <paramref name="typeColumns"/> is null.</exception>
+    /// <exception cref="ArgumentException"><paramref name="discriminators"/> holds fewer than <paramref name="rowCount"/> entries.</exception>
     public VariantColumn(string name, string typeName, byte[] discriminators, IColumn[] typeColumns, int rowCount, bool pooledDiscriminators, bool ownsColumns)
     {
         Name = name;
@@ -58,6 +60,17 @@ internal sealed class VariantColumn : IColumn<object>, IVariantColumn
         this.rowCount = rowCount;
         this.pooledDiscriminators = pooledDiscriminators;
         this.ownsColumns = ownsColumns;
+
+        // The row count cannot be derived here: each child holds only the rows that selected it and a NULL row takes
+        // a slot in none of them, so the children say nothing about the height, and the discriminators are typically
+        // a pooled buffer longer than the column. So the one input that can disagree is checked instead — otherwise
+        // the walk below would fault on a short buffer with nothing naming the cause.
+        if (discriminators.Length < rowCount)
+        {
+            throw new ArgumentException(
+                $"The discriminators for column '{name}' ({typeName}) hold {discriminators.Length} entries, fewer than the {rowCount} rows.",
+                nameof(discriminators));
+        }
 
         // Precompute each row's index into its selected type's child column: walk the discriminators once,
         // keeping a per-type running counter. A NULL row gets -1 (it addresses no child value).
@@ -135,11 +148,15 @@ internal sealed class VariantColumn : IColumn<object>, IVariantColumn
     }
 
     /// <inheritdoc/>
+    // Index through the RowCount-sliced discriminators, not the raw buffer: the buffer is usually a pooled array
+    // longer than the column, so a row past RowCount read a stale byte from its tail. That made the failure depend on
+    // the leftover value — a stale 255 returned null as though the row existed, anything else fell through to the
+    // exactly-sized local index and threw. Slicing makes it a bounds failure either way.
     public object this[int row]
     {
         get
         {
-            byte d = discriminators[row];
+            byte d = Discriminators[row];
             return d == NullDiscriminator ? null : typeColumns[d].GetValue(localIndex[row]);
         }
     }

--- a/ClickHouse.Driver.Tcp/Types/VariantColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/VariantColumn.cs
@@ -11,7 +11,8 @@ namespace ClickHouse.Driver.Tcp.Types;
 ///
 /// <para>
 /// A row's discriminator is an index into the alternative types (<c>0</c> = the first type, and so on), or
-/// <see cref="NullDiscriminator"/> (<c>255</c>) for a NULL row, which consumes no value from any child column.
+/// <see cref="IVariantColumn.NullDiscriminator"/> (<c>255</c>) for a NULL row, which consumes no value from any
+/// child column.
 /// Random access maps a row to its value through a per-row index into the selected type's child column,
 /// precomputed once by a single walk of the discriminators.
 /// </para>
@@ -24,9 +25,6 @@ namespace ClickHouse.Driver.Tcp.Types;
 /// </summary>
 internal sealed class VariantColumn : IColumn<object>, IVariantColumn
 {
-    /// <summary>The discriminator value marking a NULL row; it selects no alternative type.</summary>
-    internal const byte NullDiscriminator = 255;
-
     private readonly IColumn[] typeColumns;
     private readonly int rowCount;
     private readonly bool ownsColumns;
@@ -44,7 +42,7 @@ internal sealed class VariantColumn : IColumn<object>, IVariantColumn
     /// <summary>Initializes a variant column over its discriminator stream and per-type child columns.</summary>
     /// <param name="name">The column name.</param>
     /// <param name="typeName">The full <c>Variant(...)</c> type string.</param>
-    /// <param name="discriminators">One discriminator per row; <see cref="NullDiscriminator"/> marks a NULL row.</param>
+    /// <param name="discriminators">One discriminator per row; <see cref="IVariantColumn.NullDiscriminator"/> marks a NULL row.</param>
     /// <param name="typeColumns">One child column per alternative type, in declared (discriminator) order; each holds the values of the rows that selected it, in row order.</param>
     /// <param name="rowCount">The number of rows.</param>
     /// <param name="pooledDiscriminators">Whether <paramref name="discriminators"/> was rented and should be returned on dispose.</param>
@@ -84,7 +82,7 @@ internal sealed class VariantColumn : IColumn<object>, IVariantColumn
         for (int row = 0; row < rowCount; row++)
         {
             byte d = discriminators[row];
-            localIndex[row] = d == NullDiscriminator ? -1 : counters[d]++;
+            localIndex[row] = d == IVariantColumn.NullDiscriminator ? -1 : counters[d]++;
         }
     }
 
@@ -157,7 +155,7 @@ internal sealed class VariantColumn : IColumn<object>, IVariantColumn
         get
         {
             byte d = Discriminators[row];
-            return d == NullDiscriminator ? null : typeColumns[d].GetValue(localIndex[row]);
+            return d == IVariantColumn.NullDiscriminator ? null : typeColumns[d].GetValue(localIndex[row]);
         }
     }
 
@@ -199,15 +197,34 @@ internal sealed class VariantColumn : IColumn<object>, IVariantColumn
 }
 
 /// <summary>
-/// The dense-column contract a <c>Variant(...)</c> codec writes from without copying: the per-row discriminator
-/// stream and the per-type child columns. Implemented by <see cref="VariantColumn"/>.
+/// The zero-copy read surface of a decoded <c>Variant(T1, ..., Tn)</c> column, and the shape its codec writes from
+/// without copying: a per-row discriminator stream plus one child column per alternative type, each holding only the
+/// values of the rows that selected it, in row order. That is exactly the wire layout.
+///
+/// <para>
+/// Unlike the other composites, a <c>Variant</c> has no useful materialized element type — the
+/// <see cref="IColumn{T}"/> surface is <c>IColumn&lt;object&gt;</c>, so every row read through it is boxed. Reading
+/// columnar avoids that: dispatch on <see cref="Discriminators"/>, then read the selected type's child column,
+/// which is typed. Row <c>i</c>'s value lives at <c>LocalIndices[i]</c> within
+/// <c>GetTypeColumn(Discriminators[i])</c>, unless its discriminator is
+/// <see cref="NullDiscriminator"/>, in which case the row is NULL and occupies no slot in any child.
+/// </para>
+///
+/// <para>
+/// Child columns and both spans are borrowed views over the owning block's storage: read them in place, and copy out
+/// only what must outlive the block. A child whose type is itself a composite pattern-matches to that type's own
+/// columnar view. Obtain this view by pattern-matching a column, e.g. <c>if (column is IVariantColumn variant)</c>.
+/// </para>
 /// </summary>
-internal interface IVariantColumn : IColumn
+public interface IVariantColumn : IColumn
 {
+    /// <summary>The discriminator value marking a NULL row; it selects no alternative type.</summary>
+    public const byte NullDiscriminator = 255;
+
     /// <summary>The number of alternative types.</summary>
     int TypeCount { get; }
 
-    /// <summary>One discriminator per row; <see cref="VariantColumn.NullDiscriminator"/> marks a NULL row.</summary>
+    /// <summary>One discriminator per row; <see cref="NullDiscriminator"/> marks a NULL row.</summary>
     ReadOnlySpan<byte> Discriminators { get; }
 
     /// <summary>

--- a/ClickHouse.Driver.Tcp/Types/VariantColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/VariantColumn.cs
@@ -235,8 +235,12 @@ public interface IVariantColumn : IColumn
     /// </summary>
     ReadOnlySpan<int> LocalIndices { get; }
 
-    /// <summary>The child column for the given discriminator (holding the values of the rows that selected it).</summary>
-    /// <param name="discriminator">The alternative-type index.</param>
+    /// <summary>
+    /// The child column for the given discriminator (holding the values of the rows that selected it). A borrowed
+    /// view valid only while the owning block is alive — it is the block's to dispose, never the caller's.
+    /// </summary>
+    /// <param name="discriminator">The alternative-type index. Must be a real type index: <see cref="NullDiscriminator"/> selects no column, so guard for it before calling.</param>
     /// <returns>That type's child column.</returns>
+    /// <exception cref="IndexOutOfRangeException"><paramref name="discriminator"/> is negative or not less than <see cref="TypeCount"/> — which includes passing <see cref="NullDiscriminator"/>.</exception>
     IColumn GetTypeColumn(int discriminator);
 }


### PR DESCRIPTION
Stacked on #456 (TCP J1: LowCardinality). Adds `Variant(...)` support and the write-path prefix-signature change it sits on top of.

## J0a — `WriteStatePrefix` receives the sliced column
Widened `IColumnCodec.WriteStatePrefix(writer)` → `WriteStatePrefix(writer, column, start, length)`. A type whose prefix bytes derive from the data (a runtime-discovered type list) must see the same rows the following body writes, and each block's prefix reflects only that block's rows.

- The block writer passes the column and its block slice.
- Delegating composites (Nullable/Array/Tuple/Map/Nested) forward the outer column and row slice unchanged — **byte-identical for every type supported today**, since each inner's prefix is data-independent and ignores the arguments. Projecting an inner's *own* sliced sub-column (the flattened element sub-slice for element-space composites) is what a future data-dependent inner will need and lands later.
- LowCardinality's prefix is a fixed version marker and ignores the slice.
- Added a full-column `WriteStatePrefix(codec, writer, column)` convenience overload mirroring the existing `WriteColumn` helper.

## J3 — `Variant(T1, ..., Tn)` BASIC discriminators
A discriminated union: each row holds a value of one alternative or NULL. Only the BASIC discriminators mode is supported (the server default over the native protocol); a COMPACT prefix is rejected.

**Wire layout** (per non-empty block): `UInt64` mode word (`0` = BASIC) → each alternative's own state prefix (empty for every supported alternative) → one `UInt8` discriminator per row (`255` = NULL) → a dense run per alternative, in declared order, holding the rows that selected it.

- Alternatives are never `Nullable` — NULL is the discriminator's job — so, like Array/Tuple/Map/Nested, there is **no `Nullable(Variant(...))`** round-trip; NULL composes inside instead.
- The server sends the declared order canonicalized, so the codec does **not** reorder it.
- Surfaced by a dense `VariantColumn` (discriminators + per-type child columns) — the zero-copy write source — with a precomputed per-row local index so measurement/addressing is O(1).
- Ergonomic write source is a flat `IColumn<object>`, scattered by each value's runtime CLR type into per-type buffers via the tuple flat-write machinery.
- Composes inside a composite (`Array(Variant(...))`) and takes a composite alternative (`Variant(Array(T), ...)`).
- Its prefix is data-independent, so it needs neither the inner-projection part of J0a nor the prefix→data scratch machinery (deferred to Dynamic/J4).

## Testing
- **807 tests pass**, including 11 Variant unit tests (byte-anchored on the documented wire example) and 4 INSERT→SELECT round-trips against **ClickHouse 26.6** (basic, three-alternative, composite alternative `Variant(Array(UInt64), String)`, and `Array(Variant(...))`).
- Coverage: `VariantColumn` 100%, `VariantColumnCodec` ~92% (remainder is defensive catch/guard paths).
- Two stale tests that used `Variant(...)` as an "unsupported type" stand-in were repointed at `Point` (now that Variant resolves).
- A review pass flagged and fixed an O(n²) dense-measurement path (now O(1) via the precomputed local index) and tightened `CanWrite` to reject a wrong-arity dense column.

## Known limitation
On the *ergonomic* (`IColumn<object>`) write path, a variant whose alternatives share a convenience CLR write type (e.g. `Variant(DateTime, DateTime64)`) resolves ambiguously (lower discriminator wins). The dense `VariantColumn` path is unaffected. Noted for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)