### PR TITLE
TCP N: Add ClickHouseTcpClient: public client API (read path + inserts)

### DIFF
--- a/ClickHouse.Driver.Tcp.Tests/ClickHouse.Driver.Tcp.Tests.csproj
+++ b/ClickHouse.Driver.Tcp.Tests/ClickHouse.Driver.Tcp.Tests.csproj
@@ -6,7 +6,8 @@
     <IsTestProject>true</IsTestProject>
     <LangVersion>latest</LangVersion>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
-    <NoWarn>CS8002</NoWarn>
+    <!-- CHTCP0001: the native-TCP client is experimental; the tests opt in to exercising it. -->
+    <NoWarn>CS8002;CHTCP0001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ClickHouse.Driver.Tcp.Tests/Client/ClickHouseTcpClientOptionsTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Client/ClickHouseTcpClientOptionsTests.cs
@@ -1,0 +1,97 @@
+using System;
+
+namespace ClickHouse.Driver.Tcp.Tests.Client;
+
+[TestFixture]
+public class ClickHouseTcpClientOptionsTests
+{
+    [Test]
+    public void Defaults_WhenNotOverridden_MatchNativeProtocolConventions()
+    {
+        var options = new ClickHouseTcpClientOptions();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(options.Host, Is.EqualTo("localhost"));
+            Assert.That(options.Port, Is.EqualTo(9000));
+            Assert.That(options.Username, Is.EqualTo("default"));
+            Assert.That(options.Password, Is.EqualTo(string.Empty));
+            Assert.That(options.Database, Is.EqualTo("default"));
+            Assert.That(options.DialTimeout, Is.EqualTo(TimeSpan.FromSeconds(30)));
+            Assert.That(options.ReadTimeout, Is.EqualTo(TimeSpan.FromSeconds(300)));
+            Assert.That(options.MaxSendBufferBytes, Is.EqualTo(10 * 1024 * 1024));
+        });
+    }
+
+    [Test]
+    public void Validate_ValidOptions_DoesNotThrow()
+    {
+        var options = new ClickHouseTcpClientOptions { Host = "example", Port = 9440, Username = "u", Database = "db" };
+
+        Assert.DoesNotThrow(() => options.Validate());
+    }
+
+    [Test]
+    public void Validate_EmptyHost_ThrowsArgumentException()
+    {
+        var options = new ClickHouseTcpClientOptions { Host = "" };
+
+        Assert.Throws<ArgumentException>(() => options.Validate());
+    }
+
+    [Test]
+    public void Validate_EmptyUsername_ThrowsArgumentException()
+    {
+        var options = new ClickHouseTcpClientOptions { Username = "" };
+
+        Assert.Throws<ArgumentException>(() => options.Validate());
+    }
+
+    [TestCase(0)]
+    [TestCase(-1)]
+    [TestCase(65536)]
+    public void Validate_PortOutOfRange_ThrowsArgumentOutOfRangeException(int port)
+    {
+        var options = new ClickHouseTcpClientOptions { Port = port };
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => options.Validate());
+    }
+
+    [Test]
+    public void Validate_NonPositiveDialTimeout_ThrowsArgumentOutOfRangeException()
+    {
+        var options = new ClickHouseTcpClientOptions { DialTimeout = TimeSpan.Zero };
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => options.Validate());
+    }
+
+    [Test]
+    public void Validate_NonPositiveMaxSendBufferBytes_ThrowsArgumentOutOfRangeException()
+    {
+        var options = new ClickHouseTcpClientOptions { MaxSendBufferBytes = 0 };
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => options.Validate());
+    }
+
+    [Test]
+    public void ToHandshakeParameters_MapsCredentialsAndDatabase()
+    {
+        var options = new ClickHouseTcpClientOptions
+        {
+            Username = "alice",
+            Password = "secret",
+            Database = "analytics",
+            QuotaKey = "quota-1",
+        };
+
+        var handshake = options.ToHandshakeParameters();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(handshake.Username, Is.EqualTo("alice"));
+            Assert.That(handshake.Password, Is.EqualTo("secret"));
+            Assert.That(handshake.Database, Is.EqualTo("analytics"));
+            Assert.That(handshake.QuotaKey, Is.EqualTo("quota-1"));
+        });
+    }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Client/ClickHouseTcpClientOptionsTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Client/ClickHouseTcpClientOptionsTests.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Reflection;
 
 namespace ClickHouse.Driver.Tcp.Tests.Client;
 
@@ -71,6 +73,129 @@ public class ClickHouseTcpClientOptionsTests
         var options = new ClickHouseTcpClientOptions { MaxSendBufferBytes = 0 };
 
         Assert.Throws<ArgumentOutOfRangeException>(() => options.Validate());
+    }
+
+    [Test]
+    public void Validate_CustomSettingWithEmptyName_ThrowsArgumentException()
+    {
+        // An empty name would be written as the empty key that terminates the settings list on the wire, so the
+        // server would stop reading settings there and misread the following bytes as the next Query fields.
+        var options = new ClickHouseTcpClientOptions
+        {
+            CustomSettings = new Dictionary<string, string> { [string.Empty] = "1" },
+        };
+
+        Assert.Throws<ArgumentException>(() => options.Validate());
+    }
+
+    [Test]
+    public void Validate_CustomSettingWithNullValue_ThrowsArgumentException()
+    {
+        // A null value cannot be written, and it would otherwise throw mid-packet with bytes already buffered.
+        var options = new ClickHouseTcpClientOptions
+        {
+            CustomSettings = new Dictionary<string, string> { ["max_threads"] = null },
+        };
+
+        Assert.Throws<ArgumentException>(() => options.Validate());
+    }
+
+    [Test]
+    public void Validate_CustomSettingWithEmptyValue_DoesNotThrow()
+    {
+        // An empty value is the flag-style setting the null-value message points callers at.
+        var options = new ClickHouseTcpClientOptions
+        {
+            CustomSettings = new Dictionary<string, string> { ["some_flag"] = string.Empty },
+        };
+
+        Assert.DoesNotThrow(() => options.Validate());
+    }
+
+    [Test]
+    public void Validate_ValidCustomSettings_DoesNotThrow()
+    {
+        var options = new ClickHouseTcpClientOptions
+        {
+            CustomSettings = new Dictionary<string, string> { ["max_threads"] = "4", ["max_block_size"] = "1000" },
+        };
+
+        Assert.DoesNotThrow(() => options.Validate());
+    }
+
+    [Test]
+    public void WithOwnedCustomSettings_CopiesEveryPropertyAndSnapshotsTheSettings()
+    {
+        // WithOwnedCustomSettings copies each property by hand, so a property added later could silently stop being
+        // carried across. The two reflection loops make that a test failure: the first insists this test sets every
+        // property to a non-default value, and the second insists the copy preserves each one.
+        var original = new ClickHouseTcpClientOptions
+        {
+            Host = "copy-host",
+            Port = 1234,
+            Username = "copy-user",
+            Password = "copy-password",
+            Database = "copy-db",
+            QuotaKey = "copy-quota",
+            CustomSettings = new Dictionary<string, string> { ["max_threads"] = "4" },
+            MaxSendBufferBytes = 4096,
+            DialTimeout = TimeSpan.FromSeconds(3),
+            ReadTimeout = TimeSpan.FromSeconds(4),
+        };
+        var defaults = new ClickHouseTcpClientOptions();
+
+        var copy = original.WithOwnedCustomSettings();
+
+        PropertyInfo[] properties = typeof(ClickHouseTcpClientOptions).GetProperties();
+        Assert.That(properties, Is.Not.Empty);
+        Assert.That(copy, Is.Not.SameAs(original), "settings were present, so the copy must be a new instance");
+
+        Assert.Multiple(() =>
+        {
+            foreach (PropertyInfo property in properties)
+            {
+                Assert.That(
+                    property.GetValue(original),
+                    Is.Not.EqualTo(property.GetValue(defaults)),
+                    $"this test must set {property.Name} to a non-default value for the copy check below to mean anything");
+
+                if (property.Name == nameof(ClickHouseTcpClientOptions.CustomSettings))
+                {
+                    Assert.That(property.GetValue(copy), Is.Not.SameAs(property.GetValue(original)), "the settings must be a private snapshot");
+                    Assert.That(copy.CustomSettings, Is.EquivalentTo(original.CustomSettings));
+                }
+                else
+                {
+                    Assert.That(property.GetValue(copy), Is.EqualTo(property.GetValue(original)), $"{property.Name} was not carried into the copy");
+                }
+            }
+        });
+    }
+
+    [Test]
+    public void WithOwnedCustomSettings_NoCustomSettings_ReturnsTheSameInstance()
+    {
+        // Nothing mutable to snapshot: every other property is init-only, so the instance can be shared as-is.
+        var options = new ClickHouseTcpClientOptions { Host = "h" };
+
+        Assert.That(options.WithOwnedCustomSettings(), Is.SameAs(options));
+    }
+
+    [Test]
+    public void WithOwnedCustomSettings_CallerMutatesSettingsAfterwards_SnapshotUnaffected()
+    {
+        var callerSettings = new Dictionary<string, string> { ["max_threads"] = "4" };
+        var options = new ClickHouseTcpClientOptions { CustomSettings = callerSettings };
+
+        var copy = options.WithOwnedCustomSettings();
+        callerSettings["max_threads"] = "8";
+        callerSettings["added_later"] = "1";
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(copy.CustomSettings["max_threads"], Is.EqualTo("4"));
+            Assert.That(copy.CustomSettings.ContainsKey("added_later"), Is.False);
+        });
     }
 
     [Test]

--- a/ClickHouse.Driver.Tcp.Tests/Client/ClickHouseTcpClientOptionsTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Client/ClickHouseTcpClientOptionsTests.cs
@@ -126,9 +126,10 @@ public class ClickHouseTcpClientOptionsTests
     [Test]
     public void WithOwnedCustomSettings_CopiesEveryPropertyAndSnapshotsTheSettings()
     {
-        // WithOwnedCustomSettings copies each property by hand, so a property added later could silently stop being
-        // carried across. The two reflection loops make that a test failure: the first insists this test sets every
-        // property to a non-default value, and the second insists the copy preserves each one.
+        // WithOwnedCustomSettings replaces one property and must carry every other one across. The two reflection
+        // loops make a regression here a test failure: the first insists this test sets every property to a
+        // non-default value, and the second insists the copy preserves each one. The `with` expression satisfies
+        // this by construction; the loops stay to catch a later rewrite back to a hand-written copy.
         var original = new ClickHouseTcpClientOptions
         {
             Host = "copy-host",
@@ -196,6 +197,89 @@ public class ClickHouseTcpClientOptionsTests
             Assert.That(copy.CustomSettings["max_threads"], Is.EqualTo("4"));
             Assert.That(copy.CustomSettings.ContainsKey("added_later"), Is.False);
         });
+    }
+
+    [Test]
+    public void With_ChangingOneProperty_CarriesEveryOtherPropertyAcross()
+    {
+        var original = new ClickHouseTcpClientOptions
+        {
+            Host = "with-host",
+            Port = 1234,
+            Username = "with-user",
+            Password = "with-password",
+            Database = "with-db",
+            QuotaKey = "with-quota",
+            CustomSettings = new Dictionary<string, string> { ["max_threads"] = "4" },
+            MaxSendBufferBytes = 4096,
+            DialTimeout = TimeSpan.FromSeconds(3),
+            ReadTimeout = TimeSpan.FromSeconds(4),
+        };
+
+        var derived = original with { Port = 9440 };
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(derived.Port, Is.EqualTo(9440));
+
+            foreach (PropertyInfo property in typeof(ClickHouseTcpClientOptions).GetProperties())
+            {
+                if (property.Name == nameof(ClickHouseTcpClientOptions.Port))
+                {
+                    continue;
+                }
+
+                Assert.That(property.GetValue(derived), Is.EqualTo(property.GetValue(original)), $"{property.Name} was not carried across");
+            }
+        });
+    }
+
+    [Test]
+    public void ToString_WhenAPasswordIsSet_DoesNotIncludeIt()
+    {
+        // A record prints every property by default, which would put the plaintext password into any log line that
+        // formats the options. ClickHouseTcpClient.Options is public, so a caller can reach this.
+        var options = new ClickHouseTcpClientOptions
+        {
+            Host = "example.invalid",
+            Port = 9440,
+            Username = "alice",
+            Password = "s3cr3t",
+            Database = "analytics",
+        };
+
+        var text = options.ToString();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(text, Does.Not.Contain("s3cr3t"));
+            Assert.That(text, Does.Not.Contain(nameof(ClickHouseTcpClientOptions.Password)));
+            Assert.That(
+                text,
+                Does.Contain("example.invalid").And.Contain("9440").And.Contain("alice").And.Contain("analytics"),
+                "the endpoint, user and database stay, so the text is still useful for diagnostics");
+        });
+    }
+
+    [Test]
+    public void Equals_EqualScalarsButDistinctSettingsDictionaries_AreNotEqual()
+    {
+        // Records give value equality, but IReadOnlyDictionary has no value-equality contract, so the settings are
+        // compared by reference. This pins the limitation the type documents: do not key a cache on these options.
+        var first = new ClickHouseTcpClientOptions { CustomSettings = new Dictionary<string, string> { ["max_threads"] = "4" } };
+        var second = new ClickHouseTcpClientOptions { CustomSettings = new Dictionary<string, string> { ["max_threads"] = "4" } };
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first, Is.Not.EqualTo(second));
+            Assert.That(first, Is.EqualTo(first with { }), "the clone shares the same dictionary instance, so it does compare equal");
+        });
+    }
+
+    [Test]
+    public void Equals_SettingsAbsentAndEveryScalarEqual_AreEqual()
+    {
+        Assert.That(new ClickHouseTcpClientOptions { Host = "h", Port = 9440 }, Is.EqualTo(new ClickHouseTcpClientOptions { Host = "h", Port = 9440 }));
     }
 
     [Test]

--- a/ClickHouse.Driver.Tcp.Tests/Client/ClickHouseTcpClientSettingsTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Client/ClickHouseTcpClientSettingsTests.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+
+namespace ClickHouse.Driver.Tcp.Tests.Client;
+
+[TestFixture]
+public class ClickHouseTcpClientSettingsTests
+{
+    private const string FlattenedSetting = "output_format_native_use_flattened_dynamic_and_json_serialization";
+
+    [Test]
+    public void MergeSettings_NoSettings_InjectsFlattenedSerializationByDefault()
+    {
+        var merged = ClickHouseTcpClient.MergeSettings(clientSettings: null, perQuerySettings: null);
+
+        Assert.That(merged[FlattenedSetting], Is.EqualTo("1"));
+    }
+
+    [Test]
+    public void MergeSettings_CallerSetsFlattened_CallerValueWins()
+    {
+        var perQuery = new Dictionary<string, string> { [FlattenedSetting] = "0" };
+
+        var merged = ClickHouseTcpClient.MergeSettings(clientSettings: null, perQuery);
+
+        Assert.That(merged[FlattenedSetting], Is.EqualTo("0"));
+    }
+
+    [Test]
+    public void MergeSettings_ClientSetsFlattened_ClientValueNotOverwritten()
+    {
+        var client = new Dictionary<string, string> { [FlattenedSetting] = "0" };
+
+        var merged = ClickHouseTcpClient.MergeSettings(client, perQuerySettings: null);
+
+        Assert.That(merged[FlattenedSetting], Is.EqualTo("0"));
+    }
+
+    [Test]
+    public void MergeSettings_PerQueryOverridesClientLevelForSameKey()
+    {
+        var client = new Dictionary<string, string> { ["max_threads"] = "4" };
+        var perQuery = new Dictionary<string, string> { ["max_threads"] = "8" };
+
+        var merged = ClickHouseTcpClient.MergeSettings(client, perQuery);
+
+        Assert.That(merged["max_threads"], Is.EqualTo("8"));
+    }
+
+    [Test]
+    public void MergeSettings_UnionsClientAndPerQueryKeys()
+    {
+        var client = new Dictionary<string, string> { ["max_threads"] = "4" };
+        var perQuery = new Dictionary<string, string> { ["max_block_size"] = "1000" };
+
+        var merged = ClickHouseTcpClient.MergeSettings(client, perQuery);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(merged["max_threads"], Is.EqualTo("4"));
+            Assert.That(merged["max_block_size"], Is.EqualTo("1000"));
+            Assert.That(merged[FlattenedSetting], Is.EqualTo("1"));
+        });
+    }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Client/ClickHouseTcpClientSettingsTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Client/ClickHouseTcpClientSettingsTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace ClickHouse.Driver.Tcp.Tests.Client;
@@ -44,6 +45,35 @@ public class ClickHouseTcpClientSettingsTests
         var merged = ClickHouseTcpClient.MergeSettings(client, perQuery);
 
         Assert.That(merged["max_threads"], Is.EqualTo("8"));
+    }
+
+    [Test]
+    public void MergeSettings_PerQuerySettingWithEmptyName_ThrowsArgumentException()
+    {
+        // Per-query settings bypass the construction-time validation of the client-level ones, so the merge is the
+        // last point before the Query packet where an empty name can be rejected instead of truncating the wire
+        // settings list.
+        var perQuery = new Dictionary<string, string> { [string.Empty] = "1" };
+
+        Assert.Throws<ArgumentException>(() => ClickHouseTcpClient.MergeSettings(clientSettings: null, perQuery));
+    }
+
+    [Test]
+    public void MergeSettings_PerQuerySettingWithNullValue_ThrowsArgumentException()
+    {
+        var perQuery = new Dictionary<string, string> { ["max_threads"] = null };
+
+        Assert.Throws<ArgumentException>(() => ClickHouseTcpClient.MergeSettings(clientSettings: null, perQuery));
+    }
+
+    [Test]
+    public void MergeSettings_PerQuerySettingWithEmptyValue_IsAccepted()
+    {
+        var perQuery = new Dictionary<string, string> { ["some_flag"] = string.Empty };
+
+        var merged = ClickHouseTcpClient.MergeSettings(clientSettings: null, perQuery);
+
+        Assert.That(merged["some_flag"], Is.EqualTo(string.Empty));
     }
 
     [Test]

--- a/ClickHouse.Driver.Tcp.Tests/Client/ClickHouseTcpConnectionStringBuilderTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Client/ClickHouseTcpConnectionStringBuilderTests.cs
@@ -1,0 +1,124 @@
+using System;
+
+namespace ClickHouse.Driver.Tcp.Tests.Client;
+
+[TestFixture]
+public class ClickHouseTcpConnectionStringBuilderTests
+{
+    [Test]
+    public void ToOptions_AllKeys_ParsesEachValue()
+    {
+        var builder = new ClickHouseTcpConnectionStringBuilder(
+            "Host=db.example;Port=9440;Username=alice;Password=secret;Database=analytics;QuotaKey=q1;DialTimeout=5;ReadTimeout=60;MaxSendBufferBytes=2048");
+
+        var options = builder.ToOptions();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(options.Host, Is.EqualTo("db.example"));
+            Assert.That(options.Port, Is.EqualTo(9440));
+            Assert.That(options.Username, Is.EqualTo("alice"));
+            Assert.That(options.Password, Is.EqualTo("secret"));
+            Assert.That(options.Database, Is.EqualTo("analytics"));
+            Assert.That(options.QuotaKey, Is.EqualTo("q1"));
+            Assert.That(options.DialTimeout, Is.EqualTo(TimeSpan.FromSeconds(5)));
+            Assert.That(options.ReadTimeout, Is.EqualTo(TimeSpan.FromSeconds(60)));
+            Assert.That(options.MaxSendBufferBytes, Is.EqualTo(2048));
+        });
+    }
+
+    [Test]
+    public void ToOptions_MissingKeys_AppliesDefaults()
+    {
+        var options = new ClickHouseTcpConnectionStringBuilder("Host=only-host").ToOptions();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(options.Host, Is.EqualTo("only-host"));
+            Assert.That(options.Port, Is.EqualTo(9000));
+            Assert.That(options.Username, Is.EqualTo("default"));
+            Assert.That(options.Password, Is.EqualTo(string.Empty));
+            Assert.That(options.Database, Is.EqualTo("default"));
+            Assert.That(options.DialTimeout, Is.EqualTo(TimeSpan.FromSeconds(30)));
+        });
+    }
+
+    [Test]
+    public void ToOptions_SetPrefixedKeys_CollectedAsCustomSettings()
+    {
+        var builder = new ClickHouseTcpConnectionStringBuilder("Host=h;set_max_threads=4;set_max_block_size=1000");
+
+        var options = builder.ToOptions();
+
+        Assert.That(options.CustomSettings, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(options.CustomSettings["max_threads"], Is.EqualTo("4"));
+            Assert.That(options.CustomSettings["max_block_size"], Is.EqualTo("1000"));
+        });
+    }
+
+    [Test]
+    public void ToOptions_NoSetPrefixedKeys_LeavesCustomSettingsNull()
+    {
+        var options = new ClickHouseTcpConnectionStringBuilder("Host=h").ToOptions();
+
+        Assert.That(options.CustomSettings, Is.Null);
+    }
+
+    [Test]
+    public void FromConnectionString_DelegatesToBuilder()
+    {
+        var options = ClickHouseTcpClientOptions.FromConnectionString("Host=h;Port=1234");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(options.Host, Is.EqualTo("h"));
+            Assert.That(options.Port, Is.EqualTo(1234));
+        });
+    }
+
+    [Test]
+    public void TypedSetters_ReadBackOnSameInstance_ReturnValuesNotDefaults()
+    {
+        // The typed setters store boxed int/double; the getters must read those back rather than falling through
+        // to defaults (a set-then-get on one builder instance, without going through the connection string).
+        var builder = new ClickHouseTcpConnectionStringBuilder
+        {
+            Port = 9440,
+            MaxSendBufferBytes = 2048,
+            DialTimeout = TimeSpan.FromSeconds(7),
+            ReadTimeout = TimeSpan.FromSeconds(45),
+        };
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(builder.Port, Is.EqualTo(9440));
+            Assert.That(builder.MaxSendBufferBytes, Is.EqualTo(2048));
+            Assert.That(builder.DialTimeout, Is.EqualTo(TimeSpan.FromSeconds(7)));
+            Assert.That(builder.ReadTimeout, Is.EqualTo(TimeSpan.FromSeconds(45)));
+        });
+    }
+
+    [Test]
+    public void Setters_RoundTripThroughConnectionString()
+    {
+        var builder = new ClickHouseTcpConnectionStringBuilder
+        {
+            Host = "rt-host",
+            Port = 9001,
+            Username = "u",
+            Database = "d",
+        };
+
+        var reparsed = new ClickHouseTcpConnectionStringBuilder(builder.ConnectionString).ToOptions();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(reparsed.Host, Is.EqualTo("rt-host"));
+            Assert.That(reparsed.Port, Is.EqualTo(9001));
+            Assert.That(reparsed.Username, Is.EqualTo("u"));
+            Assert.That(reparsed.Database, Is.EqualTo("d"));
+        });
+    }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Client/ClickHouseTcpConnectionStringBuilderTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Client/ClickHouseTcpConnectionStringBuilderTests.cs
@@ -66,6 +66,61 @@ public class ClickHouseTcpConnectionStringBuilderTests
         Assert.That(options.CustomSettings, Is.Null);
     }
 
+    [TestCase("set_")]
+    [TestCase("SET_")]
+    public void ToOptions_BareSetPrefixKey_ThrowsArgumentException(string bareKey)
+    {
+        // The prefix alone names an empty setting, which on the wire is the key that terminates the settings list.
+        var builder = new ClickHouseTcpConnectionStringBuilder($"Host=h;{bareKey}=1");
+
+        Assert.Throws<ArgumentException>(() => builder.ToOptions());
+    }
+
+    [Test]
+    public void ToOptions_CustomSettingSetAsTypedValue_ConvertedToString()
+    {
+        // A setting assigned programmatically as a typed value must reach CustomSettings as its string form, not
+        // as an empty value.
+        var builder = new ClickHouseTcpConnectionStringBuilder { Host = "h" };
+        builder["set_max_threads"] = 4;
+        builder["set_ratio"] = 0.5;
+
+        var options = builder.ToOptions();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(options.CustomSettings["max_threads"], Is.EqualTo("4"));
+            Assert.That(options.CustomSettings["ratio"], Is.EqualTo("0.5"));
+        });
+    }
+
+    [Test]
+    [SetCulture("de-DE")]
+    public void ToOptions_FractionalValuesUnderCommaDecimalCulture_StayInvariant()
+    {
+        // de-DE writes 0,5 for 0.5. Values sent to the server must not pick up the ambient culture.
+        var builder = new ClickHouseTcpConnectionStringBuilder { Host = "h", DialTimeout = TimeSpan.FromMilliseconds(1500) };
+        builder["set_ratio"] = 0.5;
+
+        var options = builder.ToOptions();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(options.CustomSettings["ratio"], Is.EqualTo("0.5"));
+            Assert.That(options.DialTimeout, Is.EqualTo(TimeSpan.FromMilliseconds(1500)));
+        });
+    }
+
+    [Test]
+    public void ToOptions_SetKeyWithEmptyValue_IsDroppedAndYieldsNoSetting()
+    {
+        // The base builder removes a key whose value is empty, so 'set_some_flag=' never reaches CustomSettings at
+        // all. A flag-style setting needs an explicit value, e.g. 'set_some_flag=1'.
+        var options = new ClickHouseTcpConnectionStringBuilder("Host=h;set_some_flag=").ToOptions();
+
+        Assert.That(options.CustomSettings, Is.Null);
+    }
+
     [Test]
     public void FromConnectionString_DelegatesToBuilder()
     {

--- a/ClickHouse.Driver.Tcp.Tests/Client/ClickHouseTcpInsertOptionsTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Client/ClickHouseTcpInsertOptionsTests.cs
@@ -46,6 +46,38 @@ public class ClickHouseTcpInsertOptionsTests
     }
 
     [Test]
+    public void With_OnAQueryOptionsTypedReference_KeepsTheRuntimeTypeAndTheInsertOnlyKnobs()
+    {
+        // `with` clones through the record's virtual clone method, so it copies the runtime type rather than the
+        // static one. Deriving a per-query variant through a base-typed reference must therefore not quietly
+        // downgrade an insert options instance and reset MaxRowsPerBlock to its default.
+        ClickHouseTcpQueryOptions asQueryOptions = new ClickHouseTcpInsertOptions
+        {
+            QueryId = "insert-1",
+            MaxRowsPerBlock = 32,
+        };
+
+        var derived = asQueryOptions with { QueryId = "insert-2" };
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(derived, Is.InstanceOf<ClickHouseTcpInsertOptions>());
+            Assert.That(derived.QueryId, Is.EqualTo("insert-2"));
+            Assert.That(((ClickHouseTcpInsertOptions)derived).MaxRowsPerBlock, Is.EqualTo(32));
+        });
+    }
+
+    [Test]
+    public void With_SettingTheCapToNull_KeepsTheExplicitNullRatherThanTheDefault()
+    {
+        // The explicit-null instruction ("one block, whatever the row count") must survive a clone, since a default
+        // MaxRowsPerBlock would silently re-enable splitting.
+        var derived = new ClickHouseTcpInsertOptions { QueryId = "q" } with { MaxRowsPerBlock = null };
+
+        Assert.That(ClickHouseTcpClient.ResolveMaxRowsPerBlock(derived), Is.Null);
+    }
+
+    [Test]
     public void InsertOptions_IsUsableAsQueryOptions_SoTheSettingsMergeSeesThem()
     {
         var options = new ClickHouseTcpInsertOptions

--- a/ClickHouse.Driver.Tcp.Tests/Client/ClickHouseTcpInsertOptionsTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Client/ClickHouseTcpInsertOptionsTests.cs
@@ -1,0 +1,67 @@
+using System.Collections.Generic;
+
+namespace ClickHouse.Driver.Tcp.Tests.Client;
+
+[TestFixture]
+public class ClickHouseTcpInsertOptionsTests
+{
+    [Test]
+    public void MaxRowsPerBlock_NotSet_DefaultsToTheBlockRowCap()
+    {
+        Assert.That(new ClickHouseTcpInsertOptions().MaxRowsPerBlock, Is.EqualTo(1_000_000));
+    }
+
+    [Test]
+    public void MaxRowsPerBlock_SetToNull_StaysNullRatherThanFallingBackToTheDefault()
+    {
+        // Null means "one block, whatever the row count", which is a different instruction from "not specified".
+        // InsertAsync must therefore read the value off a default instance instead of coalescing it — a ?? would
+        // turn this back into the default and silently re-enable splitting.
+        Assert.That(new ClickHouseTcpInsertOptions { MaxRowsPerBlock = null }.MaxRowsPerBlock, Is.Null);
+    }
+
+    [Test]
+    public void ResolveMaxRowsPerBlock_NoOptions_UsesTheDefaultCap()
+    {
+        Assert.That(ClickHouseTcpClient.ResolveMaxRowsPerBlock(null), Is.EqualTo(1_000_000));
+    }
+
+    [Test]
+    public void ResolveMaxRowsPerBlock_OptionsWithoutTheCapSet_UsesTheDefaultCap()
+    {
+        Assert.That(ClickHouseTcpClient.ResolveMaxRowsPerBlock(new ClickHouseTcpInsertOptions()), Is.EqualTo(1_000_000));
+    }
+
+    [Test]
+    public void ResolveMaxRowsPerBlock_ExplicitNullCap_StaysNullSoTheInsertIsOneBlock()
+    {
+        // The case a ?? would get wrong: "not specified" must take the default, but an explicit null must survive.
+        Assert.That(ClickHouseTcpClient.ResolveMaxRowsPerBlock(new ClickHouseTcpInsertOptions { MaxRowsPerBlock = null }), Is.Null);
+    }
+
+    [Test]
+    public void ResolveMaxRowsPerBlock_ExplicitCap_IsPassedThrough()
+    {
+        Assert.That(ClickHouseTcpClient.ResolveMaxRowsPerBlock(new ClickHouseTcpInsertOptions { MaxRowsPerBlock = 32 }), Is.EqualTo(32));
+    }
+
+    [Test]
+    public void InsertOptions_IsUsableAsQueryOptions_SoTheSettingsMergeSeesThem()
+    {
+        var options = new ClickHouseTcpInsertOptions
+        {
+            QueryId = "insert-1",
+            Settings = new Dictionary<string, string> { ["max_threads"] = "4" },
+            MaxRowsPerBlock = 32,
+        };
+
+        ClickHouseTcpQueryOptions asQueryOptions = options;
+        var merged = ClickHouseTcpClient.MergeSettings(clientSettings: null, asQueryOptions.Settings);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(asQueryOptions.QueryId, Is.EqualTo("insert-1"));
+            Assert.That(merged["max_threads"], Is.EqualTo("4"));
+        });
+    }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Client/SingleConnectionSourceTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Client/SingleConnectionSourceTests.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Client;
+
+namespace ClickHouse.Driver.Tcp.Tests.Client;
+
+// These exercise the source's lifecycle without a server: with no rent, no connection is ever dialed, so
+// disposal and post-disposal rejection can be checked in isolation. The rent/redial/reuse behavior over a live
+// connection is covered by the client integration tests.
+[TestFixture]
+public class SingleConnectionSourceTests
+{
+    private static ClickHouseTcpClientOptions Options() => new() { Host = "localhost", Port = 9000 };
+
+    [Test]
+    public async Task DisposeAsync_CalledTwice_IsNoOp()
+    {
+        var source = new SingleConnectionSource(Options());
+
+        await source.DisposeAsync();
+
+        Assert.DoesNotThrowAsync(async () => await source.DisposeAsync());
+    }
+
+    [Test]
+    public async Task RentAsync_AfterDispose_ThrowsObjectDisposedException()
+    {
+        var source = new SingleConnectionSource(Options());
+        await source.DisposeAsync();
+
+        Assert.ThrowsAsync<ObjectDisposedException>(async () => await source.RentAsync(CancellationToken.None));
+    }
+
+    [Test]
+    public void RentAsync_PreCancelledToken_ThrowsOperationCanceledAndDoesNotDeadlock()
+    {
+        var source = new SingleConnectionSource(Options());
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        Assert.CatchAsync<OperationCanceledException>(async () => await source.RentAsync(cts.Token));
+
+        // The gate was released on the cancellation path, so a subsequent (also-cancelled) rent still throws
+        // its own cancellation rather than hanging on a leaked gate.
+        Assert.CatchAsync<OperationCanceledException>(async () => await source.RentAsync(cts.Token));
+    }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpClientIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpClientIntegrationTests.cs
@@ -1,0 +1,379 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Format;
+using ClickHouse.Driver.Tcp.Protocol;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Tests.Integration;
+
+// A yielded Block is borrowed — valid only for its iteration — so every read copies or compares inside the
+// await foreach, never retaining the block. The object[] rows from QueryAsync are owned and may be retained.
+[TestFixture]
+[Category("Integration")]
+public class ClickHouseTcpClientIntegrationTests
+{
+    private static readonly CancellationToken None = CancellationToken.None;
+
+    private static string UniqueTableName() => $"tcp_client_test_{Guid.NewGuid():N}";
+
+    [Test]
+    public async Task StreamAsync_SelectLiteral_ReturnsSingleBlock()
+    {
+        await using var client = TcpServerFixture.CreateClient();
+
+        int blockCount = 0;
+        byte value = 0;
+        await foreach (Block block in client.StreamAsync("SELECT 1", cancellationToken: None))
+        {
+            blockCount++;
+            value = ((IColumn<byte>)block[0]).Values[0];
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(blockCount, Is.EqualTo(1));
+            Assert.That(value, Is.EqualTo((byte)1));
+        });
+    }
+
+    [Test]
+    public async Task StreamAsync_EnumeratorDisposedEarly_ConnectionReusableForNextQuery()
+    {
+        await using var client = TcpServerFixture.CreateClient();
+
+        // Stop after the first block without draining — this disposes the enumerator mid-response, which
+        // terminates the underlying connection. The next operation must transparently redial.
+        await foreach (Block block in client.StreamAsync("SELECT number FROM system.numbers LIMIT 100000", cancellationToken: None))
+        {
+            _ = block.RowCount;
+            break;
+        }
+
+        // A fresh query on the same client succeeds (the source redialed a new connection).
+        var rows = await client.QueryAsync("SELECT 7").ToListAsync();
+
+        Assert.That(rows, Has.Count.EqualTo(1));
+        Assert.That((byte)rows[0][0], Is.EqualTo((byte)7));
+    }
+
+    [Test]
+    public async Task StreamAsync_ServerError_ThrowsAndClientStillUsable()
+    {
+        await using var client = TcpServerFixture.CreateClient();
+
+        // A server exception leaves the stream at a packet boundary, so the connection stays Ready and reusable.
+        Assert.ThrowsAsync<ClickHouseServerException>(async () =>
+        {
+            await foreach (Block _ in client.StreamAsync("SELECT * FROM table_that_does_not_exist_xyz", cancellationToken: None))
+            {
+            }
+        });
+
+        var rows = await client.QueryAsync("SELECT 1").ToListAsync();
+        Assert.That(rows, Has.Count.EqualTo(1));
+    }
+
+    [Test]
+    public async Task QueryAsync_SelectMultipleColumns_ReturnsObjectArrayRowsInHeaderOrder()
+    {
+        await using var client = TcpServerFixture.CreateClient();
+
+        var rows = await client.QueryAsync("SELECT number, toString(number) FROM system.numbers LIMIT 3").ToListAsync();
+
+        Assert.That(rows, Has.Count.EqualTo(3));
+        Assert.Multiple(() =>
+        {
+            for (int i = 0; i < 3; i++)
+            {
+                Assert.That(rows[i], Has.Length.EqualTo(2));
+                Assert.That((ulong)rows[i][0], Is.EqualTo((ulong)i));
+                Assert.That((string)rows[i][1], Is.EqualTo(i.ToString()));
+            }
+        });
+    }
+
+    [Test]
+    public async Task QueryAsync_RowRetainedPastEnumeration_StillValid()
+    {
+        await using var client = TcpServerFixture.CreateClient();
+
+        // Unlike a Block, an object[] row is owned and safe to keep after the enumeration ends.
+        object[] firstRow = null;
+        await foreach (object[] row in client.QueryAsync("SELECT number FROM system.numbers LIMIT 2"))
+        {
+            firstRow ??= row;
+        }
+
+        Assert.That(firstRow, Is.Not.Null);
+        Assert.That((ulong)firstRow[0], Is.EqualTo(0UL));
+    }
+
+    [Test]
+    public async Task ExecuteAsync_CreateInsertDropRoundTrip_Completes()
+    {
+        await using var client = TcpServerFixture.CreateClient();
+        string table = UniqueTableName();
+        try
+        {
+            await client.ExecuteAsync($"CREATE TABLE {table} (value Int32) ENGINE = Memory");
+            // INSERT ... SELECT runs entirely server-side (no client data block), so it exercises ExecuteAsync's
+            // drain-to-completion without the inline-VALUES data-stream path (that is InsertAsync's job).
+            await client.ExecuteAsync($"INSERT INTO {table} SELECT number FROM numbers(3)");
+
+            var count = await client.QueryAsync($"SELECT count() FROM {table}").ToListAsync();
+            Assert.That((ulong)count[0][0], Is.EqualTo(3UL));
+        }
+        finally
+        {
+            await client.ExecuteAsync($"DROP TABLE IF EXISTS {table}");
+        }
+    }
+
+    [Test]
+    public void ExecuteAsync_InvalidStatement_ThrowsServerException()
+    {
+        Assert.ThrowsAsync<ClickHouseServerException>(async () =>
+        {
+            await using var client = TcpServerFixture.CreateClient();
+            await client.ExecuteAsync("THIS IS NOT VALID SQL");
+        });
+    }
+
+    [Test]
+    public async Task InsertAsync_ColumnarData_RoundTripsThroughSelect()
+    {
+        await using var client = TcpServerFixture.CreateClient();
+        string table = UniqueTableName();
+        try
+        {
+            await client.ExecuteAsync($"CREATE TABLE {table} (id UInt64, name String) ENGINE = Memory");
+
+            const int rows = 2000;
+            var ids = new ulong[rows];
+            var names = new string[rows];
+            for (int i = 0; i < rows; i++)
+            {
+                ids[i] = (ulong)i;
+                names[i] = $"row-{i}";
+            }
+
+            IColumn[] columns =
+            {
+                PrimitiveColumn<ulong>.FromValues("id", "UInt64", ids),
+                new ArrayColumn<string>("name", "String", names),
+            };
+            await client.InsertAsync($"INSERT INTO {table} (id, name) VALUES", columns);
+
+            var readIds = new List<ulong>();
+            var readNames = new List<string>();
+            await foreach (Block block in client.StreamAsync($"SELECT id, name FROM {table} ORDER BY id"))
+            {
+                readIds.AddRange(((IColumn<ulong>)block[0]).Values.ToArray());
+                readNames.AddRange(((IColumn<string>)block[1]).Values.ToArray());
+            }
+
+            Assert.Multiple(() =>
+            {
+                CollectionAssert.AreEqual(ids, readIds);
+                CollectionAssert.AreEqual(names, readNames);
+            });
+        }
+        finally
+        {
+            await client.ExecuteAsync($"DROP TABLE IF EXISTS {table}");
+        }
+    }
+
+    [Test]
+    public async Task InsertAsync_TinyMaxSendBufferBytes_FlushesMidBlockAndRoundTrips()
+    {
+        // A send buffer far smaller than the encoded block forces repeated between-column flushes while the
+        // single block is written. The data must still arrive intact — this proves the cap is threaded through
+        // and that mid-block flushing does not corrupt the wire stream.
+        var options = TcpServerFixture.Options();
+        await using var client = new ClickHouseTcpClient(new ClickHouseTcpClientOptions
+        {
+            Host = options.Host,
+            Port = options.Port,
+            Username = options.Username,
+            Password = options.Password,
+            MaxSendBufferBytes = 4096,
+        });
+
+        string table = UniqueTableName();
+        try
+        {
+            await client.ExecuteAsync($"CREATE TABLE {table} (id UInt64, name String) ENGINE = Memory");
+
+            const int rows = 20000;
+            var ids = new ulong[rows];
+            var names = new string[rows];
+            for (int i = 0; i < rows; i++)
+            {
+                ids[i] = (ulong)i;
+                names[i] = $"padding-value-to-exceed-the-tiny-buffer-{i}";
+            }
+
+            await client.InsertAsync(
+                $"INSERT INTO {table} (id, name) VALUES",
+                new IColumn[]
+                {
+                    PrimitiveColumn<ulong>.FromValues("id", "UInt64", ids),
+                    new ArrayColumn<string>("name", "String", names),
+                });
+
+            var count = await client.QueryAsync($"SELECT count() FROM {table}").ToListAsync();
+            var sum = await client.QueryAsync($"SELECT sum(id) FROM {table}").ToListAsync();
+            Assert.Multiple(() =>
+            {
+                Assert.That((ulong)count[0][0], Is.EqualTo((ulong)rows));
+                Assert.That((ulong)sum[0][0], Is.EqualTo((ulong)rows * (rows - 1) / 2));
+            });
+        }
+        finally
+        {
+            await client.ExecuteAsync($"DROP TABLE IF EXISTS {table}");
+        }
+    }
+
+    [Test]
+    public async Task InsertAsync_ZeroRows_IsNoOp()
+    {
+        await using var client = TcpServerFixture.CreateClient();
+        string table = UniqueTableName();
+        try
+        {
+            await client.ExecuteAsync($"CREATE TABLE {table} (value Int32) ENGINE = Memory");
+
+            IColumn empty = PrimitiveColumn<int>.FromValues("value", "Int32", Array.Empty<int>());
+            await client.InsertAsync($"INSERT INTO {table} (value) VALUES", new[] { empty });
+
+            var count = await client.QueryAsync($"SELECT count() FROM {table}").ToListAsync();
+            Assert.That((ulong)count[0][0], Is.EqualTo(0UL));
+        }
+        finally
+        {
+            await client.ExecuteAsync($"DROP TABLE IF EXISTS {table}");
+        }
+    }
+
+    [Test]
+    public async Task InsertAsync_SchemaMismatch_ThrowsArgumentExceptionAndClientUsable()
+    {
+        await using var client = TcpServerFixture.CreateClient();
+        string table = UniqueTableName();
+        try
+        {
+            await client.ExecuteAsync($"CREATE TABLE {table} (a Int32, b Int32) ENGINE = Memory");
+
+            IColumn onlyOne = PrimitiveColumn<int>.FromValues("a", "Int32", new[] { 1, 2, 3 });
+            Assert.ThrowsAsync<ArgumentException>(async () =>
+                await client.InsertAsync($"INSERT INTO {table} VALUES", new[] { onlyOne }));
+
+            // The failed insert aborted cleanly (server saw no rows), so the client is still usable.
+            var count = await client.QueryAsync($"SELECT count() FROM {table}").ToListAsync();
+            Assert.That((ulong)count[0][0], Is.EqualTo(0UL));
+        }
+        finally
+        {
+            await client.ExecuteAsync($"DROP TABLE IF EXISTS {table}");
+        }
+    }
+
+    [Test]
+    public async Task QueryAsync_CustomSettingViaOptions_AppliesSetting()
+    {
+        await using var client = TcpServerFixture.CreateClient();
+
+        // max_block_size = 2 forces the server to split the result into more, smaller blocks. Read at the block
+        // tier so the effect (block count) is observable.
+        var options = new ClickHouseTcpQueryOptions
+        {
+            Settings = new Dictionary<string, string> { ["max_block_size"] = "2" },
+        };
+
+        int blockCount = 0;
+        int rowCount = 0;
+        await foreach (Block block in client.StreamAsync("SELECT number FROM system.numbers LIMIT 10", options))
+        {
+            blockCount++;
+            rowCount += block.RowCount;
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(rowCount, Is.EqualTo(10));
+            Assert.That(blockCount, Is.GreaterThan(1), "a small max_block_size should split the result across several blocks");
+        });
+    }
+
+    [Test]
+    public async Task QueryAsync_DynamicColumn_DecodesWithoutCallerSettingFlattenedSerialization()
+    {
+        await using var client = TcpServerFixture.CreateClient();
+
+        // The caller enables the Dynamic type but deliberately does NOT set
+        // output_format_native_use_flattened_dynamic_and_json_serialization — the client injects it, so the
+        // Dynamic column still decodes. Without that injection the block reader would desync.
+        var options = new ClickHouseTcpQueryOptions
+        {
+            Settings = new Dictionary<string, string> { ["allow_experimental_dynamic_type"] = "1" },
+        };
+
+        var rows = await client.QueryAsync("SELECT CAST(number, 'Dynamic') AS d FROM numbers(3)", options).ToListAsync();
+
+        Assert.That(rows, Has.Count.EqualTo(3));
+        Assert.That(rows.All(r => r[0] is not null), Is.True);
+    }
+
+    [Test]
+    public async Task PingAsync_LiveServer_Completes()
+    {
+        await using var client = TcpServerFixture.CreateClient();
+
+        Assert.DoesNotThrowAsync(async () => await client.PingAsync(None));
+    }
+
+    [Test]
+    public async Task Client_ConcurrentQueries_SerializeAndAllSucceed()
+    {
+        await using var client = TcpServerFixture.CreateClient();
+
+        // The single-connection source serializes these on one connection; all should still complete correctly.
+        Task<List<object[]>>[] queries = Enumerable.Range(0, 8)
+            .Select(i => client.QueryAsync($"SELECT {i}").ToListAsync())
+            .ToArray();
+
+        List<object[]>[] results = await Task.WhenAll(queries);
+
+        Assert.That(results, Has.All.Count.EqualTo(1));
+    }
+
+    [Test]
+    public async Task Client_FromConnectionString_ConnectsAndQueries()
+    {
+        await using var client = new ClickHouseTcpClient(TcpServerFixture.ConnectionString);
+
+        var rows = await client.QueryAsync("SELECT 1").ToListAsync();
+
+        Assert.That(rows, Has.Count.EqualTo(1));
+        Assert.That((byte)rows[0][0], Is.EqualTo((byte)1));
+    }
+}
+
+internal static class AsyncEnumerableTestExtensions
+{
+    public static async Task<List<T>> ToListAsync<T>(this IAsyncEnumerable<T> source)
+    {
+        var list = new List<T>();
+        await foreach (T item in source)
+        {
+            list.Add(item);
+        }
+
+        return list;
+    }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpClientIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpClientIntegrationTests.cs
@@ -310,6 +310,136 @@ public class ClickHouseTcpClientIntegrationTests
         });
     }
 
+    // 1 forces a block per row, null forces one block for all of them, and the unset case takes the default cap —
+    // every row must survive each sizing.
+    [TestCase(1, TestName = "InsertAsync_MaxRowsPerBlockOne_RoundTripsEveryRow")]
+    [TestCase(null, TestName = "InsertAsync_MaxRowsPerBlockNull_RoundTripsEveryRow")]
+    public async Task InsertAsync_MaxRowsPerBlockViaOptions_RoundTripsEveryRow(int? maxRowsPerBlock)
+    {
+        await using var client = TcpServerFixture.CreateClient();
+        string table = UniqueTableName();
+        try
+        {
+            await client.ExecuteAsync($"CREATE TABLE {table} (id UInt64) ENGINE = Memory");
+
+            const int rows = 50;
+            var ids = new ulong[rows];
+            for (int i = 0; i < rows; i++)
+            {
+                ids[i] = (ulong)i;
+            }
+
+            IColumn[] columns = { PrimitiveColumn<ulong>.FromValues("id", "UInt64", ids) };
+            await client.InsertAsync(
+                $"INSERT INTO {table} (id) VALUES",
+                columns,
+                new ClickHouseTcpInsertOptions { MaxRowsPerBlock = maxRowsPerBlock });
+
+            var readBack = await client.QueryAsync($"SELECT id FROM {table} ORDER BY id").ToListAsync();
+            CollectionAssert.AreEqual(ids, readBack.Select(r => (ulong)r[0]));
+        }
+        finally
+        {
+            await client.ExecuteAsync($"DROP TABLE IF EXISTS {table}");
+        }
+    }
+
+    [Test]
+    public async Task Options_AfterConstruction_ExposesTheConfigurationIncludingTheSendBufferCap()
+    {
+        await using var client = new ClickHouseTcpClient(new ClickHouseTcpClientOptions
+        {
+            Host = TcpServerFixture.Host,
+            Port = TcpServerFixture.Port,
+            Username = TcpServerFixture.Username,
+            Password = TcpServerFixture.Password,
+            MaxSendBufferBytes = 4096,
+            CustomSettings = new Dictionary<string, string> { ["max_threads"] = "4" },
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(client.Options.Host, Is.EqualTo(TcpServerFixture.Host));
+            Assert.That(client.Options.MaxSendBufferBytes, Is.EqualTo(4096));
+            Assert.That(client.Options.CustomSettings["max_threads"], Is.EqualTo("4"));
+        });
+    }
+
+    [Test]
+    public async Task IClickHouseTcpClient_EveryOperationUsableThroughTheInterface()
+    {
+        // The interface exists so consumers can code against it (and substitute a double), so it has to be
+        // sufficient on its own: this drives the whole surface through an interface-typed reference, never
+        // touching ClickHouseTcpClient.
+        IClickHouseTcpClient client = TcpServerFixture.CreateClient();
+        await using (client)
+        {
+            string table = UniqueTableName();
+            try
+            {
+                await client.PingAsync(None);
+                await client.ExecuteAsync($"CREATE TABLE {table} (id UInt64) ENGINE = Memory", cancellationToken: None);
+
+                var ids = new ulong[] { 1, 2, 3 };
+                IColumn[] columns = { PrimitiveColumn<ulong>.FromValues("id", "UInt64", ids) };
+                await client.InsertAsync($"INSERT INTO {table} (id) VALUES", columns, cancellationToken: None);
+
+                var rows = await client.QueryAsync($"SELECT id FROM {table} ORDER BY id").ToListAsync();
+
+                var streamed = new List<ulong>();
+                await foreach (Block block in client.StreamAsync($"SELECT id FROM {table} ORDER BY id"))
+                {
+                    streamed.AddRange(((IColumn<ulong>)block[0]).Values.ToArray());
+                }
+
+                Assert.Multiple(() =>
+                {
+                    CollectionAssert.AreEqual(ids, rows.Select(r => (ulong)r[0]));
+                    CollectionAssert.AreEqual(ids, streamed);
+                });
+            }
+            finally
+            {
+                await client.ExecuteAsync($"DROP TABLE IF EXISTS {table}");
+            }
+        }
+    }
+
+    [Test]
+    public async Task Client_CallerMutatesCustomSettingsAfterConstruction_MutationNotApplied()
+    {
+        // getSetting reports the value the server actually applied to this query, so a client-level setting and any
+        // later mutation of the caller's dictionary are both directly observable.
+        const string ReadSetting = "SELECT toString(getSetting('max_block_size'))";
+
+        var callerSettings = new Dictionary<string, string> { ["max_block_size"] = "1234" };
+        await using var client = new ClickHouseTcpClient(new ClickHouseTcpClientOptions
+        {
+            Host = TcpServerFixture.Host,
+            Port = TcpServerFixture.Port,
+            Username = TcpServerFixture.Username,
+            Password = TcpServerFixture.Password,
+            CustomSettings = callerSettings,
+        });
+
+        var configured = await client.QueryAsync(ReadSetting).ToListAsync();
+        Assert.That((string)configured[0][0], Is.EqualTo("1234"), "the client-level setting should reach the server");
+
+        // Control: the server does apply a changed value, so the mutation below would be observable if it landed.
+        var overridden = await client.QueryAsync(
+            ReadSetting,
+            new ClickHouseTcpQueryOptions { Settings = new Dictionary<string, string> { ["max_block_size"] = "4321" } })
+            .ToListAsync();
+        Assert.That((string)overridden[0][0], Is.EqualTo("4321"), "a per-query override should reach the server");
+
+        // The client owns a copy taken at construction, so this mutation cannot reach the wire (nor fault the
+        // settings merge that runs on every query).
+        callerSettings["max_block_size"] = "4321";
+
+        var afterMutation = await client.QueryAsync(ReadSetting).ToListAsync();
+        Assert.That((string)afterMutation[0][0], Is.EqualTo("1234"), "the caller's later mutation must not be applied");
+    }
+
     [Test]
     public async Task QueryAsync_DynamicColumn_DecodesWithoutCallerSettingFlattenedSerialization()
     {

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpClientQueryIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpClientQueryIntegrationTests.cs
@@ -1,0 +1,204 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Format;
+using ClickHouse.Driver.Tcp.Numerics;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Tests.Integration;
+
+// Read-path behavior through the client's block tier. The cases that also assert the connection stays Ready live in
+// ClickHouseTcpConnectionQueryIntegrationTests, because the client does not expose connection state.
+//
+// A yielded Block is borrowed — valid only for its iteration — so every test reads or copies what it needs inside
+// the await foreach, never retaining the block.
+[TestFixture]
+[Category("Integration")]
+public class ClickHouseTcpClientQueryIntegrationTests
+{
+    private static readonly CancellationToken None = CancellationToken.None;
+
+    [Test]
+    public async Task StreamAsync_SelectStringLiteral_ReturnsString()
+    {
+        await using var client = TcpServerFixture.CreateClient();
+
+        string value = null;
+        await foreach (Block block in client.StreamAsync("SELECT 'hello'", cancellationToken: None))
+        {
+            value = ((IColumn<string>)block[0]).Values[0];
+        }
+
+        Assert.That(value, Is.EqualTo("hello"));
+    }
+
+    [Test]
+    public async Task StreamAsync_NumbersWithToString_ReturnsUInt64AndStringColumns()
+    {
+        await using var client = TcpServerFixture.CreateClient();
+
+        var numbers = new List<ulong>();
+        var strings = new List<string>();
+        await foreach (Block block in client.StreamAsync("SELECT number, toString(number) FROM system.numbers LIMIT 5", cancellationToken: None))
+        {
+            numbers.AddRange(((IColumn<ulong>)block[0]).Values.ToArray());
+            strings.AddRange(((IColumn<string>)block[1]).Values.ToArray());
+        }
+
+        Assert.Multiple(() =>
+        {
+            CollectionAssert.AreEqual(new ulong[] { 0, 1, 2, 3, 4 }, numbers);
+            CollectionAssert.AreEqual(new[] { "0", "1", "2", "3", "4" }, strings);
+        });
+    }
+
+    [Test]
+    public async Task StreamAsync_AllIntegerWidths_RoundTripEachValue()
+    {
+        await using var client = TcpServerFixture.CreateClient();
+
+        int blockCount = 0;
+        byte u8 = 0;
+        sbyte i8 = 0;
+        ushort u16 = 0;
+        short i16 = 0;
+        uint u32 = 0;
+        int i32 = 0;
+        ulong u64 = 0;
+        long i64 = 0;
+        UInt128 u128 = 0;
+        Int128 i128 = 0;
+        BigInteger u256 = 0;
+        BigInteger i256 = 0;
+        await foreach (Block row in client.StreamAsync(
+            "SELECT toUInt8(1), toInt8(-1), toUInt16(2), toInt16(-2), toUInt32(3), toInt32(-3), " +
+            "toUInt64(4), toInt64(-4), toUInt128(5), toInt128(-5), toUInt256(6), toInt256(-6)",
+            cancellationToken: None))
+        {
+            blockCount++;
+            u8 = ((IColumn<byte>)row[0]).Values[0];
+            i8 = ((IColumn<sbyte>)row[1]).Values[0];
+            u16 = ((IColumn<ushort>)row[2]).Values[0];
+            i16 = ((IColumn<short>)row[3]).Values[0];
+            u32 = ((IColumn<uint>)row[4]).Values[0];
+            i32 = ((IColumn<int>)row[5]).Values[0];
+            u64 = ((IColumn<ulong>)row[6]).Values[0];
+            i64 = ((IColumn<long>)row[7]).Values[0];
+            u128 = ((IColumn<UInt128>)row[8]).Values[0];
+            i128 = ((IColumn<Int128>)row[9]).Values[0];
+            u256 = ((IColumn<UInt256>)row[10]).Values[0].ToBigInteger();
+            i256 = ((IColumn<Int256>)row[11]).Values[0].ToBigInteger();
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(blockCount, Is.EqualTo(1));
+            Assert.That(u8, Is.EqualTo((byte)1));
+            Assert.That(i8, Is.EqualTo((sbyte)-1));
+            Assert.That(u16, Is.EqualTo((ushort)2));
+            Assert.That(i16, Is.EqualTo((short)-2));
+            Assert.That(u32, Is.EqualTo(3u));
+            Assert.That(i32, Is.EqualTo(-3));
+            Assert.That(u64, Is.EqualTo(4ul));
+            Assert.That(i64, Is.EqualTo(-4L));
+            Assert.That(u128, Is.EqualTo((UInt128)5));
+            Assert.That(i128, Is.EqualTo((Int128)(-5)));
+            Assert.That(u256, Is.EqualTo(new BigInteger(6)));
+            Assert.That(i256, Is.EqualTo(new BigInteger(-6)));
+        });
+    }
+
+    [Test]
+    public async Task StreamAsync_ServerGeneratedArrayViaRange_ReadsBackEveryRow()
+    {
+        await using var client = TcpServerFixture.CreateClient();
+
+        // range(number) yields a server-authored Array(UInt64) whose offsets and values the client never wrote:
+        // row n is [0, 1, ..., n-1], so row 0 is empty and later rows grow. This validates the Array read path
+        // against offsets the server produced, independent of the client's own write path.
+        const int rowCount = 64;
+        var readBack = new List<ulong[]>(rowCount);
+        await foreach (Block block in client.StreamAsync($"SELECT range(number) AS r FROM numbers({rowCount}) ORDER BY number", cancellationToken: None))
+        {
+            Assert.That(block[0].TypeName, Is.EqualTo("Array(UInt64)"));
+            foreach (ulong[] row in ((IColumn<ulong[]>)block[0]).Values)
+            {
+                readBack.Add(row);
+            }
+        }
+
+        Assert.That(readBack, Has.Count.EqualTo(rowCount));
+        for (int n = 0; n < rowCount; n++)
+        {
+            var expected = new ulong[n];
+            for (int i = 0; i < n; i++)
+            {
+                expected[i] = (ulong)i;
+            }
+
+            Assert.That(readBack[n], Is.EqualTo(expected), $"row {n}");
+        }
+    }
+
+    [Test]
+    public async Task StreamAsync_SessionTimezoneSetting_ResolvesTimezoneLessColumnAgainstSessionTimezone()
+    {
+        await using var client = TcpServerFixture.CreateClient();
+        var options = new ClickHouseTcpQueryOptions
+        {
+            Settings = new Dictionary<string, string> { ["session_timezone"] = "Asia/Kolkata" },
+        };
+
+        DateTimeOffset value = default;
+        // toDateTime of a Unix instant yields a timezone-less DateTime column; the client applies its own
+        // session_timezone setting as that column's presentation timezone, so the value presents at +05:30.
+        await foreach (Block block in client.StreamAsync("SELECT toDateTime(1700000000)", options, None))
+        {
+            value = ((DateTimeColumn)block[0]).GetDateTimeOffset(0);
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(value.ToUnixTimeSeconds(), Is.EqualTo(1_700_000_000));
+            Assert.That(value.Offset, Is.EqualTo(new TimeSpan(5, 30, 0)));
+        });
+    }
+
+    [Test]
+    public async Task StreamAsync_SessionTimezoneSetting_DoesNotLeakIntoNextQuery()
+    {
+        // One client reuses one connection, so all three queries run on the same session — which is what makes the
+        // leak observable at all.
+        await using var client = TcpServerFixture.CreateClient();
+
+        // Baseline: the server's own timezone, with no override in play.
+        TimeSpan baseline = await SelectOffsetAsync(client, null);
+
+        // An overriding query, then a follow-up with no setting: the follow-up must match the baseline, not
+        // carry the previous query's override.
+        _ = await SelectOffsetAsync(client, "Asia/Kolkata");
+        TimeSpan afterOverride = await SelectOffsetAsync(client, null);
+
+        Assert.That(afterOverride, Is.EqualTo(baseline), "the session_timezone override must not persist to the next query");
+    }
+
+    private static async Task<TimeSpan> SelectOffsetAsync(IClickHouseTcpClient client, string sessionTimezone)
+    {
+        ClickHouseTcpQueryOptions options = sessionTimezone is null
+            ? null
+            : new ClickHouseTcpQueryOptions
+            {
+                Settings = new Dictionary<string, string> { ["session_timezone"] = sessionTimezone },
+            };
+
+        TimeSpan offset = default;
+        await foreach (Block block in client.StreamAsync("SELECT toDateTime(1700000000)", options, None))
+        {
+            offset = ((DateTimeColumn)block[0]).GetDateTimeOffset(0).Offset;
+        }
+
+        return offset;
+    }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpConnectionQueryIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpConnectionQueryIntegrationTests.cs
@@ -4,12 +4,15 @@ using System.Numerics;
 using System.Threading;
 using System.Threading.Tasks;
 using ClickHouse.Driver.Tcp.Format;
-using ClickHouse.Driver.Tcp.Numerics;
 using ClickHouse.Driver.Tcp.Protocol;
 using ClickHouse.Driver.Tcp.Types;
 
 namespace ClickHouse.Driver.Tcp.Tests.Integration;
 
+// Read-path cases that assert the connection is left Ready, which no client-level test can express because the
+// client does not expose connection state. The cases that do not need that assertion live in
+// ClickHouseTcpClientQueryIntegrationTests, driven through the client.
+//
 // A yielded Block is borrowed — valid only for its iteration — so every test reads or copies what it needs
 // inside the await foreach, never retaining the block.
 [TestFixture]
@@ -43,96 +46,6 @@ public class ClickHouseTcpConnectionQueryIntegrationTests
     }
 
     [Test]
-    public async Task QueryAsync_SelectStringLiteral_ReturnsString()
-    {
-        await using var connection = await TcpServerFixture.ConnectAsync(None);
-
-        string value = null;
-        await foreach (Block block in connection.QueryAsync("SELECT 'hello'", cancellationToken: None))
-        {
-            value = ((IColumn<string>)block[0]).Values[0];
-        }
-
-        Assert.That(value, Is.EqualTo("hello"));
-    }
-
-    [Test]
-    public async Task QueryAsync_NumbersWithToString_ReturnsUInt64AndStringColumns()
-    {
-        await using var connection = await TcpServerFixture.ConnectAsync(None);
-
-        var numbers = new List<ulong>();
-        var strings = new List<string>();
-        await foreach (Block block in connection.QueryAsync("SELECT number, toString(number) FROM system.numbers LIMIT 5", cancellationToken: None))
-        {
-            numbers.AddRange(((IColumn<ulong>)block[0]).Values.ToArray());
-            strings.AddRange(((IColumn<string>)block[1]).Values.ToArray());
-        }
-
-        Assert.Multiple(() =>
-        {
-            CollectionAssert.AreEqual(new ulong[] { 0, 1, 2, 3, 4 }, numbers);
-            CollectionAssert.AreEqual(new[] { "0", "1", "2", "3", "4" }, strings);
-        });
-    }
-
-    [Test]
-    public async Task QueryAsync_AllIntegerWidths_RoundTripEachValue()
-    {
-        await using var connection = await TcpServerFixture.ConnectAsync(None);
-
-        int blockCount = 0;
-        byte u8 = 0;
-        sbyte i8 = 0;
-        ushort u16 = 0;
-        short i16 = 0;
-        uint u32 = 0;
-        int i32 = 0;
-        ulong u64 = 0;
-        long i64 = 0;
-        UInt128 u128 = 0;
-        Int128 i128 = 0;
-        BigInteger u256 = 0;
-        BigInteger i256 = 0;
-        await foreach (Block row in connection.QueryAsync(
-            "SELECT toUInt8(1), toInt8(-1), toUInt16(2), toInt16(-2), toUInt32(3), toInt32(-3), " +
-            "toUInt64(4), toInt64(-4), toUInt128(5), toInt128(-5), toUInt256(6), toInt256(-6)",
-            cancellationToken: None))
-        {
-            blockCount++;
-            u8 = ((IColumn<byte>)row[0]).Values[0];
-            i8 = ((IColumn<sbyte>)row[1]).Values[0];
-            u16 = ((IColumn<ushort>)row[2]).Values[0];
-            i16 = ((IColumn<short>)row[3]).Values[0];
-            u32 = ((IColumn<uint>)row[4]).Values[0];
-            i32 = ((IColumn<int>)row[5]).Values[0];
-            u64 = ((IColumn<ulong>)row[6]).Values[0];
-            i64 = ((IColumn<long>)row[7]).Values[0];
-            u128 = ((IColumn<UInt128>)row[8]).Values[0];
-            i128 = ((IColumn<Int128>)row[9]).Values[0];
-            u256 = ((IColumn<UInt256>)row[10]).Values[0].ToBigInteger();
-            i256 = ((IColumn<Int256>)row[11]).Values[0].ToBigInteger();
-        }
-
-        Assert.Multiple(() =>
-        {
-            Assert.That(blockCount, Is.EqualTo(1));
-            Assert.That(u8, Is.EqualTo((byte)1));
-            Assert.That(i8, Is.EqualTo((sbyte)-1));
-            Assert.That(u16, Is.EqualTo((ushort)2));
-            Assert.That(i16, Is.EqualTo((short)-2));
-            Assert.That(u32, Is.EqualTo(3u));
-            Assert.That(i32, Is.EqualTo(-3));
-            Assert.That(u64, Is.EqualTo(4ul));
-            Assert.That(i64, Is.EqualTo(-4L));
-            Assert.That(u128, Is.EqualTo((UInt128)5));
-            Assert.That(i128, Is.EqualTo((Int128)(-5)));
-            Assert.That(u256, Is.EqualTo(new BigInteger(6)));
-            Assert.That(i256, Is.EqualTo(new BigInteger(-6)));
-        });
-    }
-
-    [Test]
     public async Task QueryAsync_LargeResultWithSmallBlocks_StreamsAllRowsAcrossBlocks()
     {
         await using var connection = await TcpServerFixture.ConnectAsync(None);
@@ -158,38 +71,6 @@ public class ClickHouseTcpConnectionQueryIntegrationTests
             Assert.That(sum, Is.EqualTo(new BigInteger(4999950000))); // 0 + 1 + ... + 99999
             Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
         });
-    }
-
-    [Test]
-    public async Task QueryAsync_ServerGeneratedArrayViaRange_ReadsBackEveryRow()
-    {
-        await using var connection = await TcpServerFixture.ConnectAsync(None);
-
-        // range(number) yields a server-authored Array(UInt64) whose offsets and values the client never wrote:
-        // row n is [0, 1, ..., n-1], so row 0 is empty and later rows grow. This validates the Array read path
-        // against offsets the server produced, independent of the client's own write path.
-        const int rowCount = 64;
-        var readBack = new List<ulong[]>(rowCount);
-        await foreach (Block block in connection.QueryAsync($"SELECT range(number) AS r FROM numbers({rowCount}) ORDER BY number", cancellationToken: None))
-        {
-            Assert.That(block[0].TypeName, Is.EqualTo("Array(UInt64)"));
-            foreach (ulong[] row in ((IColumn<ulong[]>)block[0]).Values)
-            {
-                readBack.Add(row);
-            }
-        }
-
-        Assert.That(readBack, Has.Count.EqualTo(rowCount));
-        for (int n = 0; n < rowCount; n++)
-        {
-            var expected = new ulong[n];
-            for (int i = 0; i < n; i++)
-            {
-                expected[i] = (ulong)i;
-            }
-
-            Assert.That(readBack[n], Is.EqualTo(expected), $"row {n}");
-        }
     }
 
     [Test]
@@ -236,58 +117,6 @@ public class ClickHouseTcpConnectionQueryIntegrationTests
             Assert.That(blockCount, Is.EqualTo(0), "the header block carries no rows, so nothing is yielded");
             Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready), "reaching Ready proves the stream stayed in sync through end-of-stream");
         });
-    }
-
-    [Test]
-    public async Task QueryAsync_SessionTimezoneSetting_ResolvesTimezoneLessColumnAgainstSessionTimezone()
-    {
-        await using var connection = await TcpServerFixture.ConnectAsync(None);
-        var settings = new Dictionary<string, string> { ["session_timezone"] = "Asia/Kolkata" };
-
-        DateTimeOffset value = default;
-        // toDateTime of a Unix instant yields a timezone-less DateTime column; the client applies its own
-        // session_timezone setting as that column's presentation timezone, so the value presents at +05:30.
-        await foreach (Block block in connection.QueryAsync("SELECT toDateTime(1700000000)", settings, cancellationToken: None))
-        {
-            value = ((DateTimeColumn)block[0]).GetDateTimeOffset(0);
-        }
-
-        Assert.Multiple(() =>
-        {
-            Assert.That(value.ToUnixTimeSeconds(), Is.EqualTo(1_700_000_000));
-            Assert.That(value.Offset, Is.EqualTo(new TimeSpan(5, 30, 0)));
-        });
-    }
-
-    [Test]
-    public async Task QueryAsync_SessionTimezoneSetting_DoesNotLeakIntoNextQuery()
-    {
-        await using var connection = await TcpServerFixture.ConnectAsync(None);
-
-        // Baseline: the server's own timezone, with no override in play.
-        TimeSpan baseline = await SelectOffsetAsync(connection, null);
-
-        // An overriding query, then a follow-up with no setting: the follow-up must match the baseline, not
-        // carry the previous query's override.
-        _ = await SelectOffsetAsync(connection, "Asia/Kolkata");
-        TimeSpan afterOverride = await SelectOffsetAsync(connection, null);
-
-        Assert.That(afterOverride, Is.EqualTo(baseline), "the session_timezone override must not persist to the next query");
-    }
-
-    private static async Task<TimeSpan> SelectOffsetAsync(ClickHouseTcpConnection connection, string sessionTimezone)
-    {
-        IReadOnlyDictionary<string, string> settings = sessionTimezone is null
-            ? null
-            : new Dictionary<string, string> { ["session_timezone"] = sessionTimezone };
-
-        TimeSpan offset = default;
-        await foreach (Block block in connection.QueryAsync("SELECT toDateTime(1700000000)", settings, cancellationToken: None))
-        {
-            offset = ((DateTimeColumn)block[0]).GetDateTimeOffset(0).Offset;
-        }
-
-        return offset;
     }
 
     [Test]

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ColumnarReadSurfaceIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ColumnarReadSurfaceIntegrationTests.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using ClickHouse.Driver.Tcp.Format;
-using ClickHouse.Driver.Tcp.Protocol;
 using ClickHouse.Driver.Tcp.Types;
 
 namespace ClickHouse.Driver.Tcp.Tests.Integration;
@@ -30,7 +29,7 @@ public class ColumnarReadSurfaceIntegrationTests
     private static readonly CancellationToken None = CancellationToken.None;
 
     [Test]
-    public async Task QueryAsync_NullableColumn_ExposesInnerAndNullMapThroughINullableColumn()
+    public async Task StreamAsync_NullableColumn_ExposesInnerAndNullMapThroughINullableColumn()
     {
         // A Nullable(T) column's wire layout is a dense inner column (a decoded value at *every* row, placeholder
         // included where the row is null) plus the per-row null-map that says which rows are really null. The
@@ -39,7 +38,7 @@ public class ColumnarReadSurfaceIntegrationTests
         //
         // Note the type argument is the *inner* type: a Nullable(Int32) column is an INullableColumn<int>, not an
         // INullableColumn<int?>, even though its IColumn<T> surface is IColumn<int?>.
-        await using var connection = await TcpServerFixture.ConnectAsync(None);
+        await using var client = TcpServerFixture.CreateClient();
 
         bool matchedInner = false;
         bool matchedNullable = false;
@@ -50,7 +49,7 @@ public class ColumnarReadSurfaceIntegrationTests
         int?[] materialized = null;
         var innerAtNonNullRows = new int[3];
 
-        await foreach (Block block in connection.QueryAsync(
+        await foreach (Block block in client.StreamAsync(
             "SELECT CAST(number = 1 ? NULL : toInt32(number * 10 - 10), 'Nullable(Int32)') FROM system.numbers LIMIT 4",
             cancellationToken: None))
         {
@@ -91,12 +90,12 @@ public class ColumnarReadSurfaceIntegrationTests
     }
 
     [Test]
-    public async Task QueryAsync_NullableReferenceColumn_ExposesInnerAndNullMapThroughINullableColumn()
+    public async Task StreamAsync_NullableReferenceColumn_ExposesInnerAndNullMapThroughINullableColumn()
     {
         // Nullable(String) decodes to a separate reference-typed column class with its own copy of the pair, whose
         // IColumn<T> surface is IColumn<string> (a reference is already nullable) rather than IColumn<T?>. Its view
         // is still parameterized by the inner type, so the pattern-match spelling stays uniform with the value case.
-        await using var connection = await TcpServerFixture.ConnectAsync(None);
+        await using var client = TcpServerFixture.CreateClient();
 
         bool matched = false;
         byte[] nullMap = null;
@@ -105,7 +104,7 @@ public class ColumnarReadSurfaceIntegrationTests
         int innerRowCount = 0;
         string[] materialized = null;
 
-        await foreach (Block block in connection.QueryAsync(
+        await foreach (Block block in client.StreamAsync(
             "SELECT CAST(number = 1 ? NULL : concat('v', toString(number)), 'Nullable(String)') FROM system.numbers LIMIT 3",
             cancellationToken: None))
         {
@@ -132,13 +131,13 @@ public class ColumnarReadSurfaceIntegrationTests
     }
 
     [Test]
-    public async Task QueryAsync_ArrayColumn_ExposesFlatElementsAndOffsetsThroughIArrayColumn()
+    public async Task StreamAsync_ArrayColumn_ExposesFlatElementsAndOffsetsThroughIArrayColumn()
     {
         // An Array(T) column's wire layout is every row's elements concatenated into one flat run plus the per-row
         // offsets that delimit them. The materialized IColumn<T[]> surface allocates a fresh array per row;
         // IArrayColumn<TElement> is the allocation-free alternative, so the test walks the rows through the spans
         // and checks they reconstruct what the materialized surface produced.
-        await using var connection = await TcpServerFixture.ConnectAsync(None);
+        await using var client = TcpServerFixture.CreateClient();
 
         bool matched = false;
         int rowCount = 0;
@@ -149,7 +148,7 @@ public class ColumnarReadSurfaceIntegrationTests
         int[][] materialized = null;
 
         // Rows: [], [0], [0, 1], [0, 1, 2] — an empty leading row makes a zero-length slice part of the check.
-        await foreach (Block block in connection.QueryAsync(
+        await foreach (Block block in client.StreamAsync(
             "SELECT CAST(range(number), 'Array(Int32)') FROM system.numbers LIMIT 4",
             cancellationToken: None))
         {
@@ -182,13 +181,13 @@ public class ColumnarReadSurfaceIntegrationTests
     }
 
     [Test]
-    public async Task QueryAsync_NestedArrayColumn_ExposesInnerAsAnotherArrayColumnForRecursion()
+    public async Task StreamAsync_NestedArrayColumn_ExposesInnerAsAnotherArrayColumnForRecursion()
     {
         // Why IArrayColumn exposes Inner as a column and not just InnerValues as a span: when the element type is
         // itself composite, the span's element type is the *materialized* form (here int[]), so reading it defeats
         // the point. Inner hands back the flat inner column instead, which pattern-matches to the element type's own
         // view — so a nested composite can be walked to the bottom without materializing an intermediate level.
-        await using var connection = await TcpServerFixture.ConnectAsync(None);
+        await using var client = TcpServerFixture.CreateClient();
 
         bool outerMatched = false;
         bool innerMatched = false;
@@ -198,7 +197,7 @@ public class ColumnarReadSurfaceIntegrationTests
         int[][][] materialized = null;
 
         // Rows: [[0], [0, 1]] and [[1], [1, 2]].
-        await foreach (Block block in connection.QueryAsync(
+        await foreach (Block block in client.StreamAsync(
             "SELECT [[toInt32(number)], [toInt32(number), toInt32(number + 1)]] FROM system.numbers LIMIT 2",
             cancellationToken: None))
         {
@@ -227,13 +226,13 @@ public class ColumnarReadSurfaceIntegrationTests
     }
 
     [Test]
-    public async Task QueryAsync_NamedTupleColumn_ExposesPerElementChildColumnsThroughITupleColumn()
+    public async Task StreamAsync_NamedTupleColumn_ExposesPerElementChildColumnsThroughITupleColumn()
     {
         // A Tuple(...) is stored as its N element columns side by side, each as tall as the tuple. Reading one
         // element through the materialized ValueTuple surface forces every other element to be decoded and boxed
         // into the tuple too; ITupleColumn.Children hands back the element columns directly, so a caller that wants
         // one field pays for one field. FieldNames carries the declared names, which the wire layout does not.
-        await using var connection = await TcpServerFixture.ConnectAsync(None);
+        await using var client = TcpServerFixture.CreateClient();
 
         bool matched = false;
         int childCount = 0;
@@ -243,7 +242,7 @@ public class ColumnarReadSurfaceIntegrationTests
         string[] secondElement = null;
         (int, string)[] materialized = null;
 
-        await foreach (Block block in connection.QueryAsync(
+        await foreach (Block block in client.StreamAsync(
             "SELECT CAST((toInt32(number), concat('n', toString(number))), 'Tuple(a Int32, b String)') FROM system.numbers LIMIT 3",
             cancellationToken: None))
         {
@@ -272,12 +271,12 @@ public class ColumnarReadSurfaceIntegrationTests
     }
 
     [Test]
-    public async Task QueryAsync_UnnamedTupleWithCompositeElement_OmitsFieldNamesAndAllowsChildRecursion()
+    public async Task StreamAsync_UnnamedTupleWithCompositeElement_OmitsFieldNamesAndAllowsChildRecursion()
     {
         // Two things the named case cannot show: an unnamed tuple carries no names at all (FieldNames is null, not
         // a list of nulls), and a child that is itself a composite pattern-matches to its own columnar view — so a
         // Tuple(Array(Int32), ...) can be walked into without materializing the tuple or the array rows.
-        await using var connection = await TcpServerFixture.ConnectAsync(None);
+        await using var client = TcpServerFixture.CreateClient();
 
         bool hasFieldNames = true;
         bool childIsArray = false;
@@ -285,7 +284,7 @@ public class ColumnarReadSurfaceIntegrationTests
         int[] childInnerValues = null;
 
         // Rows: ([], 'r0'), ([0], 'r1'), ([0, 1], 'r2').
-        await foreach (Block block in connection.QueryAsync(
+        await foreach (Block block in client.StreamAsync(
             "SELECT tuple(CAST(range(number), 'Array(Int32)'), concat('r', toString(number))) FROM system.numbers LIMIT 3",
             cancellationToken: None))
         {
@@ -308,12 +307,12 @@ public class ColumnarReadSurfaceIntegrationTests
     }
 
     [Test]
-    public async Task QueryAsync_MapColumn_ExposesFlatKeyAndValueColumnsThroughIMapColumn()
+    public async Task StreamAsync_MapColumn_ExposesFlatKeyAndValueColumnsThroughIMapColumn()
     {
         // A Map(K, V) is byte-identical to Array(Tuple(K, V)) on the wire: per-row offsets over two flat, aligned
         // runs. The materialized surface builds a KeyValuePair[] per row; IMapColumn hands back the two columns, so
         // a caller wanting only the keys — a common case — never builds a pair at all.
-        await using var connection = await TcpServerFixture.ConnectAsync(None);
+        await using var client = TcpServerFixture.CreateClient();
 
         bool matched = false;
         int rowCount = 0;
@@ -325,7 +324,7 @@ public class ColumnarReadSurfaceIntegrationTests
         KeyValuePair<string, int>[][] materialized = null;
 
         // Rows: {}, {'k0': 0}, {'k0': 0, 'k1': 100} — an empty leading row keeps a zero-length range in play.
-        await foreach (Block block in connection.QueryAsync(
+        await foreach (Block block in client.StreamAsync(
             """
             SELECT CAST(
                 arrayMap(i -> (concat('k', toString(i)), toInt32(i * 100)), range(number)),
@@ -369,17 +368,17 @@ public class ColumnarReadSurfaceIntegrationTests
     }
 
     [Test]
-    public async Task QueryAsync_MapColumnWithDuplicateKeys_PreservesWireOrderAndDuplicates()
+    public async Task StreamAsync_MapColumnWithDuplicateKeys_PreservesWireOrderAndDuplicates()
     {
         // The flat columns are the wire's own bytes, so they carry duplicate keys and entry order intact — the
         // property a Dictionary-shaped view would destroy. ClickHouse itself permits a literal map with a repeated
         // key, so this is reachable data, not a hypothetical.
-        await using var connection = await TcpServerFixture.ConnectAsync(None);
+        await using var client = TcpServerFixture.CreateClient();
 
         string[] flatKeys = null;
         int[] flatValues = null;
 
-        await foreach (Block block in connection.QueryAsync(
+        await foreach (Block block in client.StreamAsync(
             "SELECT CAST([('dup', 1), ('dup', 2), ('other', 3)], 'Map(String, Int32)')",
             cancellationToken: None))
         {
@@ -396,14 +395,14 @@ public class ColumnarReadSurfaceIntegrationTests
     }
 
     [Test]
-    public async Task QueryAsync_NestedColumn_ExposesPerFieldColumnsAndSharedOffsetsThroughINestedColumn()
+    public async Task StreamAsync_NestedColumn_ExposesPerFieldColumnsAndSharedOffsetsThroughINestedColumn()
     {
         // Nested is the case where the columnar view is the *primary* access path rather than an optimization: a
         // Nested can carry any number of fields, so there is no generic per-row value type for it and the
         // IColumn<T> surface has to degrade to object[][] — a boxed object[] per record, per row. INestedColumn is
         // how a consumer reads it typed. One offsets array is shared by every field, since within a row all fields
         // have the same element count.
-        await using var connection = await TcpServerFixture.ConnectAsync(None);
+        await using var client = TcpServerFixture.CreateClient();
 
         bool matched = false;
         int rowCount = 0;
@@ -417,7 +416,7 @@ public class ColumnarReadSurfaceIntegrationTests
         var recordsOfLastRow = new List<(byte A, string B)>();
 
         // Rows: [], [(0, 'f0')], [(0, 'f0'), (1, 'f1')].
-        await foreach (Block block in connection.QueryAsync(
+        await foreach (Block block in client.StreamAsync(
             """
             SELECT CAST(
                 arrayMap(i -> (toUInt8(i), concat('f', toString(i))), range(number)),
@@ -467,13 +466,13 @@ public class ColumnarReadSurfaceIntegrationTests
     }
 
     [Test]
-    public async Task QueryAsync_LowCardinalityColumn_ExposesDictionaryAndKeysThroughILowCardinalityColumn()
+    public async Task StreamAsync_LowCardinalityColumn_ExposesDictionaryAndKeysThroughILowCardinalityColumn()
     {
         // LowCardinality is the type with the widest gap between the two surfaces: the materialized one resolves
         // every row to its dictionary entry, so N rows over a K-entry dictionary produce N values. Reading the
         // dictionary and keys instead means touching each distinct value once — the whole reason the encoding exists.
         // Here 12 rows collapse onto 3 distinct values.
-        await using var connection = await TcpServerFixture.ConnectAsync(None);
+        await using var client = TcpServerFixture.CreateClient();
 
         bool matched = false;
         int rowCount = 0;
@@ -484,7 +483,7 @@ public class ColumnarReadSurfaceIntegrationTests
         string[] materialized = null;
         var resolvedThroughKeys = new List<string>();
 
-        await foreach (Block block in connection.QueryAsync(
+        await foreach (Block block in client.StreamAsync(
             "SELECT CAST(concat('v', toString(number % 3)), 'LowCardinality(String)') FROM system.numbers LIMIT 12",
             cancellationToken: None))
         {
@@ -519,13 +518,13 @@ public class ColumnarReadSurfaceIntegrationTests
     }
 
     [Test]
-    public async Task QueryAsync_LowCardinalityNullableColumn_ReservesTwoDictionarySlotsAndMarksNullWithKeyZero()
+    public async Task StreamAsync_LowCardinalityNullableColumn_ReservesTwoDictionarySlotsAndMarksNullWithKeyZero()
     {
         // LowCardinality(Nullable(T)) decodes to a different column class whose dictionary reserves *two* leading
         // slots — [0] NULL, [1] the default — so real values start at [2] and a key of 0 means NULL. That shift is
         // the one thing a consumer reading Keys directly has to know, and it is invisible from the materialized
         // surface. Note the view is still spelled with the bare inner type, matching the non-nullable case.
-        await using var connection = await TcpServerFixture.ConnectAsync(None);
+        await using var client = TcpServerFixture.CreateClient();
 
         bool matched = false;
         int dictionarySize = 0;
@@ -535,7 +534,7 @@ public class ColumnarReadSurfaceIntegrationTests
         string[] materialized = null;
         var nullRowsFromKeys = new List<int>();
 
-        await foreach (Block block in connection.QueryAsync(
+        await foreach (Block block in client.StreamAsync(
             """
             SELECT CAST(number = 1 ? NULL : concat('v', toString(number % 2)), 'LowCardinality(Nullable(String))')
             FROM system.numbers LIMIT 4
@@ -588,11 +587,11 @@ public class ColumnarReadSurfaceIntegrationTests
         //
         // Conflating the two interfaces corrupts data silently, and nothing else covers it, so it is pinned here
         // rather than in the insert fixture — this is where the slot semantics are documented.
-        await using var connection = await TcpServerFixture.ConnectAsync(None);
+        await using var client = TcpServerFixture.CreateClient();
         string table = $"tcp_lc_dense_exclusion_{Guid.NewGuid():N}";
         try
         {
-            await ExecuteAsync(connection, $"CREATE TABLE {table} (value LowCardinality(Nullable(String))) ENGINE = Memory");
+            await client.ExecuteAsync($"CREATE TABLE {table} (value LowCardinality(Nullable(String))) ENGINE = Memory");
 
             // Row 0's key is 0 deliberately. To a non-nullable dictionary slot 0 is the type default — an ordinary
             // value for a row to reference — while to a nullable dictionary it is the NULL marker. A row keyed at 0
@@ -610,10 +609,10 @@ public class ColumnarReadSurfaceIntegrationTests
             Assert.That(nonNullableDense, Is.Not.InstanceOf<IDenseLowCardinality<string>>(), "the non-nullable column must not claim dense write eligibility");
             Assert.That(nonNullableDense, Is.InstanceOf<ILowCardinalityColumn<string>>(), "though it still exposes the pair for reading");
 
-            await connection.InsertAsync($"INSERT INTO {table} (value) VALUES", new IColumn[] { nonNullableDense }, cancellationToken: None);
+            await client.InsertAsync($"INSERT INTO {table} (value) VALUES", new IColumn[] { nonNullableDense }, cancellationToken: None);
 
             var readBack = new List<string>();
-            await foreach (Block block in connection.QueryAsync($"SELECT value FROM {table}", cancellationToken: None))
+            await foreach (Block block in client.StreamAsync($"SELECT value FROM {table}", cancellationToken: None))
             {
                 readBack.AddRange(((IColumn<string>)block[0]).Values.ToArray());
             }
@@ -622,12 +621,12 @@ public class ColumnarReadSurfaceIntegrationTests
         }
         finally
         {
-            await ExecuteAsync(connection, $"DROP TABLE IF EXISTS {table}");
+            await client.ExecuteAsync($"DROP TABLE IF EXISTS {table}");
         }
     }
 
     [Test]
-    public async Task QueryAsync_VariantColumn_ExposesDiscriminatorsAndPerTypeChildColumnsThroughIVariantColumn()
+    public async Task StreamAsync_VariantColumn_ExposesDiscriminatorsAndPerTypeChildColumnsThroughIVariantColumn()
     {
         // Variant is the composite with no useful materialized element type: its IColumn<T> surface is
         // IColumn<object>, so every row read through it is boxed. The columnar view is the only typed way in —
@@ -639,7 +638,7 @@ public class ColumnarReadSurfaceIntegrationTests
             ["allow_experimental_variant_type"] = "1",
             ["allow_suspicious_variant_types"] = "1",
         };
-        await using var connection = await TcpServerFixture.ConnectAsync(None);
+        await using var client = TcpServerFixture.CreateClient();
 
         bool matched = false;
         int typeCount = 0;
@@ -653,7 +652,7 @@ public class ColumnarReadSurfaceIntegrationTests
         var materialized = new List<object>();
 
         // Rows: 100, 'a', NULL, 400, 'b' — interleaved so neither child's rows are contiguous by row index.
-        await foreach (Block block in connection.QueryAsync(
+        await foreach (Block block in client.StreamAsync(
             """
             SELECT CAST(multiIf(number = 1, CAST('a', 'Variant(String, UInt64)'),
                                 number = 2, CAST(NULL, 'Variant(String, UInt64)'),
@@ -661,7 +660,7 @@ public class ColumnarReadSurfaceIntegrationTests
                                 CAST(toUInt64((number + 1) * 100), 'Variant(String, UInt64)')), 'Variant(String, UInt64)')
             FROM system.numbers LIMIT 5
             """,
-            settings: settings,
+            new ClickHouseTcpQueryOptions { Settings = settings },
             cancellationToken: None))
         {
             IColumn column = block[0];
@@ -713,7 +712,7 @@ public class ColumnarReadSurfaceIntegrationTests
     }
 
     [Test]
-    public async Task QueryAsync_DynamicColumn_ExposesRuntimeTypeNamesAndPerTypeChildColumnsThroughIDynamicColumn()
+    public async Task StreamAsync_DynamicColumn_ExposesRuntimeTypeNamesAndPerTypeChildColumnsThroughIDynamicColumn()
     {
         // Dynamic differs from Variant in two ways the columnar view has to expose. Its type list is discovered per
         // block rather than declared, so TypeNames carries the wire's own spelling of each runtime type — that is how
@@ -723,11 +722,12 @@ public class ColumnarReadSurfaceIntegrationTests
         {
             ["allow_experimental_dynamic_type"] = "1",
 
-            // The client reads only the flattened serialization (version 3); without this the server sends version 1
-            // and the codec refuses the block rather than guessing at the layout.
+            // The codec reads only the flattened serialization (version 3); without this the server sends version 1
+            // and refuses the block rather than guessing at the layout. Set explicitly so this test states what it
+            // depends on, even though ClickHouseTcpClient also injects it.
             ["output_format_native_use_flattened_dynamic_and_json_serialization"] = "1",
         };
-        await using var connection = await TcpServerFixture.ConnectAsync(None);
+        await using var client = TcpServerFixture.CreateClient();
 
         bool matched = false;
         int typeCount = 0;
@@ -740,14 +740,14 @@ public class ColumnarReadSurfaceIntegrationTests
         var childRowCounts = new List<int>();
 
         // Rows: 'a', NULL, 100, 'b' — two runtime types plus a NULL.
-        await foreach (Block block in connection.QueryAsync(
+        await foreach (Block block in client.StreamAsync(
             """
             SELECT CAST(multiIf(number = 1, CAST(NULL, 'Dynamic'),
                                 number = 2, CAST(toInt64(100), 'Dynamic'),
                                 CAST(concat('s', toString(number)), 'Dynamic')), 'Dynamic')
             FROM system.numbers LIMIT 4
             """,
-            settings: settings,
+            new ClickHouseTcpQueryOptions { Settings = settings },
             cancellationToken: None))
         {
             IColumn column = block[0];
@@ -784,13 +784,5 @@ public class ColumnarReadSurfaceIntegrationTests
             Assert.That(childRowCounts.Sum(), Is.EqualTo(rowCount - 1), "the children together hold every non-NULL row exactly once");
             Assert.That(materialized, Is.EqualTo(new object[] { "s0", null, 100L, "s3" }));
         });
-    }
-
-    private static async Task ExecuteAsync(ClickHouseTcpConnection connection, string sql)
-    {
-        await foreach (Block block in connection.QueryAsync(sql, cancellationToken: None))
-        {
-            _ = block;
-        }
     }
 }

--- a/ClickHouse.Driver.Tcp.Tests/Integration/TcpServerFixture.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/TcpServerFixture.cs
@@ -84,4 +84,28 @@ public sealed class TcpServerFixture
                 Password = password ?? Password,
             },
             cancellationToken);
+
+    /// <summary>Builds client options pointed at the test server, optionally overriding the credentials.</summary>
+    /// <param name="username">The username to authenticate with, or null for the fixture default.</param>
+    /// <param name="password">The password to authenticate with, or null for the fixture default.</param>
+    /// <returns>Options for a <see cref="ClickHouseTcpClient"/> against the test server.</returns>
+    internal static ClickHouseTcpClientOptions Options(string username = null, string password = null)
+        => new()
+        {
+            Host = Host,
+            Port = Port,
+            Username = username ?? Username,
+            Password = password ?? Password,
+        };
+
+    /// <summary>Creates a client connected to the test server, optionally overriding the credentials.</summary>
+    /// <param name="username">The username to authenticate with, or null for the fixture default.</param>
+    /// <param name="password">The password to authenticate with, or null for the fixture default.</param>
+    /// <returns>A client against the test server.</returns>
+    internal static ClickHouseTcpClient CreateClient(string username = null, string password = null)
+        => new(Options(username, password));
+
+    /// <summary>The connection string that addresses the test server with the fixture credentials.</summary>
+    internal static string ConnectionString
+        => $"Host={Host};Port={Port};Username={Username};Password={Password}";
 }

--- a/ClickHouse.Driver.Tcp.Tests/Types/WritePathEquivalenceTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/WritePathEquivalenceTests.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Protocol;
+using ClickHouse.Driver.Tcp.Tests.Utilities;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Tests.Types;
+
+/// <summary>
+/// The safety net for the two write paths that used to be unified by densify: an <em>ergonomic</em> column (the
+/// jagged/nullable/tuple form a caller builds) and the <em>dense</em> column read back from the wire must encode to
+/// byte-identical output. Densify guaranteed this structurally by projecting the ergonomic form into the dense one
+/// before every write; now the ergonomic form is written directly through lazy views, so this asserts the two paths
+/// still agree.
+/// </summary>
+[TestFixture]
+public class WritePathEquivalenceTests
+{
+    private static IColumnCodec Resolve(string type) => ColumnCodecRegistry.Default.Resolve(type, default);
+
+    // Every case: an ergonomic column of the given type. The dense counterpart is obtained by round-tripping it
+    // through the codec (write + read back), then both are written via WriteFull and the bytes compared.
+    private static IEnumerable<TestCaseData> Cases()
+    {
+        yield return Case("Array(UInt32)", new ArrayColumn<uint[]>("c", "Array(UInt32)", new[] { new uint[] { 1, 2, 3 }, Array.Empty<uint>(), new uint[] { 4 } }));
+        yield return Case("Array(String)", new ArrayColumn<string[]>("c", "Array(String)", new[] { new[] { "a", "bb" }, Array.Empty<string>(), new[] { "héllo✓" } }));
+        yield return Case("Array(Nullable(Int32))", new ArrayColumn<int?[]>("c", "Array(Nullable(Int32))", new[] { new int?[] { 1, null, 3 }, new int?[] { null } }));
+        yield return Case("Array(Array(UInt32))", new ArrayColumn<uint[][]>("c", "Array(Array(UInt32))", new[] { new[] { new uint[] { 1, 2 }, new uint[] { 3 } }, Array.Empty<uint[]>() }));
+        yield return Case("Nullable(Int32)", new ArrayColumn<int?>("c", "Nullable(Int32)", new int?[] { 1, null, 3, null }));
+        yield return Case("Nullable(String)", new ArrayColumn<string>("c", "Nullable(String)", new[] { "a", null, "c" }));
+        yield return Case("Tuple(Int32, String)", new ArrayColumn<(int, string)>("c", "Tuple(Int32, String)", new[] { (1, "a"), (2, "bb"), (3, "ccc") }));
+        yield return Case("Map(String, Int32)", new ArrayColumn<KeyValuePair<string, int>[]>("c", "Map(String, Int32)", new[]
+        {
+            new[] { new KeyValuePair<string, int>("a", 1), new KeyValuePair<string, int>("b", 2) },
+            Array.Empty<KeyValuePair<string, int>>(),
+        }));
+    }
+
+    private static TestCaseData Case(string type, IColumn ergonomic) => new TestCaseData(type, ergonomic).SetName($"WritePathEquivalence({type})");
+
+    [TestCaseSource(nameof(Cases))]
+    public async Task WriteFull_ErgonomicAndDenseReadback_ProduceIdenticalBytes(string type, IColumn ergonomic)
+    {
+        IColumnCodec codec = Resolve(type);
+
+        byte[] ergonomicBytes = await CodecTestHarness.WriteAsync(w => codec.WriteFull(w, ergonomic));
+
+        using IColumn dense = await ReadBackAsync(codec, ergonomicBytes, ergonomic, type);
+        byte[] denseBytes = await CodecTestHarness.WriteAsync(w => codec.WriteFull(w, dense));
+
+        Assert.That(denseBytes, Is.EqualTo(ergonomicBytes), $"Ergonomic and dense write paths diverged for {type}.");
+    }
+
+    // Reads the column back from its own encoded body, consuming the state prefix first exactly as the block layer
+    // does, so composite codecs with a dictionary/type-list prefix (LowCardinality, Dynamic) decode correctly.
+    private static async Task<IColumn> ReadBackAsync(IColumnCodec codec, byte[] bytes, IColumn ergonomic, string type)
+    {
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(bytes);
+        await codec.ReadStatePrefixAsync(reader, CodecTestHarness.None);
+        return await codec.ReadColumnAsync(reader, ergonomic.Name, type, ergonomic.RowCount, CodecTestHarness.None);
+    }
+}

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClient.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClient.cs
@@ -1,0 +1,252 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Client;
+using ClickHouse.Driver.Tcp.Format;
+using ClickHouse.Driver.Tcp.Protocol;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp;
+
+/// <summary>
+/// A high-level client for a ClickHouse server over the native TCP protocol: run queries and stream results,
+/// execute statements, and insert columnar data. Build one from a <see cref="ClickHouseTcpClientOptions"/> or a
+/// connection string and reuse it — it is safe to share across threads. Operations are serialized onto the
+/// underlying connection today (one in flight at a time); a future connection pool lifts that transparently.
+///
+/// <para>
+/// This type is experimental: its surface may change in a future release. Suppress diagnostic
+/// <c>CHTCP0001</c> to acknowledge that.
+/// </para>
+/// </summary>
+[Experimental("CHTCP0001")]
+public sealed class ClickHouseTcpClient : IAsyncDisposable
+{
+    // Reading and writing Dynamic (and later JSON) requires the flattened native serialization; the client
+    // enables it on every operation so callers never have to know about it. A caller-supplied value wins.
+    private const string FlattenedSerializationSetting = "output_format_native_use_flattened_dynamic_and_json_serialization";
+
+    private readonly IConnectionSource source;
+    private readonly IReadOnlyDictionary<string, string> baseSettings;
+    private readonly int maxSendBufferBytes;
+
+    /// <summary>Creates a client from options.</summary>
+    /// <param name="options">The client configuration (endpoint, credentials, timeouts, client-level settings).</param>
+    /// <exception cref="ArgumentNullException"><paramref name="options"/> is null.</exception>
+    /// <exception cref="ArgumentException">An option value is invalid (see <see cref="ClickHouseTcpClientOptions"/>).</exception>
+    public ClickHouseTcpClient(ClickHouseTcpClientOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        options.Validate();
+        source = new SingleConnectionSource(options);
+        baseSettings = options.CustomSettings;
+        maxSendBufferBytes = options.MaxSendBufferBytes;
+    }
+
+    /// <summary>Creates a client from a connection string.</summary>
+    /// <param name="connectionString">The connection string (keys such as <c>Host</c>, <c>Port</c>, <c>Username</c>, <c>set_&lt;name&gt;</c>).</param>
+    /// <exception cref="ArgumentNullException"><paramref name="connectionString"/> is null.</exception>
+    /// <exception cref="ArgumentException">A resulting option value is invalid.</exception>
+    public ClickHouseTcpClient(string connectionString)
+        : this(ClickHouseTcpClientOptions.FromConnectionString(connectionString))
+    {
+    }
+
+    /// <summary>Test/pool seam: builds a client over an arbitrary connection source and client-level settings.</summary>
+    internal ClickHouseTcpClient(
+        IConnectionSource source,
+        IReadOnlyDictionary<string, string> baseSettings,
+        int maxSendBufferBytes = ClickHouseTcpClientOptions.DefaultMaxSendBufferBytes)
+    {
+        this.source = source;
+        this.baseSettings = baseSettings;
+        this.maxSendBufferBytes = maxSendBufferBytes;
+    }
+
+    /// <summary>
+    /// Runs a query and streams its result as a sequence of <see cref="Block"/>s — the low-level columnar tier,
+    /// with no per-row materialization.
+    /// </summary>
+    /// <remarks>
+    /// <b>Blocks are borrowed.</b> Each yielded <see cref="Block"/> is valid only for the current iteration: the
+    /// enumerator releases its storage when you advance, stop enumerating, or dispose the enumerator. Do not
+    /// dispose a yielded block yourself, and do not retain a block, any of its columns, or an
+    /// <see cref="IColumn{T}.Values"/> span past the current iteration — copy out (e.g. <c>Values.ToArray()</c>)
+    /// what must outlive the loop body. Enumerate with <c>await foreach</c> (or otherwise dispose the enumerator)
+    /// so the underlying connection is returned: reused for the next operation when the response was fully
+    /// drained, or discarded and redialed when enumeration stopped mid-response.
+    /// </remarks>
+    /// <param name="sql">The SQL text.</param>
+    /// <param name="options">Per-query options (query id, settings), or null for the client defaults.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>An async stream of the result's row-bearing blocks, each valid only for its own iteration.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="sql"/> is null.</exception>
+    public async IAsyncEnumerable<Block> StreamAsync(
+        string sql,
+        ClickHouseTcpQueryOptions options = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(sql);
+
+        IReadOnlyDictionary<string, string> settings = BuildSettings(options);
+        string queryId = options?.QueryId;
+
+        IConnectionLease lease = await source.RentAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            // The connection's own enumerator owns each block's storage and, in its finally, returns the
+            // connection to Ready or terminates it. We pass the blocks straight through without disposing them.
+            await foreach (Block block in lease.Connection
+                .QueryAsync(sql, settings, parameters: null, queryId, handlers: null, cancellationToken)
+                .ConfigureAwait(false))
+            {
+                yield return block;
+            }
+        }
+        finally
+        {
+            // Runs on natural completion, early break / enumerator disposal (which cascades disposal into the
+            // inner iterator so its finally runs first), and exceptions. Disposing the lease returns the
+            // connection to the source exactly once; the source reuses it if Ready or redials if terminated.
+            await lease.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Runs a query and streams its result one row at a time as <c>object[]</c>, each entry the boxed value of a
+    /// column in header order (pair with <see cref="Block.ColumnNames"/> — via <see cref="StreamAsync"/> — to
+    /// address by name). Each returned array is owned and safe to retain past the enumeration.
+    /// </summary>
+    /// <param name="sql">The SQL text.</param>
+    /// <param name="options">Per-query options (query id, settings), or null for the client defaults.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>An async stream of result rows.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="sql"/> is null.</exception>
+    public async IAsyncEnumerable<object[]> QueryAsync(
+        string sql,
+        ClickHouseTcpQueryOptions options = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        await foreach (Block block in StreamAsync(sql, options, cancellationToken).ConfigureAwait(false))
+        {
+            int columnCount = block.ColumnCount;
+            for (int row = 0; row < block.RowCount; row++)
+            {
+                var values = new object[columnCount];
+                for (int column = 0; column < columnCount; column++)
+                {
+                    values[column] = block[column].GetValue(row);
+                }
+
+                yield return values;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Runs a statement that produces no result rows (DDL, or DML other than an <c>INSERT ... VALUES</c>) and
+    /// returns once the server acknowledges it. Any result blocks the statement happens to produce are drained
+    /// and discarded.
+    /// </summary>
+    /// <param name="sql">The SQL text.</param>
+    /// <param name="options">Per-query options (query id, settings), or null for the client defaults.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>A task that completes when the statement is acknowledged.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="sql"/> is null.</exception>
+    public async ValueTask ExecuteAsync(
+        string sql,
+        ClickHouseTcpQueryOptions options = null,
+        CancellationToken cancellationToken = default)
+    {
+        await foreach (Block _ in StreamAsync(sql, options, cancellationToken).ConfigureAwait(false))
+        {
+            // Draining to completion is the acknowledgement; the connection is released by StreamAsync.
+        }
+    }
+
+    /// <summary>
+    /// Inserts columnar data. The columns are matched to the target's schema <b>by name</b> (order is free, and
+    /// a named subset inserts only those columns, the server filling the rest from their defaults); values are
+    /// serialized as the target's resolved type. Zero rows is a no-op.
+    /// </summary>
+    /// <param name="sql">The <c>INSERT INTO … VALUES</c> statement, with no inline <c>VALUES (...)</c> literal.</param>
+    /// <param name="columns">The row data, matched to the target columns by name.</param>
+    /// <param name="maxRowsPerBlock">A cap on the rows per wire block, applied alongside the internal byte target; null for no row cap.</param>
+    /// <param name="options">Per-query options (query id, settings), or null for the client defaults.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>A task that completes when the server acknowledges the insert.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="sql"/> or <paramref name="columns"/> is null.</exception>
+    /// <exception cref="ArgumentException">The columns' row counts differ, names are not unique, do not match the target schema, or a CLR type is not writable as its target type.</exception>
+    public async ValueTask InsertAsync(
+        string sql,
+        IReadOnlyList<IColumn> columns,
+        int? maxRowsPerBlock = ClickHouseTcpConnection.DefaultMaxRowsPerBlock,
+        ClickHouseTcpQueryOptions options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(sql);
+        ArgumentNullException.ThrowIfNull(columns);
+
+        IReadOnlyDictionary<string, string> settings = BuildSettings(options);
+        string queryId = options?.QueryId;
+
+        await using IConnectionLease lease = await source.RentAsync(cancellationToken).ConfigureAwait(false);
+        await lease.Connection.InsertAsync(
+            sql, columns, settings, parameters: null, queryId, maxRowsPerBlock, maxSendBufferBytes, handlers: null, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Checks connectivity by sending a Ping and awaiting the Pong.</summary>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>A task that completes when the server answers.</returns>
+    public async ValueTask PingAsync(CancellationToken cancellationToken = default)
+    {
+        await using IConnectionLease lease = await source.RentAsync(cancellationToken).ConfigureAwait(false);
+        await lease.Connection.PingAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public ValueTask DisposeAsync() => source.DisposeAsync();
+
+    private IReadOnlyDictionary<string, string> BuildSettings(ClickHouseTcpQueryOptions options)
+        => MergeSettings(baseSettings, options?.Settings);
+
+    /// <summary>
+    /// Merges the settings for one operation: the client-level custom settings, overlaid by the per-query
+    /// settings, with the flattened-serialization setting injected unless a caller already set it at either
+    /// level.
+    /// </summary>
+    /// <param name="clientSettings">The client-level custom settings, or null for none.</param>
+    /// <param name="perQuerySettings">The per-query settings that override the client-level ones, or null for none.</param>
+    /// <returns>The merged settings to send with the operation.</returns>
+    internal static IReadOnlyDictionary<string, string> MergeSettings(
+        IReadOnlyDictionary<string, string> clientSettings,
+        IReadOnlyDictionary<string, string> perQuerySettings)
+    {
+        var merged = new Dictionary<string, string>(StringComparer.Ordinal);
+        if (clientSettings is not null)
+        {
+            foreach (KeyValuePair<string, string> entry in clientSettings)
+            {
+                merged[entry.Key] = entry.Value;
+            }
+        }
+
+        if (perQuerySettings is not null)
+        {
+            foreach (KeyValuePair<string, string> entry in perQuerySettings)
+            {
+                merged[entry.Key] = entry.Value;
+            }
+        }
+
+        if (!merged.ContainsKey(FlattenedSerializationSetting))
+        {
+            merged[FlattenedSerializationSetting] = "1";
+        }
+
+        return merged;
+    }
+}

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClient.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClient.cs
@@ -42,7 +42,13 @@ public sealed class ClickHouseTcpClient : IAsyncDisposable
         ArgumentNullException.ThrowIfNull(options);
         options.Validate();
         source = new SingleConnectionSource(options);
-        baseSettings = options.CustomSettings;
+
+        // Copy the caller's settings into an owned dictionary: the client is shared across threads and merges
+        // these on every query, so retaining the caller's reference would let a later mutation of it fault or
+        // partially apply mid-merge.
+        baseSettings = options.CustomSettings is null
+            ? null
+            : new Dictionary<string, string>(options.CustomSettings, StringComparer.Ordinal);
         maxSendBufferBytes = options.MaxSendBufferBytes;
     }
 

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClient.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClient.cs
@@ -244,6 +244,19 @@ public sealed class ClickHouseTcpClient : IAsyncDisposable
         {
             foreach (KeyValuePair<string, string> entry in perQuerySettings)
             {
+                // Per-query settings are user-provided and, unlike client CustomSettings, not validated at
+                // construction. An empty name would collide with the empty key that terminates the wire settings
+                // list, and a null value cannot be written — reject both rather than corrupt the request.
+                if (string.IsNullOrEmpty(entry.Key))
+                {
+                    throw new ArgumentException("A query setting name must not be null or empty.", nameof(perQuerySettings));
+                }
+
+                if (entry.Value is null)
+                {
+                    throw new ArgumentException($"Query setting '{entry.Key}' has a null value; use an empty string for a flag-style setting.", nameof(perQuerySettings));
+                }
+
                 merged[entry.Key] = entry.Value;
             }
         }

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClient.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClient.cs
@@ -6,7 +6,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using ClickHouse.Driver.Tcp.Client;
 using ClickHouse.Driver.Tcp.Format;
-using ClickHouse.Driver.Tcp.Protocol;
 using ClickHouse.Driver.Tcp.Types;
 
 namespace ClickHouse.Driver.Tcp;
@@ -23,15 +22,15 @@ namespace ClickHouse.Driver.Tcp;
 /// </para>
 /// </summary>
 [Experimental("CHTCP0001")]
-public sealed class ClickHouseTcpClient : IAsyncDisposable
+public sealed class ClickHouseTcpClient : IClickHouseTcpClient
 {
     // Reading and writing Dynamic (and later JSON) requires the flattened native serialization; the client
     // enables it on every operation so callers never have to know about it. A caller-supplied value wins.
     private const string FlattenedSerializationSetting = "output_format_native_use_flattened_dynamic_and_json_serialization";
 
+    private static readonly ClickHouseTcpInsertOptions DefaultInsertOptions = new();
+
     private readonly IConnectionSource source;
-    private readonly IReadOnlyDictionary<string, string> baseSettings;
-    private readonly int maxSendBufferBytes;
 
     /// <summary>Creates a client from options.</summary>
     /// <param name="options">The client configuration (endpoint, credentials, timeouts, client-level settings).</param>
@@ -41,15 +40,8 @@ public sealed class ClickHouseTcpClient : IAsyncDisposable
     {
         ArgumentNullException.ThrowIfNull(options);
         options.Validate();
-        source = new SingleConnectionSource(options);
-
-        // Copy the caller's settings into an owned dictionary: the client is shared across threads and merges
-        // these on every query, so retaining the caller's reference would let a later mutation of it fault or
-        // partially apply mid-merge.
-        baseSettings = options.CustomSettings is null
-            ? null
-            : new Dictionary<string, string>(options.CustomSettings, StringComparer.Ordinal);
-        maxSendBufferBytes = options.MaxSendBufferBytes;
+        Options = options.WithOwnedCustomSettings();
+        source = new SingleConnectionSource(Options);
     }
 
     /// <summary>Creates a client from a connection string.</summary>
@@ -61,16 +53,18 @@ public sealed class ClickHouseTcpClient : IAsyncDisposable
     {
     }
 
-    /// <summary>Test/pool seam: builds a client over an arbitrary connection source and client-level settings.</summary>
-    internal ClickHouseTcpClient(
-        IConnectionSource source,
-        IReadOnlyDictionary<string, string> baseSettings,
-        int maxSendBufferBytes = ClickHouseTcpClientOptions.DefaultMaxSendBufferBytes)
+    /// <summary>Test/pool seam: builds a client over an arbitrary connection source.</summary>
+    internal ClickHouseTcpClient(IConnectionSource source, ClickHouseTcpClientOptions options = null)
     {
         this.source = source;
-        this.baseSettings = baseSettings;
-        this.maxSendBufferBytes = maxSendBufferBytes;
+        Options = (options ?? new ClickHouseTcpClientOptions()).WithOwnedCustomSettings();
     }
+
+    /// <summary>
+    /// The configuration this client was built with, including the client-level settings applied to every
+    /// operation. Init-only, so it reflects construction and never changes.
+    /// </summary>
+    public ClickHouseTcpClientOptions Options { get; }
 
     /// <summary>
     /// Runs a query and streams its result as a sequence of <see cref="Block"/>s — the low-level columnar tier,
@@ -180,8 +174,7 @@ public sealed class ClickHouseTcpClient : IAsyncDisposable
     /// </summary>
     /// <param name="sql">The <c>INSERT INTO … VALUES</c> statement, with no inline <c>VALUES (...)</c> literal.</param>
     /// <param name="columns">The row data, matched to the target columns by name.</param>
-    /// <param name="maxRowsPerBlock">A cap on the rows per wire block, applied alongside the internal byte target; null for no row cap.</param>
-    /// <param name="options">Per-query options (query id, settings), or null for the client defaults.</param>
+    /// <param name="options">Per-insert options (query id, settings, block sizing), or null for the client defaults.</param>
     /// <param name="cancellationToken">A token to observe for cancellation.</param>
     /// <returns>A task that completes when the server acknowledges the insert.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="sql"/> or <paramref name="columns"/> is null.</exception>
@@ -189,20 +182,39 @@ public sealed class ClickHouseTcpClient : IAsyncDisposable
     public async ValueTask InsertAsync(
         string sql,
         IReadOnlyList<IColumn> columns,
-        int? maxRowsPerBlock = ClickHouseTcpConnection.DefaultMaxRowsPerBlock,
-        ClickHouseTcpQueryOptions options = null,
+        ClickHouseTcpInsertOptions options = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(sql);
         ArgumentNullException.ThrowIfNull(columns);
 
         IReadOnlyDictionary<string, string> settings = BuildSettings(options);
-        string queryId = options?.QueryId;
 
         await using IConnectionLease lease = await source.RentAsync(cancellationToken).ConfigureAwait(false);
         await lease.Connection.InsertAsync(
-            sql, columns, settings, parameters: null, queryId, maxRowsPerBlock, maxSendBufferBytes, handlers: null, cancellationToken).ConfigureAwait(false);
+            sql,
+            columns,
+            settings,
+            parameters: null,
+            options?.QueryId,
+            ResolveMaxRowsPerBlock(options),
+            Options.MaxSendBufferBytes,
+            handlers: null,
+            cancellationToken).ConfigureAwait(false);
     }
+
+    /// <summary>
+    /// The row cap for an insert: the caller's value, or the default when they passed no options at all.
+    /// </summary>
+    /// <param name="options">The per-insert options, or null for the client defaults.</param>
+    /// <returns>The rows-per-block cap, or null to write a single block.</returns>
+    /// <remarks>
+    /// Reads through a default instance rather than coalescing, because null is a meaningful value here: an
+    /// explicit <see cref="ClickHouseTcpInsertOptions.MaxRowsPerBlock"/> of null asks for one block, so a
+    /// <c>?? Default</c> would silently re-enable splitting.
+    /// </remarks>
+    internal static int? ResolveMaxRowsPerBlock(ClickHouseTcpInsertOptions options)
+        => (options ?? DefaultInsertOptions).MaxRowsPerBlock;
 
     /// <summary>Checks connectivity by sending a Ping and awaiting the Pong.</summary>
     /// <param name="cancellationToken">A token to observe for cancellation.</param>
@@ -217,7 +229,7 @@ public sealed class ClickHouseTcpClient : IAsyncDisposable
     public ValueTask DisposeAsync() => source.DisposeAsync();
 
     private IReadOnlyDictionary<string, string> BuildSettings(ClickHouseTcpQueryOptions options)
-        => MergeSettings(baseSettings, options?.Settings);
+        => MergeSettings(Options.CustomSettings, options?.Settings);
 
     /// <summary>
     /// Merges the settings for one operation: the client-level custom settings, overlaid by the per-query

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClientOptions.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClientOptions.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+using ClickHouse.Driver.Tcp.Protocol;
+
+namespace ClickHouse.Driver.Tcp;
+
+/// <summary>
+/// Client-level configuration for a <see cref="ClickHouseTcpClient"/>: the server endpoint, credentials, and
+/// the connection-lifetime knobs. Values are init-only; build one directly or parse a connection string with
+/// <see cref="FromConnectionString"/>.
+/// </summary>
+public sealed class ClickHouseTcpClientOptions
+{
+    internal const string DefaultHost = "localhost";
+    internal const int DefaultPort = 9000;
+    internal const string DefaultUsername = "default";
+    internal const string DefaultDatabase = "default";
+    internal const int DefaultMaxSendBufferBytes = 10 * 1024 * 1024;
+    internal static readonly TimeSpan DefaultDialTimeout = TimeSpan.FromSeconds(30);
+    internal static readonly TimeSpan DefaultReadTimeout = TimeSpan.FromSeconds(300);
+
+    /// <summary>The server host name or address. Defaults to <c>localhost</c>.</summary>
+    public string Host { get; init; } = DefaultHost;
+
+    /// <summary>The server's native-protocol port. Defaults to <c>9000</c>.</summary>
+    public int Port { get; init; } = DefaultPort;
+
+    /// <summary>The user to authenticate as. Defaults to <c>default</c>.</summary>
+    public string Username { get; init; } = DefaultUsername;
+
+    /// <summary>The password, sent in plaintext and protected only by TLS. Defaults to empty.</summary>
+    public string Password { get; init; } = string.Empty;
+
+    /// <summary>The default database for queries. Defaults to <c>default</c>.</summary>
+    public string Database { get; init; } = DefaultDatabase;
+
+    /// <summary>The keyed-quota resource key, or empty when the client uses no keyed quota.</summary>
+    public string QuotaKey { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Client-level settings applied to every query and insert (a per-query
+    /// <see cref="ClickHouseTcpQueryOptions.Settings"/> value overrides the client-level one). Populated from
+    /// the <c>set_&lt;name&gt;</c> keys of a connection string, or set directly. Null means none.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> CustomSettings { get; init; }
+
+    /// <summary>
+    /// The soft cap, in bytes, on the client's send buffer during an insert: while a wire block is written, the
+    /// buffered bytes are flushed to the socket whenever they exceed this, bounding peak memory for a large
+    /// insert (a single column larger than the cap still buffers in full). Independent of the block-split target,
+    /// so blocks stay their natural size and simply stream out within this cap. Defaults to 10 MiB.
+    /// </summary>
+    public int MaxSendBufferBytes { get; init; } = DefaultMaxSendBufferBytes;
+
+    /// <summary>The deadline for establishing a connection (socket connect plus handshake). Defaults to 30s.</summary>
+    public TimeSpan DialTimeout { get; init; } = DefaultDialTimeout;
+
+    /// <summary>
+    /// The idle deadline for reading a response — reset each time a packet arrives — so a long streaming query
+    /// is not killed for taking a long time overall. Defaults to 300s. <b>Stored but not yet enforced</b>; the
+    /// idle-deadline read loop lands in a later change.
+    /// </summary>
+    public TimeSpan ReadTimeout { get; init; } = DefaultReadTimeout;
+
+    /// <summary>Parses a ClickHouse native-protocol connection string into options.</summary>
+    /// <param name="connectionString">The connection string (keys such as <c>Host</c>, <c>Port</c>, <c>Username</c>, <c>set_&lt;name&gt;</c>).</param>
+    /// <returns>The parsed options.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="connectionString"/> is null.</exception>
+    public static ClickHouseTcpClientOptions FromConnectionString(string connectionString)
+    {
+        ArgumentNullException.ThrowIfNull(connectionString);
+        return new ClickHouseTcpConnectionStringBuilder(connectionString).ToOptions();
+    }
+
+    /// <summary>Validates the options, throwing if any value is unusable. Runs at client construction.</summary>
+    /// <exception cref="ArgumentException"><see cref="Host"/>, <see cref="Username"/>, or <see cref="Database"/> is null or empty.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><see cref="Port"/> is out of range, or a timeout / buffer size is not positive.</exception>
+    internal void Validate()
+    {
+        if (string.IsNullOrEmpty(Host))
+        {
+            throw new ArgumentException("Host must not be null or empty.", nameof(Host));
+        }
+
+        if (string.IsNullOrEmpty(Username))
+        {
+            throw new ArgumentException("Username must not be null or empty.", nameof(Username));
+        }
+
+        if (string.IsNullOrEmpty(Database))
+        {
+            throw new ArgumentException("Database must not be null or empty.", nameof(Database));
+        }
+
+        if (Port is < 1 or > 65535)
+        {
+            throw new ArgumentOutOfRangeException(nameof(Port), Port, "Port must be between 1 and 65535.");
+        }
+
+        if (DialTimeout <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(DialTimeout), DialTimeout, "DialTimeout must be positive.");
+        }
+
+        if (ReadTimeout <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(ReadTimeout), ReadTimeout, "ReadTimeout must be positive.");
+        }
+
+        if (MaxSendBufferBytes <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(MaxSendBufferBytes), MaxSendBufferBytes, "MaxSendBufferBytes must be positive.");
+        }
+    }
+
+    /// <summary>Builds the handshake input for a connection from these options. The password is copied, not retained.</summary>
+    internal ClientHandshakeParameters ToHandshakeParameters()
+        => new()
+        {
+            Username = Username,
+            Password = Password ?? string.Empty,
+            Database = string.IsNullOrEmpty(Database) ? DefaultDatabase : Database,
+            QuotaKey = QuotaKey ?? string.Empty,
+        };
+}

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClientOptions.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClientOptions.cs
@@ -66,6 +66,30 @@ public sealed class ClickHouseTcpClientOptions
     /// </summary>
     public TimeSpan ReadTimeout { get; init; } = DefaultReadTimeout;
 
+    /// <summary>
+    /// These options with <see cref="CustomSettings"/> replaced by a private snapshot, or this instance when there
+    /// are none to copy. A client holds its options for its lifetime and merges the settings on every operation, so
+    /// it must own them: keeping the caller's dictionary would let a later mutation of it fault or partially apply
+    /// mid-merge. Every other property is init-only and so cannot change after construction.
+    /// </summary>
+    /// <remarks>Copies each property by hand — add new properties here too. <c>ClickHouseTcpClientOptionsTests</c> pins that.</remarks>
+    internal ClickHouseTcpClientOptions WithOwnedCustomSettings()
+        => CustomSettings is null
+            ? this
+            : new ClickHouseTcpClientOptions
+            {
+                Host = Host,
+                Port = Port,
+                Username = Username,
+                Password = Password,
+                Database = Database,
+                QuotaKey = QuotaKey,
+                CustomSettings = new Dictionary<string, string>(CustomSettings, StringComparer.Ordinal),
+                MaxSendBufferBytes = MaxSendBufferBytes,
+                DialTimeout = DialTimeout,
+                ReadTimeout = ReadTimeout,
+            };
+
     /// <summary>Parses a ClickHouse native-protocol connection string into options.</summary>
     /// <param name="connectionString">The connection string (keys such as <c>Host</c>, <c>Port</c>, <c>Username</c>, <c>set_&lt;name&gt;</c>).</param>
     /// <returns>The parsed options.</returns>

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClientOptions.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClientOptions.cs
@@ -6,10 +6,16 @@ namespace ClickHouse.Driver.Tcp;
 
 /// <summary>
 /// Client-level configuration for a <see cref="ClickHouseTcpClient"/>: the server endpoint, credentials, and
-/// the connection-lifetime knobs. Values are init-only; build one directly or parse a connection string with
-/// <see cref="FromConnectionString"/>.
+/// the connection-lifetime knobs. Values are init-only; build one directly, parse a connection string with
+/// <see cref="FromConnectionString"/>, or derive a variant of an existing instance with a <c>with</c> expression.
 /// </summary>
-public sealed class ClickHouseTcpClientOptions
+/// <remarks>
+/// Being a record, two instances compare equal when every property does. <see cref="CustomSettings"/> is compared
+/// by reference, not by content, because the declared type is an interface with no value-equality contract: two
+/// options that hold equal-but-distinct dictionaries are <b>not</b> equal. Do not use these options as a cache or
+/// pool key; use a purpose-built key type.
+/// </remarks>
+public sealed record ClickHouseTcpClientOptions
 {
     internal const string DefaultHost = "localhost";
     internal const int DefaultPort = 9000;
@@ -72,23 +78,14 @@ public sealed class ClickHouseTcpClientOptions
     /// it must own them: keeping the caller's dictionary would let a later mutation of it fault or partially apply
     /// mid-merge. Every other property is init-only and so cannot change after construction.
     /// </summary>
-    /// <remarks>Copies each property by hand — add new properties here too. <c>ClickHouseTcpClientOptionsTests</c> pins that.</remarks>
+    /// <remarks>
+    /// The <c>with</c> expression carries every other property across, so a property added later needs no change
+    /// here. Keep it that way — a hand-written copy is what silently drops a new property.
+    /// </remarks>
     internal ClickHouseTcpClientOptions WithOwnedCustomSettings()
         => CustomSettings is null
             ? this
-            : new ClickHouseTcpClientOptions
-            {
-                Host = Host,
-                Port = Port,
-                Username = Username,
-                Password = Password,
-                Database = Database,
-                QuotaKey = QuotaKey,
-                CustomSettings = new Dictionary<string, string>(CustomSettings, StringComparer.Ordinal),
-                MaxSendBufferBytes = MaxSendBufferBytes,
-                DialTimeout = DialTimeout,
-                ReadTimeout = ReadTimeout,
-            };
+            : this with { CustomSettings = new Dictionary<string, string>(CustomSettings, StringComparer.Ordinal) };
 
     /// <summary>Parses a ClickHouse native-protocol connection string into options.</summary>
     /// <param name="connectionString">The connection string (keys such as <c>Host</c>, <c>Port</c>, <c>Username</c>, <c>set_&lt;name&gt;</c>).</param>
@@ -168,4 +165,13 @@ public sealed class ClickHouseTcpClientOptions
             Database = string.IsNullOrEmpty(Database) ? DefaultDatabase : Database,
             QuotaKey = QuotaKey ?? string.Empty,
         };
+
+    /// <summary>The endpoint and user this client connects as. Never includes <see cref="Password"/>.</summary>
+    /// <remarks>
+    /// A record's generated <c>ToString</c> prints every property, which would put the plaintext password into any
+    /// log line that formats these options. This override names the safe properties explicitly instead, so a secret
+    /// added later is left out until someone chooses to include it.
+    /// </remarks>
+    public override string ToString()
+        => $"{nameof(ClickHouseTcpClientOptions)} {{ Host = {Host}, Port = {Port}, Username = {Username}, Database = {Database} }}";
 }

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClientOptions.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClientOptions.cs
@@ -28,7 +28,11 @@ public sealed class ClickHouseTcpClientOptions
     /// <summary>The user to authenticate as. Defaults to <c>default</c>.</summary>
     public string Username { get; init; } = DefaultUsername;
 
-    /// <summary>The password, sent in plaintext and protected only by TLS. Defaults to empty.</summary>
+    /// <summary>
+    /// The password, sent to the server in plaintext during the handshake. This client's native-protocol
+    /// transport is not encrypted, so the password (and all data) travels in the clear — use it only over a
+    /// trusted network. Defaults to empty.
+    /// </summary>
     public string Password { get; init; } = string.Empty;
 
     /// <summary>The default database for queries. Defaults to <c>default</c>.</summary>
@@ -110,6 +114,24 @@ public sealed class ClickHouseTcpClientOptions
         if (MaxSendBufferBytes <= 0)
         {
             throw new ArgumentOutOfRangeException(nameof(MaxSendBufferBytes), MaxSendBufferBytes, "MaxSendBufferBytes must be positive.");
+        }
+
+        if (CustomSettings is not null)
+        {
+            foreach (KeyValuePair<string, string> setting in CustomSettings)
+            {
+                // An empty setting name would collide with the empty key that terminates the settings list on the
+                // wire, silently truncating the rest; a null value cannot be written. Reject both up front.
+                if (string.IsNullOrEmpty(setting.Key))
+                {
+                    throw new ArgumentException("A custom setting name must not be null or empty.", nameof(CustomSettings));
+                }
+
+                if (setting.Value is null)
+                {
+                    throw new ArgumentException($"Custom setting '{setting.Key}' has a null value; use an empty string for a flag-style setting.", nameof(CustomSettings));
+                }
+            }
         }
     }
 

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpConnectionStringBuilder.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpConnectionStringBuilder.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Globalization;
+
+namespace ClickHouse.Driver.Tcp;
+
+/// <summary>
+/// Parses and builds ClickHouse native-protocol connection strings. Recognizes the endpoint and credential
+/// keys plus <c>set_&lt;name&gt;</c> keys, which become client-level custom settings applied to every query.
+/// Unknown keys are preserved (the base <see cref="DbConnectionStringBuilder"/> holds them) but ignored.
+/// </summary>
+#pragma warning disable CA1010 // Type inherits ICollection without implementing generic version - inherent to DbConnectionStringBuilder
+public sealed class ClickHouseTcpConnectionStringBuilder : DbConnectionStringBuilder
+#pragma warning restore CA1010
+{
+    /// <summary>The prefix that marks a connection-string key as a ClickHouse custom setting.</summary>
+    private const string CustomSettingPrefix = "set_";
+
+    /// <summary>Initializes an empty builder.</summary>
+    public ClickHouseTcpConnectionStringBuilder()
+    {
+    }
+
+    /// <summary>Initializes a builder from an existing connection string.</summary>
+    /// <param name="connectionString">The connection string to parse.</param>
+    public ClickHouseTcpConnectionStringBuilder(string connectionString)
+    {
+        ConnectionString = connectionString;
+    }
+
+    /// <summary>The server host name or address. Defaults to <c>localhost</c>.</summary>
+    public string Host
+    {
+        get => GetStringOrDefault("Host", ClickHouseTcpClientOptions.DefaultHost);
+        set => this["Host"] = value;
+    }
+
+    /// <summary>The server's native-protocol port. Defaults to <c>9000</c>.</summary>
+    public int Port
+    {
+        get => GetIntOrDefault("Port", ClickHouseTcpClientOptions.DefaultPort);
+        set => this["Port"] = value;
+    }
+
+    /// <summary>The user to authenticate as. Defaults to <c>default</c>.</summary>
+    public string Username
+    {
+        get => GetStringOrDefault("Username", ClickHouseTcpClientOptions.DefaultUsername);
+        set => this["Username"] = value;
+    }
+
+    /// <summary>The password. Defaults to empty.</summary>
+    public string Password
+    {
+        get => GetStringOrDefault("Password", string.Empty);
+        set => this["Password"] = value;
+    }
+
+    /// <summary>The default database. Defaults to <c>default</c>.</summary>
+    public string Database
+    {
+        get => GetStringOrDefault("Database", ClickHouseTcpClientOptions.DefaultDatabase);
+        set => this["Database"] = value;
+    }
+
+    /// <summary>The keyed-quota resource key. Defaults to empty.</summary>
+    public string QuotaKey
+    {
+        get => GetStringOrDefault("QuotaKey", string.Empty);
+        set => this["QuotaKey"] = value;
+    }
+
+    /// <summary>The connect-plus-handshake deadline, in seconds. Defaults to 30.</summary>
+    public TimeSpan DialTimeout
+    {
+        get => GetTimeSpanSecondsOrDefault("DialTimeout", ClickHouseTcpClientOptions.DefaultDialTimeout);
+        set => this["DialTimeout"] = value.TotalSeconds;
+    }
+
+    /// <summary>The idle read deadline, in seconds. Defaults to 300.</summary>
+    public TimeSpan ReadTimeout
+    {
+        get => GetTimeSpanSecondsOrDefault("ReadTimeout", ClickHouseTcpClientOptions.DefaultReadTimeout);
+        set => this["ReadTimeout"] = value.TotalSeconds;
+    }
+
+    /// <summary>The soft send-buffer cap, in bytes. Defaults to 10 MiB.</summary>
+    public int MaxSendBufferBytes
+    {
+        get => GetIntOrDefault("MaxSendBufferBytes", ClickHouseTcpClientOptions.DefaultMaxSendBufferBytes);
+        set => this["MaxSendBufferBytes"] = value;
+    }
+
+    /// <summary>Materializes these keys into a <see cref="ClickHouseTcpClientOptions"/>, folding <c>set_*</c> keys into <see cref="ClickHouseTcpClientOptions.CustomSettings"/>.</summary>
+    /// <returns>The equivalent options.</returns>
+    public ClickHouseTcpClientOptions ToOptions()
+    {
+        Dictionary<string, string> customSettings = null;
+        foreach (string key in Keys)
+        {
+            if (key.StartsWith(CustomSettingPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                string name = key.Substring(CustomSettingPrefix.Length);
+                (customSettings ??= new Dictionary<string, string>(StringComparer.Ordinal))[name] = GetStringOrDefault(key, null);
+            }
+        }
+
+        return new ClickHouseTcpClientOptions
+        {
+            Host = Host,
+            Port = Port,
+            Username = Username,
+            Password = Password,
+            Database = Database,
+            QuotaKey = QuotaKey,
+            DialTimeout = DialTimeout,
+            ReadTimeout = ReadTimeout,
+            MaxSendBufferBytes = MaxSendBufferBytes,
+            CustomSettings = customSettings,
+        };
+    }
+
+    private string GetStringOrDefault(string name, string @default)
+        => TryGetValue(name, out object value) && value is string s ? s : @default;
+
+    // A numeric value read back may be the string a connection string was parsed into, or the boxed int/double a
+    // typed setter stored on this same instance — handle both so a set-then-get on one builder round-trips.
+    private int GetIntOrDefault(string name, int @default)
+    {
+        if (!TryGetValue(name, out object value))
+        {
+            return @default;
+        }
+
+        return value switch
+        {
+            int i => i,
+            string s when int.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out int result) => result,
+            _ => @default,
+        };
+    }
+
+    private TimeSpan GetTimeSpanSecondsOrDefault(string name, TimeSpan @default)
+    {
+        if (!TryGetValue(name, out object value))
+        {
+            return @default;
+        }
+
+        return value switch
+        {
+            double d => TimeSpan.FromSeconds(d),
+            string s when double.TryParse(s, NumberStyles.Float, CultureInfo.InvariantCulture, out double seconds) => TimeSpan.FromSeconds(seconds),
+            _ => @default,
+        };
+    }
+}

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpConnectionStringBuilder.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpConnectionStringBuilder.cs
@@ -102,7 +102,14 @@ public sealed class ClickHouseTcpConnectionStringBuilder : DbConnectionStringBui
             if (key.StartsWith(CustomSettingPrefix, StringComparison.OrdinalIgnoreCase))
             {
                 string name = key.Substring(CustomSettingPrefix.Length);
-                (customSettings ??= new Dictionary<string, string>(StringComparer.Ordinal))[name] = GetStringOrDefault(key, null);
+                if (name.Length == 0)
+                {
+                    // '<prefix>' alone names an empty setting, which would terminate the wire settings list early.
+                    throw new ArgumentException($"Connection-string key '{key}' names an empty custom setting; a setting name must be non-empty (e.g. '{CustomSettingPrefix}max_threads').");
+                }
+
+                // Never store null (it cannot be written): a value-less set_ key becomes an empty-string setting.
+                (customSettings ??= new Dictionary<string, string>(StringComparer.Ordinal))[name] = GetStringOrDefault(key, string.Empty);
             }
         }
 

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpConnectionStringBuilder.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpConnectionStringBuilder.cs
@@ -109,7 +109,7 @@ public sealed class ClickHouseTcpConnectionStringBuilder : DbConnectionStringBui
                 }
 
                 // Never store null (it cannot be written): a value-less set_ key becomes an empty-string setting.
-                (customSettings ??= new Dictionary<string, string>(StringComparer.Ordinal))[name] = GetStringOrDefault(key, string.Empty);
+                (customSettings ??= new Dictionary<string, string>(StringComparer.Ordinal))[name] = GetCustomSettingValue(key);
             }
         }
 
@@ -127,6 +127,14 @@ public sealed class ClickHouseTcpConnectionStringBuilder : DbConnectionStringBui
             CustomSettings = customSettings,
         };
     }
+
+    // A custom setting's value as an invariant string: a string is taken as-is; a typed value set programmatically
+    // (e.g. builder["set_max_threads"] = 4) is formatted invariantly rather than silently dropped; an absent or
+    // null value becomes empty (never null, which cannot be written on the wire).
+    private string GetCustomSettingValue(string key)
+        => TryGetValue(key, out object value) && value is not null
+            ? value as string ?? Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty
+            : string.Empty;
 
     private string GetStringOrDefault(string name, string @default)
         => TryGetValue(name, out object value) && value is string s ? s : @default;

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpInsertOptions.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpInsertOptions.cs
@@ -6,7 +6,7 @@ namespace ClickHouse.Driver.Tcp;
 /// Per-insert overrides passed to <see cref="ClickHouseTcpClient.InsertAsync"/>: the query options (query id,
 /// settings) plus the knobs that only apply when the client writes a data stream.
 /// </summary>
-public sealed class ClickHouseTcpInsertOptions : ClickHouseTcpQueryOptions
+public sealed record ClickHouseTcpInsertOptions : ClickHouseTcpQueryOptions
 {
     /// <summary>
     /// A cap on the rows per wire block, applied alongside the client's internal byte target, so a wide or large

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpInsertOptions.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpInsertOptions.cs
@@ -1,0 +1,17 @@
+using ClickHouse.Driver.Tcp.Protocol;
+
+namespace ClickHouse.Driver.Tcp;
+
+/// <summary>
+/// Per-insert overrides passed to <see cref="ClickHouseTcpClient.InsertAsync"/>: the query options (query id,
+/// settings) plus the knobs that only apply when the client writes a data stream.
+/// </summary>
+public sealed class ClickHouseTcpInsertOptions : ClickHouseTcpQueryOptions
+{
+    /// <summary>
+    /// A cap on the rows per wire block, applied alongside the client's internal byte target, so a wide or large
+    /// insert is split into several blocks instead of one huge one. Defaults to 1,000,000 rows. Set null to write
+    /// the whole insert as a single block, whatever its row count.
+    /// </summary>
+    public int? MaxRowsPerBlock { get; init; } = ClickHouseTcpConnection.DefaultMaxRowsPerBlock;
+}

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpQueryOptions.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpQueryOptions.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+
+namespace ClickHouse.Driver.Tcp;
+
+/// <summary>
+/// Per-query overrides passed to a <see cref="ClickHouseTcpClient"/> operation. All members are optional; a
+/// null options argument (or a null member) falls back to the client-level defaults.
+/// </summary>
+public sealed class ClickHouseTcpQueryOptions
+{
+    /// <summary>The query id, or null to let the server assign one.</summary>
+    public string QueryId { get; init; }
+
+    /// <summary>
+    /// Settings for this query, as textual values. These override the client-level
+    /// <see cref="ClickHouseTcpClientOptions.CustomSettings"/> for any key present in both. Null means none.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Settings { get; init; }
+}

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpQueryOptions.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpQueryOptions.cs
@@ -7,7 +7,13 @@ namespace ClickHouse.Driver.Tcp;
 /// null options argument (or a null member) falls back to the client-level defaults.
 /// <see cref="ClickHouseTcpInsertOptions"/> extends this with the insert-only knobs.
 /// </summary>
-public class ClickHouseTcpQueryOptions
+/// <remarks>
+/// Being a record, one instance can hold the shared settings and each operation can derive its own variant with a
+/// <c>with</c> expression — <c>shared with { QueryId = id }</c>. A <c>with</c> expression on a variable of this type
+/// clones the runtime type, so cloning an instance that is really a <see cref="ClickHouseTcpInsertOptions"/> keeps
+/// the insert-only knobs. See <see cref="ClickHouseTcpClientOptions"/> for how <see cref="Settings"/> compares.
+/// </remarks>
+public record ClickHouseTcpQueryOptions
 {
     /// <summary>The query id, or null to let the server assign one.</summary>
     public string QueryId { get; init; }

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpQueryOptions.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpQueryOptions.cs
@@ -5,8 +5,9 @@ namespace ClickHouse.Driver.Tcp;
 /// <summary>
 /// Per-query overrides passed to a <see cref="ClickHouseTcpClient"/> operation. All members are optional; a
 /// null options argument (or a null member) falls back to the client-level defaults.
+/// <see cref="ClickHouseTcpInsertOptions"/> extends this with the insert-only knobs.
 /// </summary>
-public sealed class ClickHouseTcpQueryOptions
+public class ClickHouseTcpQueryOptions
 {
     /// <summary>The query id, or null to let the server assign one.</summary>
     public string QueryId { get; init; }

--- a/ClickHouse.Driver.Tcp/Client/IClickHouseTcpClient.cs
+++ b/ClickHouse.Driver.Tcp/Client/IClickHouseTcpClient.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Format;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp;
+
+/// <summary>
+/// The contract of a ClickHouse client that speaks the native TCP protocol: run queries and stream results,
+/// execute statements, and insert columnar data. <see cref="ClickHouseTcpClient"/> is the implementation; code
+/// against this interface to substitute a test double.
+///
+/// <para>
+/// This type is experimental: its surface may change in a future release. Suppress diagnostic
+/// <c>CHTCP0001</c> to acknowledge that.
+/// </para>
+/// </summary>
+[Experimental("CHTCP0001")]
+public interface IClickHouseTcpClient : IAsyncDisposable
+{
+    /// <summary>
+    /// The configuration this client was built with, including the client-level settings applied to every
+    /// operation.
+    /// </summary>
+    ClickHouseTcpClientOptions Options { get; }
+
+    /// <summary>
+    /// Runs a query and streams its result as a sequence of <see cref="Block"/>s — the low-level columnar tier,
+    /// with no per-row materialization.
+    /// </summary>
+    /// <remarks>
+    /// <b>Blocks are borrowed.</b> Each yielded <see cref="Block"/> is valid only for the current iteration, and
+    /// the consumer must not dispose one or retain it, its columns, or an <see cref="IColumn{T}.Values"/> span
+    /// past that point — copy out what must outlive the loop body. Enumerate with <c>await foreach</c> (or
+    /// otherwise dispose the enumerator) so the underlying connection is released. An implementation must honor
+    /// this contract.
+    /// </remarks>
+    /// <param name="sql">The SQL text.</param>
+    /// <param name="options">Per-query options (query id, settings), or null for the client defaults.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>An async stream of the result's row-bearing blocks, each valid only for its own iteration.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="sql"/> is null.</exception>
+    IAsyncEnumerable<Block> StreamAsync(
+        string sql,
+        ClickHouseTcpQueryOptions options = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Runs a query and streams its result one row at a time as <c>object[]</c>, each entry the boxed value of a
+    /// column in header order. Each returned array is owned and safe to retain past the enumeration.
+    /// </summary>
+    /// <param name="sql">The SQL text.</param>
+    /// <param name="options">Per-query options (query id, settings), or null for the client defaults.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>An async stream of result rows.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="sql"/> is null.</exception>
+    IAsyncEnumerable<object[]> QueryAsync(
+        string sql,
+        ClickHouseTcpQueryOptions options = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Runs a statement that produces no result rows (DDL, or DML other than an <c>INSERT ... VALUES</c>) and
+    /// returns once the server acknowledges it. Any result blocks are drained and discarded.
+    /// </summary>
+    /// <param name="sql">The SQL text.</param>
+    /// <param name="options">Per-query options (query id, settings), or null for the client defaults.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>A task that completes when the statement is acknowledged.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="sql"/> is null.</exception>
+    ValueTask ExecuteAsync(
+        string sql,
+        ClickHouseTcpQueryOptions options = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Inserts columnar data. The columns are matched to the target's schema <b>by name</b> (order is free, and a
+    /// named subset inserts only those columns, the server filling the rest from their defaults); values are
+    /// serialized as the target's resolved type. Zero rows is a no-op.
+    /// </summary>
+    /// <param name="sql">The <c>INSERT INTO … VALUES</c> statement, with no inline <c>VALUES (...)</c> literal.</param>
+    /// <param name="columns">The row data, matched to the target columns by name.</param>
+    /// <param name="options">Per-insert options (query id, settings, block sizing), or null for the client defaults.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>A task that completes when the server acknowledges the insert.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="sql"/> or <paramref name="columns"/> is null.</exception>
+    /// <exception cref="ArgumentException">The columns' row counts differ, names are not unique, do not match the target schema, or a CLR type is not writable as its target type.</exception>
+    ValueTask InsertAsync(
+        string sql,
+        IReadOnlyList<IColumn> columns,
+        ClickHouseTcpInsertOptions options = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Checks connectivity by sending a Ping and awaiting the Pong.</summary>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>A task that completes when the server answers.</returns>
+    ValueTask PingAsync(CancellationToken cancellationToken = default);
+}

--- a/ClickHouse.Driver.Tcp/Client/IConnectionSource.cs
+++ b/ClickHouse.Driver.Tcp/Client/IConnectionSource.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Protocol;
+
+namespace ClickHouse.Driver.Tcp.Client;
+
+/// <summary>
+/// Supplies connections to the client, hiding whether a connection is dialed fresh, reused, or drawn from a
+/// pool. A caller rents a connection for one operation and disposes the returned lease to give it back; the
+/// source decides on the next rent whether a returned connection is reusable or must be discarded and redialed.
+///
+/// <para>
+/// The single-connection implementation shipped today serializes rents so the one non-thread-safe connection
+/// only ever has one in-flight operation; a future multi-connection pool implements the same interface and
+/// hands out distinct connections without any change at the call site.
+/// </para>
+/// </summary>
+internal interface IConnectionSource : IAsyncDisposable
+{
+    /// <summary>
+    /// Rents a ready connection, waiting if none is currently available. Dispose the returned lease to return
+    /// the connection. On failure to obtain one (e.g. a dial timeout) the call throws and nothing is leased.
+    /// </summary>
+    /// <param name="cancellationToken">A token to observe while waiting for and establishing a connection.</param>
+    /// <returns>A lease over a ready connection.</returns>
+    ValueTask<IConnectionLease> RentAsync(CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// A rented connection. Disposing the lease returns the connection to its source exactly once (disposing more
+/// than once is a no-op). The lease does not own the connection's teardown — the source decides, when the lease
+/// is returned, whether to keep the connection for reuse or discard it (a connection left terminated by a failed
+/// operation is never reused).
+/// </summary>
+internal interface IConnectionLease : IAsyncDisposable
+{
+    /// <summary>The rented connection, valid until the lease is disposed.</summary>
+    ClickHouseTcpConnection Connection { get; }
+}

--- a/ClickHouse.Driver.Tcp/Client/SingleConnectionSource.cs
+++ b/ClickHouse.Driver.Tcp/Client/SingleConnectionSource.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Protocol;
+
+namespace ClickHouse.Driver.Tcp.Client;
+
+/// <summary>
+/// A minimal connection source that holds a single connection and serializes access to it. Rents wait on a
+/// gate so the one non-thread-safe connection carries at most one in-flight operation at a time; a connection
+/// left terminated by a failed operation is discarded and redialed on the next rent. This is the interim stand
+/// in for a real connection pool: it satisfies <see cref="IConnectionSource"/> so a pooled implementation can
+/// replace it without touching the client.
+/// </summary>
+internal sealed class SingleConnectionSource : IConnectionSource
+{
+    private readonly ClickHouseTcpClientOptions options;
+    private readonly SemaphoreSlim gate = new(1, 1);
+    private ClickHouseTcpConnection current;
+    private int disposed;
+
+    /// <summary>Initializes the source over the client's options; no connection is opened until the first rent.</summary>
+    /// <param name="options">The validated client options (endpoint, credentials, dial timeout).</param>
+    public SingleConnectionSource(ClickHouseTcpClientOptions options)
+    {
+        this.options = options;
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask<IConnectionLease> RentAsync(CancellationToken cancellationToken)
+    {
+        await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+        // From here the gate is held; every path must either return a lease (which releases it on dispose) or
+        // release it before throwing, or the source deadlocks.
+        try
+        {
+            if (Volatile.Read(ref disposed) != 0)
+            {
+                throw new ObjectDisposedException(nameof(SingleConnectionSource));
+            }
+
+            if (current is null || current.State == TcpConnectionState.Terminated)
+            {
+                // Discard a connection a prior operation terminated, then dial a fresh one. A terminated
+                // connection has already closed its transport, so nothing beyond dropping the reference is
+                // needed before redialing.
+                current = null;
+                current = await DialAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            return new Lease(this, current);
+        }
+        catch
+        {
+            gate.Release();
+            throw;
+        }
+    }
+
+    /// <summary>Dials and hands back a ready connection, bounding connect + handshake with the dial timeout.</summary>
+    private async ValueTask<ClickHouseTcpConnection> DialAsync(CancellationToken cancellationToken)
+    {
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        linked.CancelAfter(options.DialTimeout);
+        try
+        {
+            return await ClickHouseTcpConnection.ConnectAsync(
+                options.Host, options.Port, options.ToHandshakeParameters(), linked.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested && linked.IsCancellationRequested)
+        {
+            // The linked token, not the caller's, fired: the dial deadline elapsed. Surface it as a timeout so a
+            // hung connect is distinguishable from a caller cancellation.
+            throw new TimeoutException(
+                $"Connecting to {options.Host}:{options.Port} timed out after {options.DialTimeout.TotalSeconds:0.###}s (DialTimeout).");
+        }
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask DisposeAsync()
+    {
+        // Idempotent: only the first caller tears the source down. Marking disposed before taking the gate
+        // means a rent already parked on the gate, once admitted, observes disposed and fails cleanly rather
+        // than handing out a connection about to be closed.
+        if (Interlocked.Exchange(ref disposed, 1) != 0)
+        {
+            return;
+        }
+
+        // Take the gate so disposal waits for any in-flight operation to return its lease before closing the
+        // connection out from under it.
+        await gate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            if (current is not null)
+            {
+                await current.DisposeAsync().ConfigureAwait(false);
+                current = null;
+            }
+        }
+        finally
+        {
+            gate.Release();
+        }
+
+        // The gate is deliberately not disposed: SemaphoreSlim holds no unmanaged resource unless its
+        // AvailableWaitHandle is accessed (it never is here), and disposing it could fault a rent still parked
+        // on WaitAsync. Leaving it undisposed lets such a waiter wake, observe disposed, and throw cleanly.
+    }
+
+    /// <summary>
+    /// The lease handed to a caller. Its dispose releases the gate exactly once (guarded so a double dispose is
+    /// a no-op) and, when the returned connection is terminated, clears the source's held connection so the next
+    /// rent redials.
+    /// </summary>
+    private sealed class Lease : IConnectionLease
+    {
+        private readonly SingleConnectionSource source;
+        private int returned;
+
+        public Lease(SingleConnectionSource source, ClickHouseTcpConnection connection)
+        {
+            this.source = source;
+            Connection = connection;
+        }
+
+        public ClickHouseTcpConnection Connection { get; }
+
+        public ValueTask DisposeAsync()
+        {
+            // Return exactly once even if the caller disposes twice (e.g. an await using plus an explicit call).
+            if (Interlocked.Exchange(ref returned, 1) != 0)
+            {
+                return default;
+            }
+
+            // A connection a failed operation terminated must not be leased again; drop it so the next rent
+            // dials a fresh one. A still-ready connection stays as the source's held connection for reuse.
+            if (Connection.State == TcpConnectionState.Terminated && ReferenceEquals(source.current, Connection))
+            {
+                source.current = null;
+            }
+
+            source.gate.Release();
+            return default;
+        }
+    }
+}

--- a/ClickHouse.Driver.Tcp/Format/Block.cs
+++ b/ClickHouse.Driver.Tcp/Format/Block.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using ClickHouse.Driver.Tcp.Types;
 
 namespace ClickHouse.Driver.Tcp.Format;
@@ -15,14 +16,16 @@ namespace ClickHouse.Driver.Tcp.Format;
 /// <c>Values.ToArray()</c>) while iterating.
 /// </para>
 /// </summary>
-internal sealed class Block : IDisposable
+public sealed class Block : IDisposable
 {
+    private string[] columnNames;
+
     /// <summary>Initializes a new instance of the <see cref="Block"/> class.</summary>
     /// <param name="name">The block name (usually empty for result blocks).</param>
     /// <param name="info">The block info prefix.</param>
     /// <param name="rowCount">The number of rows every column holds.</param>
     /// <param name="columns">The decoded columns, in header order.</param>
-    public Block(string name, BlockInfo info, int rowCount, IReadOnlyList<IColumn> columns)
+    internal Block(string name, BlockInfo info, int rowCount, IReadOnlyList<IColumn> columns)
     {
         Name = name;
         Info = info;
@@ -34,7 +37,7 @@ internal sealed class Block : IDisposable
     public string Name { get; }
 
     /// <summary>The block info prefix.</summary>
-    public BlockInfo Info { get; }
+    internal BlockInfo Info { get; }
 
     /// <summary>The number of rows in the block.</summary>
     public int RowCount { get; }
@@ -44,6 +47,35 @@ internal sealed class Block : IDisposable
 
     /// <summary>The decoded columns, in header order.</summary>
     public IReadOnlyList<IColumn> Columns { get; }
+
+    /// <summary>
+    /// The column names, in header order — the same order as <see cref="Columns"/> and the <c>object[]</c> rows
+    /// produced by the client's untyped read. Pair this with a row to address values by name. Computed once and
+    /// cached; the returned list is owned (safe to retain past the block, unlike the columns themselves).
+    /// </summary>
+    public IReadOnlyList<string> ColumnNames
+    {
+        get
+        {
+            // Fully populate a local, then publish the reference with a release write so a concurrent reader
+            // never observes the array before its elements are written. A benign double-compute (two readers
+            // racing the first access) yields equivalent arrays, so only the torn-publication needs guarding.
+            string[] existing = Volatile.Read(ref columnNames);
+            if (existing is not null)
+            {
+                return existing;
+            }
+
+            var names = new string[Columns.Count];
+            for (int i = 0; i < names.Length; i++)
+            {
+                names[i] = Columns[i].Name;
+            }
+
+            Volatile.Write(ref columnNames, names);
+            return names;
+        }
+    }
 
     /// <summary>The column at <paramref name="index"/>.</summary>
     /// <param name="index">The zero-based column index.</param>

--- a/ClickHouse.Driver.Tcp/Format/Block.cs
+++ b/ClickHouse.Driver.Tcp/Format/Block.cs
@@ -13,7 +13,8 @@ namespace ClickHouse.Driver.Tcp.Format;
 /// A block <b>borrows</b> its columns' storage, which may be pooled. It is disposed by the reader that produced
 /// it — for a streamed query, when the consumer advances to the next block or stops enumerating. A consumer
 /// must not read a block's columns after that point; to retain values beyond the block, copy them (for example
-/// <c>Values.ToArray()</c>) while iterating.
+/// <c>Values.ToArray()</c>) while iterating. Do <b>not</b> dispose a block yielded by a query yourself: the
+/// reader owns its lifetime, and disposing it early would return borrowed pooled storage the reader still manages.
 /// </para>
 /// </summary>
 public sealed class Block : IDisposable


### PR DESCRIPTION
First branch of **Epic N** (client API) for the native-TCP client. Adds the user-facing entry point on top of the existing raw connection, plus the options and connection-acquisition plumbing. Stacked on `tcp/epic-j4-dynamic`.

## What's here
- **`ClickHouseTcpClient`** — `[Experimental("CHTCP0001")]`, `IAsyncDisposable`, safe to share:
  - `StreamAsync` → `IAsyncEnumerable<Block>` (low-level columnar tier)
  - `QueryAsync` → `IAsyncEnumerable<object[]>` (untyped rows, boxed via `IColumn.GetValue`)
  - `ExecuteAsync` (non-result statements), `InsertAsync` (columnar `IReadOnlyList<IColumn>`), `PingAsync`
  - Auto-enables `output_format_native_use_flattened_dynamic_and_json_serialization` so `Dynamic`/`JSON` decode without the caller knowing (caller value still wins).
- **Options** — all three options types are `record`s, so a caller holding one can derive a variant with `with { ... }` instead of rebuilding it by hand (which is how the HTTP-side `InsertOptions.WithQueryId`/`WithColumnTypes` came to silently drop properties). `ClickHouseTcpClientOptions` overrides `ToString` to keep the plaintext `Password` out of logs, since a record otherwise prints every property and `Client.Options` is public. The `Settings`/`CustomSettings` dictionaries compare by reference, not content — documented on the types and pinned by a test.
- **Options** — `ClickHouseTcpClientOptions` + `ClickHouseTcpConnectionStringBuilder` (`Host/Port/Username/Password/Database/QuotaKey/DialTimeout/ReadTimeout/MaxSendBufferBytes` + `set_<name>` custom settings), and a minimal `ClickHouseTcpQueryOptions` (`QueryId` + `Settings`).
- **Connection seam** — internal `IConnectionSource`/`IConnectionLease` with an interim `SingleConnectionSource` (one connection, serialized, redials a terminated one). `DialTimeout` bounds connect+handshake. A real pool (Epic M) implements the same interface with no client change.
- **`MaxSendBufferBytes`** threaded through `InsertAsync` as the between-column flush threshold (write memory backstop), independent of the 50 MB block-split target.
- **`Block` is now public** (constructor + `Info` stayed internal so `BlockInfo` isn't leaked); added `Block.ColumnNames`.

## Streaming release semantics
`StreamAsync` rents a connection and returns it to the source **exactly once** on full drain, early enumerator disposal, or exception (an `Interlocked` guard prevents double-return; a terminated connection is discarded and redialed on the next rent).

## Tests
- **Unit**: options validation + handshake mapping, connection-string parsing (`set_*` custom settings, defaults, round-trip), settings-merge (N1a injection / caller-wins), `SingleConnectionSource` lifecycle (idempotent dispose, rent-after-dispose, pre-cancelled token).
- **Integration (live server)**: streaming, early-dispose→redial reuse, server-error→still-usable, `object[]` rows + owned-row retention, `ExecuteAsync` round-trip, columnar insert round-trip, schema-mismatch, per-query settings, **Dynamic decode without the caller setting the flag** (proves N1a), **tiny 4 KB send-buffer flushing 20k rows intact** (proves `MaxSendBufferBytes`), concurrency, connection-string construction.

Full net9.0 suite green (1101 tests). Coverage ~93% line / ~87% branch on the new code.

## Deferred (called out)
- Row-oriented / POCO insert (N9) + POCO read (N5/N5a) → Branch 2.
- Query-parameter binding & value formatting (N11) + rich per-query options (N10) → Branch 3.
- `ReadTimeout` is parsed/stored but not yet enforced (it is the idle read-loop deadline of Q3).
- The client can throw the still-`internal` `ClickHouseServerException`/`ClickHouseProtocolException` (callers see the base `Exception`) — exception hierarchy is Q1/Epic R.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
