### PR TITLE
test: isolate every test table behind a randomized-name helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,16 +87,49 @@ var users = connection.Query<User>("SELECT * FROM users");
 - **Connection pooling**: Respect HTTP connection pool behavior, avoid connection leaks
 
 ### Testing Discipline
+
+> **Table names: never hard-code one.** Any test that touches a table must get its name from
+> `CreateTableName(...)`. This is not a style preference — the `net6/8/9/10` suites run
+> *simultaneously against one shared server*, so a fixed name lets one suite drop, truncate or read
+> another suite's table. This is the single most common way a new test becomes flaky here.
+>
+> ```csharp
+> // In a fixture deriving from AbstractConnectionTestFixture — preferred, cleans up for you:
+> var table = CreateTableName();                  // test.MyTestMethod_net9_a1b2c3d4e5f6
+>
+> // Anywhere else — you own the cleanup:
+> var table = TestUtilities.CreateTableName();    // + DROP TABLE IF EXISTS in your teardown
+> ```
+
 - **Integration tests**: Strongly prefer tests that actually call the db over unit tests.
-- **Test utilities**: before writing tests, read TestUtilities.cs to understand existing config and utility patterns.
+- **Test utilities**: before writing tests, read TestUtilities.cs to understand existing config and
+  utility patterns — including `CreateTableName`/`SanitizeTableName` (see the note above).
 - **Test matrix**: ADO provider, parameter binding, ORMs, multi-framework, multi-ClickHouse-version
 - **Negative tests**: Error handling, edge cases, concurrency scenarios
 - **Existing tests**: Only add new tests, never delete/weaken existing ones
 - **Test organization**: Client tests in `.Tests`, third-party integration tests in `.IntegrationTests`
-- **Test isolation**: Create tables in the dedicated `test` database (qualified `test.<name>`),
-  and give each table a **randomized** name (e.g. `SanitizeTableName($"...{Guid.NewGuid():N}")`,
-  as `BulkCopyTests`/`NestedArrayParameterTests` already do). Tests run across `net6/8/9/10`
-  simultaneously against a shared server, so fixed/unqualified table names collide and flake.
+- **Table naming details**:
+  - The inherited `AbstractConnectionTestFixture.CreateTableName()` registers the name so
+    `[OneTimeTearDown]` drops it. Prefer it over the static helper whenever the fixture allows.
+  - Pass a prefix only to carry a parametrized case, e.g. `CreateTableName($"bulk_{clickHouseType}")`.
+    Prefixes are sanitized, so interpolating type names, timezone ids etc. is safe — no manual
+    scrubbing needed.
+  - Names are already `test.`-qualified. Never prepend `test.` yourself. Pass
+    `database: "other_db"` to target another database, or `database: null` for an unqualified name
+    (required for `CREATE TEMPORARY TABLE`, which cannot be qualified).
+  - Because every name is unique, a plain `CREATE TABLE` cannot collide — don't add
+    `IF NOT EXISTS`, don't `DROP` before the `CREATE`, and don't wrap a test in `try/finally` just to
+    drop its table. `IF NOT EXISTS` on a unique name only hides a future isolation regression.
+    Keep it (with a `DROP`) solely in the `[SetUp]` of a fixture that deliberately shares one table.
+  - Gotcha: the server stores the *unqualified* name, so a test comparing against `system.tables` /
+    `system.columns` / `DESCRIBE` output, or against a table name in an exception message, must
+    split it: `var bare = name[(name.IndexOf('.') + 1)..];`.
+  - Gotcha: passing a qualified name to an API whose database resolution you are testing (e.g.
+    `InsertOptions.Database`, `QueryOptions.Database`) makes the override a no-op and silently voids
+    the assertion. Pass the bare name there, keeping the qualified one for read-back.
+  - A fixture may deliberately *share* one table across its tests and reset it in `[SetUp]`; that is
+    fine — hoist one `CreateTableName(...)` into the fixture rather than splitting it per test.
+  - `Utilities/TestTableNamingTests.cs` pins this contract; keep it passing.
 - **Deterministic literals**: When asserting stored values, match a literal's precision to the
   column scale (e.g. an 8-digit fractional for `DateTime64(8)`) instead of relying on
   server-side rounding/truncation, which can vary by version/settings.

--- a/ClickHouse.Driver.IntegrationTests/Linq2DbTests.cs
+++ b/ClickHouse.Driver.IntegrationTests/Linq2DbTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Net;
 using System.Numerics;
 using ClickHouse.Driver.Numerics;
@@ -49,6 +50,27 @@ public class Tests
         ];
     }
 
+    // Tables created by the tests, dropped on teardown in case a test fails before dropping its own.
+    private readonly ConcurrentQueue<string> createdTables = new();
+
+    [OneTimeTearDown]
+    public async Task DropCreatedTables()
+    {
+        using var client = TestUtilities.GetTestClickHouseClient();
+
+        while (createdTables.TryDequeue(out var table))
+        {
+            try
+            {
+                await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS {table}");
+            }
+            catch (Exception e)
+            {
+                await TestContext.Progress.WriteLineAsync($"Failed to drop test table {table}: {e.Message}");
+            }
+        }
+    }
+
     [Test]
     public async Task Linq2DbBulkCopy()
     {
@@ -57,44 +79,45 @@ public class Tests
         // Covers: ClickHouseConnection::..ctor(string)
         await using var db = new DataConnection(new DataOptions().UseClickHouse(connectionString, ClickHouseProvider.ClickHouseDriver));
 
+        // linq2db takes the table name from the mapping class, which cannot carry a per-run name, so
+        // the name is overridden explicitly here. For ClickHouse, linq2db builds "database.table" from
+        // the database name component, so the database has to be passed separately from the name.
+        var tableName = TestUtilities.CreateTableName(database: null);
+        createdTables.Enqueue($"{TestUtilities.TestDatabase}.{tableName}");
+
         // cannot use temp table as we need to test WithoutSession option, incompatible with session tables
-        var tb = await db.CreateTableAsync<Linq2DbTestTable>();
+        var tb = await db.CreateTableAsync<Linq2DbTestTable>(tableName: tableName, databaseName: TestUtilities.TestDatabase);
 
-        try
+        var options = new BulkCopyOptions()
         {
-            var options = new BulkCopyOptions()
-            {
-                // Covers: ClickHouseBulkCopy::BatchSize
-                MaxBatchSize = 10,
-                // Covers: ClickHouseBulkCopy::MaxDegreeOfParallelism
-                MaxDegreeOfParallelism = 1,
-                // Covers:
-                // ClickHouseConnectionStringBuilder::.ctor(string)
-                // ClickHouseConnectionStringBuilder::UseSession
-                // ClickHouseConnectionStringBuilder::ToString
-                WithoutSession = true
-            };
-
+            // Covers: ClickHouseBulkCopy::BatchSize
+            MaxBatchSize = 10,
+            // Covers: ClickHouseBulkCopy::MaxDegreeOfParallelism
+            MaxDegreeOfParallelism = 1,
             // Covers:
-            // ClickHouseBulkCopy::.ctor(ClickHouseConnection)
-            // ClickHouseBulkCopy::Dispose()
-            // ClickHouseBulkCopy::DestinationTableName
-            // ClickHouseBulkCopy::RowsWritten
-            // ClickHouseBulkCopy::InitAsync
-            // ClickHouseBulkCopy::ColumnNames
-            await tb.BulkCopyAsync(options, Linq2DbTestTable.TestData);
+            // ClickHouseConnectionStringBuilder::.ctor(string)
+            // ClickHouseConnectionStringBuilder::UseSession
+            // ClickHouseConnectionStringBuilder::ToString
+            WithoutSession = true
+        };
 
-            db.InlineParameters = true;
-            // Covers:
-            // ClickHouseDecimal::ToString(IFormatProvider)
-            var record = await tb.Where(r => r.Decimal == new ClickHouseDecimal(12.3M)).SingleAsync();
+        // Covers:
+        // ClickHouseBulkCopy::.ctor(ClickHouseConnection)
+        // ClickHouseBulkCopy::Dispose()
+        // ClickHouseBulkCopy::DestinationTableName
+        // ClickHouseBulkCopy::RowsWritten
+        // ClickHouseBulkCopy::InitAsync
+        // ClickHouseBulkCopy::ColumnNames
+        await tb.BulkCopyAsync(options, Linq2DbTestTable.TestData);
 
-            // optional assert could be added
-        }
-        finally
-        {
-            await tb.DropAsync();
-        }
+        db.InlineParameters = true;
+        // Covers:
+        // ClickHouseDecimal::ToString(IFormatProvider)
+        var record = await tb.Where(r => r.Decimal == new ClickHouseDecimal(12.3M)).SingleAsync();
+
+        // optional assert could be added
+
+        await tb.DropAsync();
 
         Assert.Pass();
     }

--- a/ClickHouse.Driver.IntegrationTests/TestContainerFixture.cs
+++ b/ClickHouse.Driver.IntegrationTests/TestContainerFixture.cs
@@ -7,6 +7,15 @@ namespace ClickHouse.Driver.IntegrationTests;
 [SetUpFixture]
 public class TestContainerFixture
 {
+    [OneTimeSetUp]
+    public async Task SetUp()
+    {
+        // The Tests project creates this in its own [SetUpFixture], but NUnit only runs those for the
+        // assembly under test, so this project has to create the database it puts its tables in too.
+        using var client = TestUtilities.GetTestClickHouseClient();
+        await client.ExecuteNonQueryAsync($"CREATE DATABASE IF NOT EXISTS {TestUtilities.TestDatabase}");
+    }
+
     [OneTimeTearDown]
     public async Task TearDown()
     {

--- a/ClickHouse.Driver.Tests/ADO/ConnectionTests.cs
+++ b/ClickHouse.Driver.Tests/ADO/ConnectionTests.cs
@@ -349,10 +349,9 @@ public class ConnectionTests : AbstractConnectionTestFixture
     [Test]
     public async Task ShouldPostDynamicallyGeneratedRawStream()
     {
-        var targetTable = "test.raw_stream";
+        var targetTable = CreateTableName();
 
-        await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {targetTable}");
-        await connection.ExecuteStatementAsync($"CREATE TABLE IF NOT EXISTS {targetTable} (value Int32) ENGINE Null");
+        await connection.ExecuteStatementAsync($"CREATE TABLE {targetTable} (value Int32) ENGINE Null");
         await connection.PostStreamAsync($"INSERT INTO {targetTable} FORMAT CSV", async (stream, ct) =>
         {
 

--- a/ClickHouse.Driver.Tests/ADO/RolesTests.cs
+++ b/ClickHouse.Driver.Tests/ADO/RolesTests.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using ClickHouse.Driver.ADO;
 using ClickHouse.Driver.Utility;
@@ -8,6 +10,8 @@ namespace ClickHouse.Driver.Tests.ADO;
 [TestFixture]
 public class RolesTests
 {
+    private readonly ConcurrentQueue<string> createdTables = new();
+
     private ClickHouseConnection defaultConnection;
     private string database;
     private string username;
@@ -65,6 +69,19 @@ public class RolesTests
     {
         try
         {
+            // Best-effort: a table that cannot be dropped must not fail an otherwise passing fixture
+            while (createdTables.TryDequeue(out var tableName))
+            {
+                try
+                {
+                    await defaultConnection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {database}.{tableName}");
+                }
+                catch (Exception e)
+                {
+                    TestContext.Progress.WriteLine($"Failed to drop test table {tableName}: {e.Message}");
+                }
+            }
+
             // Drop user and roles
             await defaultConnection.ExecuteStatementAsync($"DROP USER IF EXISTS {username}");
             await defaultConnection.ExecuteStatementAsync($"DROP ROLE IF EXISTS {roleName1}");
@@ -74,6 +91,18 @@ public class RolesTests
         {
             defaultConnection?.Dispose();
         }
+    }
+
+    /// <summary>
+    /// Builds a unique table name and registers it to be dropped when the fixture tears down.
+    /// Deliberately unqualified: these tests run against the connection's own database, which is
+    /// also the database the roles are granted privileges on.
+    /// </summary>
+    private string CreateTableName([CallerMemberName] string testName = null)
+    {
+        var tableName = TestUtilities.CreateTableName(database: null, testName: testName);
+        createdTables.Enqueue(tableName);
+        return tableName;
     }
 
     private ClickHouseConnection CreateClientWithRoles(params string[] roles)
@@ -153,102 +182,74 @@ public class RolesTests
     [Test]
     public async Task Insert_WithRoleThatCanInsert_ShouldSucceed()
     {
-        var tableName = $"role_insert_test_{Guid.NewGuid():N}";
+        var tableName = CreateTableName();
         using var client = CreateClientWithRoles(roleName1);
 
-        try
-        {
-            // Create table and insert using role1 (has INSERT permission)
-            await defaultConnection.ExecuteStatementAsync(
-                $"CREATE TABLE IF NOT EXISTS {tableName} (id Int32) ENGINE = MergeTree() ORDER BY id");
+        // Create table and insert using role1 (has INSERT permission)
+        await defaultConnection.ExecuteStatementAsync(
+            $"CREATE TABLE {tableName} (id Int32) ENGINE = MergeTree() ORDER BY id");
 
-            await client.ExecuteStatementAsync($"INSERT INTO {tableName} VALUES (1)");
+        await client.ExecuteStatementAsync($"INSERT INTO {tableName} VALUES (1)");
 
-            // Verify insert worked
-            var count = await defaultConnection.ExecuteScalarAsync($"SELECT count() FROM {tableName}");
-            Assert.That(count, Is.EqualTo(1UL));
-        }
-        finally
-        {
-            await defaultConnection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {tableName}");
-        }
+        // Verify insert worked
+        var count = await defaultConnection.ExecuteScalarAsync($"SELECT count() FROM {tableName}");
+        Assert.That(count, Is.EqualTo(1UL));
     }
 
     [Test]
     public async Task Insert_WithRoleThatCannotInsert_ShouldFail()
     {
-        var tableName = $"role_insert_test_{Guid.NewGuid():N}";
+        var tableName = CreateTableName();
         using var client = CreateClientWithRoles(roleName2); // role2 has no INSERT permission
 
-        try
-        {
-            await defaultConnection.ExecuteStatementAsync(
-                $"CREATE TABLE IF NOT EXISTS {tableName} (id Int32) ENGINE = MergeTree() ORDER BY id");
+        await defaultConnection.ExecuteStatementAsync(
+            $"CREATE TABLE {tableName} (id Int32) ENGINE = MergeTree() ORDER BY id");
 
-            var ex = Assert.ThrowsAsync<ClickHouseServerException>(
-                async () => await client.ExecuteStatementAsync($"INSERT INTO {tableName} VALUES (1)"));
+        var ex = Assert.ThrowsAsync<ClickHouseServerException>(
+            async () => await client.ExecuteStatementAsync($"INSERT INTO {tableName} VALUES (1)"));
 
-            Assert.That(ex.Message, Does.Contain("Not enough privileges").IgnoreCase
-                .Or.Contain("ACCESS_DENIED").IgnoreCase);
-        }
-        finally
-        {
-            await defaultConnection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {tableName}");
-        }
+        Assert.That(ex.Message, Does.Contain("Not enough privileges").IgnoreCase
+            .Or.Contain("ACCESS_DENIED").IgnoreCase);
     }
 
     [Test]
     public async Task Insert_CommandRoleOverrideAllowsInsert_ShouldSucceed()
     {
-        var tableName = $"role_insert_test_{Guid.NewGuid():N}";
+        var tableName = CreateTableName();
         using var client = CreateClientWithRoles(roleName2); // Connection has role2 (no INSERT)
 
-        try
-        {
-            await defaultConnection.ExecuteStatementAsync(
-                $"CREATE TABLE IF NOT EXISTS {tableName} (id Int32) ENGINE = MergeTree() ORDER BY id");
+        await defaultConnection.ExecuteStatementAsync(
+            $"CREATE TABLE {tableName} (id Int32) ENGINE = MergeTree() ORDER BY id");
 
-            // Override with role1 (has INSERT permission) at command level
-            using var command = client.CreateCommand($"INSERT INTO {tableName} VALUES (1)");
-            command.Roles.Add(roleName1);
-            await command.ExecuteNonQueryAsync();
+        // Override with role1 (has INSERT permission) at command level
+        using var command = client.CreateCommand($"INSERT INTO {tableName} VALUES (1)");
+        command.Roles.Add(roleName1);
+        await command.ExecuteNonQueryAsync();
 
-            // Verify insert worked
-            var count = await defaultConnection.ExecuteScalarAsync($"SELECT count() FROM {tableName}");
-            Assert.That(count, Is.EqualTo(1UL));
-        }
-        finally
-        {
-            await defaultConnection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {tableName}");
-        }
+        // Verify insert worked
+        var count = await defaultConnection.ExecuteScalarAsync($"SELECT count() FROM {tableName}");
+        Assert.That(count, Is.EqualTo(1UL));
     }
 
     [Test]
     public async Task CreateTable_WithRoleThatCanCreate_ShouldSucceed()
     {
-        var tableName = $"role_create_test_{Guid.NewGuid():N}";
+        var tableName = CreateTableName();
         using var client = CreateClientWithRoles(roleName1); // role1 has CREATE TABLE permission
 
-        try
-        {
-            await client.ExecuteStatementAsync(
-                $"CREATE TABLE {tableName} (id Int32) ENGINE = MergeTree() ORDER BY id");
+        await client.ExecuteStatementAsync(
+            $"CREATE TABLE {tableName} (id Int32) ENGINE = MergeTree() ORDER BY id");
 
-            // Verify table was created
-            var exists = await defaultConnection.ExecuteScalarAsync(
-                $"SELECT count() FROM system.tables WHERE database = '{database}' AND name = '{tableName}'");
-            Assert.That(exists, Is.EqualTo(1UL));
-        }
-        finally
-        {
-            await defaultConnection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {tableName}");
-        }
+        // Verify table was created
+        var exists = await defaultConnection.ExecuteScalarAsync(
+            $"SELECT count() FROM system.tables WHERE database = '{database}' AND name = '{tableName}'");
+        Assert.That(exists, Is.EqualTo(1UL));
     }
 
     [Test]
     public void CreateTable_WithRoleThatCannotCreate_ShouldFail()
     {
-        var tableName = $"role_create_test_{Guid.NewGuid():N}";
+        var tableName = CreateTableName();
         using var client = CreateClientWithRoles(roleName2); // role2 has no CREATE TABLE permission
 
         var ex = Assert.ThrowsAsync<ClickHouseServerException>(
@@ -262,25 +263,18 @@ public class RolesTests
     [Test]
     public async Task CreateTable_CommandRoleOverrideAllowsCreate_ShouldSucceed()
     {
-        var tableName = $"role_create_test_{Guid.NewGuid():N}";
+        var tableName = CreateTableName();
         using var client = CreateClientWithRoles(roleName2); // Connection has role2 (no CREATE TABLE)
 
-        try
-        {
-            // Override with role1 (has CREATE TABLE permission) at command level
-            using var command = client.CreateCommand(
-                $"CREATE TABLE {tableName} (id Int32) ENGINE = MergeTree() ORDER BY id");
-            command.Roles.Add(roleName1);
-            await command.ExecuteNonQueryAsync();
+        // Override with role1 (has CREATE TABLE permission) at command level
+        using var command = client.CreateCommand(
+            $"CREATE TABLE {tableName} (id Int32) ENGINE = MergeTree() ORDER BY id");
+        command.Roles.Add(roleName1);
+        await command.ExecuteNonQueryAsync();
 
-            // Verify table was created
-            var exists = await defaultConnection.ExecuteScalarAsync(
-                $"SELECT count() FROM system.tables WHERE database = '{database}' AND name = '{tableName}'");
-            Assert.That(exists, Is.EqualTo(1UL));
-        }
-        finally
-        {
-            await defaultConnection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {tableName}");
-        }
+        // Verify table was created
+        var exists = await defaultConnection.ExecuteScalarAsync(
+            $"SELECT count() FROM system.tables WHERE database = '{database}' AND name = '{tableName}'");
+        Assert.That(exists, Is.EqualTo(1UL));
     }
 }

--- a/ClickHouse.Driver.Tests/ADO/SessionConnectionTest.cs
+++ b/ClickHouse.Driver.Tests/ADO/SessionConnectionTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Data.Common;
 using System.Net;
 using System.Net.Http;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using ClickHouse.Driver.ADO;
 using ClickHouse.Driver.Utility;
@@ -35,26 +36,36 @@ public class SessionConnectionTest
         return new ClickHouseConnection(settings);
     }
 
+    /// <summary>
+    /// Builds a unique name for a temporary table. Temporary tables live outside any database, so the
+    /// name has to stay unqualified, and they disappear with their session, so they need no cleanup.
+    /// </summary>
+    private static string CreateTempTableName([CallerMemberName] string testName = null) =>
+        TestUtilities.CreateTableName(database: null, testName: testName);
+
     [Test]
     public async Task TempTableShouldBeCreatedSuccessfullyIfUseSessionEnabled()
     {
+        var table = CreateTempTableName();
         using var connection = CreateConnection(true);
-        await connection.ExecuteStatementAsync("CREATE TEMPORARY TABLE test_temp_table (value UInt8)");
-        await connection.ExecuteScalarAsync("SELECT COUNT(*) from test_temp_table");
+        await connection.ExecuteStatementAsync($"CREATE TEMPORARY TABLE {table} (value UInt8)");
+        await connection.ExecuteScalarAsync($"SELECT COUNT(*) from {table}");
     }
 
     [Test]
     public async Task TempTableShouldBeCreatedSuccessfullyIfSessionIdPassed()
     {
+        var table = CreateTempTableName();
         var sessionId = "TEST-" + Guid.NewGuid().ToString();
         using var connection = CreateConnection(true, sessionId);
-        await connection.ExecuteStatementAsync("CREATE TEMPORARY TABLE test_temp_table (value UInt8)");
-        await connection.ExecuteScalarAsync("SELECT COUNT(*) from test_temp_table");
+        await connection.ExecuteStatementAsync($"CREATE TEMPORARY TABLE {table} (value UInt8)");
+        await connection.ExecuteScalarAsync($"SELECT COUNT(*) from {table}");
     }
     
     [Test]
     public async Task QueryWithTempTable_SessionIdSetInClickHouseClientSettings_TableShouldBeCreatedSuccessfully()
     {
+        var table = CreateTempTableName();
         var sessionId = "TEST-" + Guid.NewGuid().ToString();
         var builder = TestUtilities.GetConnectionStringBuilder();
         var settings = new ClickHouseClientSettings(builder)
@@ -64,18 +75,19 @@ public class SessionConnectionTest
         };
 
         var connection = new ClickHouseConnection(settings);
-        await connection.ExecuteStatementAsync("CREATE TEMPORARY TABLE test_temp_table (value UInt8)");
-        await connection.ExecuteScalarAsync("SELECT COUNT(*) from test_temp_table");
+        await connection.ExecuteStatementAsync($"CREATE TEMPORARY TABLE {table} (value UInt8)");
+        await connection.ExecuteScalarAsync($"SELECT COUNT(*) from {table}");
     }
 
     [Test]
     public async Task TempTableShouldFailIfSessionDisabled()
     {
+        var table = CreateTempTableName();
         using var connection = CreateConnection(false);
         try
         {
-            await connection.ExecuteStatementAsync("CREATE TEMPORARY TABLE test_temp_table (value UInt8)");
-            await connection.ExecuteScalarAsync("SELECT COUNT(*) from test_temp_table");
+            await connection.ExecuteStatementAsync($"CREATE TEMPORARY TABLE {table} (value UInt8)");
+            await connection.ExecuteScalarAsync($"SELECT COUNT(*) from {table}");
             Assert.Fail("ClickHouse should not be able to use temp table if session is disabled");
         }
         catch (ClickHouseServerException e) when (e.ErrorCode == 60) // Error 60 means the table does not exist
@@ -86,11 +98,12 @@ public class SessionConnectionTest
     [Test]
     public async Task TempTableShouldFailIfSessionDisabledAndSessionIdPassed()
     {
+        var table = CreateTempTableName();
         using var connection = CreateConnection(false, "ASD");
         try
         {
-            await connection.ExecuteStatementAsync("CREATE TEMPORARY TABLE test_temp_table (value UInt8)");
-            await connection.ExecuteScalarAsync("SELECT COUNT(*) from test_temp_table");
+            await connection.ExecuteStatementAsync($"CREATE TEMPORARY TABLE {table} (value UInt8)");
+            await connection.ExecuteScalarAsync($"SELECT COUNT(*) from {table}");
             Assert.Fail("ClickHouse should not be able to use temp table if session is disabled");
         }
         catch (ClickHouseServerException e) when (e.ErrorCode == 60) // Error 60 means the table does not exist
@@ -101,6 +114,7 @@ public class SessionConnectionTest
     [Test]
     public async Task Session_WithCustomHttpClient_ShouldWork()
     {
+        var table = CreateTempTableName();
         var sessionId = "TEST-" + Guid.NewGuid().ToString();
         var handler = new HttpClientHandler
         {
@@ -110,7 +124,7 @@ public class SessionConnectionTest
         using var httpClient = new HttpClient(handler);
 
         using var connection = CreateConnectionWithHttpClient(httpClient, useSession: true, sessionId);
-        await connection.ExecuteStatementAsync("CREATE TEMPORARY TABLE test_temp_table (value UInt8)");
-        await connection.ExecuteScalarAsync("SELECT COUNT(*) from test_temp_table");
+        await connection.ExecuteStatementAsync($"CREATE TEMPORARY TABLE {table} (value UInt8)");
+        await connection.ExecuteScalarAsync($"SELECT COUNT(*) from {table}");
     }
 }

--- a/ClickHouse.Driver.Tests/AbstractConnectionTestFixture.cs
+++ b/ClickHouse.Driver.Tests/AbstractConnectionTestFixture.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using System.Text;
+using System;
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
 using ClickHouse.Driver.ADO;
-using NUnit.Framework;
 
 namespace ClickHouse.Driver.Tests;
 
@@ -11,27 +11,65 @@ public abstract class AbstractConnectionTestFixture : IDisposable
     protected readonly ClickHouseConnection connection;
     protected readonly ClickHouseClient client;
 
+    private readonly ConcurrentQueue<string> createdTables = new();
+    private bool disposed;
+
     protected AbstractConnectionTestFixture()
     {
         client = TestUtilities.GetTestClickHouseClient();
         connection = client.CreateConnection();
     }
 
-    protected static string SanitizeTableName(string input)
-    {
-        var builder = new StringBuilder();
-        foreach (var c in input)
-        {
-            if (char.IsLetterOrDigit(c) || c == '_')
-                builder.Append(c);
-        }
+    protected static string SanitizeTableName(string input) => TestUtilities.SanitizeTableName(input);
 
-        return builder.ToString();
+    /// <summary>
+    /// Builds a unique, database-qualified table name and registers it to be dropped when this
+    /// fixture tears down. See <see cref="TestUtilities.CreateTableName"/> for the naming scheme.
+    /// </summary>
+    /// <param name="prefix">
+    /// Readable part of the name; defaults to the calling test's name. Sanitized, so interpolating
+    /// test-case values into it is safe.
+    /// </param>
+    /// <param name="database">
+    /// Database to qualify the name with, <see cref="TestUtilities.TestDatabase"/> by default. Pass
+    /// <c>null</c> for an unqualified name.
+    /// </param>
+    /// <param name="testName">Do not pass explicitly; filled in by the compiler.</param>
+    protected string CreateTableName(string prefix = null, string database = TestUtilities.TestDatabase, [CallerMemberName] string testName = null)
+    {
+        var name = TestUtilities.CreateTableName(prefix, database, testName);
+        createdTables.Enqueue(name);
+        return name;
+    }
+
+    /// <summary>
+    /// Drops every table handed out by <see cref="CreateTableName"/>. Best-effort: a table that
+    /// cannot be dropped must not fail an otherwise passing fixture.
+    /// </summary>
+    private void DropCreatedTables()
+    {
+        while (createdTables.TryDequeue(out var table))
+        {
+            try
+            {
+                client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS {table}").GetAwaiter().GetResult();
+            }
+            catch (Exception e)
+            {
+                TestContext.Progress.WriteLine($"Failed to drop test table {table}: {e.Message}");
+            }
+        }
     }
 
     [OneTimeTearDown]
     public void Dispose()
     {
+        // NUnit both invokes [OneTimeTearDown] and disposes the fixture instance, so this can run twice.
+        if (disposed)
+            return;
+        disposed = true;
+
+        DropCreatedTables();
         connection?.Dispose();
         client?.Dispose();
     }

--- a/ClickHouse.Driver.Tests/BulkCopy/BulkCopyTests.cs
+++ b/ClickHouse.Driver.Tests/BulkCopy/BulkCopyTests.cs
@@ -82,10 +82,9 @@ public class BulkCopyTests : AbstractConnectionTestFixture
     [TestCaseSource(typeof(BulkCopyTests), nameof(GetInsertSingleValueTestCases))]
     public async Task ShouldExecuteSingleValueInsertViaBulkCopy(string clickHouseType, object insertedValue)
     {
-        var targetTable = "test." + SanitizeTableName($"bulk_single_{clickHouseType}");
+        var targetTable = CreateTableName($"bulk_single_{clickHouseType}");
 
-        await connection.ExecuteStatementAsync($"TRUNCATE TABLE IF EXISTS {targetTable}");
-        await connection.ExecuteStatementAsync($"CREATE TABLE IF NOT EXISTS {targetTable} (value {clickHouseType}) ENGINE Memory");
+        await connection.ExecuteStatementAsync($"CREATE TABLE {targetTable} (value {clickHouseType}) ENGINE Memory");
 
         var batchSentInvocationCount = 0L;
 
@@ -116,10 +115,9 @@ public class BulkCopyTests : AbstractConnectionTestFixture
     [RequiredFeature(Feature.Date32)]
     public async Task ShouldInsertDateOnly()
     {
-        var targetTable = "test.bulk_dateonly";
+        var targetTable = CreateTableName();
 
-        await connection.ExecuteStatementAsync($"TRUNCATE TABLE IF EXISTS {targetTable}");
-        await connection.ExecuteStatementAsync($"CREATE TABLE IF NOT EXISTS {targetTable} (value Date32) ENGINE Memory");
+        await connection.ExecuteStatementAsync($"CREATE TABLE {targetTable} (value Date32) ENGINE Memory");
 
         using var bulkCopy = new ClickHouseBulkCopy(connection)
         {
@@ -144,10 +142,9 @@ public class BulkCopyTests : AbstractConnectionTestFixture
     [TestCaseSource(typeof(BulkCopyTests), nameof(GetStringInsertTestCases))]
     public async Task ShouldInsertStringOrFixedString(string columnType, string tableSuffix, object input, byte[] testData)
     {
-        var targetTable = $"test.bulk_{tableSuffix}";
+        var targetTable = CreateTableName($"bulk_{tableSuffix}");
 
-        await connection.ExecuteStatementAsync($"TRUNCATE TABLE IF EXISTS {targetTable}");
-        await connection.ExecuteStatementAsync($"CREATE TABLE IF NOT EXISTS {targetTable} (value {columnType}) ENGINE Memory");
+        await connection.ExecuteStatementAsync($"CREATE TABLE {targetTable} (value {columnType}) ENGINE Memory");
 
         using var bulkCopy = new ClickHouseBulkCopy(connection) { DestinationTableName = targetTable };
         await bulkCopy.WriteToServerAsync(Enumerable.Repeat(new object[] { input }, 1));
@@ -163,11 +160,10 @@ public class BulkCopyTests : AbstractConnectionTestFixture
     [Test]
     public async Task WriteToServerAsync_FixedStringWithNonSeekableStreamTooLong_ThrowsArgumentException()
     {
-        var targetTable = "test.bulk_fixedstring_stream_too_long";
+        var targetTable = CreateTableName();
         var tooLongData = new byte[] { 1, 2, 3, 4, 5, 6 }; // 6 bytes for FixedString(4)
 
-        await connection.ExecuteStatementAsync($"TRUNCATE TABLE IF EXISTS {targetTable}");
-        await connection.ExecuteStatementAsync($"CREATE TABLE IF NOT EXISTS {targetTable} (fs FixedString(4), num Int32) ENGINE Memory");
+        await connection.ExecuteStatementAsync($"CREATE TABLE {targetTable} (fs FixedString(4), num Int32) ENGINE Memory");
 
         // Compress data, then decompress via GZipStream (which is non-seekable)
         using var compressedStream = new MemoryStream();
@@ -190,11 +186,10 @@ public class BulkCopyTests : AbstractConnectionTestFixture
     [Test]
     public async Task WriteToServerAsync_FixedStringWithSeekableStreamTooLong_ThrowsArgumentException()
     {
-        var targetTable = "test.bulk_fixedstring_seekable_stream_too_long";
+        var targetTable = CreateTableName();
         var tooLongData = new byte[] { 1, 2, 3, 4, 5, 6 }; // 6 bytes for FixedString(4)
 
-        await connection.ExecuteStatementAsync($"TRUNCATE TABLE IF EXISTS {targetTable}");
-        await connection.ExecuteStatementAsync($"CREATE TABLE IF NOT EXISTS {targetTable} (fs FixedString(4), num Int32) ENGINE Memory");
+        await connection.ExecuteStatementAsync($"CREATE TABLE {targetTable} (fs FixedString(4), num Int32) ENGINE Memory");
 
         using var bulkCopy = new ClickHouseBulkCopy(connection) { DestinationTableName = targetTable };
 
@@ -209,11 +204,10 @@ public class BulkCopyTests : AbstractConnectionTestFixture
     [Test]
     public async Task WriteToServerAsync_FixedStringWithReadOnlyMemoryTooLong_ThrowsArgumentException()
     {
-        var targetTable = "test.bulk_fixedstring_memory_too_long";
+        var targetTable = CreateTableName();
         var tooLongData = new byte[] { 1, 2, 3, 4, 5, 6 }; // 6 bytes for FixedString(4)
 
-        await connection.ExecuteStatementAsync($"TRUNCATE TABLE IF EXISTS {targetTable}");
-        await connection.ExecuteStatementAsync($"CREATE TABLE IF NOT EXISTS {targetTable} (fs FixedString(4), num Int32) ENGINE Memory");
+        await connection.ExecuteStatementAsync($"CREATE TABLE {targetTable} (fs FixedString(4), num Int32) ENGINE Memory");
 
         using var bulkCopy = new ClickHouseBulkCopy(connection) { DestinationTableName = targetTable };
 
@@ -230,9 +224,8 @@ public class BulkCopyTests : AbstractConnectionTestFixture
         // Bytes that are invalid UTF-8 sequences
         var invalidUtf8 = new byte[] { 0xFF, 0xFE, 0x00, 0x01 };
 
-        var targetTable = "test.bulk_string_invalid_utf8";
-        await connection.ExecuteStatementAsync($"TRUNCATE TABLE IF EXISTS {targetTable}");
-        await connection.ExecuteStatementAsync($"CREATE TABLE IF NOT EXISTS {targetTable} (value String) ENGINE Memory");
+        var targetTable = CreateTableName();
+        await connection.ExecuteStatementAsync($"CREATE TABLE {targetTable} (value String) ENGINE Memory");
 
         // Insert using byte[]
         using var bulkCopy = new ClickHouseBulkCopy(connection) { DestinationTableName = targetTable };
@@ -255,9 +248,8 @@ public class BulkCopyTests : AbstractConnectionTestFixture
     [Test]
     public async Task ShouldReadStringAsStringByDefault()
     {
-        var targetTable = "test.bulk_string_default_read";
-        await connection.ExecuteStatementAsync($"TRUNCATE TABLE IF EXISTS {targetTable}");
-        await connection.ExecuteStatementAsync($"CREATE TABLE IF NOT EXISTS {targetTable} (value String) ENGINE Memory");
+        var targetTable = CreateTableName();
+        await connection.ExecuteStatementAsync($"CREATE TABLE {targetTable} (value String) ENGINE Memory");
 
         using var bulkCopy = new ClickHouseBulkCopy(connection) { DestinationTableName = targetTable };
         await bulkCopy.WriteToServerAsync(Enumerable.Repeat(new object[] { "hello" }, 1));
@@ -277,10 +269,9 @@ public class BulkCopyTests : AbstractConnectionTestFixture
         var sw = new Stopwatch();
         var duration = TimeSpan.FromMinutes(5);
 
-        var targetTable = "test." + SanitizeTableName($"bulk_load_test");
+        var targetTable = CreateTableName();
 
-        await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {targetTable}");
-        await connection.ExecuteStatementAsync($"CREATE TABLE IF NOT EXISTS {targetTable} (int Int32, str String, dt DateTime) ENGINE Null");
+        await connection.ExecuteStatementAsync($"CREATE TABLE {targetTable} (int Int32, str String, dt DateTime) ENGINE Null");
 
         var cb = TestUtilities.GetConnectionStringBuilder();
         cb.UseSession = false;
@@ -312,10 +303,9 @@ public class BulkCopyTests : AbstractConnectionTestFixture
     [Test]
     public async Task ShouldExecuteInsertWithLessColumns()
     {
-        var targetTable = $"test.multiple_columns";
+        var targetTable = CreateTableName();
 
-        await connection.ExecuteStatementAsync($"TRUNCATE TABLE IF EXISTS {targetTable}");
-        await connection.ExecuteStatementAsync($"CREATE TABLE IF NOT EXISTS {targetTable} (value1 Nullable(UInt8), value2 Nullable(Float32), value3 Nullable(Int8)) ENGINE Memory");
+        await connection.ExecuteStatementAsync($"CREATE TABLE {targetTable} (value1 Nullable(UInt8), value2 Nullable(Float32), value3 Nullable(Int8)) ENGINE Memory");
 
         using var bulkCopy = new ClickHouseBulkCopy(connection)
         {
@@ -330,10 +320,9 @@ public class BulkCopyTests : AbstractConnectionTestFixture
     [Test]
     public async Task ShouldExecuteInsertWithBacktickedColumns()
     {
-        var targetTable = $"test.backticked_columns";
+        var targetTable = CreateTableName();
 
-        await connection.ExecuteStatementAsync($"TRUNCATE TABLE IF EXISTS {targetTable}");
-        await connection.ExecuteStatementAsync($"CREATE TABLE IF NOT EXISTS {targetTable} (`field.id` Nullable(UInt8), `@value` Nullable(UInt8)) ENGINE Memory");
+        await connection.ExecuteStatementAsync($"CREATE TABLE {targetTable} (`field.id` Nullable(UInt8), `@value` Nullable(UInt8)) ENGINE Memory");
 
         using var bulkCopy = new ClickHouseBulkCopy(connection)
         {
@@ -348,10 +337,9 @@ public class BulkCopyTests : AbstractConnectionTestFixture
     [Test]
     public async Task ShouldDetectColumnsAutomaticallyOnInit()
     {
-        var targetTable = $"test.auto_detect_columns";
+        var targetTable = CreateTableName();
 
-        await connection.ExecuteStatementAsync($"TRUNCATE TABLE IF EXISTS {targetTable}");
-        await connection.ExecuteStatementAsync($"CREATE TABLE IF NOT EXISTS {targetTable} (field1 UInt8, field2 Int8, field3 String) ENGINE Memory");
+        await connection.ExecuteStatementAsync($"CREATE TABLE {targetTable} (field1 UInt8, field2 Int8, field3 String) ENGINE Memory");
 
         using var bulkCopy = new ClickHouseBulkCopy(connection)
         {
@@ -379,10 +367,9 @@ public class BulkCopyTests : AbstractConnectionTestFixture
     [TestCase("with!exclamation")]
     public async Task ShouldExecuteBulkInsertWithComplexColumnName(string columnName)
     {
-        var targetTable = "test." + SanitizeTableName($"bulk_complex_{columnName}");
+        var targetTable = CreateTableName($"bulk_complex_{columnName}");
 
-        await connection.ExecuteStatementAsync($"TRUNCATE TABLE IF EXISTS {targetTable}");
-        await connection.ExecuteStatementAsync($"CREATE TABLE IF NOT EXISTS {targetTable} (`{columnName.Replace("`", "\\`")}` Int32) ENGINE Memory");
+        await connection.ExecuteStatementAsync($"CREATE TABLE {targetTable} (`{columnName.Replace("`", "\\`")}` Int32) ENGINE Memory");
 
         using var bulkCopy = new ClickHouseBulkCopy(connection)
         {
@@ -399,11 +386,11 @@ public class BulkCopyTests : AbstractConnectionTestFixture
     [Test]
     public async Task ShouldInsertIntoTableWithLotsOfColumns()
     {
-        var tableName = "test.bulk_long_columns";
+        var tableName = CreateTableName();
         var columnCount = 3900;
 
         //Generating create tbl statement with a lot of columns 
-        var query = $"CREATE TABLE IF NOT EXISTS {tableName}(\n";
+        var query = $"CREATE TABLE {tableName}(\n";
         var columns = Enumerable.Range(1, columnCount)
             .Select(x => $" some_loooooooooooooonnnnnnnnnnnngggggggg_column_name_{x} Int32");
         query += string.Join(",\n", columns);
@@ -421,10 +408,9 @@ public class BulkCopyTests : AbstractConnectionTestFixture
     [Test]
     public async Task ShouldThrowSpecialExceptionOnSerializationFailure()
     {
-        var targetTable = "test." + SanitizeTableName($"bulk_exception_uint8");
+        var targetTable = CreateTableName();
 
-        await connection.ExecuteStatementAsync($"TRUNCATE TABLE IF EXISTS {targetTable}");
-        await connection.ExecuteStatementAsync($"CREATE TABLE IF NOT EXISTS {targetTable} (value UInt8) ENGINE Memory");
+        await connection.ExecuteStatementAsync($"CREATE TABLE {targetTable} (value UInt8) ENGINE Memory");
 
         var rows = Enumerable.Range(250, 10).Select(n => new object[] { n }).ToArray();
 
@@ -444,10 +430,9 @@ public class BulkCopyTests : AbstractConnectionTestFixture
     [Test]
     public async Task ShouldExecuteBulkInsertIntoSimpleAggregatedFunctionColumn()
     {
-        var targetTable = "test." + SanitizeTableName($"bulk_simple_aggregated_function");
+        var targetTable = CreateTableName();
 
-        await connection.ExecuteStatementAsync($"TRUNCATE TABLE IF EXISTS {targetTable}");
-        await connection.ExecuteStatementAsync($"CREATE TABLE IF NOT EXISTS {targetTable} (value SimpleAggregateFunction(anyLast,Nullable(Float64))) ENGINE Memory");
+        await connection.ExecuteStatementAsync($"CREATE TABLE {targetTable} (value SimpleAggregateFunction(anyLast,Nullable(Float64))) ENGINE Memory");
 
         using var bulkCopy = new ClickHouseBulkCopy(connection)
         {
@@ -470,10 +455,9 @@ public class BulkCopyTests : AbstractConnectionTestFixture
     [Test]
     public async Task ShouldNotLoseRowsOnMultipleBatches()
     {
-        var targetTable = "test.bulk_multiple_batches"; ;
+        var targetTable = CreateTableName();
 
-        await connection.ExecuteStatementAsync($"TRUNCATE TABLE IF EXISTS {targetTable}");
-        await connection.ExecuteStatementAsync($"CREATE TABLE IF NOT EXISTS {targetTable} (value Int32) ENGINE Memory");
+        await connection.ExecuteStatementAsync($"CREATE TABLE {targetTable} (value Int32) ENGINE Memory");
 
         using var bulkCopy = new ClickHouseBulkCopy(connection)
         {
@@ -497,10 +481,9 @@ public class BulkCopyTests : AbstractConnectionTestFixture
     [Test]
     public async Task ShouldExecuteWithDBNullArrays()
     {
-        var targetTable = $"test.bulk_dbnull_array";
+        var targetTable = CreateTableName();
 
-        await connection.ExecuteStatementAsync($"TRUNCATE TABLE IF EXISTS {targetTable}");
-        await connection.ExecuteStatementAsync($"CREATE TABLE IF NOT EXISTS {targetTable} (stringValue Array(String), intValue Array(Int32)) ENGINE Memory");
+        await connection.ExecuteStatementAsync($"CREATE TABLE {targetTable} (stringValue Array(String), intValue Array(Int32)) ENGINE Memory");
 
         using var bulkCopy = new ClickHouseBulkCopy(connection)
         {
@@ -519,8 +502,7 @@ public class BulkCopyTests : AbstractConnectionTestFixture
     [Test]
     public async Task ShouldBulkInsertJaggedArrayColumn()
     {
-        var targetTable = "test.bulk_jagged_array";
-        await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {targetTable}");
+        var targetTable = CreateTableName();
         await connection.ExecuteStatementAsync($"CREATE TABLE {targetTable} (id Int32, arr Array(Array(Int32))) ENGINE Memory");
 
         using var bulkCopy = new ClickHouseBulkCopy(connection)
@@ -550,8 +532,7 @@ public class BulkCopyTests : AbstractConnectionTestFixture
     [Test]
     public async Task ShouldBulkInsertMultidimArrayColumn()
     {
-        var targetTable = "test.bulk_multidim_array";
-        await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {targetTable}");
+        var targetTable = CreateTableName();
         await connection.ExecuteStatementAsync($"CREATE TABLE {targetTable} (id Int32, arr Array(Array(UInt8))) ENGINE Memory");
 
         using var bulkCopy = new ClickHouseBulkCopy(connection)
@@ -577,8 +558,7 @@ public class BulkCopyTests : AbstractConnectionTestFixture
     [Test]
     public async Task ShouldBulkInsertMultidim3DArrayColumn()
     {
-        var targetTable = "test.bulk_multidim_3d_array";
-        await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {targetTable}");
+        var targetTable = CreateTableName();
         await connection.ExecuteStatementAsync($"CREATE TABLE {targetTable} (id Int32, arr Array(Array(Array(Int32)))) ENGINE Memory");
 
         using var bulkCopy = new ClickHouseBulkCopy(connection)
@@ -609,10 +589,9 @@ public class BulkCopyTests : AbstractConnectionTestFixture
     [Test]
     public async Task ShouldInsertNestedTable()
     {
-        var targetTable = "test.bulk_nested";
+        var targetTable = CreateTableName();
 
-        await connection.ExecuteStatementAsync($"TRUNCATE TABLE IF EXISTS {targetTable}");
-        await connection.ExecuteStatementAsync($"CREATE TABLE IF NOT EXISTS {targetTable} (`_id` UUID, `Comments` Nested(Id Nullable(String), Comment Nullable(String))) ENGINE Memory");
+        await connection.ExecuteStatementAsync($"CREATE TABLE {targetTable} (`_id` UUID, `Comments` Nested(Id Nullable(String), Comment Nullable(String))) ENGINE Memory");
 
         using var bulkCopy = new ClickHouseBulkCopy(connection)
         {
@@ -632,10 +611,9 @@ public class BulkCopyTests : AbstractConnectionTestFixture
     [Test]
     public async Task ShouldInsertDoubleNestedTable()
     {
-        var targetTable = "test.bulk_double_nested";
+        var targetTable = CreateTableName();
 
-        await connection.ExecuteStatementAsync($"TRUNCATE TABLE IF EXISTS {targetTable}");
-        await connection.ExecuteStatementAsync($"CREATE TABLE IF NOT EXISTS {targetTable} (Id Int64, Threads Nested(Id Int64, Comments Nested(Id Int64, Text String))) ENGINE Memory");
+        await connection.ExecuteStatementAsync($"CREATE TABLE {targetTable} (Id Int64, Threads Nested(Id Int64, Comments Nested(Id Int64, Text String))) ENGINE Memory");
 
         using var bulkCopy = new ClickHouseBulkCopy(connection)
         {
@@ -676,14 +654,12 @@ public class BulkCopyTests : AbstractConnectionTestFixture
         const int setSize = 3000000;
         int dbNullIndex = (int)(setSize * fraction);
 
-        var targetTable = "test." + SanitizeTableName($"bulk_million_inserts");
-
+        var targetTable = CreateTableName();
 
         var data = Enumerable.Repeat(new object[] { 1 }, setSize).ToArray();
         data[dbNullIndex][0] = DBNull.Value;
 
-        //await connection.ExecuteStatementAsync($"TRUNCATE TABLE IF EXISTS {targetTable}");
-        await connection.ExecuteStatementAsync($"CREATE TABLE IF NOT EXISTS {targetTable} (value Int16) ENGINE Null");
+        await connection.ExecuteStatementAsync($"CREATE TABLE {targetTable} (value Int16) ENGINE Null");
 
         using var bulkCopy = new ClickHouseBulkCopy(connection)
         {
@@ -698,10 +674,9 @@ public class BulkCopyTests : AbstractConnectionTestFixture
     [Test]
     public async Task ShouldNotAffectSharedArrayPool()
     {
-        var targetTable = "test." + SanitizeTableName($"array_pool");
+        var targetTable = CreateTableName();
 
-        await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {targetTable}");
-        await connection.ExecuteStatementAsync($"CREATE TABLE IF NOT EXISTS {targetTable} (int Int32, str String, dt DateTime) ENGINE Null");
+        await connection.ExecuteStatementAsync($"CREATE TABLE {targetTable} (int Int32, str String, dt DateTime) ENGINE Null");
 
         const int poolSize = 8;
         using var bulkCopy = new ClickHouseBulkCopy(connection)
@@ -721,9 +696,8 @@ public class BulkCopyTests : AbstractConnectionTestFixture
     [RequiredFeature(Feature.Json)]
     public async Task ShouldInsertJson()
     {
-        var targetTable = "test." + SanitizeTableName($"bulk_json");
-        await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {targetTable}");
-        await connection.ExecuteStatementAsync($"CREATE TABLE IF NOT EXISTS {targetTable} (value JSON) ENGINE Memory");
+        var targetTable = CreateTableName();
+        await connection.ExecuteStatementAsync($"CREATE TABLE {targetTable} (value JSON) ENGINE Memory");
 
         using var jsonConnection = TestUtilities.GetTestClickHouseConnection(jsonWriteMode: JsonWriteMode.String);
         using var bulkCopy = new ClickHouseBulkCopy(jsonConnection)
@@ -747,9 +721,8 @@ public class BulkCopyTests : AbstractConnectionTestFixture
     [RequiredFeature(Feature.Json)]
     public async Task ShouldInsertJsonWithComplexTypes()
     {
-        var targetTable = "test." + SanitizeTableName($"bulk_json_complex");
-        await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {targetTable}");
-        await connection.ExecuteStatementAsync($"CREATE TABLE IF NOT EXISTS {targetTable} (value JSON) ENGINE Memory");
+        var targetTable = CreateTableName();
+        await connection.ExecuteStatementAsync($"CREATE TABLE {targetTable} (value JSON) ENGINE Memory");
 
         using var jsonConnection = TestUtilities.GetTestClickHouseConnection(jsonWriteMode: JsonWriteMode.String);
         using var bulkCopy = new ClickHouseBulkCopy(jsonConnection)
@@ -795,9 +768,8 @@ public class BulkCopyTests : AbstractConnectionTestFixture
     [RequiredFeature(Feature.Json)]
     public async Task ShouldInsertJsonFromString()
     {
-        var targetTable = "test." + SanitizeTableName($"bulk_json_string");
-        await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {targetTable}");
-        await connection.ExecuteStatementAsync($"CREATE TABLE IF NOT EXISTS {targetTable} (value JSON) ENGINE Memory");
+        var targetTable = CreateTableName();
+        await connection.ExecuteStatementAsync($"CREATE TABLE {targetTable} (value JSON) ENGINE Memory");
 
         using var jsonConnection = TestUtilities.GetTestClickHouseConnection(jsonWriteMode: JsonWriteMode.String);
         using var bulkCopy = new ClickHouseBulkCopy(jsonConnection)
@@ -826,9 +798,8 @@ public class BulkCopyTests : AbstractConnectionTestFixture
     public async Task ShouldInsertJsonFromAnonymousObject_BinaryMode()
     {
         using var binaryClient = TestUtilities.GetTestClickHouseClient(jsonWriteMode: JsonWriteMode.Binary, jsonReadMode: JsonReadMode.Binary);
-        var targetTable = "test." + SanitizeTableName($"bulk_json_anon");
-        await binaryClient.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS {targetTable}");
-        await binaryClient.ExecuteNonQueryAsync($"CREATE TABLE IF NOT EXISTS {targetTable} (value JSON) ENGINE Memory");
+        var targetTable = CreateTableName();
+        await binaryClient.ExecuteNonQueryAsync($"CREATE TABLE {targetTable} (value JSON) ENGINE Memory");
 
         using var bulkCopy = new ClickHouseBulkCopy(binaryClient.CreateConnection())
         {
@@ -857,9 +828,8 @@ public class BulkCopyTests : AbstractConnectionTestFixture
     [RequiredFeature(Feature.Json)]
     public async Task ShouldInsertJsonFromAnonymousObject_StringMode()
     {
-        var targetTable = "test." + SanitizeTableName($"bulk_json_anon");
-        await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {targetTable}");
-        await connection.ExecuteStatementAsync($"CREATE TABLE IF NOT EXISTS {targetTable} (value JSON) ENGINE Memory");
+        var targetTable = CreateTableName();
+        await connection.ExecuteStatementAsync($"CREATE TABLE {targetTable} (value JSON) ENGINE Memory");
 
         using var bulkCopy = new ClickHouseBulkCopy(connection)
         {
@@ -887,11 +857,10 @@ public class BulkCopyTests : AbstractConnectionTestFixture
     public async Task ShouldInsertTupleWithEnum()
     {
         // Reproduces issue https://github.com/DarkWanderer/ClickHouse.Client/issues/538: Enum inside named tuple field causes exception
-        var targetTable = "test." + SanitizeTableName($"bulk_tuple_with_enum");
-        
-        await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {targetTable}");
+        var targetTable = CreateTableName();
+
         await connection.ExecuteStatementAsync($@"
-            CREATE TABLE IF NOT EXISTS {targetTable} 
+            CREATE TABLE {targetTable} 
             (
                 id Int32,
                 data Tuple(name String, status Enum8('Active' = 0, 'Inactive' = 1))
@@ -941,10 +910,9 @@ public class BulkCopyTests : AbstractConnectionTestFixture
     [RequiredFeature(Feature.QBit)]
     public async Task ShouldInsertQBitFloat32()
     {
-        var targetTable = "test." + SanitizeTableName("bulk_qbit_float32");
+        var targetTable = CreateTableName();
 
-        await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {targetTable}");
-        await connection.ExecuteStatementAsync($"CREATE TABLE IF NOT EXISTS {targetTable} (vec QBit(Float32, 9)) ENGINE Memory");
+        await connection.ExecuteStatementAsync($"CREATE TABLE {targetTable} (vec QBit(Float32, 9)) ENGINE Memory");
 
         using var bulkCopy = new ClickHouseBulkCopy(connection)
         {
@@ -967,10 +935,9 @@ public class BulkCopyTests : AbstractConnectionTestFixture
     [RequiredFeature(Feature.QBit)]
     public async Task ShouldInsertQBitFloat64()
     {
-        var targetTable = "test." + SanitizeTableName("bulk_qbit_float64");
+        var targetTable = CreateTableName();
 
-        await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {targetTable}");
-        await connection.ExecuteStatementAsync($"CREATE TABLE IF NOT EXISTS {targetTable} (vec QBit(Float64, 8)) ENGINE Memory");
+        await connection.ExecuteStatementAsync($"CREATE TABLE {targetTable} (vec QBit(Float64, 8)) ENGINE Memory");
 
         using var bulkCopy = new ClickHouseBulkCopy(connection)
         {
@@ -993,10 +960,9 @@ public class BulkCopyTests : AbstractConnectionTestFixture
     [RequiredFeature(Feature.QBit)]
     public async Task ShouldInsertQBitBFloat16()
     {
-        var targetTable = "test." + SanitizeTableName("bulk_qbit_bfloat16");
+        var targetTable = CreateTableName();
 
-        await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {targetTable}");
-        await connection.ExecuteStatementAsync($"CREATE TABLE IF NOT EXISTS {targetTable} (vec QBit(BFloat16, 6)) ENGINE Memory");
+        await connection.ExecuteStatementAsync($"CREATE TABLE {targetTable} (vec QBit(BFloat16, 6)) ENGINE Memory");
 
         using var bulkCopy = new ClickHouseBulkCopy(connection)
         {
@@ -1023,10 +989,9 @@ public class BulkCopyTests : AbstractConnectionTestFixture
     [Test]
     public async Task WriteToServerAsync_WithoutInitAsync_AutoInitializesSuccessfully()
     {
-        var targetTable = "test." + SanitizeTableName("bulk_auto_init");
+        var targetTable = CreateTableName();
 
-        await connection.ExecuteStatementAsync($"TRUNCATE TABLE IF EXISTS {targetTable}");
-        await connection.ExecuteStatementAsync($"CREATE TABLE IF NOT EXISTS {targetTable} (value Int32) ENGINE Memory");
+        await connection.ExecuteStatementAsync($"CREATE TABLE {targetTable} (value Int32) ENGINE Memory");
 
         using var bulkCopy = new ClickHouseBulkCopy(connection)
         {
@@ -1044,10 +1009,9 @@ public class BulkCopyTests : AbstractConnectionTestFixture
     [Test]
     public async Task WriteToServerAsync_ConcurrentCalls_InitializesOnlyOnce()
     {
-        var targetTable = "test." + SanitizeTableName("bulk_concurrent_init");
+        var targetTable = CreateTableName();
 
-        await connection.ExecuteStatementAsync($"TRUNCATE TABLE IF EXISTS {targetTable}");
-        await connection.ExecuteStatementAsync($"CREATE TABLE IF NOT EXISTS {targetTable} (value Int32) ENGINE Memory");
+        await connection.ExecuteStatementAsync($"CREATE TABLE {targetTable} (value Int32) ENGINE Memory");
 
         using var bulkCopy = new ClickHouseBulkCopy(connection)
         {

--- a/ClickHouse.Driver.Tests/BulkCopy/BulkCopyWithDefaultsTests.cs
+++ b/ClickHouse.Driver.Tests/BulkCopy/BulkCopyWithDefaultsTests.cs
@@ -31,11 +31,10 @@ public class BulkCopyWithDefaultsTests : AbstractConnectionTestFixture
     [TestCaseSource(typeof(BulkCopyWithDefaultsTests), nameof(Get))]
     public async Task ShouldExecuteSingleValueInsertViaBulkCopyWithDefaults(string clickhouseType, object insertValue, object expectedValue, string tableName)
     {
-        var targetTable = "test." + SanitizeTableName($"bulk_single_default_{tableName}");
+        var targetTable = CreateTableName($"bulk_single_default_{tableName}");
 
-        await connection.ExecuteStatementAsync($"TRUNCATE TABLE IF EXISTS {targetTable}");
         await connection.ExecuteStatementAsync(
-            $"CREATE TABLE IF NOT EXISTS {targetTable} (`value` {clickhouseType}) ENGINE Memory");
+            $"CREATE TABLE {targetTable} (`value` {clickhouseType}) ENGINE Memory");
 
         using var bulkCopyWithDefaults = new ClickHouseBulkCopy(connection, RowBinaryFormat.RowBinaryWithDefaults)
         {

--- a/ClickHouse.Driver.Tests/ClickHouseClientQueryOptionsTests.cs
+++ b/ClickHouse.Driver.Tests/ClickHouseClientQueryOptionsTests.cs
@@ -15,14 +15,11 @@ namespace ClickHouse.Driver.Tests;
 [TestFixture]
 public class ClickHouseClientQueryOptionsTests : AbstractConnectionTestFixture
 {
-    private string CreateTestTableName([CallerMemberName] string testName = null)
-        => SanitizeTableName($"test_opts_{testName}_{Guid.NewGuid():N}");
-
     private async Task<string> CreateSimpleTestTableAsync([CallerMemberName] string testName = null)
     {
-        var tableName = $"test.{CreateTestTableName(testName)}";
+        var tableName = CreateTableName(testName);
         await client.ExecuteNonQueryAsync($@"
-            CREATE TABLE IF NOT EXISTS {tableName}
+            CREATE TABLE {tableName}
             (id UInt64, value String)
             ENGINE = MergeTree() ORDER BY id");
         return tableName;
@@ -30,9 +27,9 @@ public class ClickHouseClientQueryOptionsTests : AbstractConnectionTestFixture
 
     private async Task<string> CreateTableWithDefaultsAsync([CallerMemberName] string testName = null)
     {
-        var tableName = $"test.{CreateTestTableName(testName)}";
+        var tableName = CreateTableName(testName);
         await client.ExecuteNonQueryAsync($@"
-            CREATE TABLE IF NOT EXISTS {tableName}
+            CREATE TABLE {tableName}
             (
                 id UInt64,
                 name String,
@@ -130,24 +127,20 @@ public class ClickHouseClientQueryOptionsTests : AbstractConnectionTestFixture
     public async Task ExecuteNonQueryAsync_WithDatabaseOverride_CreatesTableInSpecifiedDatabase()
     {
         await client.ExecuteNonQueryAsync("CREATE DATABASE IF NOT EXISTS test_secondary");
-        var tableName = $"test_table_{Guid.NewGuid():N}"[..30];
 
-        try
-        {
-            var options = new QueryOptions { Database = "test_secondary" };
-            await client.ExecuteNonQueryAsync(
-                $"CREATE TABLE {tableName} (id UInt64) ENGINE = MergeTree() ORDER BY id",
-                options: options);
+        // The query runs against test_secondary, and system.tables stores the unqualified name
+        var qualifiedTableName = CreateTableName(database: "test_secondary");
+        var tableName = TestUtilities.BareTableName(qualifiedTableName);
 
-            // Verify table exists in test_secondary
-            var exists = await client.ExecuteScalarAsync(
-                $"SELECT count() FROM system.tables WHERE database = 'test_secondary' AND name = '{tableName}'");
-            Assert.That(exists, Is.EqualTo(1UL));
-        }
-        finally
-        {
-            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test_secondary.{tableName}");
-        }
+        var options = new QueryOptions { Database = "test_secondary" };
+        await client.ExecuteNonQueryAsync(
+            $"CREATE TABLE {tableName} (id UInt64) ENGINE = MergeTree() ORDER BY id",
+            options: options);
+
+        // Verify table exists in test_secondary
+        var exists = await client.ExecuteScalarAsync(
+            $"SELECT count() FROM system.tables WHERE database = 'test_secondary' AND name = '{tableName}'");
+        Assert.That(exists, Is.EqualTo(1UL));
     }
 
     [Test]
@@ -165,27 +158,23 @@ public class ClickHouseClientQueryOptionsTests : AbstractConnectionTestFixture
     public async Task ExecuteReaderAsync_WithDatabaseOverride_ReturnsDataFromSpecifiedDatabase()
     {
         await client.ExecuteNonQueryAsync("CREATE DATABASE IF NOT EXISTS test_secondary");
-        var tableName = $"test_data_{Guid.NewGuid():N}"[..30];
 
-        try
-        {
-            // Create and populate table in test_secondary
-            await client.ExecuteNonQueryAsync(
-                $"CREATE TABLE test_secondary.{tableName} (id UInt64, value String) ENGINE = MergeTree() ORDER BY id");
-            await client.ExecuteNonQueryAsync(
-                $"INSERT INTO test_secondary.{tableName} VALUES (1, 'from_secondary')");
+        // The SELECT resolves the name against the overridden database, so it has to be unqualified
+        var qualifiedTableName = CreateTableName(database: "test_secondary");
+        var tableName = TestUtilities.BareTableName(qualifiedTableName);
 
-            var options = new QueryOptions { Database = "test_secondary" };
-            using var reader = await client.ExecuteReaderAsync(
-                $"SELECT value FROM {tableName}", options: options);
+        // Create and populate table in test_secondary
+        await client.ExecuteNonQueryAsync(
+            $"CREATE TABLE {qualifiedTableName} (id UInt64, value String) ENGINE = MergeTree() ORDER BY id");
+        await client.ExecuteNonQueryAsync(
+            $"INSERT INTO {qualifiedTableName} VALUES (1, 'from_secondary')");
 
-            Assert.That(reader.Read(), Is.True);
-            Assert.That(reader.GetString(0), Is.EqualTo("from_secondary"));
-        }
-        finally
-        {
-            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test_secondary.{tableName}");
-        }
+        var options = new QueryOptions { Database = "test_secondary" };
+        using var reader = await client.ExecuteReaderAsync(
+            $"SELECT value FROM {tableName}", options: options);
+
+        Assert.That(reader.Read(), Is.True);
+        Assert.That(reader.GetString(0), Is.EqualTo("from_secondary"));
     }
 
     [Test]
@@ -263,7 +252,6 @@ public class ClickHouseClientQueryOptionsTests : AbstractConnectionTestFixture
         }
         finally
         {
-            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS {tableName}");
             await client.ExecuteNonQueryAsync($"DROP USER IF EXISTS {userName}");
             await client.ExecuteNonQueryAsync($"DROP ROLE IF EXISTS {roleName}");
         }
@@ -458,12 +446,16 @@ public class ClickHouseClientQueryOptionsTests : AbstractConnectionTestFixture
             SessionId = sessionId
         };
 
+        // Static helper with database: null — a temporary table cannot be database-qualified, and
+        // registering it for the fixture drop would aim an unqualified DROP at the default database.
+        var tempTable = TestUtilities.CreateTableName(database: null);
+
         await client.ExecuteNonQueryAsync(
-            "CREATE TEMPORARY TABLE temp_test_persist (id UInt8)", options: options);
+            $"CREATE TEMPORARY TABLE {tempTable} (id UInt8)", options: options);
 
         // Should be accessible with same session
         var count = await client.ExecuteScalarAsync(
-            "SELECT count() FROM temp_test_persist", options: options);
+            $"SELECT count() FROM {tempTable}", options: options);
         Assert.That(count, Is.EqualTo(0UL));
     }
 
@@ -472,13 +464,14 @@ public class ClickHouseClientQueryOptionsTests : AbstractConnectionTestFixture
     {
         // First create a temp table with session disabled
         var options = new QueryOptions { UseSession = false };
+        var tempTable = TestUtilities.CreateTableName(database: null);
 
         await client.ExecuteNonQueryAsync(
-            "CREATE TEMPORARY TABLE temp_test_nosession (id UInt8)", options: options);
+            $"CREATE TEMPORARY TABLE {tempTable} (id UInt8)", options: options);
 
         // Without session, temp table not accessible in next query
         var ex = Assert.ThrowsAsync<ClickHouseServerException>(async () =>
-            await client.ExecuteScalarAsync("SELECT count() FROM temp_test_nosession", options: options));
+            await client.ExecuteScalarAsync($"SELECT count() FROM {tempTable}", options: options));
 
         Assert.That(ex!.ErrorCode, Is.EqualTo(60)); // UNKNOWN_TABLE
     }
@@ -693,25 +686,19 @@ public class ClickHouseClientQueryOptionsTests : AbstractConnectionTestFixture
     public async Task InsertBinaryAsync_WithSmallBatchSize_InsertsInMultipleBatches()
     {
         var tableName = await CreateSimpleTestTableAsync();
-        try
-        {
-            var options = new InsertOptions { BatchSize = 10 };
-            var rows = GenerateTestRows(100).ToList();
 
-            await client.InsertBinaryAsync(tableName, new[] { "id", "value" }, rows, options);
+        var options = new InsertOptions { BatchSize = 10 };
+        var rows = GenerateTestRows(100).ToList();
 
-            // All rows should be inserted regardless of batch size
-            var count = await client.ExecuteScalarAsync($"SELECT count() FROM {tableName}");
-            Assert.That(count, Is.EqualTo(100UL));
+        await client.InsertBinaryAsync(tableName, new[] { "id", "value" }, rows, options);
 
-            // Verify data integrity
-            var distinctCount = await client.ExecuteScalarAsync($"SELECT count(DISTINCT id) FROM {tableName}");
-            Assert.That(distinctCount, Is.EqualTo(100UL));
-        }
-        finally
-        {
-            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS {tableName}");
-        }
+        // All rows should be inserted regardless of batch size
+        var count = await client.ExecuteScalarAsync($"SELECT count() FROM {tableName}");
+        Assert.That(count, Is.EqualTo(100UL));
+
+        // Verify data integrity
+        var distinctCount = await client.ExecuteScalarAsync($"SELECT count(DISTINCT id) FROM {tableName}");
+        Assert.That(distinctCount, Is.EqualTo(100UL));
     }
 
     [TestCase(0)]
@@ -744,208 +731,168 @@ public class ClickHouseClientQueryOptionsTests : AbstractConnectionTestFixture
     public async Task InsertBinaryAsync_WithBatchesExceedingParallelism_ReturnsCorrectRowCount()
     {
         var tableName = await CreateSimpleTestTableAsync();
-        try
+
+        var options = new InsertOptions
         {
-            var options = new InsertOptions
-            {
-                BatchSize = 10,
-                MaxDegreeOfParallelism = 2
-            };
-            var rows = GenerateTestRows(50).ToList();
+            BatchSize = 10,
+            MaxDegreeOfParallelism = 2
+        };
+        var rows = GenerateTestRows(50).ToList();
 
-            var inserted = await client.InsertBinaryAsync(
-                tableName, new[] { "id", "value" }, rows, options);
+        var inserted = await client.InsertBinaryAsync(
+            tableName, new[] { "id", "value" }, rows, options);
 
-            // 50 rows in 5 batches with parallelism 2: must return 50, not 20
-            Assert.That(inserted, Is.EqualTo(50));
+        // 50 rows in 5 batches with parallelism 2: must return 50, not 20
+        Assert.That(inserted, Is.EqualTo(50));
 
-            var count = await client.ExecuteScalarAsync($"SELECT count() FROM {tableName}");
-            Assert.That(count, Is.EqualTo(50UL));
-        }
-        finally
-        {
-            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS {tableName}");
-        }
+        var count = await client.ExecuteScalarAsync($"SELECT count() FROM {tableName}");
+        Assert.That(count, Is.EqualTo(50UL));
     }
 
     [Test]
     public async Task InsertBinaryAsync_WithRowBinaryFormat_InsertsSuccessfully()
     {
         var tableName = await CreateSimpleTestTableAsync();
-        try
-        {
-            var options = new InsertOptions { Format = RowBinaryFormat.RowBinary };
-            var rows = GenerateTestRows(50).ToList();
 
-            var inserted = await client.InsertBinaryAsync(
-                tableName, new[] { "id", "value" }, rows, options);
+        var options = new InsertOptions { Format = RowBinaryFormat.RowBinary };
+        var rows = GenerateTestRows(50).ToList();
 
-            Assert.That(inserted, Is.EqualTo(50));
+        var inserted = await client.InsertBinaryAsync(
+            tableName, new[] { "id", "value" }, rows, options);
 
-            var count = await client.ExecuteScalarAsync($"SELECT count() FROM {tableName}");
-            Assert.That(count, Is.EqualTo(50UL));
-        }
-        finally
-        {
-            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS {tableName}");
-        }
+        Assert.That(inserted, Is.EqualTo(50));
+
+        var count = await client.ExecuteScalarAsync($"SELECT count() FROM {tableName}");
+        Assert.That(count, Is.EqualTo(50UL));
     }
 
     [Test]
     public async Task InsertBinaryAsync_WithRowBinaryWithDefaultsFormat_InsertsWithDefaults()
     {
         var tableName = await CreateTableWithDefaultsAsync();
-        try
+
+        var options = new InsertOptions { Format = RowBinaryFormat.RowBinaryWithDefaults };
+        var rows = new List<object[]>
         {
-            var options = new InsertOptions { Format = RowBinaryFormat.RowBinaryWithDefaults };
-            var rows = new List<object[]>
-            {
-                new object[] { 1UL, "Name1", DateTime.UtcNow, 1.5f },
-                new object[] { 2UL, "Name2", DateTime.UtcNow, 2.5f },
-            };
+            new object[] { 1UL, "Name1", DateTime.UtcNow, 1.5f },
+            new object[] { 2UL, "Name2", DateTime.UtcNow, 2.5f },
+        };
 
-            var inserted = await client.InsertBinaryAsync(
-                tableName, new[] { "id", "name", "created_at", "value" }, rows, options);
+        var inserted = await client.InsertBinaryAsync(
+            tableName, new[] { "id", "name", "created_at", "value" }, rows, options);
 
-            Assert.That(inserted, Is.EqualTo(2));
+        Assert.That(inserted, Is.EqualTo(2));
 
-            var count = await client.ExecuteScalarAsync($"SELECT count() FROM {tableName}");
-            Assert.That(count, Is.EqualTo(2UL));
-        }
-        finally
-        {
-            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS {tableName}");
-        }
+        var count = await client.ExecuteScalarAsync($"SELECT count() FROM {tableName}");
+        Assert.That(count, Is.EqualTo(2UL));
     }
 
     [Test]
     public async Task InsertBinaryAsync_WithRowBinaryWithDefaultsFormat_OmittedColumnsUseDefaults()
     {
         var tableName = await CreateTableWithDefaultsAsync();
-        try
+
+        var options = new InsertOptions { Format = RowBinaryFormat.RowBinaryWithDefaults };
+        var rows = new List<object[]>
         {
-            var options = new InsertOptions { Format = RowBinaryFormat.RowBinaryWithDefaults };
-            var rows = new List<object[]>
-            {
-                new object[] { 1UL, "Name1" },
-                new object[] { 2UL, "Name2" },
-            };
+            new object[] { 1UL, "Name1" },
+            new object[] { 2UL, "Name2" },
+        };
 
-            // Insert only id and name columns - created_at and value should use defaults
-            var inserted = await client.InsertBinaryAsync(
-                tableName, new[] { "id", "name" }, rows, options);
+        // Insert only id and name columns - created_at and value should use defaults
+        var inserted = await client.InsertBinaryAsync(
+            tableName, new[] { "id", "name" }, rows, options);
 
-            Assert.That(inserted, Is.EqualTo(2));
+        Assert.That(inserted, Is.EqualTo(2));
 
-            // Verify default values were used
-            using var reader = await client.ExecuteReaderAsync(
-                $"SELECT id, name, value FROM {tableName} ORDER BY id");
+        // Verify default values were used
+        using var reader = await client.ExecuteReaderAsync(
+            $"SELECT id, name, value FROM {tableName} ORDER BY id");
 
-            reader.Read();
-            Assert.That(reader.GetValue(0), Is.EqualTo(1UL));
-            Assert.That(reader.GetString(1), Is.EqualTo("Name1"));
-            Assert.That(reader.GetFloat(2), Is.EqualTo(42.5f)); // Default value
+        reader.Read();
+        Assert.That(reader.GetValue(0), Is.EqualTo(1UL));
+        Assert.That(reader.GetString(1), Is.EqualTo("Name1"));
+        Assert.That(reader.GetFloat(2), Is.EqualTo(42.5f)); // Default value
 
-            reader.Read();
-            Assert.That(reader.GetValue(0), Is.EqualTo(2UL));
-            Assert.That(reader.GetString(1), Is.EqualTo("Name2"));
-            Assert.That(reader.GetFloat(2), Is.EqualTo(42.5f)); // Default value
-        }
-        finally
-        {
-            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS {tableName}");
-        }
+        reader.Read();
+        Assert.That(reader.GetValue(0), Is.EqualTo(2UL));
+        Assert.That(reader.GetString(1), Is.EqualTo("Name2"));
+        Assert.That(reader.GetFloat(2), Is.EqualTo(42.5f)); // Default value
     }
 
     [Test]
     public async Task InsertBinaryAsync_WithDatabaseOverride_InsertsToSpecifiedDatabase()
     {
         await client.ExecuteNonQueryAsync("CREATE DATABASE IF NOT EXISTS test_secondary");
-        var tableName = $"insert_test_{Guid.NewGuid():N}"[..30];
 
-        try
-        {
-            await client.ExecuteNonQueryAsync(
-                $"CREATE TABLE test_secondary.{tableName} (id UInt64, value String) ENGINE = MergeTree() ORDER BY id");
+        // The insert resolves the name against the overridden database, so it has to be unqualified
+        var qualifiedTableName = CreateTableName(database: "test_secondary");
+        var tableName = TestUtilities.BareTableName(qualifiedTableName);
 
-            var options = new InsertOptions { Database = "test_secondary" };
-            var rows = GenerateTestRows(10).ToList();
+        await client.ExecuteNonQueryAsync(
+            $"CREATE TABLE {qualifiedTableName} (id UInt64, value String) ENGINE = MergeTree() ORDER BY id");
 
-            var inserted = await client.InsertBinaryAsync(
-                tableName, new[] { "id", "value" }, rows, options);
+        var options = new InsertOptions { Database = "test_secondary" };
+        var rows = GenerateTestRows(10).ToList();
 
-            Assert.That(inserted, Is.EqualTo(10));
+        var inserted = await client.InsertBinaryAsync(
+            tableName, new[] { "id", "value" }, rows, options);
 
-            var count = await client.ExecuteScalarAsync($"SELECT count() FROM test_secondary.{tableName}");
-            Assert.That(count, Is.EqualTo(10UL));
-        }
-        finally
-        {
-            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test_secondary.{tableName}");
-        }
+        Assert.That(inserted, Is.EqualTo(10));
+
+        var count = await client.ExecuteScalarAsync($"SELECT count() FROM {qualifiedTableName}");
+        Assert.That(count, Is.EqualTo(10UL));
     }
 
     [Test]
     public async Task InsertBinaryAsync_WithQueryId_QueryIdApplied()
     {
         var tableName = await CreateSimpleTestTableAsync();
-        try
-        {
-            var customQueryId = $"insert_qid_{Guid.NewGuid():N}";
-            var options = new InsertOptions { QueryId = customQueryId };
-            var rows = GenerateTestRows(10).ToList();
 
-            await client.InsertBinaryAsync(tableName, new[] { "id", "value" }, rows, options);
+        var customQueryId = $"insert_qid_{Guid.NewGuid():N}";
+        var options = new InsertOptions { QueryId = customQueryId };
+        var rows = GenerateTestRows(10).ToList();
 
-            await client.ExecuteNonQueryAsync("SYSTEM FLUSH LOGS");
+        await client.InsertBinaryAsync(tableName, new[] { "id", "value" }, rows, options);
 
-            var count = await client.ExecuteScalarAsync(
-                $"SELECT count() FROM system.query_log WHERE query_id LIKE '{customQueryId}%'");
-            Assert.That(count, Is.GreaterThan(0UL), "Custom query ID should appear in query_log");
-        }
-        finally
-        {
-            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS {tableName}");
-        }
+        await client.ExecuteNonQueryAsync("SYSTEM FLUSH LOGS");
+
+        var count = await client.ExecuteScalarAsync(
+            $"SELECT count() FROM system.query_log WHERE query_id LIKE '{customQueryId}%'");
+        Assert.That(count, Is.GreaterThan(0UL), "Custom query ID should appear in query_log");
     }
 
     [Test]
     public async Task InsertBinaryAsync_WithQueryId_SchemaProbeAndBatchesHaveUniqueQueryIds()
     {
         var tableName = await CreateSimpleTestTableAsync();
-        try
+
+        var (trackedClient, handler) = CreateClientWithTracking();
+        using (trackedClient)
         {
-            var (trackedClient, handler) = CreateClientWithTracking();
-            using (trackedClient)
+            var customQueryId = $"insert_unique_qid_{Guid.NewGuid():N}";
+            var options = new InsertOptions
             {
-                var customQueryId = $"insert_unique_qid_{Guid.NewGuid():N}";
-                var options = new InsertOptions
-                {
-                    QueryId = customQueryId,
-                    BatchSize = 5,
-                };
-                var rows = GenerateTestRows(15).ToList(); // 3 batches of 5
+                QueryId = customQueryId,
+                BatchSize = 5,
+            };
+            var rows = GenerateTestRows(15).ToList(); // 3 batches of 5
 
-                await trackedClient.InsertBinaryAsync(tableName, new[] { "id", "value" }, rows, options);
+            await trackedClient.InsertBinaryAsync(tableName, new[] { "id", "value" }, rows, options);
 
-                // Extract query_id from all captured requests
-                var queryIds = handler.Requests
-                    .Select(r => HttpUtility.ParseQueryString(r.RequestUri.Query).Get("query_id"))
-                    .Where(id => id != null)
-                    .ToList();
+            // Extract query_id from all captured requests
+            var queryIds = handler.Requests
+                .Select(r => HttpUtility.ParseQueryString(r.RequestUri.Query).Get("query_id"))
+                .Where(id => id != null)
+                .ToList();
 
-                // Should have 4 requests: 1 schema probe + 3 batch inserts
-                Assert.That(queryIds, Has.Count.EqualTo(4),
-                    $"Expected 4 requests (1 schema + 3 batches), got {queryIds.Count}");
+            // Should have 4 requests: 1 schema probe + 3 batch inserts
+            Assert.That(queryIds, Has.Count.EqualTo(4),
+                $"Expected 4 requests (1 schema + 3 batches), got {queryIds.Count}");
 
-                // All query IDs must be unique
-                Assert.That(queryIds, Is.Unique,
-                    "All requests within InsertBinaryAsync must have unique query IDs to avoid QUERY_WITH_SAME_ID_IS_ALREADY_RUNNING");
-            }
-        }
-        finally
-        {
-            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS {tableName}");
+            // All query IDs must be unique
+            Assert.That(queryIds, Is.Unique,
+                "All requests within InsertBinaryAsync must have unique query IDs to avoid QUERY_WITH_SAME_ID_IS_ALREADY_RUNNING");
         }
     }
 
@@ -1019,27 +966,21 @@ public class ClickHouseClientQueryOptionsTests : AbstractConnectionTestFixture
     public async Task InsertBinaryAsync_WithCustomSettings_SettingsApplied()
     {
         var tableName = await CreateSimpleTestTableAsync();
-        try
+
+        var options = new InsertOptions
         {
-            var options = new InsertOptions
+            CustomSettings = new Dictionary<string, object>
             {
-                CustomSettings = new Dictionary<string, object>
-                {
-                    { "insert_quorum", 0 }
-                }
-            };
-            var rows = GenerateTestRows(10).ToList();
+                { "insert_quorum", 0 }
+            }
+        };
+        var rows = GenerateTestRows(10).ToList();
 
-            // Should succeed with the custom setting
-            var inserted = await client.InsertBinaryAsync(
-                tableName, new[] { "id", "value" }, rows, options);
+        // Should succeed with the custom setting
+        var inserted = await client.InsertBinaryAsync(
+            tableName, new[] { "id", "value" }, rows, options);
 
-            Assert.That(inserted, Is.EqualTo(10));
-        }
-        finally
-        {
-            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS {tableName}");
-        }
+        Assert.That(inserted, Is.EqualTo(10));
     }
 
     [Test]
@@ -1080,25 +1021,19 @@ public class ClickHouseClientQueryOptionsTests : AbstractConnectionTestFixture
     public async Task InsertBinaryAsync_WithSessionAndSingleParallelism_Succeeds()
     {
         var tableName = await CreateSimpleTestTableAsync();
-        try
-        {
-            var options = new InsertOptions
-            {
-                UseSession = true,
-                MaxDegreeOfParallelism = 1,
-                BatchSize = 5,
-            };
-            var rows = GenerateTestRows(10).ToList();
 
-            var inserted = await client.InsertBinaryAsync(
-                tableName, new[] { "id", "value" }, rows, options);
-
-            Assert.That(inserted, Is.EqualTo(10));
-        }
-        finally
+        var options = new InsertOptions
         {
-            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS {tableName}");
-        }
+            UseSession = true,
+            MaxDegreeOfParallelism = 1,
+            BatchSize = 5,
+        };
+        var rows = GenerateTestRows(10).ToList();
+
+        var inserted = await client.InsertBinaryAsync(
+            tableName, new[] { "id", "value" }, rows, options);
+
+        Assert.That(inserted, Is.EqualTo(10));
     }
 
     [Test]

--- a/ClickHouse.Driver.Tests/Copy/InsertBinaryPocoTests.cs
+++ b/ClickHouse.Driver.Tests/Copy/InsertBinaryPocoTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
-using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using ClickHouse.Driver.ADO;
 using ClickHouse.Driver.Copy;
@@ -13,9 +12,6 @@ namespace ClickHouse.Driver.Tests.Copy;
 [TestFixture]
 public class InsertBinaryPocoTests : AbstractConnectionTestFixture
 {
-    private string CreateTestTableName([CallerMemberName] string testName = null)
-        => SanitizeTableName($"test_poco_{testName}_{Guid.NewGuid():N}");
-
     private class SimplePoco
     {
         public ulong Id { get; set; }
@@ -171,60 +167,52 @@ public class InsertBinaryPocoTests : AbstractConnectionTestFixture
     [Test]
     public async Task InsertBinaryAsync_AllScalarTypes_RoundTripsViaFastPath()
     {
-        var tableName = CreateTestTableName();
-        try
+        var tableName = CreateTableName();
+        await client.ExecuteNonQueryAsync(
+            $"CREATE TABLE {tableName} (" +
+            "I8 Int8, I16 Int16, I32 Int32, I64 Int64, " +
+            "U8 UInt8, U16 UInt16, U32 UInt32, U64 UInt64, " +
+            "F32 Float32, F64 Float64, Flag Bool, Text String, OptionalScore Nullable(Int32)) " +
+            "ENGINE = MergeTree() ORDER BY I64");
+
+        client.RegisterBinaryInsertType<AllScalarsPoco>();
+
+        var row = new AllScalarsPoco
         {
-            await client.ExecuteNonQueryAsync(
-                $"CREATE TABLE IF NOT EXISTS test.{tableName} (" +
-                "I8 Int8, I16 Int16, I32 Int32, I64 Int64, " +
-                "U8 UInt8, U16 UInt16, U32 UInt32, U64 UInt64, " +
-                "F32 Float32, F64 Float64, Flag Bool, Text String, OptionalScore Nullable(Int32)) " +
-                "ENGINE = MergeTree() ORDER BY I64");
+            I8 = -42,
+            I16 = -12345,
+            I32 = -1_234_567_890,
+            I64 = -1_234_567_890_123L,
+            U8 = 200,
+            U16 = 54321,
+            U32 = 4_000_000_000u,
+            U64 = 18_000_000_000_000_000_000ul,
+            F32 = 3.14159f,
+            F64 = 2.718281828459045,
+            Flag = true,
+            Text = "hello ünïcode 🚀",
+            OptionalScore = null,
+        };
 
-            client.RegisterBinaryInsertType<AllScalarsPoco>();
+        var inserted = await client.InsertBinaryAsync(tableName, new[] { row });
+        Assert.That(inserted, Is.EqualTo(1));
 
-            var row = new AllScalarsPoco
-            {
-                I8 = -42,
-                I16 = -12345,
-                I32 = -1_234_567_890,
-                I64 = -1_234_567_890_123L,
-                U8 = 200,
-                U16 = 54321,
-                U32 = 4_000_000_000u,
-                U64 = 18_000_000_000_000_000_000ul,
-                F32 = 3.14159f,
-                F64 = 2.718281828459045,
-                Flag = true,
-                Text = "hello ünïcode 🚀",
-                OptionalScore = null,
-            };
-
-            var inserted = await client.InsertBinaryAsync(
-                tableName, new[] { row }, new InsertOptions { Database = "test" });
-            Assert.That(inserted, Is.EqualTo(1));
-
-            using var reader = await client.ExecuteReaderAsync(
-                $"SELECT I8, I16, I32, I64, U8, U16, U32, U64, F32, F64, Flag, Text, OptionalScore FROM test.{tableName}");
-            Assert.That(reader.Read(), Is.True);
-            Assert.That(reader.GetFieldValue<sbyte>(0), Is.EqualTo(row.I8));
-            Assert.That(reader.GetFieldValue<short>(1), Is.EqualTo(row.I16));
-            Assert.That(reader.GetFieldValue<int>(2), Is.EqualTo(row.I32));
-            Assert.That(reader.GetFieldValue<long>(3), Is.EqualTo(row.I64));
-            Assert.That(reader.GetFieldValue<byte>(4), Is.EqualTo(row.U8));
-            Assert.That(reader.GetFieldValue<ushort>(5), Is.EqualTo(row.U16));
-            Assert.That(reader.GetFieldValue<uint>(6), Is.EqualTo(row.U32));
-            Assert.That(reader.GetFieldValue<ulong>(7), Is.EqualTo(row.U64));
-            Assert.That(reader.GetFieldValue<float>(8), Is.EqualTo(row.F32));
-            Assert.That(reader.GetFieldValue<double>(9), Is.EqualTo(row.F64));
-            Assert.That(reader.GetFieldValue<bool>(10), Is.EqualTo(row.Flag));
-            Assert.That(reader.GetFieldValue<string>(11), Is.EqualTo(row.Text));
-            Assert.That(reader.IsDBNull(12), Is.True);
-        }
-        finally
-        {
-            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
-        }
+        using var reader = await client.ExecuteReaderAsync(
+            $"SELECT I8, I16, I32, I64, U8, U16, U32, U64, F32, F64, Flag, Text, OptionalScore FROM {tableName}");
+        Assert.That(reader.Read(), Is.True);
+        Assert.That(reader.GetFieldValue<sbyte>(0), Is.EqualTo(row.I8));
+        Assert.That(reader.GetFieldValue<short>(1), Is.EqualTo(row.I16));
+        Assert.That(reader.GetFieldValue<int>(2), Is.EqualTo(row.I32));
+        Assert.That(reader.GetFieldValue<long>(3), Is.EqualTo(row.I64));
+        Assert.That(reader.GetFieldValue<byte>(4), Is.EqualTo(row.U8));
+        Assert.That(reader.GetFieldValue<ushort>(5), Is.EqualTo(row.U16));
+        Assert.That(reader.GetFieldValue<uint>(6), Is.EqualTo(row.U32));
+        Assert.That(reader.GetFieldValue<ulong>(7), Is.EqualTo(row.U64));
+        Assert.That(reader.GetFieldValue<float>(8), Is.EqualTo(row.F32));
+        Assert.That(reader.GetFieldValue<double>(9), Is.EqualTo(row.F64));
+        Assert.That(reader.GetFieldValue<bool>(10), Is.EqualTo(row.Flag));
+        Assert.That(reader.GetFieldValue<string>(11), Is.EqualTo(row.Text));
+        Assert.That(reader.IsDBNull(12), Is.True);
     }
 
     // Exercises the Stage 2 box-free write fast path for the bespoke value types
@@ -245,51 +233,43 @@ public class InsertBinaryPocoTests : AbstractConnectionTestFixture
     [Test]
     public async Task InsertBinaryAsync_AllValueTypes_RoundTripsViaFastPath()
     {
-        var tableName = CreateTestTableName();
-        try
+        var tableName = CreateTableName();
+        await client.ExecuteNonQueryAsync(
+            $"CREATE TABLE {tableName} (" +
+            "Uid UUID, Dt DateTime, Dt64 DateTime64(3), D Date, Dec Decimal(18, 4), Big Int128, " +
+            "OptionalUid Nullable(UUID), OptionalDt Nullable(DateTime), OptionalDec Nullable(Decimal(18, 4))) " +
+            "ENGINE = MergeTree() ORDER BY Uid");
+
+        client.RegisterBinaryInsertType<AllValueTypesPoco>();
+
+        var row = new AllValueTypesPoco
         {
-            await client.ExecuteNonQueryAsync(
-                $"CREATE TABLE IF NOT EXISTS test.{tableName} (" +
-                "Uid UUID, Dt DateTime, Dt64 DateTime64(3), D Date, Dec Decimal(18, 4), Big Int128, " +
-                "OptionalUid Nullable(UUID), OptionalDt Nullable(DateTime), OptionalDec Nullable(Decimal(18, 4))) " +
-                "ENGINE = MergeTree() ORDER BY Uid");
+            Uid = Guid.Parse("11223344-5566-7788-99aa-bbccddeeff00"),
+            Dt = new DateTime(2024, 3, 14, 15, 9, 26, DateTimeKind.Unspecified),
+            Dt64 = new DateTime(2024, 3, 14, 15, 9, 26, 123, DateTimeKind.Unspecified),
+            D = new DateTime(2024, 3, 14, 0, 0, 0, DateTimeKind.Unspecified),
+            Dec = 123456.7891m,
+            Big = new BigInteger(123456789012345L),
+            OptionalUid = null,
+            OptionalDt = new DateTime(2020, 1, 1, 12, 0, 0, DateTimeKind.Unspecified),
+            OptionalDec = null,
+        };
 
-            client.RegisterBinaryInsertType<AllValueTypesPoco>();
+        var inserted = await client.InsertBinaryAsync(tableName, new[] { row });
+        Assert.That(inserted, Is.EqualTo(1));
 
-            var row = new AllValueTypesPoco
-            {
-                Uid = Guid.Parse("11223344-5566-7788-99aa-bbccddeeff00"),
-                Dt = new DateTime(2024, 3, 14, 15, 9, 26, DateTimeKind.Unspecified),
-                Dt64 = new DateTime(2024, 3, 14, 15, 9, 26, 123, DateTimeKind.Unspecified),
-                D = new DateTime(2024, 3, 14, 0, 0, 0, DateTimeKind.Unspecified),
-                Dec = 123456.7891m,
-                Big = new BigInteger(123456789012345L),
-                OptionalUid = null,
-                OptionalDt = new DateTime(2020, 1, 1, 12, 0, 0, DateTimeKind.Unspecified),
-                OptionalDec = null,
-            };
-
-            var inserted = await client.InsertBinaryAsync(
-                tableName, new[] { row }, new InsertOptions { Database = "test" });
-            Assert.That(inserted, Is.EqualTo(1));
-
-            using var reader = await client.ExecuteReaderAsync(
-                $"SELECT Uid, Dt, Dt64, D, Dec, Big, OptionalUid, OptionalDt, OptionalDec FROM test.{tableName}");
-            Assert.That(reader.Read(), Is.True);
-            Assert.That(reader.GetFieldValue<Guid>(0), Is.EqualTo(row.Uid));
-            Assert.That(reader.GetFieldValue<DateTime>(1), Is.EqualTo(row.Dt));
-            Assert.That(reader.GetFieldValue<DateTime>(2), Is.EqualTo(row.Dt64));
-            Assert.That(reader.GetFieldValue<DateTime>(3), Is.EqualTo(row.D));
-            Assert.That(Convert.ToDecimal(reader.GetValue(4)), Is.EqualTo(row.Dec));
-            Assert.That(reader.GetFieldValue<BigInteger>(5), Is.EqualTo(row.Big));
-            Assert.That(reader.IsDBNull(6), Is.True);
-            Assert.That(reader.GetFieldValue<DateTime>(7), Is.EqualTo(row.OptionalDt.Value));
-            Assert.That(reader.IsDBNull(8), Is.True);
-        }
-        finally
-        {
-            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
-        }
+        using var reader = await client.ExecuteReaderAsync(
+            $"SELECT Uid, Dt, Dt64, D, Dec, Big, OptionalUid, OptionalDt, OptionalDec FROM {tableName}");
+        Assert.That(reader.Read(), Is.True);
+        Assert.That(reader.GetFieldValue<Guid>(0), Is.EqualTo(row.Uid));
+        Assert.That(reader.GetFieldValue<DateTime>(1), Is.EqualTo(row.Dt));
+        Assert.That(reader.GetFieldValue<DateTime>(2), Is.EqualTo(row.Dt64));
+        Assert.That(reader.GetFieldValue<DateTime>(3), Is.EqualTo(row.D));
+        Assert.That(Convert.ToDecimal(reader.GetValue(4)), Is.EqualTo(row.Dec));
+        Assert.That(reader.GetFieldValue<BigInteger>(5), Is.EqualTo(row.Big));
+        Assert.That(reader.IsDBNull(6), Is.True);
+        Assert.That(reader.GetFieldValue<DateTime>(7), Is.EqualTo(row.OptionalDt.Value));
+        Assert.That(reader.IsDBNull(8), Is.True);
     }
 
     private enum Priority { Low = 1, High = 9 }
@@ -307,39 +287,31 @@ public class InsertBinaryPocoTests : AbstractConnectionTestFixture
     [Test]
     public async Task InsertBinaryAsync_CoercedValueTypes_RoundTripsViaFastPath()
     {
-        var tableName = CreateTestTableName();
-        try
+        var tableName = CreateTableName();
+        await client.ExecuteNonQueryAsync(
+            $"CREATE TABLE {tableName} " +
+            "(WideId Int64, When DateTime, Level Int32, Day Date) ENGINE = MergeTree() ORDER BY WideId");
+
+        client.RegisterBinaryInsertType<CoercedPoco>();
+
+        var row = new CoercedPoco
         {
-            await client.ExecuteNonQueryAsync(
-                $"CREATE TABLE IF NOT EXISTS test.{tableName} " +
-                "(WideId Int64, When DateTime, Level Int32, Day Date) ENGINE = MergeTree() ORDER BY WideId");
+            WideId = 123456,
+            When = new DateTimeOffset(2024, 3, 14, 15, 9, 26, TimeSpan.FromHours(2)),
+            Level = Priority.High,
+            Day = new DateOnly(2024, 3, 14),
+        };
 
-            client.RegisterBinaryInsertType<CoercedPoco>();
+        var inserted = await client.InsertBinaryAsync(tableName, new[] { row });
+        Assert.That(inserted, Is.EqualTo(1));
 
-            var row = new CoercedPoco
-            {
-                WideId = 123456,
-                When = new DateTimeOffset(2024, 3, 14, 15, 9, 26, TimeSpan.FromHours(2)),
-                Level = Priority.High,
-                Day = new DateOnly(2024, 3, 14),
-            };
-
-            var inserted = await client.InsertBinaryAsync(
-                tableName, new[] { row }, new InsertOptions { Database = "test" });
-            Assert.That(inserted, Is.EqualTo(1));
-
-            using var reader = await client.ExecuteReaderAsync(
-                $"SELECT WideId, When, Level, Day FROM test.{tableName}");
-            Assert.That(reader.Read(), Is.True);
-            Assert.That(reader.GetFieldValue<long>(0), Is.EqualTo(row.WideId));
-            Assert.That(reader.GetFieldValue<DateTime>(1), Is.EqualTo(row.When.UtcDateTime));
-            Assert.That(reader.GetFieldValue<int>(2), Is.EqualTo((int)row.Level));
-            Assert.That(reader.GetFieldValue<DateTime>(3).Date, Is.EqualTo(new DateTime(2024, 3, 14)));
-        }
-        finally
-        {
-            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
-        }
+        using var reader = await client.ExecuteReaderAsync(
+            $"SELECT WideId, When, Level, Day FROM {tableName}");
+        Assert.That(reader.Read(), Is.True);
+        Assert.That(reader.GetFieldValue<long>(0), Is.EqualTo(row.WideId));
+        Assert.That(reader.GetFieldValue<DateTime>(1), Is.EqualTo(row.When.UtcDateTime));
+        Assert.That(reader.GetFieldValue<int>(2), Is.EqualTo((int)row.Level));
+        Assert.That(reader.GetFieldValue<DateTime>(3).Date, Is.EqualTo(new DateTime(2024, 3, 14)));
     }
 
     [Test]
@@ -356,31 +328,21 @@ public class InsertBinaryPocoTests : AbstractConnectionTestFixture
     public async Task InsertBinaryAsync_NoParameterlessConstructor_InsertsSuccessfully()
     {
         // RegisterBinaryInsertType<T> does not need to construct instances, so the absence of a public parameterless ctor must not block insert.
-        var tableName = CreateTestTableName();
-        try
-        {
-            await client.ExecuteNonQueryAsync(
-                $"CREATE TABLE IF NOT EXISTS test.{tableName} (Id UInt64, Value String) ENGINE = MergeTree() ORDER BY Id");
+        var tableName = CreateTableName();
+        await client.ExecuteNonQueryAsync(
+            $"CREATE TABLE {tableName} (Id UInt64, Value String) ENGINE = MergeTree() ORDER BY Id");
 
-            client.RegisterBinaryInsertType<NoCtorPoco>();
+        client.RegisterBinaryInsertType<NoCtorPoco>();
 
-            var inserted = await client.InsertBinaryAsync(
-                tableName,
-                new[] { new NoCtorPoco(7, "kept") },
-                new InsertOptions { Database = "test" });
+        var inserted = await client.InsertBinaryAsync(tableName, new[] { new NoCtorPoco(7, "kept") });
 
-            Assert.That(inserted, Is.EqualTo(1));
+        Assert.That(inserted, Is.EqualTo(1));
 
-            using var reader = await client.ExecuteReaderAsync(
-                $"SELECT Id, Value FROM test.{tableName}");
-            Assert.That(reader.Read(), Is.True);
-            Assert.That(reader.GetFieldValue<ulong>(0), Is.EqualTo(7UL));
-            Assert.That(reader.GetFieldValue<string>(1), Is.EqualTo("kept"));
-        }
-        finally
-        {
-            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
-        }
+        using var reader = await client.ExecuteReaderAsync(
+            $"SELECT Id, Value FROM {tableName}");
+        Assert.That(reader.Read(), Is.True);
+        Assert.That(reader.GetFieldValue<ulong>(0), Is.EqualTo(7UL));
+        Assert.That(reader.GetFieldValue<string>(1), Is.EqualTo("kept"));
     }
 
     [Test]
@@ -420,627 +382,497 @@ public class InsertBinaryPocoTests : AbstractConnectionTestFixture
     [Test]
     public async Task InsertBinaryAsync_WithWrongExplicitType_ShouldThrowSerializationException()
     {
-        var tableName = CreateTestTableName();
-        try
+        var tableName = CreateTableName();
+        await client.ExecuteNonQueryAsync($@"
+            CREATE TABLE {tableName}
+            (Id UInt64, Value UInt64)
+            ENGINE = MergeTree() ORDER BY Id");
+
+        client.RegisterBinaryInsertType<PocoWithWrongExplicitType>();
+
+        var rows = new[]
         {
-            await client.ExecuteNonQueryAsync($@"
-                CREATE TABLE IF NOT EXISTS test.{tableName}
-                (Id UInt64, Value UInt64)
-                ENGINE = MergeTree() ORDER BY Id");
+            new PocoWithWrongExplicitType { Id = 1, Value = "not_a_number" },
+        };
 
-            client.RegisterBinaryInsertType<PocoWithWrongExplicitType>();
+        // The type mismatch (string → UInt64) should fail during serialization
+        // and be wrapped in ClickHouseBulkCopySerializationException with row context
+        var ex = Assert.ThrowsAsync<ClickHouseBulkCopySerializationException>(async () =>
+            await client.InsertBinaryAsync(tableName, rows));
 
-            var rows = new[]
-            {
-                new PocoWithWrongExplicitType { Id = 1, Value = "not_a_number" },
-            };
-
-            // The type mismatch (string → UInt64) should fail during serialization
-            // and be wrapped in ClickHouseBulkCopySerializationException with row context
-            var ex = Assert.ThrowsAsync<ClickHouseBulkCopySerializationException>(async () =>
-                await client.InsertBinaryAsync(tableName, rows, new InsertOptions { Database = "test" }));
-
-            Assert.That(ex.Row, Is.Not.Null);
-            Assert.That(ex.InnerException, Is.Not.Null);
-        }
-        finally
-        {
-            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
-        }
+        Assert.That(ex.Row, Is.Not.Null);
+        Assert.That(ex.InnerException, Is.Not.Null);
     }
 
     [Test]
     public async Task InsertBinaryAsync_WithInternalGetter_ShouldExcludeProperty()
     {
-        var tableName = CreateTestTableName();
-        try
+        var tableName = CreateTableName();
+        // Table has a Value column with DEFAULT — if the internal-getter property
+        // were included, it would either serialize wrong or fail.
+        await client.ExecuteNonQueryAsync($@"
+            CREATE TABLE {tableName}
+            (Id UInt64, Value String DEFAULT 'default_val')
+            ENGINE = MergeTree() ORDER BY Id");
+
+        client.RegisterBinaryInsertType<PocoWithInternalGetter>();
+
+        var rows = new[]
         {
-            // Table has a Value column with DEFAULT — if the internal-getter property
-            // were included, it would either serialize wrong or fail.
-            await client.ExecuteNonQueryAsync($@"
-                CREATE TABLE IF NOT EXISTS test.{tableName}
-                (Id UInt64, Value String DEFAULT 'default_val')
-                ENGINE = MergeTree() ORDER BY Id");
+            new PocoWithInternalGetter { Id = 1, Value = "hidden" },
+        };
 
-            client.RegisterBinaryInsertType<PocoWithInternalGetter>();
+        var inserted = await client.InsertBinaryAsync(
+            tableName, rows, new InsertOptions { Format = RowBinaryFormat.RowBinaryWithDefaults });
 
-            var rows = new[]
-            {
-                new PocoWithInternalGetter { Id = 1, Value = "hidden" },
-            };
+        Assert.That(inserted, Is.EqualTo(1));
 
-            var inserted = await client.InsertBinaryAsync(
-                tableName, rows, new InsertOptions { Database = "test", Format = RowBinaryFormat.RowBinaryWithDefaults });
+        using var reader = await client.ExecuteReaderAsync(
+            $"SELECT Id, Value FROM {tableName}");
 
-            Assert.That(inserted, Is.EqualTo(1));
-
-            using var reader = await client.ExecuteReaderAsync(
-                $"SELECT Id, Value FROM test.{tableName}",
-                options: new QueryOptions { Database = "test" });
-
-            Assert.That(reader.Read(), Is.True);
-            Assert.That(reader.GetValue(0), Is.EqualTo(1UL));
-            Assert.That(reader.GetValue(1), Is.EqualTo("default_val"));
-        }
-        finally
-        {
-            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
-        }
+        Assert.That(reader.Read(), Is.True);
+        Assert.That(reader.GetValue(0), Is.EqualTo(1UL));
+        Assert.That(reader.GetValue(1), Is.EqualTo("default_val"));
     }
 
     [Test]
     public async Task InsertBinaryAsync_WithProtectedGetter_ShouldExcludeProperty()
     {
-        var tableName = CreateTestTableName();
-        try
+        var tableName = CreateTableName();
+        await client.ExecuteNonQueryAsync($@"
+            CREATE TABLE {tableName}
+            (Id UInt64, Value String DEFAULT 'default_val')
+            ENGINE = MergeTree() ORDER BY Id");
+
+        client.RegisterBinaryInsertType<PocoWithProtectedGetter>();
+
+        var rows = new[]
         {
-            await client.ExecuteNonQueryAsync($@"
-                CREATE TABLE IF NOT EXISTS test.{tableName}
-                (Id UInt64, Value String DEFAULT 'default_val')
-                ENGINE = MergeTree() ORDER BY Id");
+            new PocoWithProtectedGetter { Id = 1, Value = "hidden" },
+        };
 
-            client.RegisterBinaryInsertType<PocoWithProtectedGetter>();
+        var inserted = await client.InsertBinaryAsync(
+            tableName, rows, new InsertOptions { Format = RowBinaryFormat.RowBinaryWithDefaults });
 
-            var rows = new[]
-            {
-                new PocoWithProtectedGetter { Id = 1, Value = "hidden" },
-            };
+        Assert.That(inserted, Is.EqualTo(1));
 
-            var inserted = await client.InsertBinaryAsync(
-                tableName, rows, new InsertOptions { Database = "test", Format = RowBinaryFormat.RowBinaryWithDefaults });
+        using var reader = await client.ExecuteReaderAsync(
+            $"SELECT Id, Value FROM {tableName}");
 
-            Assert.That(inserted, Is.EqualTo(1));
-
-            using var reader = await client.ExecuteReaderAsync(
-                $"SELECT Id, Value FROM test.{tableName}",
-                options: new QueryOptions { Database = "test" });
-
-            Assert.That(reader.Read(), Is.True);
-            Assert.That(reader.GetValue(0), Is.EqualTo(1UL));
-            Assert.That(reader.GetValue(1), Is.EqualTo("default_val"));
-        }
-        finally
-        {
-            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
-        }
+        Assert.That(reader.Read(), Is.True);
+        Assert.That(reader.GetValue(0), Is.EqualTo(1UL));
+        Assert.That(reader.GetValue(1), Is.EqualTo("default_val"));
     }
 
     [Test]
     public async Task InsertBinaryAsync_WithPrivateGetter_ShouldExcludeProperty()
     {
-        var tableName = CreateTestTableName();
-        try
+        var tableName = CreateTableName();
+        await client.ExecuteNonQueryAsync($@"
+            CREATE TABLE {tableName}
+            (Id UInt64, Value String DEFAULT 'default_val')
+            ENGINE = MergeTree() ORDER BY Id");
+
+        client.RegisterBinaryInsertType<PocoWithPrivateGetter>();
+
+        var rows = new[]
         {
-            await client.ExecuteNonQueryAsync($@"
-                CREATE TABLE IF NOT EXISTS test.{tableName}
-                (Id UInt64, Value String DEFAULT 'default_val')
-                ENGINE = MergeTree() ORDER BY Id");
+            new PocoWithPrivateGetter { Id = 1, Value = "hidden" },
+        };
 
-            client.RegisterBinaryInsertType<PocoWithPrivateGetter>();
+        var inserted = await client.InsertBinaryAsync(
+            tableName, rows, new InsertOptions { Format = RowBinaryFormat.RowBinaryWithDefaults });
 
-            var rows = new[]
-            {
-                new PocoWithPrivateGetter { Id = 1, Value = "hidden" },
-            };
+        Assert.That(inserted, Is.EqualTo(1));
 
-            var inserted = await client.InsertBinaryAsync(
-                tableName, rows, new InsertOptions { Database = "test", Format = RowBinaryFormat.RowBinaryWithDefaults });
+        using var reader = await client.ExecuteReaderAsync(
+            $"SELECT Id, Value FROM {tableName}");
 
-            Assert.That(inserted, Is.EqualTo(1));
-
-            using var reader = await client.ExecuteReaderAsync(
-                $"SELECT Id, Value FROM test.{tableName}",
-                options: new QueryOptions { Database = "test" });
-
-            Assert.That(reader.Read(), Is.True);
-            Assert.That(reader.GetValue(0), Is.EqualTo(1UL));
-            Assert.That(reader.GetValue(1), Is.EqualTo("default_val"));
-        }
-        finally
-        {
-            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
-        }
+        Assert.That(reader.Read(), Is.True);
+        Assert.That(reader.GetValue(0), Is.EqualTo(1UL));
+        Assert.That(reader.GetValue(1), Is.EqualTo("default_val"));
     }
 
     [Test]
     public async Task InsertBinaryAsync_WithPoco_ShouldRoundTripData()
     {
-        var tableName = CreateTestTableName();
-        try
+        var tableName = CreateTableName();
+        await client.ExecuteNonQueryAsync($@"
+            CREATE TABLE {tableName}
+            (Id UInt64, Value String)
+            ENGINE = MergeTree() ORDER BY Id");
+
+        client.RegisterBinaryInsertType<SimplePoco>();
+
+        var rows = Enumerable.Range(1, 10).Select(i => new SimplePoco
         {
-            await client.ExecuteNonQueryAsync($@"
-                CREATE TABLE IF NOT EXISTS test.{tableName}
-                (Id UInt64, Value String)
-                ENGINE = MergeTree() ORDER BY Id");
+            Id = (ulong)i,
+            Value = $"Value_{i}",
+        });
 
-            client.RegisterBinaryInsertType<SimplePoco>();
+        var inserted = await client.InsertBinaryAsync(tableName, rows);
 
-            var rows = Enumerable.Range(1, 10).Select(i => new SimplePoco
-            {
-                Id = (ulong)i,
-                Value = $"Value_{i}",
-            });
+        Assert.That(inserted, Is.EqualTo(10));
 
-            var inserted = await client.InsertBinaryAsync(
-                tableName,
-                rows,
-                new InsertOptions { Database = "test" });
+        var count = await client.ExecuteScalarAsync(
+            $"SELECT count() FROM {tableName}");
+        Assert.That(count, Is.EqualTo(10UL));
 
-            Assert.That(inserted, Is.EqualTo(10));
+        using var reader = await client.ExecuteReaderAsync(
+            $"SELECT Id, Value FROM {tableName} ORDER BY Id");
 
-            var count = await client.ExecuteScalarAsync(
-                $"SELECT count() FROM test.{tableName}");
-            Assert.That(count, Is.EqualTo(10UL));
-
-            using var reader = await client.ExecuteReaderAsync(
-                $"SELECT Id, Value FROM test.{tableName} ORDER BY Id",
-                options: new QueryOptions { Database = "test" });
-
-            var results = new List<(ulong Id, string Value)>();
-            while (reader.Read())
-            {
-                results.Add(((ulong)reader.GetValue(0), (string)reader.GetValue(1)));
-            }
-
-            Assert.That(results, Has.Count.EqualTo(10));
-            Assert.That(results[0].Id, Is.EqualTo(1UL));
-            Assert.That(results[0].Value, Is.EqualTo("Value_1"));
-            Assert.That(results[9].Id, Is.EqualTo(10UL));
-            Assert.That(results[9].Value, Is.EqualTo("Value_10"));
-        }
-        finally
+        var results = new List<(ulong Id, string Value)>();
+        while (reader.Read())
         {
-            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
+            results.Add(((ulong)reader.GetValue(0), (string)reader.GetValue(1)));
         }
+
+        Assert.That(results, Has.Count.EqualTo(10));
+        Assert.That(results[0].Id, Is.EqualTo(1UL));
+        Assert.That(results[0].Value, Is.EqualTo("Value_1"));
+        Assert.That(results[9].Id, Is.EqualTo(10UL));
+        Assert.That(results[9].Value, Is.EqualTo("Value_10"));
     }
 
     [Test]
     public async Task InsertBinaryAsync_WithReversedPropertyOrder_ShouldMapCorrectly()
     {
-        var tableName = CreateTestTableName();
-        try
+        var tableName = CreateTableName();
+        // Table columns: Id first, Value second
+        await client.ExecuteNonQueryAsync($@"
+            CREATE TABLE {tableName}
+            (Id UInt64, Value String)
+            ENGINE = MergeTree() ORDER BY Id");
+
+        // POCO declares Value first, Id second — opposite of table order
+        client.RegisterBinaryInsertType<ReversedPropertyOrderPoco>();
+
+        var rows = new[]
         {
-            // Table columns: Id first, Value second
-            await client.ExecuteNonQueryAsync($@"
-                CREATE TABLE IF NOT EXISTS test.{tableName}
-                (Id UInt64, Value String)
-                ENGINE = MergeTree() ORDER BY Id");
+            new ReversedPropertyOrderPoco { Id = 1, Value = "first" },
+            new ReversedPropertyOrderPoco { Id = 2, Value = "second" },
+        };
 
-            // POCO declares Value first, Id second — opposite of table order
-            client.RegisterBinaryInsertType<ReversedPropertyOrderPoco>();
+        var inserted = await client.InsertBinaryAsync(tableName, rows);
 
-            var rows = new[]
-            {
-                new ReversedPropertyOrderPoco { Id = 1, Value = "first" },
-                new ReversedPropertyOrderPoco { Id = 2, Value = "second" },
-            };
+        Assert.That(inserted, Is.EqualTo(2));
 
-            var inserted = await client.InsertBinaryAsync(
-                tableName, rows, new InsertOptions { Database = "test" });
+        using var reader = await client.ExecuteReaderAsync(
+            $"SELECT Id, Value FROM {tableName} ORDER BY Id");
 
-            Assert.That(inserted, Is.EqualTo(2));
+        Assert.That(reader.Read(), Is.True);
+        Assert.That(reader.GetValue(0), Is.EqualTo(1UL));
+        Assert.That(reader.GetValue(1), Is.EqualTo("first"));
 
-            using var reader = await client.ExecuteReaderAsync(
-                $"SELECT Id, Value FROM test.{tableName} ORDER BY Id",
-                options: new QueryOptions { Database = "test" });
-
-            Assert.That(reader.Read(), Is.True);
-            Assert.That(reader.GetValue(0), Is.EqualTo(1UL));
-            Assert.That(reader.GetValue(1), Is.EqualTo("first"));
-
-            Assert.That(reader.Read(), Is.True);
-            Assert.That(reader.GetValue(0), Is.EqualTo(2UL));
-            Assert.That(reader.GetValue(1), Is.EqualTo("second"));
-        }
-        finally
-        {
-            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
-        }
+        Assert.That(reader.Read(), Is.True);
+        Assert.That(reader.GetValue(0), Is.EqualTo(2UL));
+        Assert.That(reader.GetValue(1), Is.EqualTo("second"));
     }
 
     [Test]
     public async Task InsertBinaryAsync_WithColumnNameAttribute_ShouldMapCorrectly()
     {
-        var tableName = CreateTestTableName();
-        try
+        var tableName = CreateTableName();
+        await client.ExecuteNonQueryAsync($@"
+            CREATE TABLE {tableName}
+            (id UInt64, value String)
+            ENGINE = MergeTree() ORDER BY id");
+
+        client.RegisterBinaryInsertType<PocoWithColumnNames>();
+
+        var rows = new[]
         {
-            await client.ExecuteNonQueryAsync($@"
-                CREATE TABLE IF NOT EXISTS test.{tableName}
-                (id UInt64, value String)
-                ENGINE = MergeTree() ORDER BY id");
+            new PocoWithColumnNames { UserId = 1, UserName = "Alice" },
+            new PocoWithColumnNames { UserId = 2, UserName = "Bob" },
+        };
 
-            client.RegisterBinaryInsertType<PocoWithColumnNames>();
+        var inserted = await client.InsertBinaryAsync(tableName, rows);
 
-            var rows = new[]
-            {
-                new PocoWithColumnNames { UserId = 1, UserName = "Alice" },
-                new PocoWithColumnNames { UserId = 2, UserName = "Bob" },
-            };
+        Assert.That(inserted, Is.EqualTo(2));
 
-            var inserted = await client.InsertBinaryAsync(
-                tableName, rows, new InsertOptions { Database = "test" });
+        using var reader = await client.ExecuteReaderAsync(
+            $"SELECT id, value FROM {tableName} ORDER BY id");
 
-            Assert.That(inserted, Is.EqualTo(2));
+        Assert.That(reader.Read(), Is.True);
+        Assert.That(reader.GetValue(0), Is.EqualTo(1UL));
+        Assert.That(reader.GetValue(1), Is.EqualTo("Alice"));
 
-            using var reader = await client.ExecuteReaderAsync(
-                $"SELECT id, value FROM test.{tableName} ORDER BY id",
-                options: new QueryOptions { Database = "test" });
-
-            Assert.That(reader.Read(), Is.True);
-            Assert.That(reader.GetValue(0), Is.EqualTo(1UL));
-            Assert.That(reader.GetValue(1), Is.EqualTo("Alice"));
-
-            Assert.That(reader.Read(), Is.True);
-            Assert.That(reader.GetValue(0), Is.EqualTo(2UL));
-            Assert.That(reader.GetValue(1), Is.EqualTo("Bob"));
-        }
-        finally
-        {
-            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
-        }
+        Assert.That(reader.Read(), Is.True);
+        Assert.That(reader.GetValue(0), Is.EqualTo(2UL));
+        Assert.That(reader.GetValue(1), Is.EqualTo("Bob"));
     }
 
     [Test]
     public async Task InsertBinaryAsync_WithNotMapped_ShouldExcludeProperty()
     {
-        var tableName = CreateTestTableName();
-        try
+        var tableName = CreateTableName();
+        await client.ExecuteNonQueryAsync($@"
+            CREATE TABLE {tableName}
+            (Id UInt64, Value String)
+            ENGINE = MergeTree() ORDER BY Id");
+
+        client.RegisterBinaryInsertType<PocoWithNotMapped>();
+
+        var rows = new[]
         {
-            await client.ExecuteNonQueryAsync($@"
-                CREATE TABLE IF NOT EXISTS test.{tableName}
-                (Id UInt64, Value String)
-                ENGINE = MergeTree() ORDER BY Id");
+            new PocoWithNotMapped { Id = 1, Value = "test", InternalState = "should_be_ignored" },
+        };
 
-            client.RegisterBinaryInsertType<PocoWithNotMapped>();
+        var inserted = await client.InsertBinaryAsync(tableName, rows);
 
-            var rows = new[]
-            {
-                new PocoWithNotMapped { Id = 1, Value = "test", InternalState = "should_be_ignored" },
-            };
+        Assert.That(inserted, Is.EqualTo(1));
 
-            var inserted = await client.InsertBinaryAsync(
-                tableName, rows, new InsertOptions { Database = "test" });
-
-            Assert.That(inserted, Is.EqualTo(1));
-
-            var count = await client.ExecuteScalarAsync(
-                $"SELECT count() FROM test.{tableName}");
-            Assert.That(count, Is.EqualTo(1UL));
-        }
-        finally
-        {
-            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
-        }
+        var count = await client.ExecuteScalarAsync(
+            $"SELECT count() FROM {tableName}");
+        Assert.That(count, Is.EqualTo(1UL));
     }
 
     [Test]
     public async Task InsertBinaryAsync_WithWriteOnlyProperty_ShouldExcludeIt()
     {
-        var tableName = CreateTestTableName();
-        try
+        var tableName = CreateTableName();
+        // Table includes a WriteOnly column with a DEFAULT — if the property were
+        // mistakenly included, the insert would fail or write wrong data.
+        await client.ExecuteNonQueryAsync($@"
+            CREATE TABLE {tableName}
+            (Id UInt64, Value String, WriteOnly String DEFAULT 'default_value')
+            ENGINE = MergeTree() ORDER BY Id");
+
+        client.RegisterBinaryInsertType<PocoWithWriteOnlyProperty>();
+
+        var rows = new[]
         {
-            // Table includes a WriteOnly column with a DEFAULT — if the property were
-            // mistakenly included, the insert would fail or write wrong data.
-            await client.ExecuteNonQueryAsync($@"
-                CREATE TABLE IF NOT EXISTS test.{tableName}
-                (Id UInt64, Value String, WriteOnly String DEFAULT 'default_value')
-                ENGINE = MergeTree() ORDER BY Id");
+            new PocoWithWriteOnlyProperty { Id = 1, Value = "test", WriteOnly = "ignored" },
+        };
 
-            client.RegisterBinaryInsertType<PocoWithWriteOnlyProperty>();
+        var inserted = await client.InsertBinaryAsync(
+            tableName, rows, new InsertOptions { Format = RowBinaryFormat.RowBinaryWithDefaults });
 
-            var rows = new[]
-            {
-                new PocoWithWriteOnlyProperty { Id = 1, Value = "test", WriteOnly = "ignored" },
-            };
+        Assert.That(inserted, Is.EqualTo(1));
 
-            var inserted = await client.InsertBinaryAsync(
-                tableName, rows, new InsertOptions { Database = "test", Format = RowBinaryFormat.RowBinaryWithDefaults });
+        using var reader = await client.ExecuteReaderAsync(
+            $"SELECT Id, Value, WriteOnly FROM {tableName}");
 
-            Assert.That(inserted, Is.EqualTo(1));
-
-            using var reader = await client.ExecuteReaderAsync(
-                $"SELECT Id, Value, WriteOnly FROM test.{tableName}",
-                options: new QueryOptions { Database = "test" });
-
-            Assert.That(reader.Read(), Is.True);
-            Assert.That(reader.GetValue(0), Is.EqualTo(1UL));
-            Assert.That(reader.GetValue(1), Is.EqualTo("test"));
-            Assert.That(reader.GetValue(2), Is.EqualTo("default_value"));
-        }
-        finally
-        {
-            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
-        }
+        Assert.That(reader.Read(), Is.True);
+        Assert.That(reader.GetValue(0), Is.EqualTo(1UL));
+        Assert.That(reader.GetValue(1), Is.EqualTo("test"));
+        Assert.That(reader.GetValue(2), Is.EqualTo("default_value"));
     }
 
     [Test]
     public async Task InsertBinaryAsync_WithIndexer_ShouldExcludeIt()
     {
-        var tableName = CreateTestTableName();
-        try
+        var tableName = CreateTableName();
+        await client.ExecuteNonQueryAsync($@"
+            CREATE TABLE {tableName}
+            (Id UInt64, Value String)
+            ENGINE = MergeTree() ORDER BY Id");
+
+        client.RegisterBinaryInsertType<PocoWithIndexer>();
+
+        var rows = new[]
         {
-            await client.ExecuteNonQueryAsync($@"
-                CREATE TABLE IF NOT EXISTS test.{tableName}
-                (Id UInt64, Value String)
-                ENGINE = MergeTree() ORDER BY Id");
+            new PocoWithIndexer { Id = 1, Value = "test" },
+        };
 
-            client.RegisterBinaryInsertType<PocoWithIndexer>();
+        var inserted = await client.InsertBinaryAsync(tableName, rows);
 
-            var rows = new[]
-            {
-                new PocoWithIndexer { Id = 1, Value = "test" },
-            };
+        Assert.That(inserted, Is.EqualTo(1));
 
-            var inserted = await client.InsertBinaryAsync(
-                tableName, rows, new InsertOptions { Database = "test" });
+        using var reader = await client.ExecuteReaderAsync(
+            $"SELECT Id, Value FROM {tableName}");
 
-            Assert.That(inserted, Is.EqualTo(1));
-
-            using var reader = await client.ExecuteReaderAsync(
-                $"SELECT Id, Value FROM test.{tableName}",
-                options: new QueryOptions { Database = "test" });
-
-            Assert.That(reader.Read(), Is.True);
-            Assert.That(reader.GetValue(0), Is.EqualTo(1UL));
-            Assert.That(reader.GetValue(1), Is.EqualTo("test"));
-        }
-        finally
-        {
-            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
-        }
+        Assert.That(reader.Read(), Is.True);
+        Assert.That(reader.GetValue(0), Is.EqualTo(1UL));
+        Assert.That(reader.GetValue(1), Is.EqualTo("test"));
     }
 
     [Test]
     public async Task InsertBinaryAsync_WithExplicitTypes_ShouldSkipSchemaProbe()
     {
-        var tableName = CreateTestTableName();
-        try
+        var tableName = CreateTableName();
+        await client.ExecuteNonQueryAsync($@"
+            CREATE TABLE {tableName}
+            (Id UInt64, Value String)
+            ENGINE = MergeTree() ORDER BY Id");
+
+        client.RegisterBinaryInsertType<PocoWithExplicitTypes>();
+
+        var queryId = $"test_poco_explicit_skip_{Guid.NewGuid():N}";
+        var rows = new[]
         {
-            await client.ExecuteNonQueryAsync($@"
-                CREATE TABLE IF NOT EXISTS test.{tableName}
-                (Id UInt64, Value String)
-                ENGINE = MergeTree() ORDER BY Id");
+            new PocoWithExplicitTypes { Id = 42, Value = "explicit" },
+        };
 
-            client.RegisterBinaryInsertType<PocoWithExplicitTypes>();
+        var inserted = await client.InsertBinaryAsync(
+            tableName, rows, new InsertOptions { QueryId = queryId });
 
-            var queryId = $"test_poco_explicit_skip_{Guid.NewGuid():N}";
-            var rows = new[]
-            {
-                new PocoWithExplicitTypes { Id = 42, Value = "explicit" },
-            };
+        Assert.That(inserted, Is.EqualTo(1));
 
-            var inserted = await client.InsertBinaryAsync(
-                tableName, rows, new InsertOptions { Database = "test", QueryId = queryId });
+        // Verify data round-tripped correctly
+        using var reader = await client.ExecuteReaderAsync(
+            $"SELECT Id, Value FROM {tableName}");
 
-            Assert.That(inserted, Is.EqualTo(1));
+        Assert.That(reader.Read(), Is.True);
+        Assert.That(reader.GetValue(0), Is.EqualTo(42UL));
+        Assert.That(reader.GetValue(1), Is.EqualTo("explicit"));
 
-            // Verify data round-tripped correctly
-            using var reader = await client.ExecuteReaderAsync(
-                $"SELECT Id, Value FROM test.{tableName}",
-                options: new QueryOptions { Database = "test" });
-
-            Assert.That(reader.Read(), Is.True);
-            Assert.That(reader.GetValue(0), Is.EqualTo(42UL));
-            Assert.That(reader.GetValue(1), Is.EqualTo("explicit"));
-
-            // Verify no schema probe query was sent
-            await client.ExecuteNonQueryAsync("SYSTEM FLUSH LOGS");
-            var probeCount = await client.ExecuteScalarAsync(
-                $"SELECT count() FROM system.query_log " +
-                $"WHERE query_id LIKE '{queryId}%' " +
-                $"AND query LIKE '%WHERE 1=0%' " +
-                $"AND type = 'QueryFinish'");
-            Assert.That(probeCount, Is.EqualTo(0UL),
-                "No schema probe query should be sent when all properties have explicit types");
-        }
-        finally
-        {
-            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
-        }
+        // Verify no schema probe query was sent
+        await client.ExecuteNonQueryAsync("SYSTEM FLUSH LOGS");
+        var probeCount = await client.ExecuteScalarAsync(
+            $"SELECT count() FROM system.query_log " +
+            $"WHERE query_id LIKE '{queryId}%' " +
+            $"AND query LIKE '%WHERE 1=0%' " +
+            $"AND type = 'QueryFinish'");
+        Assert.That(probeCount, Is.EqualTo(0UL),
+            "No schema probe query should be sent when all properties have explicit types");
     }
 
     [Test]
     public async Task InsertBinaryAsync_WithUserProvidedColumnTypes_ShouldTakePrecedenceOverAttributes()
     {
-        var tableName = CreateTestTableName();
-        try
+        var tableName = CreateTableName();
+        await client.ExecuteNonQueryAsync($@"
+            CREATE TABLE {tableName}
+            (Id UInt64, Value String)
+            ENGINE = MergeTree() ORDER BY Id");
+
+        // PocoWithExplicitTypes has [ClickHouseColumn(Type = "UInt64")] and [ClickHouseColumn(Type = "String")]
+        // but we override via InsertOptions.ColumnTypes, these should take precedence
+        client.RegisterBinaryInsertType<PocoWithExplicitTypes>();
+
+        var rows = new[]
         {
-            await client.ExecuteNonQueryAsync($@"
-                CREATE TABLE IF NOT EXISTS test.{tableName}
-                (Id UInt64, Value String)
-                ENGINE = MergeTree() ORDER BY Id");
+            new PocoWithExplicitTypes { Id = 1, Value = "overridden" },
+        };
 
-            // PocoWithExplicitTypes has [ClickHouseColumn(Type = "UInt64")] and [ClickHouseColumn(Type = "String")]
-            // but we override via InsertOptions.ColumnTypes, these should take precedence
-            client.RegisterBinaryInsertType<PocoWithExplicitTypes>();
-
-            var rows = new[]
-            {
-                new PocoWithExplicitTypes { Id = 1, Value = "overridden" },
-            };
-
-            var options = new InsertOptions
-            {
-                Database = "test",
-                ColumnTypes = new Dictionary<string, string>
-                {
-                    ["Id"] = "UInt64",
-                    ["Value"] = "String",
-                },
-            };
-
-            var inserted = await client.InsertBinaryAsync(tableName, rows, options);
-            Assert.That(inserted, Is.EqualTo(1));
-
-            using var reader = await client.ExecuteReaderAsync(
-                $"SELECT Id, Value FROM test.{tableName}",
-                options: new QueryOptions { Database = "test" });
-
-            Assert.That(reader.Read(), Is.True);
-            Assert.That(reader.GetValue(0), Is.EqualTo(1UL));
-            Assert.That(reader.GetValue(1), Is.EqualTo("overridden"));
-        }
-        finally
+        var options = new InsertOptions
         {
-            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
-        }
+            ColumnTypes = new Dictionary<string, string>
+            {
+                ["Id"] = "UInt64",
+                ["Value"] = "String",
+            },
+        };
+
+        var inserted = await client.InsertBinaryAsync(tableName, rows, options);
+        Assert.That(inserted, Is.EqualTo(1));
+
+        using var reader = await client.ExecuteReaderAsync(
+            $"SELECT Id, Value FROM {tableName}");
+
+        Assert.That(reader.Read(), Is.True);
+        Assert.That(reader.GetValue(0), Is.EqualTo(1UL));
+        Assert.That(reader.GetValue(1), Is.EqualTo("overridden"));
     }
 
     [Test]
     public async Task InsertBinaryAsync_WithPartialTypes_ShouldProbeForMissing()
     {
-        var tableName = CreateTestTableName();
-        try
+        var tableName = CreateTableName();
+        await client.ExecuteNonQueryAsync($@"
+            CREATE TABLE {tableName}
+            (Id UInt64, Value String)
+            ENGINE = MergeTree() ORDER BY Id");
+
+        client.RegisterBinaryInsertType<PocoWithPartialTypes>();
+
+        var rows = new[]
         {
-            await client.ExecuteNonQueryAsync($@"
-                CREATE TABLE IF NOT EXISTS test.{tableName}
-                (Id UInt64, Value String)
-                ENGINE = MergeTree() ORDER BY Id");
+            new PocoWithPartialTypes { Id = 99, Value = "partial" },
+        };
 
-            client.RegisterBinaryInsertType<PocoWithPartialTypes>();
+        var inserted = await client.InsertBinaryAsync(tableName, rows);
 
-            var rows = new[]
-            {
-                new PocoWithPartialTypes { Id = 99, Value = "partial" },
-            };
+        Assert.That(inserted, Is.EqualTo(1));
 
-            var inserted = await client.InsertBinaryAsync(
-                tableName, rows, new InsertOptions { Database = "test" });
+        using var reader = await client.ExecuteReaderAsync(
+            $"SELECT Id, Value FROM {tableName}");
 
-            Assert.That(inserted, Is.EqualTo(1));
-
-            using var reader = await client.ExecuteReaderAsync(
-                $"SELECT Id, Value FROM test.{tableName}",
-                options: new QueryOptions { Database = "test" });
-
-            Assert.That(reader.Read(), Is.True);
-            Assert.That(reader.GetValue(0), Is.EqualTo(99UL));
-            Assert.That(reader.GetValue(1), Is.EqualTo("partial"));
-        }
-        finally
-        {
-            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
-        }
+        Assert.That(reader.Read(), Is.True);
+        Assert.That(reader.GetValue(0), Is.EqualTo(99UL));
+        Assert.That(reader.GetValue(1), Is.EqualTo("partial"));
     }
 
     [Test]
     public async Task InsertBinaryAsync_WithNullableProperties_ShouldInsertNulls()
     {
-        var tableName = CreateTestTableName();
-        try
+        var tableName = CreateTableName();
+        await client.ExecuteNonQueryAsync($@"
+            CREATE TABLE {tableName}
+            (Id UInt64, Value String, OptionalScore Nullable(Int32))
+            ENGINE = MergeTree() ORDER BY Id");
+
+        client.RegisterBinaryInsertType<PocoWithNullable>();
+
+        var rows = new[]
         {
-            await client.ExecuteNonQueryAsync($@"
-                CREATE TABLE IF NOT EXISTS test.{tableName}
-                (Id UInt64, Value String, OptionalScore Nullable(Int32))
-                ENGINE = MergeTree() ORDER BY Id");
+            new PocoWithNullable { Id = 1, Value = "with_score", OptionalScore = 100 },
+            new PocoWithNullable { Id = 2, Value = "no_score", OptionalScore = null },
+        };
 
-            client.RegisterBinaryInsertType<PocoWithNullable>();
+        var inserted = await client.InsertBinaryAsync(tableName, rows);
 
-            var rows = new[]
-            {
-                new PocoWithNullable { Id = 1, Value = "with_score", OptionalScore = 100 },
-                new PocoWithNullable { Id = 2, Value = "no_score", OptionalScore = null },
-            };
+        Assert.That(inserted, Is.EqualTo(2));
 
-            var inserted = await client.InsertBinaryAsync(
-                tableName, rows, new InsertOptions { Database = "test" });
+        using var reader = await client.ExecuteReaderAsync(
+            $"SELECT Id, Value, OptionalScore FROM {tableName} ORDER BY Id");
 
-            Assert.That(inserted, Is.EqualTo(2));
+        Assert.That(reader.Read(), Is.True);
+        Assert.That(reader.GetValue(0), Is.EqualTo(1UL));
+        Assert.That(reader.GetValue(2), Is.EqualTo(100));
 
-            using var reader = await client.ExecuteReaderAsync(
-                $"SELECT Id, Value, OptionalScore FROM test.{tableName} ORDER BY Id",
-                options: new QueryOptions { Database = "test" });
-
-            Assert.That(reader.Read(), Is.True);
-            Assert.That(reader.GetValue(0), Is.EqualTo(1UL));
-            Assert.That(reader.GetValue(2), Is.EqualTo(100));
-
-            Assert.That(reader.Read(), Is.True);
-            Assert.That(reader.GetValue(0), Is.EqualTo(2UL));
-            Assert.That(reader.IsDBNull(2), Is.True);
-        }
-        finally
-        {
-            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
-        }
+        Assert.That(reader.Read(), Is.True);
+        Assert.That(reader.GetValue(0), Is.EqualTo(2UL));
+        Assert.That(reader.IsDBNull(2), Is.True);
     }
 
     [Test]
     public async Task InsertBinaryAsync_AfterAlterTableAddsColumn_ShouldInsertSuccessfully()
     {
-        var tableName = CreateTestTableName();
-        try
+        var tableName = CreateTableName();
+        await client.ExecuteNonQueryAsync($@"
+            CREATE TABLE {tableName}
+            (Id UInt64, Value String)
+            ENGINE = MergeTree() ORDER BY Id");
+
+        client.RegisterBinaryInsertType<SimplePoco>();
+
+        var firstBatch = new[]
         {
-            await client.ExecuteNonQueryAsync($@"
-                CREATE TABLE IF NOT EXISTS test.{tableName}
-                (Id UInt64, Value String)
-                ENGINE = MergeTree() ORDER BY Id");
+            new SimplePoco { Id = 1, Value = "before_alter" },
+        };
 
-            client.RegisterBinaryInsertType<SimplePoco>();
+        var inserted = await client.InsertBinaryAsync(tableName, firstBatch);
 
-            var firstBatch = new[]
-            {
-                new SimplePoco { Id = 1, Value = "before_alter" },
-            };
+        Assert.That(inserted, Is.EqualTo(1));
 
-            var inserted = await client.InsertBinaryAsync(
-                tableName, firstBatch, new InsertOptions { Database = "test" });
+        // Add a new column with a default value
+        await client.ExecuteNonQueryAsync(
+            $"ALTER TABLE {tableName} ADD COLUMN Extra String DEFAULT 'default_extra'");
 
-            Assert.That(inserted, Is.EqualTo(1));
-
-            // Add a new column with a default value
-            await client.ExecuteNonQueryAsync(
-                $"ALTER TABLE test.{tableName} ADD COLUMN Extra String DEFAULT 'default_extra'");
-
-            // Insert again with the same POCO (which doesn't have the new column)
-            var secondBatch = new[]
-            {
-                new SimplePoco { Id = 2, Value = "after_alter" },
-            };
-
-            inserted = await client.InsertBinaryAsync(
-                tableName, secondBatch, new InsertOptions { Database = "test" });
-
-            Assert.That(inserted, Is.EqualTo(1));
-
-            // Verify both rows exist and the new column got its default value
-            using var reader = await client.ExecuteReaderAsync(
-                $"SELECT Id, Value, Extra FROM test.{tableName} ORDER BY Id",
-                options: new QueryOptions { Database = "test" });
-
-            Assert.That(reader.Read(), Is.True);
-            Assert.That(reader.GetValue(0), Is.EqualTo(1UL));
-            Assert.That(reader.GetValue(1), Is.EqualTo("before_alter"));
-
-            Assert.That(reader.Read(), Is.True);
-            Assert.That(reader.GetValue(0), Is.EqualTo(2UL));
-            Assert.That(reader.GetValue(1), Is.EqualTo("after_alter"));
-            Assert.That(reader.GetValue(2), Is.EqualTo("default_extra"));
-        }
-        finally
+        // Insert again with the same POCO (which doesn't have the new column)
+        var secondBatch = new[]
         {
-            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
-        }
+            new SimplePoco { Id = 2, Value = "after_alter" },
+        };
+
+        inserted = await client.InsertBinaryAsync(tableName, secondBatch);
+
+        Assert.That(inserted, Is.EqualTo(1));
+
+        // Verify both rows exist and the new column got its default value
+        using var reader = await client.ExecuteReaderAsync(
+            $"SELECT Id, Value, Extra FROM {tableName} ORDER BY Id");
+
+        Assert.That(reader.Read(), Is.True);
+        Assert.That(reader.GetValue(0), Is.EqualTo(1UL));
+        Assert.That(reader.GetValue(1), Is.EqualTo("before_alter"));
+
+        Assert.That(reader.Read(), Is.True);
+        Assert.That(reader.GetValue(0), Is.EqualTo(2UL));
+        Assert.That(reader.GetValue(1), Is.EqualTo("after_alter"));
+        Assert.That(reader.GetValue(2), Is.EqualTo("default_extra"));
     }
 
     private class PocoWithReservedWords
@@ -1060,83 +892,67 @@ public class InsertBinaryPocoTests : AbstractConnectionTestFixture
     [Test]
     public async Task InsertBinaryAsync_WithReservedWordColumns_ShouldRoundTripData()
     {
-        var tableName = CreateTestTableName();
-        try
+        var tableName = CreateTableName();
+        await client.ExecuteNonQueryAsync($@"
+            CREATE TABLE {tableName}
+            (Id UInt64, `index` UInt32, `key` String, `order` Int32)
+            ENGINE = MergeTree() ORDER BY Id");
+
+        client.RegisterBinaryInsertType<PocoWithReservedWords>();
+
+        var rows = new[]
         {
-            await client.ExecuteNonQueryAsync($@"
-                CREATE TABLE IF NOT EXISTS test.{tableName}
-                (Id UInt64, `index` UInt32, `key` String, `order` Int32)
-                ENGINE = MergeTree() ORDER BY Id");
+            new PocoWithReservedWords { Id = 1, Index = 10, Key = "first", Order = 100 },
+            new PocoWithReservedWords { Id = 2, Index = 20, Key = "second", Order = 200 },
+        };
 
-            client.RegisterBinaryInsertType<PocoWithReservedWords>();
+        var inserted = await client.InsertBinaryAsync(tableName, rows);
 
-            var rows = new[]
-            {
-                new PocoWithReservedWords { Id = 1, Index = 10, Key = "first", Order = 100 },
-                new PocoWithReservedWords { Id = 2, Index = 20, Key = "second", Order = 200 },
-            };
+        Assert.That(inserted, Is.EqualTo(2));
 
-            var inserted = await client.InsertBinaryAsync(
-                tableName, rows, new InsertOptions { Database = "test" });
+        using var reader = await client.ExecuteReaderAsync(
+            $"SELECT Id, `index`, `key`, `order` FROM {tableName} ORDER BY Id");
 
-            Assert.That(inserted, Is.EqualTo(2));
+        Assert.That(reader.Read(), Is.True);
+        Assert.That(reader.GetValue(0), Is.EqualTo(1UL));
+        Assert.That(reader.GetValue(1), Is.EqualTo(10u));
+        Assert.That(reader.GetValue(2), Is.EqualTo("first"));
+        Assert.That(reader.GetValue(3), Is.EqualTo(100));
 
-            using var reader = await client.ExecuteReaderAsync(
-                $"SELECT Id, `index`, `key`, `order` FROM test.{tableName} ORDER BY Id",
-                options: new QueryOptions { Database = "test" });
-
-            Assert.That(reader.Read(), Is.True);
-            Assert.That(reader.GetValue(0), Is.EqualTo(1UL));
-            Assert.That(reader.GetValue(1), Is.EqualTo(10u));
-            Assert.That(reader.GetValue(2), Is.EqualTo("first"));
-            Assert.That(reader.GetValue(3), Is.EqualTo(100));
-
-            Assert.That(reader.Read(), Is.True);
-            Assert.That(reader.GetValue(0), Is.EqualTo(2UL));
-            Assert.That(reader.GetValue(1), Is.EqualTo(20u));
-            Assert.That(reader.GetValue(2), Is.EqualTo("second"));
-            Assert.That(reader.GetValue(3), Is.EqualTo(200));
-        }
-        finally
-        {
-            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
-        }
+        Assert.That(reader.Read(), Is.True);
+        Assert.That(reader.GetValue(0), Is.EqualTo(2UL));
+        Assert.That(reader.GetValue(1), Is.EqualTo(20u));
+        Assert.That(reader.GetValue(2), Is.EqualTo("second"));
+        Assert.That(reader.GetValue(3), Is.EqualTo(200));
     }
 
     [Test]
     public async Task InsertBinaryAsync_WithMultipleBatches_ShouldInsertAll()
     {
-        var tableName = CreateTestTableName();
-        try
+        var tableName = CreateTableName();
+        await client.ExecuteNonQueryAsync($@"
+            CREATE TABLE {tableName}
+            (Id UInt64, Value String)
+            ENGINE = MergeTree() ORDER BY Id");
+
+        client.RegisterBinaryInsertType<SimplePoco>();
+
+        var rows = Enumerable.Range(1, 500).Select(i => new SimplePoco
         {
-            await client.ExecuteNonQueryAsync($@"
-                CREATE TABLE IF NOT EXISTS test.{tableName}
-                (Id UInt64, Value String)
-                ENGINE = MergeTree() ORDER BY Id");
+            Id = (ulong)i,
+            Value = $"Value_{i}",
+        });
 
-            client.RegisterBinaryInsertType<SimplePoco>();
+        var inserted = await client.InsertBinaryAsync(
+            tableName,
+            rows,
+            new InsertOptions { BatchSize = 100 });
 
-            var rows = Enumerable.Range(1, 500).Select(i => new SimplePoco
-            {
-                Id = (ulong)i,
-                Value = $"Value_{i}",
-            });
+        Assert.That(inserted, Is.EqualTo(500));
 
-            var inserted = await client.InsertBinaryAsync(
-                tableName,
-                rows,
-                new InsertOptions { Database = "test", BatchSize = 100 });
-
-            Assert.That(inserted, Is.EqualTo(500));
-
-            var count = await client.ExecuteScalarAsync(
-                $"SELECT count() FROM test.{tableName}");
-            Assert.That(count, Is.EqualTo(500UL));
-        }
-        finally
-        {
-            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
-        }
+        var count = await client.ExecuteScalarAsync(
+            $"SELECT count() FROM {tableName}");
+        Assert.That(count, Is.EqualTo(500UL));
     }
 
 }

--- a/ClickHouse.Driver.Tests/Copy/PocoReadTests.cs
+++ b/ClickHouse.Driver.Tests/Copy/PocoReadTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using ClickHouse.Driver.ADO;
 using ClickHouse.Driver.ADO.Parameters;
@@ -15,9 +14,6 @@ namespace ClickHouse.Driver.Tests.Copy;
 [TestFixture]
 public class PocoReadTests : AbstractConnectionTestFixture
 {
-    private string CreateTestTableName([CallerMemberName] string testName = null)
-        => SanitizeTableName($"test_pocoread_{testName}_{Guid.NewGuid():N}");
-
     public class SimplePoco
     {
         public ulong Id { get; set; }

--- a/ClickHouse.Driver.Tests/InsertBinaryCompressionTests.cs
+++ b/ClickHouse.Driver.Tests/InsertBinaryCompressionTests.cs
@@ -14,9 +14,6 @@ namespace ClickHouse.Driver.Tests;
 [Category("Cloud")]
 public class InsertBinaryCompressionTests : AbstractConnectionTestFixture
 {
-    private string CreateTestTableName([CallerMemberName] string testName = null)
-        => SanitizeTableName($"test_compress_{testName}_{Guid.NewGuid():N}");
-
     private class SimplePoco
     {
         public ulong Id { get; set; }
@@ -25,9 +22,9 @@ public class InsertBinaryCompressionTests : AbstractConnectionTestFixture
 
     private async Task<string> CreateTableAsync([CallerMemberName] string testName = null)
     {
-        var tableName = CreateTestTableName(testName);
+        var tableName = CreateTableName(testName);
         await client.ExecuteNonQueryAsync($@"
-            CREATE TABLE IF NOT EXISTS test.{tableName}
+            CREATE TABLE {tableName}
             (Id UInt64, Value String)
             ENGINE = MergeTree() ORDER BY Id");
         return tableName;
@@ -55,46 +52,38 @@ public class InsertBinaryCompressionTests : AbstractConnectionTestFixture
         [ValueSource(nameof(Compressors))] IClickHouseCompressor compressor)
     {
         var tableName = await CreateTableAsync();
-        try
+        var options = new InsertOptions
         {
-            var options = new InsertOptions
+            Compressor = compressor,
+            ColumnTypes = new Dictionary<string, string>
             {
-                Database = "test",
-                Compressor = compressor,
-                ColumnTypes = new Dictionary<string, string>
-                {
-                    ["Id"] = "UInt64",
-                    ["Value"] = "String",
-                },
-            };
+                ["Id"] = "UInt64",
+                ["Value"] = "String",
+            },
+        };
 
-            await client.InsertBinaryAsync(
-                tableName,
-                new[] { "Id", "Value" },
-                new List<object[]>
-                {
-                    new object[] { 1UL, "hello" },
-                    new object[] { 2UL, "world" },
-                },
-                options);
+        await client.InsertBinaryAsync(
+            tableName,
+            new[] { "Id", "Value" },
+            new List<object[]>
+            {
+                new object[] { 1UL, "hello" },
+                new object[] { 2UL, "world" },
+            },
+            options);
 
-            using var reader = await client.ExecuteReaderAsync(
-                $"SELECT Id, Value FROM test.{tableName} ORDER BY Id");
+        using var reader = await client.ExecuteReaderAsync(
+            $"SELECT Id, Value FROM {tableName} ORDER BY Id");
 
-            Assert.That(reader.Read(), Is.True);
-            Assert.That(reader.GetFieldValue<ulong>(0), Is.EqualTo(1UL));
-            Assert.That(reader.GetString(1), Is.EqualTo("hello"));
+        Assert.That(reader.Read(), Is.True);
+        Assert.That(reader.GetFieldValue<ulong>(0), Is.EqualTo(1UL));
+        Assert.That(reader.GetString(1), Is.EqualTo("hello"));
 
-            Assert.That(reader.Read(), Is.True);
-            Assert.That(reader.GetFieldValue<ulong>(0), Is.EqualTo(2UL));
-            Assert.That(reader.GetString(1), Is.EqualTo("world"));
+        Assert.That(reader.Read(), Is.True);
+        Assert.That(reader.GetFieldValue<ulong>(0), Is.EqualTo(2UL));
+        Assert.That(reader.GetString(1), Is.EqualTo("world"));
 
-            Assert.That(reader.Read(), Is.False);
-        }
-        finally
-        {
-            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
-        }
+        Assert.That(reader.Read(), Is.False);
     }
 
     [Test]
@@ -102,42 +91,34 @@ public class InsertBinaryCompressionTests : AbstractConnectionTestFixture
         [ValueSource(nameof(Compressors))] IClickHouseCompressor compressor)
     {
         var tableName = await CreateTableAsync();
-        try
-        {
-            client.RegisterBinaryInsertType<SimplePoco>();
+        client.RegisterBinaryInsertType<SimplePoco>();
 
-            var options = new InsertOptions
+        var options = new InsertOptions
+        {
+            Compressor = compressor,
+        };
+
+        await client.InsertBinaryAsync(
+            tableName,
+            new[]
             {
-                Database = "test",
-                Compressor = compressor,
-            };
+                new SimplePoco { Id = 1UL, Value = "hello" },
+                new SimplePoco { Id = 2UL, Value = "world" },
+            },
+            options);
 
-            await client.InsertBinaryAsync(
-                tableName,
-                new[]
-                {
-                    new SimplePoco { Id = 1UL, Value = "hello" },
-                    new SimplePoco { Id = 2UL, Value = "world" },
-                },
-                options);
+        using var reader = await client.ExecuteReaderAsync(
+            $"SELECT Id, Value FROM {tableName} ORDER BY Id");
 
-            using var reader = await client.ExecuteReaderAsync(
-                $"SELECT Id, Value FROM test.{tableName} ORDER BY Id");
+        Assert.That(reader.Read(), Is.True);
+        Assert.That(reader.GetFieldValue<ulong>(0), Is.EqualTo(1UL));
+        Assert.That(reader.GetString(1), Is.EqualTo("hello"));
 
-            Assert.That(reader.Read(), Is.True);
-            Assert.That(reader.GetFieldValue<ulong>(0), Is.EqualTo(1UL));
-            Assert.That(reader.GetString(1), Is.EqualTo("hello"));
+        Assert.That(reader.Read(), Is.True);
+        Assert.That(reader.GetFieldValue<ulong>(0), Is.EqualTo(2UL));
+        Assert.That(reader.GetString(1), Is.EqualTo("world"));
 
-            Assert.That(reader.Read(), Is.True);
-            Assert.That(reader.GetFieldValue<ulong>(0), Is.EqualTo(2UL));
-            Assert.That(reader.GetString(1), Is.EqualTo("world"));
-
-            Assert.That(reader.Read(), Is.False);
-        }
-        finally
-        {
-            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
-        }
+        Assert.That(reader.Read(), Is.False);
     }
 
     [Test]
@@ -147,38 +128,30 @@ public class InsertBinaryCompressionTests : AbstractConnectionTestFixture
         // to the (leave-open) memory stream, is seeked to 0, and posted without Content-Encoding.
         const int rowCount = 2500;
         var tableName = await CreateTableAsync();
-        try
+        var options = new InsertOptions
         {
-            var options = new InsertOptions
+            Compressor = null,
+            BatchSize = 1000,
+            ColumnTypes = new Dictionary<string, string>
             {
-                Database = "test",
-                Compressor = null,
-                BatchSize = 1000,
-                ColumnTypes = new Dictionary<string, string>
-                {
-                    ["Id"] = "UInt64",
-                    ["Value"] = "String",
-                },
-            };
+                ["Id"] = "UInt64",
+                ["Value"] = "String",
+            },
+        };
 
-            var rows = Enumerable.Range(0, rowCount)
-                .Select(i => new object[] { (ulong)i, $"value_{i}" })
-                .ToList();
+        var rows = Enumerable.Range(0, rowCount)
+            .Select(i => new object[] { (ulong)i, $"value_{i}" })
+            .ToList();
 
-            await client.InsertBinaryAsync(tableName, new[] { "Id", "Value" }, rows, options);
+        await client.InsertBinaryAsync(tableName, new[] { "Id", "Value" }, rows, options);
 
-            var count = (ulong)await client.ExecuteScalarAsync($"SELECT count() FROM test.{tableName}");
-            Assert.That(count, Is.EqualTo((ulong)rowCount));
+        var count = (ulong)await client.ExecuteScalarAsync($"SELECT count() FROM {tableName}");
+        Assert.That(count, Is.EqualTo((ulong)rowCount));
 
-            var sum = await client.ExecuteScalarAsync($"SELECT sum(Id) FROM test.{tableName}");
-            // sum(Id) comes back as a UInt64 aggregate (ulong); it fits well within Int64 here, so
-            // Convert.ToInt64 normalizes it for comparison regardless of the exact returned CLR type.
-            var expected = ((long)rowCount - 1) * rowCount / 2;
-            Assert.That(Convert.ToInt64(sum), Is.EqualTo(expected));
-        }
-        finally
-        {
-            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
-        }
+        var sum = await client.ExecuteScalarAsync($"SELECT sum(Id) FROM {tableName}");
+        // sum(Id) comes back as a UInt64 aggregate (ulong); it fits well within Int64 here, so
+        // Convert.ToInt64 normalizes it for comparison regardless of the exact returned CLR type.
+        var expected = ((long)rowCount - 1) * rowCount / 2;
+        Assert.That(Convert.ToInt64(sum), Is.EqualTo(expected));
     }
 }

--- a/ClickHouse.Driver.Tests/InsertBinarySchemaTests.cs
+++ b/ClickHouse.Driver.Tests/InsertBinarySchemaTests.cs
@@ -12,14 +12,18 @@ namespace ClickHouse.Driver.Tests;
 [TestFixture]
 public class InsertBinarySchemaTests : AbstractConnectionTestFixture
 {
-    private string CreateTestTableName([CallerMemberName] string testName = null)
-        => SanitizeTableName($"test_schema_{testName}_{Guid.NewGuid():N}");
-
+    /// <summary>
+    /// Creates the table and returns its database-qualified name. Tests that set
+    /// <see cref="InsertOptions.Database"/> must hand the API under test the bare name
+    /// (<see cref="TestUtilities.BareTableName"/>) — a qualified name resolves the database on its
+    /// own, so the override would be a no-op and the schema cache would be keyed on a dotted table
+    /// name no real caller produces. The qualified name stays in DDL and read-back queries.
+    /// </summary>
     private async Task<string> CreateSimpleTestTableAsync([CallerMemberName] string testName = null)
     {
-        var tableName = CreateTestTableName(testName);
+        var tableName = CreateTableName(testName);
         await client.ExecuteNonQueryAsync($@"
-            CREATE TABLE IF NOT EXISTS test.{tableName}
+            CREATE TABLE {tableName}
             (id UInt64, value String)
             ENGINE = MergeTree() ORDER BY id");
         return tableName;
@@ -46,79 +50,67 @@ public class InsertBinarySchemaTests : AbstractConnectionTestFixture
     public async Task InsertBinaryAsync_WithColumnTypes_ShouldSkipSchemaQuery()
     {
         var tableName = await CreateSimpleTestTableAsync();
-        try
+        var bareTableName = TestUtilities.BareTableName(tableName);
+        var queryId = $"test_col_types_skip_{Guid.NewGuid():N}";
+        var options = new InsertOptions
         {
-            var queryId = $"test_col_types_skip_{Guid.NewGuid():N}";
-            var options = new InsertOptions
+            Database = "test",
+            QueryId = queryId,
+            ColumnTypes = new Dictionary<string, string>
             {
-                Database = "test",
-                QueryId = queryId,
-                ColumnTypes = new Dictionary<string, string>
-                {
-                    ["id"] = "UInt64",
-                    ["value"] = "String",
-                },
-            };
+                ["id"] = "UInt64",
+                ["value"] = "String",
+            },
+        };
 
-            await client.InsertBinaryAsync(
-                tableName,
-                new[] { "id", "value" },
-                GenerateTestRows(5).ToList(),
-                options);
+        await client.InsertBinaryAsync(
+            bareTableName,
+            new[] { "id", "value" },
+            GenerateTestRows(5).ToList(),
+            options);
 
-            var probeCount = await CountSchemaProbeQueriesAsync(queryId);
-            Assert.That(probeCount, Is.EqualTo(0UL),
-                "No schema probe query should be sent when ColumnTypes is provided");
-        }
-        finally
-        {
-            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
-        }
+        var probeCount = await CountSchemaProbeQueriesAsync(queryId);
+        Assert.That(probeCount, Is.EqualTo(0UL),
+            "No schema probe query should be sent when ColumnTypes is provided");
     }
 
     [Test]
     public async Task InsertBinaryAsync_WithColumnTypes_ShouldRoundTripData()
     {
         var tableName = await CreateSimpleTestTableAsync();
-        try
+        var bareTableName = TestUtilities.BareTableName(tableName);
+        var options = new InsertOptions
         {
-            var options = new InsertOptions
+            Database = "test",
+            ColumnTypes = new Dictionary<string, string>
             {
-                Database = "test",
-                ColumnTypes = new Dictionary<string, string>
-                {
-                    ["id"] = "UInt64",
-                    ["value"] = "String",
-                },
-            };
+                ["id"] = "UInt64",
+                ["value"] = "String",
+            },
+        };
 
-            await client.InsertBinaryAsync(
-                tableName,
-                new[] { "id", "value" },
-                new List<object[]>
-                {
-                    new object[] { 1UL, "hello" },
-                    new object[] { 2UL, "world" },
-                },
-                options);
+        await client.InsertBinaryAsync(
+            bareTableName,
+            new[] { "id", "value" },
+            new List<object[]>
+            {
+                new object[] { 1UL, "hello" },
+                new object[] { 2UL, "world" },
+            },
+            options);
 
-            using var reader = await client.ExecuteReaderAsync(
-                $"SELECT id, value FROM test.{tableName} ORDER BY id");
+        using var reader = await client.ExecuteReaderAsync(
+            $"SELECT id, value FROM {tableName} ORDER BY id");
 
-            Assert.That(reader.Read(), Is.True);
-            Assert.That(reader.GetFieldValue<ulong>(0), Is.EqualTo(1UL));
-            Assert.That(reader.GetString(1), Is.EqualTo("hello"));
+        Assert.That(reader.Read(), Is.True);
+        Assert.That(reader.GetFieldValue<ulong>(0), Is.EqualTo(1UL));
+        Assert.That(reader.GetString(1), Is.EqualTo("hello"));
 
-            Assert.That(reader.Read(), Is.True);
-            Assert.That(reader.GetFieldValue<ulong>(0), Is.EqualTo(2UL));
-            Assert.That(reader.GetString(1), Is.EqualTo("world"));
+        Assert.That(reader.Read(), Is.True);
+        Assert.That(reader.GetFieldValue<ulong>(0), Is.EqualTo(2UL));
+        Assert.That(reader.GetString(1), Is.EqualTo("world"));
 
-            Assert.That(reader.Read(), Is.False);
-        }
-        finally
-        {
-            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
-        }
+        Assert.That(reader.Read(), Is.False);
     }
 
     [Test]
@@ -185,209 +177,182 @@ public class InsertBinarySchemaTests : AbstractConnectionTestFixture
     public async Task InsertBinaryAsync_WithSchemaCache_ShouldQueryOnce()
     {
         var tableName = await CreateSimpleTestTableAsync();
-        try
+        var bareTableName = TestUtilities.BareTableName(tableName);
+        var queryId = $"test_cache_once_{Guid.NewGuid():N}";
+        var options = new InsertOptions
         {
-            var queryId = $"test_cache_once_{Guid.NewGuid():N}";
-            var options = new InsertOptions
-            {
-                Database = "test",
-                QueryId = queryId,
-                UseSchemaCache = true,
-            };
+            Database = "test",
+            QueryId = queryId,
+            UseSchemaCache = true,
+        };
 
-            // First insert — should trigger schema probe
-            await client.InsertBinaryAsync(
-                tableName,
-                new[] { "id", "value" },
-                GenerateTestRows(3).ToList(),
-                options);
+        // First insert — should trigger schema probe
+        await client.InsertBinaryAsync(
+            bareTableName,
+            new[] { "id", "value" },
+            GenerateTestRows(3).ToList(),
+            options);
 
-            // Second insert — should reuse cached schema
-            await client.InsertBinaryAsync(
-                tableName,
-                new[] { "id", "value" },
-                GenerateTestRows(3, startId: 100).ToList(),
-                options);
+        // Second insert — should reuse cached schema
+        await client.InsertBinaryAsync(
+            bareTableName,
+            new[] { "id", "value" },
+            GenerateTestRows(3, startId: 100).ToList(),
+            options);
 
-            var probeCount = await CountSchemaProbeQueriesAsync(queryId);
-            Assert.That(probeCount, Is.EqualTo(1UL),
-                "Only one schema probe query should be sent when UseSchemaCache is true");
-        }
-        finally
-        {
-            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
-        }
+        var probeCount = await CountSchemaProbeQueriesAsync(queryId);
+        Assert.That(probeCount, Is.EqualTo(1UL),
+            "Only one schema probe query should be sent when UseSchemaCache is true");
     }
 
     [Test]
     public async Task InsertBinaryAsync_WithSchemaCache_DifferentColumns_ShouldQueryOnce()
     {
-        var tableName = CreateTestTableName();
+        var tableName = CreateTableName();
         await client.ExecuteNonQueryAsync($@"
-            CREATE TABLE IF NOT EXISTS test.{tableName}
+            CREATE TABLE {tableName}
             (id UInt64, value String, extra String DEFAULT 'x')
             ENGINE = MergeTree() ORDER BY id");
-        try
+
+        var bareTableName = TestUtilities.BareTableName(tableName);
+        var queryId = $"test_cache_diffcols_{Guid.NewGuid():N}";
+        var options = new InsertOptions
         {
-            var queryId = $"test_cache_diffcols_{Guid.NewGuid():N}";
-            var options = new InsertOptions
-            {
-                Database = "test",
-                QueryId = queryId,
-                UseSchemaCache = true,
-            };
+            Database = "test",
+            QueryId = queryId,
+            UseSchemaCache = true,
+        };
 
-            // Insert with columns [id, value]
-            await client.InsertBinaryAsync(
-                tableName,
-                new[] { "id", "value" },
-                new List<object[]> { new object[] { 1UL, "a" } },
-                options);
+        // Insert with columns [id, value]
+        await client.InsertBinaryAsync(
+            bareTableName,
+            new[] { "id", "value" },
+            new List<object[]> { new object[] { 1UL, "a" } },
+            options);
 
-            // Insert with columns [id, extra] — same table, should reuse cached schema
-            await client.InsertBinaryAsync(
-                tableName,
-                new[] { "id", "extra" },
-                new List<object[]> { new object[] { 2UL, "b" } },
-                options);
+        // Insert with columns [id, extra] — same table, should reuse cached schema
+        await client.InsertBinaryAsync(
+            bareTableName,
+            new[] { "id", "extra" },
+            new List<object[]> { new object[] { 2UL, "b" } },
+            options);
 
-            var probeCount = await CountSchemaProbeQueriesAsync(queryId);
-            Assert.That(probeCount, Is.EqualTo(1UL),
-                "Cache is per-table — different column subsets should share the same cached schema");
-        }
-        finally
-        {
-            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
-        }
+        var probeCount = await CountSchemaProbeQueriesAsync(queryId);
+        Assert.That(probeCount, Is.EqualTo(1UL),
+            "Cache is per-table — different column subsets should share the same cached schema");
     }
 
     [Test]
     public async Task InsertBinaryAsync_WithColumnTypesAndSchemaCache_ShouldPreferColumnTypes()
     {
         var tableName = await CreateSimpleTestTableAsync();
-        try
+        var bareTableName = TestUtilities.BareTableName(tableName);
+        var queryId = $"test_types_priority_{Guid.NewGuid():N}";
+        var options = new InsertOptions
         {
-            var queryId = $"test_types_priority_{Guid.NewGuid():N}";
-            var options = new InsertOptions
+            Database = "test",
+            QueryId = queryId,
+            ColumnTypes = new Dictionary<string, string>
             {
-                Database = "test",
-                QueryId = queryId,
-                ColumnTypes = new Dictionary<string, string>
-                {
-                    ["id"] = "UInt64",
-                    ["value"] = "String",
-                },
-                UseSchemaCache = true,
-            };
+                ["id"] = "UInt64",
+                ["value"] = "String",
+            },
+            UseSchemaCache = true,
+        };
 
-            await client.InsertBinaryAsync(
-                tableName,
-                new[] { "id", "value" },
-                GenerateTestRows(3).ToList(),
-                options);
+        await client.InsertBinaryAsync(
+            bareTableName,
+            new[] { "id", "value" },
+            GenerateTestRows(3).ToList(),
+            options);
 
-            var probeCount = await CountSchemaProbeQueriesAsync(queryId);
-            Assert.That(probeCount, Is.EqualTo(0UL),
-                "ColumnTypes should take priority over UseSchemaCache — no schema query expected");
-        }
-        finally
-        {
-            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
-        }
+        var probeCount = await CountSchemaProbeQueriesAsync(queryId);
+        Assert.That(probeCount, Is.EqualTo(0UL),
+            "ColumnTypes should take priority over UseSchemaCache — no schema query expected");
     }
 
     [Test]
     public async Task InsertBinaryAsync_WithSchemaCache_SubsetThenSuperset_ShouldRoundTripData()
     {
-        var tableName = CreateTestTableName();
+        var tableName = CreateTableName();
         await client.ExecuteNonQueryAsync($@"
-            CREATE TABLE IF NOT EXISTS test.{tableName}
+            CREATE TABLE {tableName}
             (id UInt64, value String, extra String DEFAULT 'default_val')
             ENGINE = MergeTree() ORDER BY id");
-        try
+
+        var bareTableName = TestUtilities.BareTableName(tableName);
+        var options = new InsertOptions
         {
-            var options = new InsertOptions
-            {
-                Database = "test",
-                UseSchemaCache = true,
-            };
+            Database = "test",
+            UseSchemaCache = true,
+        };
 
-            // First insert uses only [id, value] — cache should be populated with SELECT *
-            await client.InsertBinaryAsync(
-                tableName,
-                new[] { "id", "value" },
-                new List<object[]> { new object[] { 1UL, "first" } },
-                options);
+        // First insert uses only [id, value] — cache should be populated with SELECT *
+        await client.InsertBinaryAsync(
+            bareTableName,
+            new[] { "id", "value" },
+            new List<object[]> { new object[] { 1UL, "first" } },
+            options);
 
-            // Second insert uses [id, value, extra] — must work from the same cached schema
-            await client.InsertBinaryAsync(
-                tableName,
-                new[] { "id", "value", "extra" },
-                new List<object[]> { new object[] { 2UL, "second", "custom_val" } },
-                options);
+        // Second insert uses [id, value, extra] — must work from the same cached schema
+        await client.InsertBinaryAsync(
+            bareTableName,
+            new[] { "id", "value", "extra" },
+            new List<object[]> { new object[] { 2UL, "second", "custom_val" } },
+            options);
 
-            // Verify both rows round-tripped correctly
-            using var reader = await client.ExecuteReaderAsync(
-                $"SELECT id, value, extra FROM test.{tableName} ORDER BY id");
+        // Verify both rows round-tripped correctly
+        using var reader = await client.ExecuteReaderAsync(
+            $"SELECT id, value, extra FROM {tableName} ORDER BY id");
 
-            Assert.That(reader.Read(), Is.True);
-            Assert.That(reader.GetFieldValue<ulong>(0), Is.EqualTo(1UL));
-            Assert.That(reader.GetString(1), Is.EqualTo("first"));
-            Assert.That(reader.GetString(2), Is.EqualTo("default_val"));
+        Assert.That(reader.Read(), Is.True);
+        Assert.That(reader.GetFieldValue<ulong>(0), Is.EqualTo(1UL));
+        Assert.That(reader.GetString(1), Is.EqualTo("first"));
+        Assert.That(reader.GetString(2), Is.EqualTo("default_val"));
 
-            Assert.That(reader.Read(), Is.True);
-            Assert.That(reader.GetFieldValue<ulong>(0), Is.EqualTo(2UL));
-            Assert.That(reader.GetString(1), Is.EqualTo("second"));
-            Assert.That(reader.GetString(2), Is.EqualTo("custom_val"));
+        Assert.That(reader.Read(), Is.True);
+        Assert.That(reader.GetFieldValue<ulong>(0), Is.EqualTo(2UL));
+        Assert.That(reader.GetString(1), Is.EqualTo("second"));
+        Assert.That(reader.GetString(2), Is.EqualTo("custom_val"));
 
-            Assert.That(reader.Read(), Is.False);
-        }
-        finally
-        {
-            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
-        }
+        Assert.That(reader.Read(), Is.False);
     }
 
     [Test]
     public async Task InsertBinaryAsync_WithSchemaCache_NullColumns_ShouldInsertAllColumns()
     {
-        var tableName = CreateTestTableName();
+        var tableName = CreateTableName();
         await client.ExecuteNonQueryAsync($@"
-            CREATE TABLE IF NOT EXISTS test.{tableName}
+            CREATE TABLE {tableName}
             (id UInt64, value String)
             ENGINE = MergeTree() ORDER BY id");
-        try
+
+        var bareTableName = TestUtilities.BareTableName(tableName);
+        var options = new InsertOptions
         {
-            var options = new InsertOptions
-            {
-                Database = "test",
-                UseSchemaCache = true,
-            };
+            Database = "test",
+            UseSchemaCache = true,
+        };
 
-            // Insert with null columns — should use all columns from cached SELECT *
-            await client.InsertBinaryAsync(
-                tableName,
-                null,
-                new List<object[]> { new object[] { 1UL, "hello" }, new object[] { 2UL, "world" } },
-                options);
+        // Insert with null columns — should use all columns from cached SELECT *
+        await client.InsertBinaryAsync(
+            bareTableName,
+            null,
+            new List<object[]> { new object[] { 1UL, "hello" }, new object[] { 2UL, "world" } },
+            options);
 
-            using var reader = await client.ExecuteReaderAsync(
-                $"SELECT id, value FROM test.{tableName} ORDER BY id");
+        using var reader = await client.ExecuteReaderAsync(
+            $"SELECT id, value FROM {tableName} ORDER BY id");
 
-            Assert.That(reader.Read(), Is.True);
-            Assert.That(reader.GetFieldValue<ulong>(0), Is.EqualTo(1UL));
-            Assert.That(reader.GetString(1), Is.EqualTo("hello"));
+        Assert.That(reader.Read(), Is.True);
+        Assert.That(reader.GetFieldValue<ulong>(0), Is.EqualTo(1UL));
+        Assert.That(reader.GetString(1), Is.EqualTo("hello"));
 
-            Assert.That(reader.Read(), Is.True);
-            Assert.That(reader.GetFieldValue<ulong>(0), Is.EqualTo(2UL));
-            Assert.That(reader.GetString(1), Is.EqualTo("world"));
+        Assert.That(reader.Read(), Is.True);
+        Assert.That(reader.GetFieldValue<ulong>(0), Is.EqualTo(2UL));
+        Assert.That(reader.GetString(1), Is.EqualTo("world"));
 
-            Assert.That(reader.Read(), Is.False);
-        }
-        finally
-        {
-            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
-        }
+        Assert.That(reader.Read(), Is.False);
     }
 
     [Test]
@@ -395,143 +360,128 @@ public class InsertBinarySchemaTests : AbstractConnectionTestFixture
     {
         // All columns are the same type (String), so a wrong order would silently swap values
         // rather than causing a type error
-        var tableName = CreateTestTableName();
+        var tableName = CreateTableName();
         await client.ExecuteNonQueryAsync($@"
-            CREATE TABLE IF NOT EXISTS test.{tableName}
+            CREATE TABLE {tableName}
             (first String, second String, third String)
             ENGINE = MergeTree() ORDER BY first");
-        try
+
+        var bareTableName = TestUtilities.BareTableName(tableName);
+        var options = new InsertOptions
         {
-            var options = new InsertOptions
-            {
-                Database = "test",
-                UseSchemaCache = true,
-            };
+            Database = "test",
+            UseSchemaCache = true,
+        };
 
-            await client.InsertBinaryAsync(
-                tableName,
-                null,
-                new List<object[]> { new object[] { "aaa", "bbb", "ccc" } },
-                options);
+        await client.InsertBinaryAsync(
+            bareTableName,
+            null,
+            new List<object[]> { new object[] { "aaa", "bbb", "ccc" } },
+            options);
 
-            using var reader = await client.ExecuteReaderAsync(
-                $"SELECT first, second, third FROM test.{tableName}");
+        using var reader = await client.ExecuteReaderAsync(
+            $"SELECT first, second, third FROM {tableName}");
 
-            Assert.That(reader.Read(), Is.True);
-            Assert.That(reader.GetString(0), Is.EqualTo("aaa"), "first column");
-            Assert.That(reader.GetString(1), Is.EqualTo("bbb"), "second column");
-            Assert.That(reader.GetString(2), Is.EqualTo("ccc"), "third column");
-        }
-        finally
-        {
-            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
-        }
+        Assert.That(reader.Read(), Is.True);
+        Assert.That(reader.GetString(0), Is.EqualTo("aaa"), "first column");
+        Assert.That(reader.GetString(1), Is.EqualTo("bbb"), "second column");
+        Assert.That(reader.GetString(2), Is.EqualTo("ccc"), "third column");
     }
 
     [Test]
     public async Task InsertBinaryAsync_WithSchemaCache_OptionsDatabaseOverridesClientDatabase()
     {
         // Create a table in the "test" database
-        var tableName = CreateTestTableName();
+        var tableName = CreateTableName();
         await client.ExecuteNonQueryAsync($@"
-            CREATE TABLE IF NOT EXISTS test.{tableName}
+            CREATE TABLE {tableName}
             (id UInt64, value String)
             ENGINE = MergeTree() ORDER BY id");
-        try
+
+        // The insert has to receive the unqualified name — a qualified one would resolve the
+        // database on its own and the override under test would never be exercised.
+        var bareTableName = TestUtilities.BareTableName(tableName);
+
+        // Create a client whose Settings.Database = "default"
+        var builder = TestUtilities.GetConnectionStringBuilder();
+        builder.Database = "default";
+        using var clientWithDefaultDb = new ClickHouseClient(new ClickHouseClientSettings(builder));
+
+        var options = new InsertOptions
         {
-            // Create a client whose Settings.Database = "default"
-            var builder = TestUtilities.GetConnectionStringBuilder();
-            builder.Database = "default";
-            using var clientWithDefaultDb = new ClickHouseClient(new ClickHouseClientSettings(builder));
+            // InsertOptions.Database should override the client's "default" database
+            Database = "test",
+            UseSchemaCache = true,
+        };
 
-            var options = new InsertOptions
-            {
-                // InsertOptions.Database should override the client's "default" database
-                Database = "test",
-                UseSchemaCache = true,
-            };
+        await clientWithDefaultDb.InsertBinaryAsync(
+            bareTableName,
+            new[] { "id", "value" },
+            new List<object[]> { new object[] { 1UL, "overridden" } },
+            options);
 
-            await clientWithDefaultDb.InsertBinaryAsync(
-                tableName,
-                new[] { "id", "value" },
-                new List<object[]> { new object[] { 1UL, "overridden" } },
-                options);
-
-            var value = await client.ExecuteScalarAsync(
-                $"SELECT value FROM test.{tableName} WHERE id = 1");
-            Assert.That(value, Is.EqualTo("overridden"),
-                "InsertOptions.Database should override ClickHouseClientSettings.Database");
-        }
-        finally
-        {
-            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
-        }
+        var value = await client.ExecuteScalarAsync(
+            $"SELECT value FROM {tableName} WHERE id = 1");
+        Assert.That(value, Is.EqualTo("overridden"),
+            "InsertOptions.Database should override ClickHouseClientSettings.Database");
     }
 
     [Test]
     public async Task InsertBinaryAsync_WithSchemaCache_FallsBackToClientDatabase()
     {
         // Create a table in the "test" database
-        var tableName = CreateTestTableName();
+        var tableName = CreateTableName();
         await client.ExecuteNonQueryAsync($@"
-            CREATE TABLE IF NOT EXISTS test.{tableName}
+            CREATE TABLE {tableName}
             (id UInt64, value String)
             ENGINE = MergeTree() ORDER BY id");
-        try
-        {
-            // Create a client whose Settings.Database = "test"
-            var builder = TestUtilities.GetConnectionStringBuilder();
-            builder.Database = "test";
-            using var clientWithTestDb = new ClickHouseClient(new ClickHouseClientSettings(builder));
 
-            // No Database on InsertOptions — should fall back to client's "test"
-            var options = new InsertOptions { UseSchemaCache = true };
+        // The insert has to receive the unqualified name, otherwise the fallback under test
+        // would be bypassed by the qualification.
+        var bareTableName = TestUtilities.BareTableName(tableName);
 
-            await clientWithTestDb.InsertBinaryAsync(
-                tableName,
-                new[] { "id", "value" },
-                new List<object[]> { new object[] { 1UL, "fallback" } },
-                options);
+        // Create a client whose Settings.Database = "test"
+        var builder = TestUtilities.GetConnectionStringBuilder();
+        builder.Database = "test";
+        using var clientWithTestDb = new ClickHouseClient(new ClickHouseClientSettings(builder));
 
-            var value = await client.ExecuteScalarAsync(
-                $"SELECT value FROM test.{tableName} WHERE id = 1");
-            Assert.That(value, Is.EqualTo("fallback"),
-                "Should fall back to ClickHouseClientSettings.Database when InsertOptions.Database is null");
-        }
-        finally
-        {
-            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
-        }
+        // No Database on InsertOptions — should fall back to client's "test"
+        var options = new InsertOptions { UseSchemaCache = true };
+
+        await clientWithTestDb.InsertBinaryAsync(
+            bareTableName,
+            new[] { "id", "value" },
+            new List<object[]> { new object[] { 1UL, "fallback" } },
+            options);
+
+        var value = await client.ExecuteScalarAsync(
+            $"SELECT value FROM {tableName} WHERE id = 1");
+        Assert.That(value, Is.EqualTo("fallback"),
+            "Should fall back to ClickHouseClientSettings.Database when InsertOptions.Database is null");
     }
 
     [Test]
     public async Task InsertBinaryAsync_DefaultBehavior_ShouldQueryEveryTime()
     {
         var tableName = await CreateSimpleTestTableAsync();
-        try
-        {
-            var queryId = $"test_default_{Guid.NewGuid():N}";
+        var bareTableName = TestUtilities.BareTableName(tableName);
+        var queryId = $"test_default_{Guid.NewGuid():N}";
 
-            // Two inserts with no schema options
-            await client.InsertBinaryAsync(
-                tableName,
-                new[] { "id", "value" },
-                GenerateTestRows(3).ToList(),
-                new InsertOptions { Database = "test", QueryId = queryId });
+        // Two inserts with no schema options
+        await client.InsertBinaryAsync(
+            bareTableName,
+            new[] { "id", "value" },
+            GenerateTestRows(3).ToList(),
+            new InsertOptions { Database = "test", QueryId = queryId });
 
-            await client.InsertBinaryAsync(
-                tableName,
-                new[] { "id", "value" },
-                GenerateTestRows(3, startId: 100).ToList(),
-                new InsertOptions { Database = "test", QueryId = queryId });
+        await client.InsertBinaryAsync(
+            bareTableName,
+            new[] { "id", "value" },
+            GenerateTestRows(3, startId: 100).ToList(),
+            new InsertOptions { Database = "test", QueryId = queryId });
 
-            var probeCount = await CountSchemaProbeQueriesAsync(queryId);
-            Assert.That(probeCount, Is.EqualTo(2UL),
-                "Default behavior should query schema on every insert");
-        }
-        finally
-        {
-            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS test.{tableName}");
-        }
+        var probeCount = await CountSchemaProbeQueriesAsync(queryId);
+        Assert.That(probeCount, Is.EqualTo(2UL),
+            "Default behavior should query schema on every insert");
     }
 }

--- a/ClickHouse.Driver.Tests/Logging/ClickHouseBulkCopyLoggingTests.cs
+++ b/ClickHouse.Driver.Tests/Logging/ClickHouseBulkCopyLoggingTests.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -16,17 +16,45 @@ namespace ClickHouse.Driver.Tests.Logging;
 
 public class ClickHouseBulkCopyLoggingTests
 {
-    private string targetTable = "test.bulk_copy_logging_table";
-    
+    private readonly ConcurrentQueue<string> createdTables = new();
+
+    private string targetTable;
+
     [SetUp]
     public async Task SetUp()
     {
         var settings = new ClickHouseClientSettings(TestUtilities.GetConnectionStringBuilder());
-        var connection = new ClickHouseConnection(settings);
+        using var connection = new ClickHouseConnection(settings);
+
+        targetTable = TestUtilities.CreateTableName("bulk_copy_logging");
+        createdTables.Enqueue(targetTable);
 
         await connection.ExecuteStatementAsync($"CREATE DATABASE IF NOT EXISTS test;");
-        await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {targetTable}");
-        await connection.ExecuteStatementAsync($"CREATE TABLE IF NOT EXISTS {targetTable} (int Int32) ENGINE Null");
+        await connection.ExecuteStatementAsync($"CREATE TABLE {targetTable} (int Int32) ENGINE Null");
+    }
+
+    /// <summary>
+    /// This fixture does not derive from <see cref="AbstractConnectionTestFixture"/>, so the tables
+    /// handed out by <see cref="SetUp"/> are dropped here. Best-effort: a table which cannot be
+    /// dropped must not fail an otherwise passing fixture.
+    /// </summary>
+    [OneTimeTearDown]
+    public async Task DropCreatedTables()
+    {
+        var settings = new ClickHouseClientSettings(TestUtilities.GetConnectionStringBuilder());
+        using var connection = new ClickHouseConnection(settings);
+
+        foreach (var table in createdTables)
+        {
+            try
+            {
+                await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {table}");
+            }
+            catch (Exception e)
+            {
+                TestContext.Progress.WriteLine($"Failed to drop test table {table}: {e.Message}");
+            }
+        }
     }
 
     [Test]

--- a/ClickHouse.Driver.Tests/ORM/DapperContribTests.cs
+++ b/ClickHouse.Driver.Tests/ORM/DapperContribTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reflection;
 using System.Threading.Tasks;
 using ClickHouse.Driver.Utility;
 using Dapper.Contrib.Extensions;
@@ -13,15 +14,41 @@ public class DapperContribTests : AbstractConnectionTestFixture
     // TODO: DateTimeTimeOffset
     private readonly static TestRecord referenceRecord = new(1, "value", new DateTime(2023, 4, 15, 1, 2, 3, DateTimeKind.Utc));
 
-    [Table("test.dapper_contrib")]
+    // Dapper.Contrib caches the resolved table name per POCO type for the lifetime of the process,
+    // so the randomized name is shared by every test in this fixture rather than created per test.
+    private static string tableName;
+
     public record class TestRecord(int Id, string Value, DateTime Timestamp);
+
+    [OneTimeSetUp]
+    public void SetUpTableNameMapper()
+    {
+        tableName = CreateTableName("dapper_contrib");
+
+        // Dapper.Contrib derives the table name from the POCO type name or its [Table] attribute, both
+        // of which are compile-time constants, so its resolution hook is the only way to hand it a name
+        // that is unique per run. Other types keep Contrib's own naming rules.
+        SqlMapperExtensions.TableNameMapper = type => type == typeof(TestRecord)
+            ? tableName
+            : type.GetCustomAttribute<TableAttribute>(false)?.Name ?? $"{type.Name}s";
+    }
+
+    [OneTimeTearDown]
+    public void ResetTableNameMapper()
+    {
+        // The mapper is process-wide, and the fallback above only approximates Contrib's own naming
+        // rules. Clearing it keeps a future Contrib fixture from silently inheriting them. Safe for
+        // this fixture's own tests: Contrib has already cached TestRecord's resolved name by now.
+        SqlMapperExtensions.TableNameMapper = null;
+    }
 
     [SetUp]
     public async Task SetUp()
     {
-        await connection.ExecuteStatementAsync("TRUNCATE TABLE IF EXISTS test.dapper_contrib");
-        await connection.ExecuteStatementAsync("CREATE TABLE IF NOT EXISTS test.dapper_contrib (Id Int32, Value String, Timestamp DateTime('UTC')) ENGINE Memory");
-        await connection.ExecuteStatementAsync("INSERT INTO test.dapper_contrib VALUES (1, 'value', toDateTime('2023/04/15 01:02:03', 'UTC'))");
+        await connection.ExecuteStatementAsync($"CREATE TABLE IF NOT EXISTS {tableName} (Id Int32, Value String, Timestamp DateTime('UTC')) ENGINE Memory");
+        // Tests in this fixture share one table, so its contents are reset before each of them
+        await connection.ExecuteStatementAsync($"TRUNCATE TABLE IF EXISTS {tableName}");
+        await connection.ExecuteStatementAsync($"INSERT INTO {tableName} VALUES (1, 'value', toDateTime('2023/04/15 01:02:03', 'UTC'))");
     }
 
     [Test]

--- a/ClickHouse.Driver.Tests/ORM/DapperTests.cs
+++ b/ClickHouse.Driver.Tests/ORM/DapperTests.cs
@@ -233,24 +233,23 @@ public class DapperTests : AbstractConnectionTestFixture
     [TestCase(0.0001)]
     public async Task ShouldWriteDecimalWithTypeInference(decimal expected)
     {
-        await connection.ExecuteStatementAsync("TRUNCATE TABLE IF EXISTS test.dapper_decimal");
-        await connection.ExecuteStatementAsync("CREATE TABLE IF NOT EXISTS test.dapper_decimal (balance Decimal64(4)) ENGINE Memory");
+        var targetTable = CreateTableName();
+        await connection.ExecuteStatementAsync($"CREATE TABLE {targetTable} (balance Decimal64(4)) ENGINE Memory");
 
-
-        var sql = @"INSERT INTO test.dapper_decimal (balance) VALUES (@balance)";
+        var sql = $@"INSERT INTO {targetTable} (balance) VALUES (@balance)";
         await connection.ExecuteAsync(sql, new { balance = expected });
 
-        var actual = (ClickHouseDecimal) await connection.ExecuteScalarAsync("SELECT * FROM test.dapper_decimal");
+        var actual = (ClickHouseDecimal) await connection.ExecuteScalarAsync($"SELECT * FROM {targetTable}");
         Assert.That(actual.ToDecimal(CultureInfo.InvariantCulture), Is.EqualTo(expected));
     }
 
     [Test]
     public async Task ShouldWriteTwoFieldsWithTheSamePrefix()
     {
-        await connection.ExecuteStatementAsync("TRUNCATE TABLE IF EXISTS test.dapper_prefixes");
-        await connection.ExecuteStatementAsync("CREATE TABLE IF NOT EXISTS test.dapper_prefixes (testField Int32, testFieldWithSuffix Int32) ENGINE Memory");
+        var targetTable = CreateTableName();
+        await connection.ExecuteStatementAsync($"CREATE TABLE {targetTable} (testField Int32, testFieldWithSuffix Int32) ENGINE Memory");
 
-        const string sql = "INSERT INTO test.dapper_prefixes (testField, testFieldWithSuffix) VALUES (@testField, @testFieldWithSuffix)";
+        var sql = $"INSERT INTO {targetTable} (testField, testFieldWithSuffix) VALUES (@testField, @testFieldWithSuffix)";
         await connection.ExecuteAsync(sql, new { testField = 1, testFieldWithSuffix = 2 });
     }
 
@@ -259,13 +258,13 @@ public class DapperTests : AbstractConnectionTestFixture
     [TestCase(null)]
     public async Task ShouldWriteNullableDoubleWithTypeInference(double? expected)
     {
-        await connection.ExecuteStatementAsync("TRUNCATE TABLE IF EXISTS test.dapper_nullable_double");
-        await connection.ExecuteStatementAsync("CREATE TABLE IF NOT EXISTS test.dapper_nullable_double (balance Nullable(Float64)) ENGINE Memory");
+        var targetTable = CreateTableName();
+        await connection.ExecuteStatementAsync($"CREATE TABLE {targetTable} (balance Nullable(Float64)) ENGINE Memory");
 
-        var sql = @"INSERT INTO test.dapper_nullable_double (balance) VALUES (@balance)";
+        var sql = $@"INSERT INTO {targetTable} (balance) VALUES (@balance)";
         await connection.ExecuteAsync(sql, new { balance = expected });
 
-        var actual = await connection.ExecuteScalarAsync("SELECT * FROM test.dapper_nullable_double");
+        var actual = await connection.ExecuteScalarAsync($"SELECT * FROM {targetTable}");
         if (expected is null)
             Assert.That(actual, Is.InstanceOf<DBNull>());
         else
@@ -283,15 +282,15 @@ public class DapperTests : AbstractConnectionTestFixture
     [Test]
     public async Task ShouldInsertAndSelectWithAnonymousObject()
     {
-        await connection.ExecuteStatementAsync("TRUNCATE TABLE IF EXISTS test.dapper_anon");
-        await connection.ExecuteStatementAsync("CREATE TABLE IF NOT EXISTS test.dapper_anon (id Int32, name String, value Float64) ENGINE Memory");
+        var targetTable = CreateTableName();
+        await connection.ExecuteStatementAsync($"CREATE TABLE {targetTable} (id Int32, name String, value Float64) ENGINE Memory");
 
         // Anonymous object as parameter source - the most common Dapper pattern
         await connection.ExecuteAsync(
-            "INSERT INTO test.dapper_anon (id, name, value) VALUES (@Id, @Name, @Value)",
+            $"INSERT INTO {targetTable} (id, name, value) VALUES (@Id, @Name, @Value)",
             new { Id = 1, Name = "alice", Value = 3.14 });
 
-        var rows = (await connection.QueryAsync<SimpleRow>("SELECT id, name, value FROM test.dapper_anon")).ToList();
+        var rows = (await connection.QueryAsync<SimpleRow>($"SELECT id, name, value FROM {targetTable}")).ToList();
         Assert.That(rows, Has.Count.EqualTo(1));
         Assert.That(rows[0].Id, Is.EqualTo(1));
         Assert.That(rows[0].Name, Is.EqualTo("alice"));
@@ -301,15 +300,15 @@ public class DapperTests : AbstractConnectionTestFixture
     [Test]
     public async Task ShouldInsertWithPocoParameters()
     {
-        await connection.ExecuteStatementAsync("TRUNCATE TABLE IF EXISTS test.dapper_poco");
-        await connection.ExecuteStatementAsync("CREATE TABLE IF NOT EXISTS test.dapper_poco (id Int32, name String, value Float64) ENGINE Memory");
+        var targetTable = CreateTableName();
+        await connection.ExecuteStatementAsync($"CREATE TABLE {targetTable} (id Int32, name String, value Float64) ENGINE Memory");
 
         // POCO class as parameter source - Dapper reflects its properties identically to anonymous objects
         var param = new SimpleRow { Id = 42, Name = "bob", Value = 99.9 };
         await connection.ExecuteAsync(
-            "INSERT INTO test.dapper_poco (id, name, value) VALUES (@Id, @Name, @Value)", param);
+            $"INSERT INTO {targetTable} (id, name, value) VALUES (@Id, @Name, @Value)", param);
 
-        var rows = (await connection.QueryAsync<SimpleRow>("SELECT id, name, value FROM test.dapper_poco")).ToList();
+        var rows = (await connection.QueryAsync<SimpleRow>($"SELECT id, name, value FROM {targetTable}")).ToList();
         Assert.That(rows, Has.Count.EqualTo(1));
         Assert.That(rows[0].Id, Is.EqualTo(42));
         Assert.That(rows[0].Name, Is.EqualTo("bob"));
@@ -318,16 +317,16 @@ public class DapperTests : AbstractConnectionTestFixture
     [Test]
     public async Task ShouldSelectWithDynamicParametersFromDictionary()
     {
-        await connection.ExecuteStatementAsync("TRUNCATE TABLE IF EXISTS test.dapper_dynparams");
-        await connection.ExecuteStatementAsync("CREATE TABLE IF NOT EXISTS test.dapper_dynparams (id Int32, name String) ENGINE Memory");
-        await connection.ExecuteStatementAsync("INSERT INTO test.dapper_dynparams VALUES (1, 'alice'), (2, 'bob'), (3, 'carol')");
+        var targetTable = CreateTableName();
+        await connection.ExecuteStatementAsync($"CREATE TABLE {targetTable} (id Int32, name String) ENGINE Memory");
+        await connection.ExecuteStatementAsync($"INSERT INTO {targetTable} VALUES (1, 'alice'), (2, 'bob'), (3, 'carol')");
 
         // DynamicParameters constructed from a dictionary
         var dict = new Dictionary<string, object> { { "Id", 2 } };
         var dynParams = new DynamicParameters(dict);
 
         var rows = (await connection.QueryAsync<SimpleRow>(
-            "SELECT id, name FROM test.dapper_dynparams WHERE id = @Id", dynParams)).ToList();
+            $"SELECT id, name FROM {targetTable} WHERE id = @Id", dynParams)).ToList();
 
         Assert.That(rows, Has.Count.EqualTo(1));
         Assert.That(rows[0].Name, Is.EqualTo("bob"));
@@ -336,15 +335,15 @@ public class DapperTests : AbstractConnectionTestFixture
     [Test]
     public async Task ShouldSelectWithDynamicParametersFromAnonymousObject()
     {
-        await connection.ExecuteStatementAsync("TRUNCATE TABLE IF EXISTS test.dapper_dynparams2");
-        await connection.ExecuteStatementAsync("CREATE TABLE IF NOT EXISTS test.dapper_dynparams2 (id Int32, name String) ENGINE Memory");
-        await connection.ExecuteStatementAsync("INSERT INTO test.dapper_dynparams2 VALUES (1, 'alice'), (2, 'bob')");
+        var targetTable = CreateTableName();
+        await connection.ExecuteStatementAsync($"CREATE TABLE {targetTable} (id Int32, name String) ENGINE Memory");
+        await connection.ExecuteStatementAsync($"INSERT INTO {targetTable} VALUES (1, 'alice'), (2, 'bob')");
 
         // DynamicParameters constructed from an anonymous object
         var dynParams = new DynamicParameters(new { Id = 1 });
 
         var rows = (await connection.QueryAsync<SimpleRow>(
-            "SELECT id, name FROM test.dapper_dynparams2 WHERE id = @Id", dynParams)).ToList();
+            $"SELECT id, name FROM {targetTable} WHERE id = @Id", dynParams)).ToList();
 
         Assert.That(rows, Has.Count.EqualTo(1));
         Assert.That(rows[0].Name, Is.EqualTo("alice"));
@@ -366,11 +365,11 @@ public class DapperTests : AbstractConnectionTestFixture
     [Test]
     public async Task ShouldSelectPureFromTable_MappingToPoco()
     {
-        await connection.ExecuteStatementAsync("TRUNCATE TABLE IF EXISTS test.dapper_pure");
-        await connection.ExecuteStatementAsync("CREATE TABLE IF NOT EXISTS test.dapper_pure (id Int32, name String, value Float64) ENGINE Memory");
-        await connection.ExecuteStatementAsync("INSERT INTO test.dapper_pure VALUES (10, 'test', 1.5), (20, 'test2', 2.5)");
+        var targetTable = CreateTableName();
+        await connection.ExecuteStatementAsync($"CREATE TABLE {targetTable} (id Int32, name String, value Float64) ENGINE Memory");
+        await connection.ExecuteStatementAsync($"INSERT INTO {targetTable} VALUES (10, 'test', 1.5), (20, 'test2', 2.5)");
 
-        var rows = (await connection.QueryAsync<SimpleRow>("SELECT id, name, value FROM test.dapper_pure ORDER BY id")).ToList();
+        var rows = (await connection.QueryAsync<SimpleRow>($"SELECT id, name, value FROM {targetTable} ORDER BY id")).ToList();
 
         Assert.That(rows, Has.Count.EqualTo(2));
         Assert.That(rows[0].Id, Is.EqualTo(10));
@@ -380,13 +379,13 @@ public class DapperTests : AbstractConnectionTestFixture
     [Test]
     public async Task ShouldSelectWithMultipleAnonymousParameters()
     {
-        await connection.ExecuteStatementAsync("TRUNCATE TABLE IF EXISTS test.dapper_multi");
-        await connection.ExecuteStatementAsync("CREATE TABLE IF NOT EXISTS test.dapper_multi (id Int32, name String, value Float64) ENGINE Memory");
-        await connection.ExecuteStatementAsync("INSERT INTO test.dapper_multi VALUES (1, 'alice', 1.0), (2, 'bob', 2.0), (3, 'carol', 3.0)");
+        var targetTable = CreateTableName();
+        await connection.ExecuteStatementAsync($"CREATE TABLE {targetTable} (id Int32, name String, value Float64) ENGINE Memory");
+        await connection.ExecuteStatementAsync($"INSERT INTO {targetTable} VALUES (1, 'alice', 1.0), (2, 'bob', 2.0), (3, 'carol', 3.0)");
 
         // Multiple parameters from a single anonymous object
         var rows = (await connection.QueryAsync<SimpleRow>(
-            "SELECT id, name, value FROM test.dapper_multi WHERE id >= @MinId AND name = @Name",
+            $"SELECT id, name, value FROM {targetTable} WHERE id >= @MinId AND name = @Name",
             new { MinId = 1, Name = "bob" })).ToList();
 
         Assert.That(rows, Has.Count.EqualTo(1));
@@ -405,12 +404,12 @@ public class DapperTests : AbstractConnectionTestFixture
     {
         // Pure SELECT returning a tuple column - no tuple PARAMETER, just tuple in RESULT
         // This tests whether Dapper can materialize a tuple column into a POCO
-        await connection.ExecuteStatementAsync("TRUNCATE TABLE IF EXISTS test.dapper_tuple_col");
-        await connection.ExecuteStatementAsync("CREATE TABLE IF NOT EXISTS test.dapper_tuple_col (id Int32, coords Tuple(Int32, Int32)) ENGINE Memory");
-        await connection.ExecuteStatementAsync("INSERT INTO test.dapper_tuple_col VALUES (1, (10, 20))");
+        var targetTable = CreateTableName();
+        await connection.ExecuteStatementAsync($"CREATE TABLE {targetTable} (id Int32, coords Tuple(Int32, Int32)) ENGINE Memory");
+        await connection.ExecuteStatementAsync($"INSERT INTO {targetTable} VALUES (1, (10, 20))");
 
         var rows = (await connection.QueryAsync<RowWithTuple>(
-            "SELECT id, coords FROM test.dapper_tuple_col")).ToList();
+            $"SELECT id, coords FROM {targetTable}")).ToList();
 
         Assert.That(rows, Has.Count.EqualTo(1));
         Assert.That(rows[0].Id, Is.EqualTo(1));
@@ -433,13 +432,13 @@ public class DapperTests : AbstractConnectionTestFixture
     {
         // ClickHouse doesn't support Dapper's automatic IN expansion (@Ids -> @Ids1, @Ids2, ...).
         // Instead, use has() with an Array parameter and ClickHouse native {param:Type} syntax.
-        await connection.ExecuteStatementAsync("TRUNCATE TABLE IF EXISTS test.dapper_in");
-        await connection.ExecuteStatementAsync("CREATE TABLE IF NOT EXISTS test.dapper_in (id Int32, name String) ENGINE Memory");
-        await connection.ExecuteStatementAsync("INSERT INTO test.dapper_in VALUES (1, 'alice'), (2, 'bob'), (3, 'carol'), (4, 'dave')");
+        var targetTable = CreateTableName();
+        await connection.ExecuteStatementAsync($"CREATE TABLE {targetTable} (id Int32, name String) ENGINE Memory");
+        await connection.ExecuteStatementAsync($"INSERT INTO {targetTable} VALUES (1, 'alice'), (2, 'bob'), (3, 'carol'), (4, 'dave')");
 
         var parameters = new Dictionary<string, object> { { "ids", new[] { 1, 3 } } };
         var rows = (await connection.QueryAsync<SimpleRow>(
-            "SELECT id, name FROM test.dapper_in WHERE has({ids:Array(Int32)}, id) ORDER BY id",
+            $"SELECT id, name FROM {targetTable} WHERE has({{ids:Array(Int32)}}, id) ORDER BY id",
             parameters)).ToList();
 
         Assert.That(rows, Has.Count.EqualTo(2));
@@ -453,12 +452,12 @@ public class DapperTests : AbstractConnectionTestFixture
         // Test Dapper's native IN expansion: WHERE id IN @Ids
         // Dapper rewrites this to WHERE id IN (@Ids1, @Ids2, ...) with individual params.
         // Each @IdsN then gets replaced by {IdsN:Type} via ReplacePlaceholders.
-        await connection.ExecuteStatementAsync("TRUNCATE TABLE IF EXISTS test.dapper_in2");
-        await connection.ExecuteStatementAsync("CREATE TABLE IF NOT EXISTS test.dapper_in2 (id Int32, name String) ENGINE Memory");
-        await connection.ExecuteStatementAsync("INSERT INTO test.dapper_in2 VALUES (1, 'alice'), (2, 'bob'), (3, 'carol')");
+        var targetTable = CreateTableName();
+        await connection.ExecuteStatementAsync($"CREATE TABLE {targetTable} (id Int32, name String) ENGINE Memory");
+        await connection.ExecuteStatementAsync($"INSERT INTO {targetTable} VALUES (1, 'alice'), (2, 'bob'), (3, 'carol')");
 
         var rows = (await connection.QueryAsync<SimpleRow>(
-            "SELECT id, name FROM test.dapper_in2 WHERE id IN @Ids ORDER BY id",
+            $"SELECT id, name FROM {targetTable} WHERE id IN @Ids ORDER BY id",
             new { Ids = new[] { 1, 3 } })).ToList();
 
         Assert.That(rows, Has.Count.EqualTo(2));
@@ -469,9 +468,9 @@ public class DapperTests : AbstractConnectionTestFixture
     [Test]
     public async Task ShouldInsertWithExceptSyntax()
     {
-        await connection.ExecuteStatementAsync("TRUNCATE TABLE IF EXISTS test.dapper_except");
-        await connection.ExecuteStatementAsync(@"
-            CREATE TABLE IF NOT EXISTS test.dapper_except (
+        var targetTable = CreateTableName();
+        await connection.ExecuteStatementAsync($@"
+            CREATE TABLE {targetTable} (
                 id UInt32,
                 name String,
                 value Float64,
@@ -481,11 +480,11 @@ public class DapperTests : AbstractConnectionTestFixture
         ");
 
         // Insert using Dapper with EXCEPT syntax
-        var sql = "INSERT INTO test.dapper_except (* EXCEPT (created, updated)) VALUES (@id, @name, @value)";
+        var sql = $"INSERT INTO {targetTable} (* EXCEPT (created, updated)) VALUES (@id, @name, @value)";
         await connection.ExecuteAsync(sql, new { id = 100, name = "dapper-test", value = 123.45 });
 
         // Verify the insert worked and defaults were applied
-        var result = await connection.QueryAsync("SELECT * FROM test.dapper_except");
+        var result = await connection.QueryAsync($"SELECT * FROM {targetTable}");
         var row = result.Single() as IDictionary<string, object>;
         
         Assert.That(row, Is.Not.Null);

--- a/ClickHouse.Driver.Tests/SQL/NestedArrayParameterTests.cs
+++ b/ClickHouse.Driver.Tests/SQL/NestedArrayParameterTests.cs
@@ -353,28 +353,19 @@ public class NestedArrayParameterTests : AbstractConnectionTestFixture
     [TestCaseSource(nameof(InsertReadbackCases))]
     public async Task InsertParameterizedIntoTable_ReadsBackAsJagged(string ddlType, object input, object expectedJagged)
     {
-        var tableName = SanitizeTableName($"nested_insert_{Guid.NewGuid():N}");
-        var fqn = $"test.{tableName}";
-        await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {fqn}");
+        var fqn = CreateTableName("nested_insert");
         await connection.ExecuteStatementAsync($"CREATE TABLE {fqn} (arr {ddlType}) ENGINE Memory");
 
-        try
+        using (var insert = connection.CreateCommand())
         {
-            using (var insert = connection.CreateCommand())
-            {
-                insert.CommandText = $"INSERT INTO {fqn} VALUES ({{values:{ddlType}}})";
-                insert.AddParameter("values", input);
-                await insert.ExecuteNonQueryAsync();
-            }
+            insert.CommandText = $"INSERT INTO {fqn} VALUES ({{values:{ddlType}}})";
+            insert.AddParameter("values", input);
+            await insert.ExecuteNonQueryAsync();
+        }
 
-            using var reader = await connection.ExecuteReaderAsync($"SELECT arr FROM {fqn}");
-            Assert.That(reader.Read(), Is.True);
-            Assert.That(reader.GetValue(0), Is.EqualTo(expectedJagged));
-        }
-        finally
-        {
-            await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {fqn}");
-        }
+        using var reader = await connection.ExecuteReaderAsync($"SELECT arr FROM {fqn}");
+        Assert.That(reader.Read(), Is.True);
+        Assert.That(reader.GetValue(0), Is.EqualTo(expectedJagged));
     }
 
     // ----- ClickHouseClient (primary API) coverage -----
@@ -409,85 +400,61 @@ public class NestedArrayParameterTests : AbstractConnectionTestFixture
     [Test]
     public async Task ClientInsertBinaryAsync_JaggedArrayColumn_RoundTripsViaPrimaryApi()
     {
-        var tableName = SanitizeTableName($"nested_client_jagged_{Guid.NewGuid():N}");
-        var fqn = $"test.{tableName}";
-        await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS {fqn}");
+        var fqn = CreateTableName("nested_client_jagged");
         await client.ExecuteNonQueryAsync($"CREATE TABLE {fqn} (id Int32, arr Array(Array(Int32))) ENGINE Memory");
-        try
-        {
-            var rows = new List<object[]>
-            {
-                new object[] { 0, new int[][] { new[] { 1, 2 }, new[] { 3 } } },
-                new object[] { 1, new int[][] { new[] { 4, 5, 6 } } },
-            };
-            await client.InsertBinaryAsync(fqn, new[] { "id", "arr" }, rows);
 
-            using var reader = await client.ExecuteReaderAsync($"SELECT arr FROM {fqn} ORDER BY id");
-            Assert.That(reader.Read(), Is.True);
-            Assert.That((int[][])reader.GetValue(0), Is.EqualTo(rows[0][1]));
-            Assert.That(reader.Read(), Is.True);
-            Assert.That((int[][])reader.GetValue(0), Is.EqualTo(rows[1][1]));
-        }
-        finally
+        var rows = new List<object[]>
         {
-            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS {fqn}");
-        }
+            new object[] { 0, new int[][] { new[] { 1, 2 }, new[] { 3 } } },
+            new object[] { 1, new int[][] { new[] { 4, 5, 6 } } },
+        };
+        await client.InsertBinaryAsync(fqn, new[] { "id", "arr" }, rows);
+
+        using var reader = await client.ExecuteReaderAsync($"SELECT arr FROM {fqn} ORDER BY id");
+        Assert.That(reader.Read(), Is.True);
+        Assert.That((int[][])reader.GetValue(0), Is.EqualTo(rows[0][1]));
+        Assert.That(reader.Read(), Is.True);
+        Assert.That((int[][])reader.GetValue(0), Is.EqualTo(rows[1][1]));
     }
 
     [Test]
     public async Task ClientInsertBinaryAsync_MultidimArrayColumn_RoundTripsViaPrimaryApi()
     {
-        var tableName = SanitizeTableName($"nested_client_multidim_{Guid.NewGuid():N}");
-        var fqn = $"test.{tableName}";
-        await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS {fqn}");
+        var fqn = CreateTableName("nested_client_multidim");
         await client.ExecuteNonQueryAsync($"CREATE TABLE {fqn} (id Int32, arr Array(Array(UInt8))) ENGINE Memory");
-        try
-        {
-            var matrix = new byte[,] { { 10, 20 }, { 30, 40 } };
-            await client.InsertBinaryAsync(
-                fqn,
-                new[] { "id", "arr" },
-                new List<object[]> { new object[] { 0, matrix } });
 
-            using var reader = await client.ExecuteReaderAsync($"SELECT arr FROM {fqn}");
-            Assert.That(reader.Read(), Is.True);
-            var got = (byte[][])reader.GetValue(0);
-            Assert.That(got[0], Is.EqualTo(new byte[] { 10, 20 }));
-            Assert.That(got[1], Is.EqualTo(new byte[] { 30, 40 }));
-        }
-        finally
-        {
-            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS {fqn}");
-        }
+        var matrix = new byte[,] { { 10, 20 }, { 30, 40 } };
+        await client.InsertBinaryAsync(
+            fqn,
+            new[] { "id", "arr" },
+            new List<object[]> { new object[] { 0, matrix } });
+
+        using var reader = await client.ExecuteReaderAsync($"SELECT arr FROM {fqn}");
+        Assert.That(reader.Read(), Is.True);
+        var got = (byte[][])reader.GetValue(0);
+        Assert.That(got[0], Is.EqualTo(new byte[] { 10, 20 }));
+        Assert.That(got[1], Is.EqualTo(new byte[] { 30, 40 }));
     }
 
     [Test]
     public async Task ClientInsertBinaryAsync_Multidim3DArrayColumn_RoundTripsViaPrimaryApi()
     {
-        var tableName = SanitizeTableName($"nested_client_3d_{Guid.NewGuid():N}");
-        var fqn = $"test.{tableName}";
-        await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS {fqn}");
+        var fqn = CreateTableName("nested_client_3d");
         await client.ExecuteNonQueryAsync($"CREATE TABLE {fqn} (id Int32, arr Array(Array(Array(Int32)))) ENGINE Memory");
-        try
-        {
-            var cube = new int[2, 2, 2] { { { 1, 2 }, { 3, 4 } }, { { 5, 6 }, { 7, 8 } } };
-            await client.InsertBinaryAsync(
-                fqn,
-                new[] { "id", "arr" },
-                new List<object[]> { new object[] { 0, cube } });
 
-            using var reader = await client.ExecuteReaderAsync($"SELECT arr FROM {fqn}");
-            Assert.That(reader.Read(), Is.True);
-            var got = (int[][][])reader.GetValue(0);
-            Assert.That(got[0][0], Is.EqualTo(new[] { 1, 2 }));
-            Assert.That(got[0][1], Is.EqualTo(new[] { 3, 4 }));
-            Assert.That(got[1][0], Is.EqualTo(new[] { 5, 6 }));
-            Assert.That(got[1][1], Is.EqualTo(new[] { 7, 8 }));
-        }
-        finally
-        {
-            await client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS {fqn}");
-        }
+        var cube = new int[2, 2, 2] { { { 1, 2 }, { 3, 4 } }, { { 5, 6 }, { 7, 8 } } };
+        await client.InsertBinaryAsync(
+            fqn,
+            new[] { "id", "arr" },
+            new List<object[]> { new object[] { 0, cube } });
+
+        using var reader = await client.ExecuteReaderAsync($"SELECT arr FROM {fqn}");
+        Assert.That(reader.Read(), Is.True);
+        var got = (int[][][])reader.GetValue(0);
+        Assert.That(got[0][0], Is.EqualTo(new[] { 1, 2 }));
+        Assert.That(got[0][1], Is.EqualTo(new[] { 3, 4 }));
+        Assert.That(got[1][0], Is.EqualTo(new[] { 5, 6 }));
+        Assert.That(got[1][1], Is.EqualTo(new[] { 7, 8 }));
     }
 
     // ----- GetFieldValue<T> with multidim T (materialises jagged result as rectangular) -----
@@ -660,8 +627,7 @@ public class NestedArrayParameterTests : AbstractConnectionTestFixture
     public async Task GetFieldValueMultidim_InsertedAsMultidimReadAsMultidim_FullRoundTrip()
     {
         // The headline use case: schema is rectangular by construction, so both ends use T[,].
-        const string table = "test.nested_multidim_roundtrip";
-        await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {table}");
+        var table = CreateTableName();
         await connection.ExecuteStatementAsync(
             $"CREATE TABLE {table} (id Int32, m Array(Array(UInt8))) ENGINE Memory");
 

--- a/ClickHouse.Driver.Tests/SQL/ParameterizedInsertTests.cs
+++ b/ClickHouse.Driver.Tests/SQL/ParameterizedInsertTests.cs
@@ -12,30 +12,30 @@ public class ParameterizedInsertTests : AbstractConnectionTestFixture
     [Test]
     public async Task ShouldInsertParameterizedFloat64Array()
     {
-        await connection.ExecuteStatementAsync("DROP TABLE IF EXISTS test.float_array");
-        await connection.ExecuteStatementAsync("CREATE TABLE IF NOT EXISTS test.float_array (arr Array(Float64)) ENGINE Memory");
+        var table = CreateTableName();
+        await connection.ExecuteStatementAsync($"CREATE TABLE {table} (arr Array(Float64)) ENGINE Memory");
 
         var command = connection.CreateCommand();
         command.AddParameter("values", new[] { 1.0, 2.0, 3.0 });
-        command.CommandText = "INSERT INTO test.float_array VALUES ({values:Array(Float32)})";
+        command.CommandText = $"INSERT INTO {table} VALUES ({{values:Array(Float32)}})";
         await command.ExecuteNonQueryAsync();
 
-        var count = await connection.ExecuteScalarAsync("SELECT COUNT(*) FROM test.float_array");
+        var count = await connection.ExecuteScalarAsync($"SELECT COUNT(*) FROM {table}");
         Assert.That(count, Is.EqualTo(1));
     }
 
     [Test]
     public async Task ShouldInsertEnum8()
     {
-        await connection.ExecuteStatementAsync("DROP TABLE IF EXISTS test.insert_enum8");
-        await connection.ExecuteStatementAsync("CREATE TABLE IF NOT EXISTS test.insert_enum8 (enum Enum8('a' = -1, 'b' = 127)) ENGINE Memory");
+        var table = CreateTableName();
+        await connection.ExecuteStatementAsync($"CREATE TABLE {table} (enum Enum8('a' = -1, 'b' = 127)) ENGINE Memory");
 
         var command = connection.CreateCommand();
         command.AddParameter("value", "a");
-        command.CommandText = "INSERT INTO test.insert_enum8 VALUES ({value:Enum8('a' = -1, 'b' = 127)})";
+        command.CommandText = $"INSERT INTO {table} VALUES ({{value:Enum8('a' = -1, 'b' = 127)}})";
         await command.ExecuteNonQueryAsync();
 
-        var count = await connection.ExecuteScalarAsync("SELECT COUNT(*) FROM test.insert_enum8");
+        var count = await connection.ExecuteScalarAsync($"SELECT COUNT(*) FROM {table}");
         Assert.That(count, Is.EqualTo(1));
     }
 
@@ -43,44 +43,44 @@ public class ParameterizedInsertTests : AbstractConnectionTestFixture
     [RequiredFeature(Feature.UUIDParameters)]
     public async Task ShouldInsertParameterizedUUIDArray()
     {
-        await connection.ExecuteStatementAsync("DROP TABLE IF EXISTS test.uuid_array");
+        var table = CreateTableName();
         await connection.ExecuteStatementAsync(
-            "CREATE TABLE IF NOT EXISTS test.uuid_array (arr Array(UUID)) ENGINE Memory");
+            $"CREATE TABLE {table} (arr Array(UUID)) ENGINE Memory");
 
         var command = connection.CreateCommand();
         command.AddParameter("values", new[] { Guid.NewGuid(), Guid.NewGuid(), });
-        command.CommandText = "INSERT INTO test.uuid_array VALUES ({values:Array(UUID)})";
+        command.CommandText = $"INSERT INTO {table} VALUES ({{values:Array(UUID)}})";
         await command.ExecuteNonQueryAsync();
 
-        var count = await connection.ExecuteScalarAsync("SELECT COUNT(*) FROM test.uuid_array");
+        var count = await connection.ExecuteScalarAsync($"SELECT COUNT(*) FROM {table}");
         Assert.That(count, Is.EqualTo(1));
     }
 
     [Test]
     public async Task ShouldInsertStringWithNewline()
     {
-        await connection.ExecuteStatementAsync("DROP TABLE IF EXISTS test.string_with_newline");
+        var table = CreateTableName();
         await connection.ExecuteStatementAsync(
-            "CREATE TABLE IF NOT EXISTS test.string_with_newline (str_value String) ENGINE Memory");
+            $"CREATE TABLE {table} (str_value String) ENGINE Memory");
 
         var command = connection.CreateCommand();
 
         var strValue = "Hello \n ClickHouse";
 
         command.AddParameter("str_value", strValue);
-        command.CommandText = "INSERT INTO test.string_with_newline VALUES ({str_value:String})";
+        command.CommandText = $"INSERT INTO {table} VALUES ({{str_value:String}})";
         await command.ExecuteNonQueryAsync();
 
-        var count = await connection.ExecuteScalarAsync("SELECT COUNT(*) FROM test.string_with_newline");
+        var count = await connection.ExecuteScalarAsync($"SELECT COUNT(*) FROM {table}");
         Assert.That(count, Is.EqualTo(1));
     }
 
     [Test]
     public async Task ShouldInsertWithExceptSyntax()
     {
-        await connection.ExecuteStatementAsync("DROP TABLE IF EXISTS test.insert_except");
-        await connection.ExecuteStatementAsync(@"
-            CREATE TABLE IF NOT EXISTS test.insert_except (
+        var table = CreateTableName();
+        await connection.ExecuteStatementAsync($@"
+            CREATE TABLE {table} (
                 id Int32,
                 name String,
                 value Float64,
@@ -94,14 +94,14 @@ public class ParameterizedInsertTests : AbstractConnectionTestFixture
         command.AddParameter("id", 42);
         command.AddParameter("name", "test-except");
         command.AddParameter("value", 99.99);
-        command.CommandText = "INSERT INTO test.insert_except (* EXCEPT (created, updated)) VALUES ({id:Int32}, {name:String}, {value:Float64})";
+        command.CommandText = $"INSERT INTO {table} (* EXCEPT (created, updated)) VALUES ({{id:Int32}}, {{name:String}}, {{value:Float64}})";
         await command.ExecuteNonQueryAsync();
 
-        var count = await connection.ExecuteScalarAsync("SELECT COUNT(*) FROM test.insert_except");
+        var count = await connection.ExecuteScalarAsync($"SELECT COUNT(*) FROM {table}");
         Assert.That(count, Is.EqualTo(1));
 
         // Verify all columns including defaults using SELECT *
-        using var reader = await connection.ExecuteReaderAsync("SELECT * FROM test.insert_except");
+        using var reader = await connection.ExecuteReaderAsync($"SELECT * FROM {table}");
         Assert.That(reader.Read(), Is.True);
         Assert.That(reader.FieldCount, Is.EqualTo(5));
         Assert.That(reader.GetInt32(0), Is.EqualTo(42));

--- a/ClickHouse.Driver.Tests/SQL/RawStreamInsertTests.cs
+++ b/ClickHouse.Driver.Tests/SQL/RawStreamInsertTests.cs
@@ -43,8 +43,7 @@ public class RawStreamInsertTests : AbstractConnectionTestFixture
     [TestCase("TSV", TsvData, true, true, TestName = "TSV")]
     public async Task ShouldInsertCsv(string format, string data, bool useColumns, bool useCompression)
     {
-        var tableName = $"test.raw_csv_{format}_{useColumns}_{useCompression}";
-        await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {tableName}");
+        var tableName = CreateTableName($"raw_csv_{format}_{useColumns}_{useCompression}");
         await connection.ExecuteStatementAsync($"""
             CREATE TABLE {tableName} (
                 id UInt64,
@@ -75,9 +74,9 @@ public class RawStreamInsertTests : AbstractConnectionTestFixture
     [Test]
     public async Task ShouldInsertJsonCompactEachRow()
     {
-        await connection.ExecuteStatementAsync("DROP TABLE IF EXISTS test.raw_json_compact");
-        await connection.ExecuteStatementAsync("""
-            CREATE TABLE test.raw_json_compact (
+        var tableName = CreateTableName();
+        await connection.ExecuteStatementAsync($"""
+            CREATE TABLE {tableName} (
                 date Date,
                 season UInt16,
                 home_team String,
@@ -89,28 +88,28 @@ public class RawStreamInsertTests : AbstractConnectionTestFixture
 
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(JsonCompactEachRowData));
         using var response = await client.InsertRawStreamAsync(
-            table: "test.raw_json_compact",
+            table: tableName,
             stream: stream,
             format: "JSONCompactEachRow",
             columns: new[] { "date", "season", "home_team", "away_team", "home_score", "away_score" });
 
         Assert.That(response.IsSuccessStatusCode, Is.True);
 
-        var count = await connection.ExecuteScalarAsync("SELECT count() FROM test.raw_json_compact");
+        var count = await connection.ExecuteScalarAsync($"SELECT count() FROM {tableName}");
         Assert.That(count, Is.EqualTo(7));
 
         // Verify specific data
         var bradfordAwayScore = await connection.ExecuteScalarAsync(
-            "SELECT away_score FROM test.raw_json_compact WHERE home_team = 'Sutton United'");
+            $"SELECT away_score FROM {tableName} WHERE home_team = 'Sutton United'");
         Assert.That(bradfordAwayScore, Is.EqualTo(4));
     }
 
     [Test]
     public async Task ShouldInsertWithQueryId()
     {
-        await connection.ExecuteStatementAsync("DROP TABLE IF EXISTS test.raw_query_id");
-        await connection.ExecuteStatementAsync("""
-            CREATE TABLE test.raw_query_id (
+        var tableName = CreateTableName();
+        await connection.ExecuteStatementAsync($"""
+            CREATE TABLE {tableName} (
                 id UInt64,
                 name String,
                 value Float32
@@ -121,7 +120,7 @@ public class RawStreamInsertTests : AbstractConnectionTestFixture
 
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(CsvDataNoHeader));
         using var response = await client.InsertRawStreamAsync(
-            table: "test.raw_query_id",
+            table: tableName,
             stream: stream,
             format: "CSV",
             columns: new[] { "id", "name", "value" },
@@ -137,9 +136,9 @@ public class RawStreamInsertTests : AbstractConnectionTestFixture
     [Test]
     public async Task ShouldInsertPartialColumns()
     {
-        await connection.ExecuteStatementAsync("DROP TABLE IF EXISTS test.raw_partial_columns");
-        await connection.ExecuteStatementAsync("""
-            CREATE TABLE test.raw_partial_columns (
+        var tableName = CreateTableName();
+        await connection.ExecuteStatementAsync($"""
+            CREATE TABLE {tableName} (
                 id UInt64,
                 name String,
                 value Float32 DEFAULT 0.0,
@@ -155,18 +154,18 @@ public class RawStreamInsertTests : AbstractConnectionTestFixture
 
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(partialCsv));
         using var response = await client.InsertRawStreamAsync(
-            table: "test.raw_partial_columns",
+            table: tableName,
             stream: stream,
             format: "CSV",
             columns: new[] { "id", "name" });
 
         Assert.That(response.IsSuccessStatusCode, Is.True);
 
-        var count = await connection.ExecuteScalarAsync("SELECT count() FROM test.raw_partial_columns");
+        var count = await connection.ExecuteScalarAsync($"SELECT count() FROM {tableName}");
         Assert.That(count, Is.EqualTo(2));
 
         // Verify defaults were applied
-        var valueSum = await connection.ExecuteScalarAsync("SELECT sum(value) FROM test.raw_partial_columns");
+        var valueSum = await connection.ExecuteScalarAsync($"SELECT sum(value) FROM {tableName}");
         Assert.That((double)valueSum, Is.EqualTo(0.0));
     }
 }

--- a/ClickHouse.Driver.Tests/SQL/SqlAlterTests.cs
+++ b/ClickHouse.Driver.Tests/SQL/SqlAlterTests.cs
@@ -10,6 +10,9 @@ public class SqlAlterTests
 {
     private readonly DbConnection connection;
 
+    // Cannot derive from AbstractConnectionTestFixture: these tests need a session-enabled connection.
+    private readonly string targetTable = TestUtilities.CreateTableName("table_delete_from");
+
     public SqlAlterTests()
     {
         var builder = TestUtilities.GetConnectionStringBuilder();
@@ -21,13 +24,22 @@ public class SqlAlterTests
     [Test]
     public async Task ShouldExecuteAlterTable()
     {
-        await connection.ExecuteScalarAsync($"CREATE TABLE IF NOT EXISTS test.table_delete_from (value Int32) ENGINE MergeTree ORDER BY value");
-        await connection.ExecuteScalarAsync($"ALTER TABLE test.table_delete_from DELETE WHERE 1=1");
+        await connection.ExecuteScalarAsync($"CREATE TABLE {targetTable} (value Int32) ENGINE MergeTree ORDER BY value");
+        await connection.ExecuteScalarAsync($"ALTER TABLE {targetTable} DELETE WHERE 1=1");
     }
 
     [OneTimeTearDown]
     public void Dispose()
     {
+        try
+        {
+            connection?.ExecuteStatementAsync($"DROP TABLE IF EXISTS {targetTable}").GetAwaiter().GetResult();
+        }
+        catch
+        {
+            // Best effort: a leftover table must not fail an otherwise passing fixture.
+        }
+
         connection?.Dispose();
     }
 }

--- a/ClickHouse.Driver.Tests/SQL/SqlParameterizedSelectTests.cs
+++ b/ClickHouse.Driver.Tests/SQL/SqlParameterizedSelectTests.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using ClickHouse.Driver.ADO;
 using ClickHouse.Driver.Types;
@@ -15,11 +17,23 @@ namespace ClickHouse.Driver.Tests.SQL;
 public class SqlParameterizedSelectTests : IDisposable
 {
     private readonly ClickHouseConnection connection;
+    private readonly ConcurrentQueue<string> createdTables = new();
 
     public SqlParameterizedSelectTests(bool useCompression)
     {
         connection = TestUtilities.GetTestClickHouseConnection(useCompression);
         connection.Open();
+    }
+
+    /// <summary>
+    /// This fixture does not derive from <see cref="AbstractConnectionTestFixture"/>, so it tracks
+    /// the names it hands out and drops them itself in <see cref="Dispose"/>.
+    /// </summary>
+    private string CreateTableName(string prefix = null, [CallerMemberName] string testName = null)
+    {
+        var name = TestUtilities.CreateTableName(prefix, testName: testName);
+        createdTables.Enqueue(name);
+        return name;
     }
 
     public static IEnumerable<TestCaseData> TypedQueryParameters => TestCases.GetDataTypeSamples()
@@ -229,7 +243,7 @@ public class SqlParameterizedSelectTests : IDisposable
         // the value verbatim and the server applies its own backtick quoting/escaping, so a backtick
         // cannot break out. If the client escaped the value (e.g. via Escape()), this column would not
         // resolve.
-        var table = $"poly_ident_{Guid.NewGuid():N}";
+        var table = CreateTableName("poly_ident");
         using (var createCmd = connection.CreateCommand())
         {
             // Column literally named  weird`col  (inner backtick doubled per ClickHouse DDL quoting).
@@ -237,27 +251,18 @@ public class SqlParameterizedSelectTests : IDisposable
             await createCmd.ExecuteNonQueryAsync();
         }
 
-        try
+        using (var insertCmd = connection.CreateCommand())
         {
-            using (var insertCmd = connection.CreateCommand())
-            {
-                insertCmd.CommandText = $"INSERT INTO {table} VALUES (7, 9)";
-                await insertCmd.ExecuteNonQueryAsync();
-            }
-
-            using var selectCmd = connection.CreateCommand();
-            selectCmd.CommandText = $"SELECT {{c:Identifier}} FROM {table}";
-            selectCmd.AddParameter("c", "weird`col"); // raw value, single backtick, no client-side escaping
-
-            var result = (await selectCmd.ExecuteReaderAsync()).GetEnsureSingleRow().Single();
-            Assert.That(result, Is.EqualTo(7));
+            insertCmd.CommandText = $"INSERT INTO {table} VALUES (7, 9)";
+            await insertCmd.ExecuteNonQueryAsync();
         }
-        finally
-        {
-            using var dropCmd = connection.CreateCommand();
-            dropCmd.CommandText = $"DROP TABLE IF EXISTS {table}";
-            await dropCmd.ExecuteNonQueryAsync();
-        }
+
+        using var selectCmd = connection.CreateCommand();
+        selectCmd.CommandText = $"SELECT {{c:Identifier}} FROM {table}";
+        selectCmd.AddParameter("c", "weird`col"); // raw value, single backtick, no client-side escaping
+
+        var result = (await selectCmd.ExecuteReaderAsync()).GetEnsureSingleRow().Single();
+        Assert.That(result, Is.EqualTo(7));
     }
 
     [Test]
@@ -304,5 +309,31 @@ public class SqlParameterizedSelectTests : IDisposable
         Assert.That(result, Is.EqualTo(0UL)); // value of the `number` column, not the literal "number"
     }
 
-    public void Dispose() => connection?.Dispose();
+    /// <summary>
+    /// Drops every name handed out by <see cref="CreateTableName"/>. Best-effort: a table that
+    /// cannot be dropped must not fail an otherwise passing fixture.
+    /// </summary>
+    private void DropCreatedTables()
+    {
+        while (createdTables.TryDequeue(out var table))
+        {
+            try
+            {
+                connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {table}").GetAwaiter().GetResult();
+            }
+            catch (Exception e)
+            {
+                TestContext.Progress.WriteLine($"Failed to drop test table {table}: {e.Message}");
+            }
+        }
+    }
+
+    [OneTimeTearDown]
+    public void Dispose()
+    {
+        // NUnit both invokes [OneTimeTearDown] and disposes the fixture instance, so this can run
+        // twice; draining the queue and disposing the connection are both idempotent.
+        DropCreatedTables();
+        connection?.Dispose();
+    }
 }

--- a/ClickHouse.Driver.Tests/Types/AggregateHelperTests.cs
+++ b/ClickHouse.Driver.Tests/Types/AggregateHelperTests.cs
@@ -9,10 +9,9 @@ public class AggregateHelperTests : AbstractConnectionTestFixture
     [Test]
     public async Task ShouldThrowCorrectExceptionWhenSelectingAggregateFunction()
     {
-        var targetTable = "test.aggregate_test";
+        var targetTable = CreateTableName();
 
-        await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {targetTable}");
-        await connection.ExecuteStatementAsync($"CREATE TABLE IF NOT EXISTS {targetTable} (value AggregateFunction(uniq, UInt8)) ENGINE Memory");
+        await connection.ExecuteStatementAsync($"CREATE TABLE {targetTable} (value AggregateFunction(uniq, UInt8)) ENGINE Memory");
         await connection.ExecuteStatementAsync($"INSERT INTO {targetTable} SELECT uniqState(1)");
 
         using var reader = await connection.ExecuteReaderAsync($"SELECT * from {targetTable}");

--- a/ClickHouse.Driver.Tests/Types/DateTimeBinaryRangeTests.cs
+++ b/ClickHouse.Driver.Tests/Types/DateTimeBinaryRangeTests.cs
@@ -28,11 +28,14 @@ public class DateTimeBinaryRangeTests : AbstractConnectionTestFixture
     [SetUp]
     public async Task SetUp()
     {
-        var testName = SanitizeTableName(TestContext.CurrentContext.Test.Name);
-        var suffix = $"{testName}_{Guid.NewGuid():N}";
-        DateTimeTable = $"test.dt_range_{suffix}";
-        DateTable = $"test.date_range_{suffix}";
-        Date32Table = $"test.date32_range_{suffix}";
+        // Deliberately the static helper rather than the fixture's tracking overload: TearDown below
+        // keeps the table when a test fails so it can be inspected, and a registered name would be
+        // dropped by the fixture's own teardown regardless.
+        // [CallerMemberName] would resolve to SetUp here, so the owning test's name is passed explicitly.
+        var testName = TestContext.CurrentContext.Test.Name;
+        DateTimeTable = TestUtilities.CreateTableName($"dt_range_{testName}");
+        DateTable = TestUtilities.CreateTableName($"date_range_{testName}");
+        Date32Table = TestUtilities.CreateTableName($"date32_range_{testName}");
 
         // Range validation happens in client-side RowBinary serialization; Memory is enough here.
         await client.ExecuteNonQueryAsync($"CREATE TABLE {DateTimeTable} (t DateTime('UTC')) ENGINE = Memory");

--- a/ClickHouse.Driver.Tests/Types/DynamicTests.cs
+++ b/ClickHouse.Driver.Tests/Types/DynamicTests.cs
@@ -234,7 +234,7 @@ public class DynamicTests : AbstractConnectionTestFixture
     [RequiredFeature(Feature.Dynamic)]
     public async Task Write_Int32_ShouldRoundTrip()
     {
-        var targetTable = "test.dynamic_write_int32";
+        var targetTable = CreateTableName();
         await connection.ExecuteStatementAsync(
             $"CREATE OR REPLACE TABLE {targetTable} (id UInt32, value Dynamic) ENGINE = Memory");
 
@@ -250,7 +250,7 @@ public class DynamicTests : AbstractConnectionTestFixture
     [RequiredFeature(Feature.Dynamic)]
     public async Task Write_Int64_ShouldRoundTrip()
     {
-        var targetTable = "test.dynamic_write_int64";
+        var targetTable = CreateTableName();
         await connection.ExecuteStatementAsync(
             $"CREATE OR REPLACE TABLE {targetTable} (id UInt32, value Dynamic) ENGINE = Memory");
 
@@ -266,7 +266,7 @@ public class DynamicTests : AbstractConnectionTestFixture
     [RequiredFeature(Feature.Dynamic)]
     public async Task Write_Double_ShouldRoundTrip()
     {
-        var targetTable = "test.dynamic_write_double";
+        var targetTable = CreateTableName();
         await connection.ExecuteStatementAsync(
             $"CREATE OR REPLACE TABLE {targetTable} (id UInt32, value Dynamic) ENGINE = Memory");
 
@@ -282,7 +282,7 @@ public class DynamicTests : AbstractConnectionTestFixture
     [RequiredFeature(Feature.Dynamic)]
     public async Task Write_String_ShouldRoundTrip()
     {
-        var targetTable = "test.dynamic_write_string";
+        var targetTable = CreateTableName();
         await connection.ExecuteStatementAsync(
             $"CREATE OR REPLACE TABLE {targetTable} (id UInt32, value Dynamic) ENGINE = Memory");
 
@@ -298,7 +298,7 @@ public class DynamicTests : AbstractConnectionTestFixture
     [RequiredFeature(Feature.Dynamic)]
     public async Task Write_Bool_ShouldRoundTrip()
     {
-        var targetTable = "test.dynamic_write_bool";
+        var targetTable = CreateTableName();
         await connection.ExecuteStatementAsync(
             $"CREATE OR REPLACE TABLE {targetTable} (id UInt32, value Dynamic) ENGINE = Memory");
 
@@ -316,7 +316,7 @@ public class DynamicTests : AbstractConnectionTestFixture
     [RequiredFeature(Feature.Dynamic)]
     public async Task Write_DateTime_ShouldRoundTrip()
     {
-        var targetTable = "test.dynamic_write_datetime";
+        var targetTable = CreateTableName();
         await connection.ExecuteStatementAsync(
             $"CREATE OR REPLACE TABLE {targetTable} (id UInt32, value Dynamic) ENGINE = Memory");
 
@@ -340,7 +340,7 @@ public class DynamicTests : AbstractConnectionTestFixture
     [RequiredFeature(Feature.Dynamic)]
     public async Task Write_Guid_ShouldRoundTrip()
     {
-        var targetTable = "test.dynamic_write_guid";
+        var targetTable = CreateTableName();
         await connection.ExecuteStatementAsync(
             $"CREATE OR REPLACE TABLE {targetTable} (id UInt32, value Dynamic) ENGINE = Memory");
 
@@ -358,7 +358,7 @@ public class DynamicTests : AbstractConnectionTestFixture
     [RequiredFeature(Feature.Dynamic)]
     public async Task Write_Decimal_ShouldPreservePrecision()
     {
-        var targetTable = "test.dynamic_write_decimal";
+        var targetTable = CreateTableName();
         await connection.ExecuteStatementAsync(
             $"CREATE OR REPLACE TABLE {targetTable} (id UInt32, value Dynamic) ENGINE = Memory");
 
@@ -377,7 +377,7 @@ public class DynamicTests : AbstractConnectionTestFixture
     [RequiredFeature(Feature.Dynamic)]
     public async Task Write_IntArray_ShouldRoundTrip()
     {
-        var targetTable = "test.dynamic_write_int_array";
+        var targetTable = CreateTableName();
         await connection.ExecuteStatementAsync(
             $"CREATE OR REPLACE TABLE {targetTable} (id UInt32, value Dynamic) ENGINE = Memory");
 
@@ -396,7 +396,7 @@ public class DynamicTests : AbstractConnectionTestFixture
     [RequiredFeature(Feature.Dynamic)]
     public async Task Write_StringList_ShouldRoundTrip()
     {
-        var targetTable = "test.dynamic_write_string_list";
+        var targetTable = CreateTableName();
         await connection.ExecuteStatementAsync(
             $"CREATE OR REPLACE TABLE {targetTable} (id UInt32, value Dynamic) ENGINE = Memory");
 
@@ -415,7 +415,7 @@ public class DynamicTests : AbstractConnectionTestFixture
     [RequiredFeature(Feature.Dynamic)]
     public async Task Write_Dictionary_ShouldRoundTrip()
     {
-        var targetTable = "test.dynamic_write_dictionary";
+        var targetTable = CreateTableName();
         await connection.ExecuteStatementAsync(
             $"CREATE OR REPLACE TABLE {targetTable} (id UInt32, value Dynamic) ENGINE = Memory");
 
@@ -435,7 +435,7 @@ public class DynamicTests : AbstractConnectionTestFixture
     [RequiredFeature(Feature.Dynamic)]
     public async Task Write_MixedTypesInSameColumn_ShouldRoundTrip()
     {
-        var targetTable = "test.dynamic_write_mixed";
+        var targetTable = CreateTableName();
         await connection.ExecuteStatementAsync(
             $"CREATE OR REPLACE TABLE {targetTable} (id UInt32, value Dynamic) ENGINE = Memory");
 
@@ -466,7 +466,7 @@ public class DynamicTests : AbstractConnectionTestFixture
     [RequiredFeature(Feature.Dynamic)]
     public async Task Write_Null_ShouldRoundTrip()
     {
-        var targetTable = "test.dynamic_write_null";
+        var targetTable = CreateTableName();
         await connection.ExecuteStatementAsync(
             $"CREATE OR REPLACE TABLE {targetTable} (id UInt32, value Dynamic) ENGINE = Memory");
 

--- a/ClickHouse.Driver.Tests/Types/JsonModeTests.cs
+++ b/ClickHouse.Driver.Tests/Types/JsonModeTests.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using ClickHouse.Driver.ADO;
@@ -18,6 +20,42 @@ namespace ClickHouse.Driver.Tests.Types;
 [Category("Cloud")]
 public class JsonModeTests
 {
+    // Cannot derive from AbstractConnectionTestFixture: every test needs its own connection with
+    // specific JSON read/write modes, so table cleanup is tracked here instead.
+    private readonly ConcurrentQueue<string> createdTables = new();
+
+    /// <summary>
+    /// Builds a unique table name and registers it to be dropped when this fixture tears down.
+    /// See <see cref="TestUtilities.CreateTableName"/> for the naming scheme.
+    /// </summary>
+    private string CreateTableName([CallerMemberName] string testName = null)
+    {
+        var name = TestUtilities.CreateTableName(testName: testName);
+        createdTables.Enqueue(name);
+        return name;
+    }
+
+    [OneTimeTearDown]
+    public void DropCreatedTables()
+    {
+        if (createdTables.IsEmpty)
+            return;
+
+        using var client = TestUtilities.GetTestClickHouseClient();
+        while (createdTables.TryDequeue(out var table))
+        {
+            try
+            {
+                client.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS {table}").GetAwaiter().GetResult();
+            }
+            catch (Exception e)
+            {
+                // Best effort: a leftover table must not fail an otherwise passing fixture.
+                TestContext.Progress.WriteLine($"Failed to drop test table {table}: {e.Message}");
+            }
+        }
+    }
+
     private ClickHouseClientSettings GetSettingsWithJsonMode(JsonReadMode readMode = JsonReadMode.Binary, JsonWriteMode writeMode = JsonWriteMode.Binary)
     {
         var builder = TestUtilities.GetConnectionStringBuilder();
@@ -125,8 +163,7 @@ public class JsonModeTests
     {
         using var connection = GetConnectionWithJsonMode(writeMode: JsonWriteMode.String);
 
-        var tableName = "test.json_write_string_mode";
-        await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {tableName}");
+        var tableName = CreateTableName();
         await connection.ExecuteStatementAsync($"CREATE TABLE {tableName} (id UInt32, data Json) ENGINE = Memory");
 
         using var bulkCopy = new ClickHouseBulkCopy(connection)
@@ -164,8 +201,7 @@ public class JsonModeTests
         // JsonObject is serialized to string via ToJsonString() in string mode
         using var connection = GetConnectionWithJsonMode(writeMode: JsonWriteMode.String);
 
-        var tableName = "test.json_write_jsonobject_string_mode";
-        await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {tableName}");
+        var tableName = CreateTableName();
         await connection.ExecuteStatementAsync($"CREATE TABLE {tableName} (id UInt32, data Json) ENGINE = Memory");
 
         using var bulkCopy = new ClickHouseBulkCopy(connection)
@@ -200,8 +236,7 @@ public class JsonModeTests
     {
         using var connection = GetConnectionWithJsonMode(readMode: JsonReadMode.String, writeMode: JsonWriteMode.String);
 
-        var tableName = "test.json_roundtrip_string";
-        await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {tableName}");
+        var tableName = CreateTableName();
         await connection.ExecuteStatementAsync($"CREATE TABLE {tableName} (data Json) ENGINE = Memory");
 
         var originalJson = "{\"key\": \"value\", \"num\": 42}";
@@ -233,8 +268,7 @@ public class JsonModeTests
         // Tests: JsonObject jo => jo.ToJsonString() in WriteAsString
         using var connection = GetConnectionWithJsonMode(writeMode: JsonWriteMode.String);
 
-        var tableName = "test.json_write_jsonobject_string_mode";
-        await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {tableName}");
+        var tableName = CreateTableName();
         await connection.ExecuteStatementAsync($"CREATE TABLE {tableName} (id UInt32, data Json) ENGINE = Memory");
 
         using var bulkCopy = new ClickHouseBulkCopy(connection)
@@ -270,8 +304,7 @@ public class JsonModeTests
         // Tests: JsonNode jn => jn.ToJsonString() in WriteAsString
         using var connection = GetConnectionWithJsonMode(writeMode: JsonWriteMode.String);
 
-        var tableName = "test.json_write_jsonnode_string_mode";
-        await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {tableName}");
+        var tableName = CreateTableName();
         await connection.ExecuteStatementAsync($"CREATE TABLE {tableName} (id UInt32, data Json) ENGINE = Memory");
 
         using var bulkCopy = new ClickHouseBulkCopy(connection)
@@ -305,8 +338,7 @@ public class JsonModeTests
         // To write a POCO as a string, serialize it to JSON string first
         using var connection = GetConnectionWithJsonMode(writeMode: JsonWriteMode.String);
 
-        var tableName = "test.json_write_poco_string_mode";
-        await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {tableName}");
+        var tableName = CreateTableName();
         await connection.ExecuteStatementAsync($"CREATE TABLE {tableName} (id UInt32, data Json) ENGINE = Memory");
 
         using var bulkCopy = new ClickHouseBulkCopy(connection)
@@ -340,8 +372,7 @@ public class JsonModeTests
         // Uses date_time_input_format=best_effort to parse ISO 8601 datetime strings
         using var connection = GetConnectionWithJsonMode(writeMode: JsonWriteMode.String);
 
-        var tableName = "test.json_typed_datetime_schema";
-        await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {tableName}");
+        var tableName = CreateTableName();
         await connection.ExecuteStatementAsync($@"
             CREATE TABLE {tableName}
             (
@@ -397,8 +428,7 @@ public class JsonModeTests
         // String inputs require JsonWriteMode.String
         using var connection = GetConnectionWithJsonMode(writeMode: JsonWriteMode.Binary);
 
-        var tableName = "test.json_string_binary_mode_error";
-        await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {tableName}");
+        var tableName = CreateTableName();
         await connection.ExecuteStatementAsync($"CREATE TABLE {tableName} (data Json) ENGINE = Memory");
 
         using var bulkCopy = new ClickHouseBulkCopy(connection)
@@ -422,8 +452,7 @@ public class JsonModeTests
         // JsonNode inputs require JsonWriteMode.String
         using var connection = GetConnectionWithJsonMode(writeMode: JsonWriteMode.Binary);
 
-        var tableName = "test.json_node_binary_mode_error";
-        await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {tableName}");
+        var tableName = CreateTableName();
         await connection.ExecuteStatementAsync($"CREATE TABLE {tableName} (data Json) ENGINE = Memory");
 
         using var bulkCopy = new ClickHouseBulkCopy(connection)
@@ -447,8 +476,7 @@ public class JsonModeTests
         // POCOs can be written with String mode via JsonSerializer
         using var connection = GetConnectionWithJsonMode(writeMode: JsonWriteMode.String);
 
-        var tableName = "test.json_poco_string_mode";
-        await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {tableName}");
+        var tableName = CreateTableName();
         await connection.ExecuteStatementAsync($"CREATE TABLE {tableName} (data Json) ENGINE = Memory");
 
         using var bulkCopy = new ClickHouseBulkCopy(connection)
@@ -604,8 +632,7 @@ public class JsonModeTests
     {
         using var connection = GetConnectionWithJsonMode(readMode: JsonReadMode.Binary, writeMode: JsonWriteMode.String);
 
-        var tableName = "test.json_roundtrip_default";
-        await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {tableName}");
+        var tableName = CreateTableName();
         await connection.ExecuteStatementAsync($"CREATE TABLE {tableName} (id UInt32, data JSON) ENGINE = Memory");
 
         var original = new JsonObject
@@ -628,8 +655,6 @@ public class JsonModeTests
         Assert.That(result["count"].GetValue<long>(), Is.EqualTo(42));
         Assert.That(result["active"].GetValue<bool>(), Is.True);
         Assert.That(((JsonArray)result["tags"]).Count, Is.EqualTo(3));
-
-        await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {tableName}");
     }
 
     /// <summary>
@@ -642,8 +667,7 @@ public class JsonModeTests
     {
         using var connection = GetConnectionWithJsonMode(readMode: JsonReadMode.String, writeMode: JsonWriteMode.String);
 
-        var tableName = "test.json_roundtrip_string";
-        await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {tableName}");
+        var tableName = CreateTableName();
         await connection.ExecuteStatementAsync($"CREATE TABLE {tableName} (id UInt32, data JSON) ENGINE = Memory");
 
         var original = """{"name":"test","value":123}""";
@@ -663,8 +687,6 @@ public class JsonModeTests
 
         // In string read mode, the server may return numbers as quoted strings
         Assert.That(long.Parse(resultParsed["value"].ToString()), Is.EqualTo(long.Parse(originalParsed["value"].ToString())));
-
-        await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {tableName}");
     }
 
     /// <summary>
@@ -677,8 +699,7 @@ public class JsonModeTests
     {
         using var connection = GetConnectionWithJsonMode(readMode: JsonReadMode.Binary, writeMode: JsonWriteMode.String);
 
-        var tableName = "test.json_roundtrip_poco";
-        await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {tableName}");
+        var tableName = CreateTableName();
         await connection.ExecuteStatementAsync($"CREATE TABLE {tableName} (id UInt32, data JSON) ENGINE = Memory");
 
         var original = new { name = "poco_test", score = 99, enabled = true };
@@ -694,8 +715,6 @@ public class JsonModeTests
         Assert.That(result["name"].GetValue<string>(), Is.EqualTo("poco_test"));
         Assert.That(result["score"].GetValue<long>(), Is.EqualTo(99));
         Assert.That(result["enabled"].GetValue<bool>(), Is.True);
-
-        await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {tableName}");
     }
 
     /// <summary>
@@ -707,8 +726,7 @@ public class JsonModeTests
     {
         using var connection = GetConnectionWithJsonMode(readMode: JsonReadMode.Binary, writeMode: JsonWriteMode.String);
 
-        var tableName = "test.json_roundtrip_nested";
-        await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {tableName}");
+        var tableName = CreateTableName();
         await connection.ExecuteStatementAsync($"CREATE TABLE {tableName} (id UInt32, data JSON) ENGINE = Memory");
 
         var original = new JsonObject
@@ -733,8 +751,6 @@ public class JsonModeTests
         var result = (JsonObject)reader.GetValue(0);
         Assert.That(result["user"]["profile"]["name"].GetValue<string>(), Is.EqualTo("deep"));
         Assert.That(result["user"]["profile"]["level"].GetValue<long>(), Is.EqualTo(3));
-
-        await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {tableName}");
     }
 
     /// <summary>
@@ -746,8 +762,7 @@ public class JsonModeTests
     {
         using var connection = GetConnectionWithJsonMode(readMode: JsonReadMode.Binary, writeMode: JsonWriteMode.String);
 
-        var tableName = "test.json_roundtrip_multi";
-        await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {tableName}");
+        var tableName = CreateTableName();
         await connection.ExecuteStatementAsync($"CREATE TABLE {tableName} (id UInt32, data JSON) ENGINE = Memory");
 
         var rows = new List<object[]>
@@ -774,8 +789,6 @@ public class JsonModeTests
         Assert.That(results[0], Is.EqualTo((1u, 100L)));
         Assert.That(results[1], Is.EqualTo((2u, 200L)));
         Assert.That(results[2], Is.EqualTo((3u, 300L)));
-
-        await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {tableName}");
     }
 
     #endregion

--- a/ClickHouse.Driver.Tests/Types/JsonTypeTests.cs
+++ b/ClickHouse.Driver.Tests/Types/JsonTypeTests.cs
@@ -258,7 +258,7 @@ public class JsonTypeTests : AbstractConnectionTestFixture
     [TestCase("level1_int Int64, skip_items Int32, nested.level2_string String, SKIP path.to.skip, skip path.to.ignore")]
     public async Task ShouldSelectDataWithComplexHintedJsonType(string jsonDefinition)
     {
-        var targetTable = "test.select_data_complex_hinted_json";
+        var targetTable = CreateTableName();
 
         await connection.ExecuteStatementAsync(
             $@"
@@ -337,7 +337,7 @@ public class JsonTypeTests : AbstractConnectionTestFixture
     [Test]
     public async Task Write_WithUInt64Hint_ShouldPreservePrecision()
     {
-        var targetTable = "test.json_write_uint64_hint";
+        var targetTable = CreateTableName();
         await connection.ExecuteStatementAsync(
             $@"CREATE OR REPLACE TABLE {targetTable} (
                 id UInt32,
@@ -367,7 +367,7 @@ public class JsonTypeTests : AbstractConnectionTestFixture
     [Test]
     public async Task Write_WithMultipleRowsAndTrailingColumns_ShouldRoundTrip()
     {
-        var targetTable = "test.json_write_multiple_rows_trailing";
+        var targetTable = CreateTableName();
         await connection.ExecuteStatementAsync(
             $@"CREATE OR REPLACE TABLE {targetTable} (
                 id UInt32,
@@ -414,7 +414,7 @@ public class JsonTypeTests : AbstractConnectionTestFixture
     [Test]
     public async Task Write_WithInt64Hint_ShouldWriteCorrectType()
     {
-        var targetTable = "test.json_write_int64_hint";
+        var targetTable = CreateTableName();
         await connection.ExecuteStatementAsync(
             $@"CREATE OR REPLACE TABLE {targetTable} (
                 id UInt32,
@@ -439,7 +439,7 @@ public class JsonTypeTests : AbstractConnectionTestFixture
     [Test]
     public async Task Write_WithUuidHint_ShouldPreserveGuid()
     {
-        var targetTable = "test.json_write_uuid_hint";
+        var targetTable = CreateTableName();
         await connection.ExecuteStatementAsync(
             $@"CREATE OR REPLACE TABLE {targetTable} (
                 id UInt32,
@@ -466,7 +466,7 @@ public class JsonTypeTests : AbstractConnectionTestFixture
     [Test]
     public async Task Write_WithDecimalHint_ShouldPreservePrecision()
     {
-        var targetTable = "test.json_write_decimal_hint";
+        var targetTable = CreateTableName();
         await connection.ExecuteStatementAsync(
             $@"CREATE OR REPLACE TABLE {targetTable} (
                 id UInt32,
@@ -493,7 +493,7 @@ public class JsonTypeTests : AbstractConnectionTestFixture
     [Test]
     public async Task Write_WithNestedHints_ShouldWriteNestedFields()
     {
-        var targetTable = "test.json_write_nested_hint";
+        var targetTable = CreateTableName();
         await connection.ExecuteStatementAsync(
             $@"CREATE OR REPLACE TABLE {targetTable} (
                 id UInt32,
@@ -518,7 +518,7 @@ public class JsonTypeTests : AbstractConnectionTestFixture
     [Test]
     public async Task Write_WithMixedHintedAndUnhinted_ShouldHandleBoth()
     {
-        var targetTable = "test.json_write_mixed_hint";
+        var targetTable = CreateTableName();
         await connection.ExecuteStatementAsync(
             $@"CREATE OR REPLACE TABLE {targetTable} (
                 id UInt32,
@@ -546,7 +546,7 @@ public class JsonTypeTests : AbstractConnectionTestFixture
     [Test]
     public async Task Write_WithArrayHint_ShouldWriteTypedArray()
     {
-        var targetTable = "test.json_write_array_hint";
+        var targetTable = CreateTableName();
         await connection.ExecuteStatementAsync(
             $@"CREATE OR REPLACE TABLE {targetTable} (
                 id UInt32,
@@ -573,7 +573,7 @@ public class JsonTypeTests : AbstractConnectionTestFixture
     [Test]
     public async Task Write_WithArrayHint_ShouldWriteTypedList()
     {
-        var targetTable = "test.json_write_list_hint";
+        var targetTable = CreateTableName();
         await connection.ExecuteStatementAsync(
             $@"CREATE OR REPLACE TABLE {targetTable} (
                 id UInt32,
@@ -601,7 +601,7 @@ public class JsonTypeTests : AbstractConnectionTestFixture
     [Test]
     public async Task Write_WithPocoObject_ShouldSerializeCorrectly()
     {
-        var targetTable = "test.json_write_poco";
+        var targetTable = CreateTableName();
         await connection.ExecuteStatementAsync(
             $@"CREATE OR REPLACE TABLE {targetTable} (
                 id UInt32,
@@ -629,7 +629,7 @@ public class JsonTypeTests : AbstractConnectionTestFixture
         // DateTime hints require Binary mode for proper type conversion
         using var binaryClient = TestUtilities.GetTestClickHouseClient(jsonWriteMode: JsonWriteMode.Binary, jsonReadMode: JsonReadMode.Binary);
 
-        var targetTable = "test.json_write_datetime_hint";
+        var targetTable = CreateTableName();
         await binaryClient.ExecuteNonQueryAsync(
             $@"CREATE OR REPLACE TABLE {targetTable} (
                 id UInt32,
@@ -662,7 +662,7 @@ public class JsonTypeTests : AbstractConnectionTestFixture
     {
         using var binaryClient = TestUtilities.GetTestClickHouseClient(jsonWriteMode: JsonWriteMode.Binary, jsonReadMode: JsonReadMode.Binary);
         binaryClient.RegisterJsonSerializationType<UnhintedDecimalData>();
-        var targetTable = "test.json_write_unhinted_decimal";
+        var targetTable = CreateTableName();
         await binaryClient.ExecuteNonQueryAsync(
             $@"CREATE OR REPLACE TABLE {targetTable} (
                 id UInt32,
@@ -689,7 +689,7 @@ public class JsonTypeTests : AbstractConnectionTestFixture
     [Test]
     public async Task Write_WithNoHints_ShouldUseExistingBehavior()
     {
-        var targetTable = "test.json_write_no_hints";
+        var targetTable = CreateTableName();
         await connection.ExecuteStatementAsync(
             $@"CREATE OR REPLACE TABLE {targetTable} (
                 id UInt32,
@@ -719,7 +719,7 @@ public class JsonTypeTests : AbstractConnectionTestFixture
         using var binaryClient = TestUtilities.GetTestClickHouseClient(jsonWriteMode: JsonWriteMode.Binary, jsonReadMode: JsonReadMode.Binary);
         binaryClient.RegisterJsonSerializationType<TestPocoWithPathAttribute>();
 
-        var targetTable = "test.json_write_poco_path_attr";
+        var targetTable = CreateTableName();
         await binaryClient.ExecuteNonQueryAsync(
             $@"CREATE OR REPLACE TABLE {targetTable} (
                 id UInt32,
@@ -748,7 +748,7 @@ public class JsonTypeTests : AbstractConnectionTestFixture
         using var binaryClient = TestUtilities.GetTestClickHouseClient(jsonWriteMode: JsonWriteMode.Binary, jsonReadMode: JsonReadMode.Binary);
         binaryClient.RegisterJsonSerializationType<TestPocoWithIgnoreAttribute>();
 
-        var targetTable = "test.json_write_poco_ignore_attr";
+        var targetTable = CreateTableName();
         await binaryClient.ExecuteNonQueryAsync(
             $@"CREATE OR REPLACE TABLE {targetTable} (
                 id UInt32,
@@ -772,7 +772,7 @@ public class JsonTypeTests : AbstractConnectionTestFixture
     [Test]
     public async Task Write_WithCaseSensitiveHint_ShouldMatchExactCase()
     {
-        var targetTable = "test.json_write_case_sensitive";
+        var targetTable = CreateTableName();
         // Column has exact case hint "UserId" matching the POCO property
         await connection.ExecuteStatementAsync(
             $@"CREATE OR REPLACE TABLE {targetTable} (
@@ -797,7 +797,7 @@ public class JsonTypeTests : AbstractConnectionTestFixture
     [Test]
     public async Task Write_WithCaseMismatchedHint_ShouldNotMatch()
     {
-        var targetTable = "test.json_write_case_mismatch";
+        var targetTable = CreateTableName();
         // Column has lowercase hint "userid", but POCO property is "UserId" - should NOT match
         await connection.ExecuteStatementAsync(
             $@"CREATE OR REPLACE TABLE {targetTable} (
@@ -865,7 +865,7 @@ public class JsonTypeTests : AbstractConnectionTestFixture
     [Test]
     public async Task Write_WithNullableHintedProperty_ShouldWriteNull()
     {
-        var targetTable = "test.json_write_nullable_hinted";
+        var targetTable = CreateTableName();
         await client.ExecuteNonQueryAsync(
             $@"CREATE OR REPLACE TABLE {targetTable} (
                 id UInt32,
@@ -891,7 +891,7 @@ public class JsonTypeTests : AbstractConnectionTestFixture
     public async Task Write_WithNullableUnhintedProperty_ShouldSkipField()
     {
         // Nullable/LowCardinality(Nullable) types are not allowed inside Variant type
-        var targetTable = "test.json_write_nullable_unhinted";
+        var targetTable = CreateTableName();
         await connection.ExecuteStatementAsync(
             $@"CREATE OR REPLACE TABLE {targetTable} (
                 id UInt32,
@@ -917,7 +917,7 @@ public class JsonTypeTests : AbstractConnectionTestFixture
     public async Task Write_WithNonNullableNullProperty_ShouldSkipField()
     {
         using var binaryClient = TestUtilities.GetTestClickHouseClient(jsonWriteMode: JsonWriteMode.Binary, jsonReadMode: JsonReadMode.Binary);
-        var targetTable = "test.json_write_nonnullable_null";
+        var targetTable = CreateTableName();
         await binaryClient.ExecuteNonQueryAsync(
             $@"CREATE OR REPLACE TABLE {targetTable} (
                 id UInt32,
@@ -955,7 +955,7 @@ public class JsonTypeTests : AbstractConnectionTestFixture
         // Tests the BinaryTypeIndex.Nothing path in WriteHintedValue
         // When a non-nullable hint (Int64) receives a null value, we write Nothing type
         // ClickHouse converts Nothing to the default value for the hinted type (0 for Int64)
-        var targetTable = "test.json_write_nonnullable_hint_null";
+        var targetTable = CreateTableName();
         await connection.ExecuteStatementAsync(
             $@"CREATE OR REPLACE TABLE {targetTable} (
                 id UInt32,
@@ -988,7 +988,7 @@ public class JsonTypeTests : AbstractConnectionTestFixture
     [Test]
     public async Task Write_WithDictionaryHint_ShouldWriteMap()
     {
-        var targetTable = "test.json_write_dictionary_hint";
+        var targetTable = CreateTableName();
         await connection.ExecuteStatementAsync(
             $@"CREATE OR REPLACE TABLE {targetTable} (
                 id UInt32,
@@ -1073,7 +1073,7 @@ public class JsonTypeTests : AbstractConnectionTestFixture
         using var binaryClient = TestUtilities.GetTestClickHouseClient(jsonWriteMode: JsonWriteMode.Binary, jsonReadMode: JsonReadMode.Binary);
         binaryClient.RegisterJsonSerializationType<ComprehensiveTypesData>();
 
-        var targetTable = "test.json_write_comprehensive_types";
+        var targetTable = CreateTableName();
         await binaryClient.ExecuteNonQueryAsync(
             $@"CREATE OR REPLACE TABLE {targetTable} (
                 id UInt32,
@@ -1224,7 +1224,7 @@ public class JsonTypeTests : AbstractConnectionTestFixture
         using var binaryClient = TestUtilities.GetTestClickHouseClient(jsonWriteMode: JsonWriteMode.Binary, jsonReadMode: JsonReadMode.Binary);
         binaryClient.RegisterJsonSerializationType<CircularRefA>();
         binaryClient.RegisterJsonSerializationType<CircularRefB>();
-        var targetTable = "test.json_write_circular_ref";
+        var targetTable = CreateTableName();
         await connection.ExecuteStatementAsync(
             $@"CREATE OR REPLACE TABLE {targetTable} (
                 id UInt32,
@@ -1255,7 +1255,7 @@ public class JsonTypeTests : AbstractConnectionTestFixture
     {
         using var binaryClient = TestUtilities.GetTestClickHouseClient(jsonWriteMode: JsonWriteMode.Binary, jsonReadMode: JsonReadMode.Binary);
         binaryClient.RegisterJsonSerializationType<SelfReferencing>();
-        var targetTable = "test.json_write_self_ref";
+        var targetTable = CreateTableName();
         await client.ExecuteNonQueryAsync(
             $@"CREATE OR REPLACE TABLE {targetTable} (
                 id UInt32,
@@ -1282,7 +1282,7 @@ public class JsonTypeTests : AbstractConnectionTestFixture
     [RequiredFeature(Feature.Json | Feature.Time)]
     public async Task Write_WithTimeSpan_ShouldWriteAsTime64()
     {
-        var targetTable = "test.json_write_timespan";
+        var targetTable = CreateTableName();
         await connection.ExecuteStatementAsync(
             $@"CREATE OR REPLACE TABLE {targetTable} (
                 id UInt32,
@@ -1318,7 +1318,7 @@ public class JsonTypeTests : AbstractConnectionTestFixture
     {
         using var binaryConnection = TestUtilities.GetTestClickHouseConnection(jsonWriteMode: JsonWriteMode.Binary, jsonReadMode: JsonReadMode.Binary);
 
-        var targetTable = "test.json_write_unregistered_type";
+        var targetTable = CreateTableName();
         await binaryConnection.ExecuteStatementAsync(
             $@"CREATE OR REPLACE TABLE {targetTable} (
                 id UInt32,
@@ -1356,7 +1356,7 @@ public class JsonTypeTests : AbstractConnectionTestFixture
         binaryClient.RegisterJsonSerializationType<WrongTypeData>();
 
         // POCO has string property, but schema expects Int64
-        var targetTable = "test.json_write_wrong_type";
+        var targetTable = CreateTableName();
         await binaryClient.ExecuteNonQueryAsync(
             $@"CREATE OR REPLACE TABLE {targetTable} (
                 id UInt32,
@@ -1388,7 +1388,7 @@ public class JsonTypeTests : AbstractConnectionTestFixture
     public async Task Write_WithMissingHintedProperty_ShouldSucceedWithNull()
     {
         // POCO is missing a property that the schema hints for - should be default
-        var targetTable = "test.json_write_missing_property";
+        var targetTable = CreateTableName();
         await connection.ExecuteStatementAsync(
             $@"CREATE OR REPLACE TABLE {targetTable} (
                 id UInt32,
@@ -1421,7 +1421,7 @@ public class JsonTypeTests : AbstractConnectionTestFixture
     [RequiredFeature(Feature.Json)]
     public async Task Write_WithEmptyPoco_ShouldWriteEmptyObject()
     {
-        var targetTable = "test.json_write_empty_poco";
+        var targetTable = CreateTableName();
         await connection.ExecuteStatementAsync(
             $@"CREATE OR REPLACE TABLE {targetTable} (
                 id UInt32,
@@ -1453,7 +1453,7 @@ public class JsonTypeTests : AbstractConnectionTestFixture
     [RequiredFeature(Feature.Json)]
     public async Task Write_WithAllNullProperties_ShouldWriteEmptyObject()
     {
-        var targetTable = "test.json_write_all_nulls";
+        var targetTable = CreateTableName();
         await connection.ExecuteStatementAsync(
             $@"CREATE OR REPLACE TABLE {targetTable} (
                 id UInt32,
@@ -1489,7 +1489,7 @@ public class JsonTypeTests : AbstractConnectionTestFixture
     [RequiredFeature(Feature.Json)]
     public async Task Write_PocoWithIndexer_ShouldIgnoreIndexer()
     {
-        var targetTable = "test.json_write_indexer";
+        var targetTable = CreateTableName();
         await client.ExecuteNonQueryAsync(
             $@"CREATE OR REPLACE TABLE {targetTable} (
                 id UInt32,

--- a/ClickHouse.Driver.Tests/Types/TimezoneHandlingTests.cs
+++ b/ClickHouse.Driver.Tests/Types/TimezoneHandlingTests.cs
@@ -181,6 +181,7 @@ public class WriteDateTimeHttpParamTests : IDisposable
     protected readonly ClickHouseClient client;
     private readonly string tableName;
     private readonly string sessionTimezone;
+    private bool disposed;
 
     public WriteDateTimeHttpParamTests(string sessionTimezone)
     {
@@ -190,12 +191,29 @@ public class WriteDateTimeHttpParamTests : IDisposable
         client = new ClickHouseClient(settings);
         connection = client.CreateConnection();
         client.ExecuteNonQueryAsync("CREATE DATABASE IF NOT EXISTS test;").GetAwaiter().GetResult();
-        tableName = $"test.datetime_http_test_{sessionTimezone.Replace('/', '_').Replace('-', '_')}";
+        // One table per fixture instance, recreated per test below, so the session_timezone
+        // cases stay apart from each other and from the other concurrent test suites.
+        tableName = TestUtilities.CreateTableName($"datetime_http_{sessionTimezone}");
     }
 
     [OneTimeTearDown]
     public void Dispose()
     {
+        // NUnit both invokes [OneTimeTearDown] and disposes the fixture instance, so this can run twice.
+        if (disposed)
+            return;
+        disposed = true;
+
+        try
+        {
+            connection?.ExecuteStatementAsync($"DROP TABLE IF EXISTS {tableName}").GetAwaiter().GetResult();
+        }
+        catch (Exception e)
+        {
+            // Best effort: a leftover table must not fail an otherwise passing fixture.
+            TestContext.Progress.WriteLine($"Failed to drop test table {tableName}: {e.Message}");
+        }
+
         connection?.Dispose();
         client?.Dispose();
     }
@@ -203,6 +221,7 @@ public class WriteDateTimeHttpParamTests : IDisposable
     [SetUp]
     public async Task SetUp()
     {
+        // Each test inserts a single row and reads it back, so the shared table is reset here.
         await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {tableName}");
         await connection.ExecuteStatementAsync($@"
             CREATE TABLE {tableName} (
@@ -430,6 +449,7 @@ public class InferredDateTimeHttpParamTests : IDisposable
     protected readonly ClickHouseClient client;
     private readonly string tableName;
     private readonly string sessionTimezone;
+    private bool disposed;
 
     public InferredDateTimeHttpParamTests(string sessionTimezone)
     {
@@ -439,12 +459,29 @@ public class InferredDateTimeHttpParamTests : IDisposable
         client = new ClickHouseClient(settings);
         connection = client.CreateConnection();
         client.ExecuteNonQueryAsync("CREATE DATABASE IF NOT EXISTS test;").GetAwaiter().GetResult();
-        tableName = $"test.datetime_inferred_test_{sessionTimezone.Replace('/', '_').Replace('-', '_')}";
+        // One table per fixture instance, recreated per test below, so the session_timezone
+        // cases stay apart from each other and from the other concurrent test suites.
+        tableName = TestUtilities.CreateTableName($"datetime_inferred_{sessionTimezone}");
     }
 
     [OneTimeTearDown]
     public void Dispose()
     {
+        // NUnit both invokes [OneTimeTearDown] and disposes the fixture instance, so this can run twice.
+        if (disposed)
+            return;
+        disposed = true;
+
+        try
+        {
+            connection?.ExecuteStatementAsync($"DROP TABLE IF EXISTS {tableName}").GetAwaiter().GetResult();
+        }
+        catch (Exception e)
+        {
+            // Best effort: a leftover table must not fail an otherwise passing fixture.
+            TestContext.Progress.WriteLine($"Failed to drop test table {tableName}: {e.Message}");
+        }
+
         connection?.Dispose();
         client?.Dispose();
     }
@@ -452,6 +489,7 @@ public class InferredDateTimeHttpParamTests : IDisposable
     [SetUp]
     public async Task SetUp()
     {
+        // Each test inserts a single row and reads it back, so the shared table is reset here.
         await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {tableName}");
         await connection.ExecuteStatementAsync($@"
             CREATE TABLE {tableName} (
@@ -708,12 +746,21 @@ public class InferredDateTimeHttpParamTests : IDisposable
 [TestFixture]
 public class WriteDateTimeBulkCopyTests : AbstractConnectionTestFixture
 {
+    private readonly string tableName;
+
+    public WriteDateTimeBulkCopyTests()
+    {
+        // Shared by every test in the fixture (recreated per test below); the base fixture drops it.
+        tableName = CreateTableName("datetime_bulk_test");
+    }
+
     [SetUp]
     public async Task SetUp()
     {
-        await connection.ExecuteStatementAsync("DROP TABLE IF EXISTS test.datetime_bulk_test");
-        await connection.ExecuteStatementAsync(@"
-            CREATE TABLE test.datetime_bulk_test (
+        // Each test inserts a single row and reads it back, so the shared table is reset here.
+        await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {tableName}");
+        await connection.ExecuteStatementAsync($@"
+            CREATE TABLE {tableName} (
                 dt_utc DateTime('UTC'),
                 dt_amsterdam DateTime('Europe/Amsterdam'),
                 dt_no_tz DateTime
@@ -723,7 +770,7 @@ public class WriteDateTimeBulkCopyTests : AbstractConnectionTestFixture
     [TearDown]
     public async Task TearDown()
     {
-        await connection.ExecuteStatementAsync("DROP TABLE IF EXISTS test.datetime_bulk_test");
+        await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {tableName}");
     }
 
     [Test]
@@ -738,12 +785,12 @@ public class WriteDateTimeBulkCopyTests : AbstractConnectionTestFixture
 
         using var bulkCopy = new ClickHouseBulkCopy(connection)
         {
-            DestinationTableName = "test.datetime_bulk_test",
+            DestinationTableName = tableName,
             ColumnNames = [col],
         };
         await bulkCopy.WriteToServerAsync([[dt]]);
 
-        var result = (DateTime)await connection.ExecuteScalarAsync($"SELECT {col} FROM test.datetime_bulk_test");
+        var result = (DateTime)await connection.ExecuteScalarAsync($"SELECT {col} FROM {tableName}");
         Assert.That(result.Ticks, Is.EqualTo(dt.Ticks));
     }
 
@@ -755,12 +802,12 @@ public class WriteDateTimeBulkCopyTests : AbstractConnectionTestFixture
 
         using var bulkCopy = new ClickHouseBulkCopy(connection)
         {
-            DestinationTableName = "test.datetime_bulk_test",
+            DestinationTableName = tableName,
             ColumnNames = ["dt_amsterdam"],
         };
         await bulkCopy.WriteToServerAsync([[original]]);
 
-        var reader = (ClickHouseDataReader)await connection.ExecuteReaderAsync("SELECT dt_amsterdam FROM test.datetime_bulk_test");
+        var reader = (ClickHouseDataReader)await connection.ExecuteReaderAsync($"SELECT dt_amsterdam FROM {tableName}");
         Assert.That(reader.Read(), Is.True);
         var dto = reader.GetDateTimeOffset(0);
 
@@ -779,12 +826,12 @@ public class WriteDateTimeBulkCopyTests : AbstractConnectionTestFixture
 
         using var bulkCopy = new ClickHouseBulkCopy(connection)
         {
-            DestinationTableName = "test.datetime_bulk_test",
+            DestinationTableName = tableName,
             ColumnNames = [col],
         };
         await bulkCopy.WriteToServerAsync([[utcDt]]);
 
-        var unix = Convert.ToInt64(await connection.ExecuteScalarAsync($"SELECT toUnixTimestamp({col}) FROM test.datetime_bulk_test"));
+        var unix = Convert.ToInt64(await connection.ExecuteScalarAsync($"SELECT toUnixTimestamp({col}) FROM {tableName}"));
         Assert.That(unix, Is.EqualTo(expected));
     }
 
@@ -799,12 +846,12 @@ public class WriteDateTimeBulkCopyTests : AbstractConnectionTestFixture
 
         using var bulkCopy = new ClickHouseBulkCopy(connection)
         {
-            DestinationTableName = "test.datetime_bulk_test",
+            DestinationTableName = tableName,
             ColumnNames = [col],
         };
         await bulkCopy.WriteToServerAsync([[localDt]]);
 
-        var unix = Convert.ToInt64(await connection.ExecuteScalarAsync($"SELECT toUnixTimestamp({col}) FROM test.datetime_bulk_test"));
+        var unix = Convert.ToInt64(await connection.ExecuteScalarAsync($"SELECT toUnixTimestamp({col}) FROM {tableName}"));
         Assert.That(unix, Is.EqualTo(expected));
     }
 
@@ -819,12 +866,12 @@ public class WriteDateTimeBulkCopyTests : AbstractConnectionTestFixture
 
         using var bulkCopy = new ClickHouseBulkCopy(connection)
         {
-            DestinationTableName = "test.datetime_bulk_test",
+            DestinationTableName = tableName,
             ColumnNames = [col],
         };
         await bulkCopy.WriteToServerAsync([[dto]]);
 
-        var unix = Convert.ToInt64(await connection.ExecuteScalarAsync($"SELECT toUnixTimestamp({col}) FROM test.datetime_bulk_test"));
+        var unix = Convert.ToInt64(await connection.ExecuteScalarAsync($"SELECT toUnixTimestamp({col}) FROM {tableName}"));
         Assert.That(unix, Is.EqualTo(expected));
     }
 
@@ -838,13 +885,13 @@ public class WriteDateTimeBulkCopyTests : AbstractConnectionTestFixture
 
         using var bulkCopy = new ClickHouseBulkCopy(connection)
         {
-            DestinationTableName = "test.datetime_bulk_test",
+            DestinationTableName = tableName,
             ColumnNames = ["dt_utc"]
         };
         
         await bulkCopy.WriteToServerAsync([[dt]]);
 
-        var result = (DateTime)await connection.ExecuteScalarAsync("SELECT dt_utc FROM test.datetime_bulk_test");
+        var result = (DateTime)await connection.ExecuteScalarAsync($"SELECT dt_utc FROM {tableName}");
         Assert.That(result, Is.EqualTo(DateTimeConversions.DateTimeEpochStart));
     }
 
@@ -858,13 +905,13 @@ public class WriteDateTimeBulkCopyTests : AbstractConnectionTestFixture
 
         using var bulkCopy = new ClickHouseBulkCopy(connection)
         {
-            DestinationTableName = "test.datetime_bulk_test",
+            DestinationTableName = tableName,
             ColumnNames = ["dt_utc"]
         };
 
         await bulkCopy.WriteToServerAsync([[dto]]);
 
-        var result = (DateTime)await connection.ExecuteScalarAsync("SELECT dt_utc FROM test.datetime_bulk_test");
+        var result = (DateTime)await connection.ExecuteScalarAsync($"SELECT dt_utc FROM {tableName}");
         Assert.That(result, Is.EqualTo(DateTimeConversions.DateTimeEpochStart));
     }
 }
@@ -881,6 +928,7 @@ public class WriteDateTime64HttpParamTests : IDisposable
     protected readonly ClickHouseConnection connection;
     protected readonly ClickHouseClient client;
     private readonly string tableName;
+    private bool disposed;
 
     public WriteDateTime64HttpParamTests(string sessionTimezone)
     {
@@ -889,12 +937,29 @@ public class WriteDateTime64HttpParamTests : IDisposable
         client = new ClickHouseClient(settings);
         connection = client.CreateConnection();
         client.ExecuteNonQueryAsync("CREATE DATABASE IF NOT EXISTS test;").GetAwaiter().GetResult();
-        tableName = $"test.datetime64_http_test_{sessionTimezone.Replace('/', '_').Replace('-', '_')}";
+        // One table per fixture instance, recreated per test below, so the session_timezone
+        // cases stay apart from each other and from the other concurrent test suites.
+        tableName = TestUtilities.CreateTableName($"datetime64_http_{sessionTimezone}");
     }
 
     [OneTimeTearDown]
     public void Dispose()
     {
+        // NUnit both invokes [OneTimeTearDown] and disposes the fixture instance, so this can run twice.
+        if (disposed)
+            return;
+        disposed = true;
+
+        try
+        {
+            connection?.ExecuteStatementAsync($"DROP TABLE IF EXISTS {tableName}").GetAwaiter().GetResult();
+        }
+        catch (Exception e)
+        {
+            // Best effort: a leftover table must not fail an otherwise passing fixture.
+            TestContext.Progress.WriteLine($"Failed to drop test table {tableName}: {e.Message}");
+        }
+
         connection?.Dispose();
         client?.Dispose();
     }
@@ -902,6 +967,7 @@ public class WriteDateTime64HttpParamTests : IDisposable
     [SetUp]
     public async Task SetUp()
     {
+        // Each test inserts a single row and reads it back, so the shared table is reset here.
         await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {tableName}");
         await connection.ExecuteStatementAsync($@"
             CREATE TABLE {tableName} (
@@ -1002,12 +1068,21 @@ public class WriteDateTime64HttpParamTests : IDisposable
 [TestFixture]
 public class WriteDateTime64BulkCopyTests : AbstractConnectionTestFixture
 {
+    private readonly string tableName;
+
+    public WriteDateTime64BulkCopyTests()
+    {
+        // Shared by every test in the fixture (recreated per test below); the base fixture drops it.
+        tableName = CreateTableName("datetime64_bulk_test");
+    }
+
     [SetUp]
     public async Task SetUp()
     {
-        await connection.ExecuteStatementAsync("DROP TABLE IF EXISTS test.datetime64_bulk_test");
-        await connection.ExecuteStatementAsync(@"
-            CREATE TABLE test.datetime64_bulk_test (
+        // Each test inserts a single row and reads it back, so the shared table is reset here.
+        await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {tableName}");
+        await connection.ExecuteStatementAsync($@"
+            CREATE TABLE {tableName} (
                 dt64_utc DateTime64(3, 'UTC'),
                 dt64_amsterdam DateTime64(3, 'Europe/Amsterdam'),
                 dt64_no_tz DateTime64(3)
@@ -1017,7 +1092,7 @@ public class WriteDateTime64BulkCopyTests : AbstractConnectionTestFixture
     [TearDown]
     public async Task TearDown()
     {
-        await connection.ExecuteStatementAsync("DROP TABLE IF EXISTS test.datetime64_bulk_test");
+        await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {tableName}");
     }
 
     [Test]
@@ -1027,13 +1102,13 @@ public class WriteDateTime64BulkCopyTests : AbstractConnectionTestFixture
 
         using var bulkCopy = new ClickHouseBulkCopy(connection)
         {
-            DestinationTableName = "test.datetime64_bulk_test",
+            DestinationTableName = tableName,
             ColumnNames = ["dt64_utc"]
         };
         
         await bulkCopy.WriteToServerAsync([[dt]]);
 
-        var result = (DateTime)await connection.ExecuteScalarAsync("SELECT dt64_utc FROM test.datetime64_bulk_test");
+        var result = (DateTime)await connection.ExecuteScalarAsync($"SELECT dt64_utc FROM {tableName}");
         Assert.That(result, Is.EqualTo(DateTimeConversions.DateTimeEpochStart));
     }
 
@@ -1048,12 +1123,12 @@ public class WriteDateTime64BulkCopyTests : AbstractConnectionTestFixture
 
         using var bulkCopy = new ClickHouseBulkCopy(connection)
         {
-            DestinationTableName = "test.datetime64_bulk_test",
+            DestinationTableName = tableName,
             ColumnNames = [col],
         };
         await bulkCopy.WriteToServerAsync([[utcDt]]);
 
-        var unixMs = Convert.ToInt64(await connection.ExecuteScalarAsync($"SELECT toUnixTimestamp64Milli({col}) FROM test.datetime64_bulk_test"));
+        var unixMs = Convert.ToInt64(await connection.ExecuteScalarAsync($"SELECT toUnixTimestamp64Milli({col}) FROM {tableName}"));
         Assert.That(unixMs, Is.EqualTo(expected));
     }
 
@@ -1069,12 +1144,12 @@ public class WriteDateTime64BulkCopyTests : AbstractConnectionTestFixture
 
         using var bulkCopy = new ClickHouseBulkCopy(connection)
         {
-            DestinationTableName = "test.datetime64_bulk_test",
+            DestinationTableName = tableName,
             ColumnNames = [col],
         };
         await bulkCopy.WriteToServerAsync([[dt]]);
 
-        var result = (DateTime)await connection.ExecuteScalarAsync($"SELECT {col} FROM test.datetime64_bulk_test");
+        var result = (DateTime)await connection.ExecuteScalarAsync($"SELECT {col} FROM {tableName}");
         Assert.That(result.Ticks, Is.EqualTo(dt.Ticks));
     }
 
@@ -1089,12 +1164,12 @@ public class WriteDateTime64BulkCopyTests : AbstractConnectionTestFixture
 
         using var bulkCopy = new ClickHouseBulkCopy(connection)
         {
-            DestinationTableName = "test.datetime64_bulk_test",
+            DestinationTableName = tableName,
             ColumnNames = [col],
         };
         await bulkCopy.WriteToServerAsync([[localDt]]);
 
-        var unixMs = Convert.ToInt64(await connection.ExecuteScalarAsync($"SELECT toUnixTimestamp64Milli({col}) FROM test.datetime64_bulk_test"));
+        var unixMs = Convert.ToInt64(await connection.ExecuteScalarAsync($"SELECT toUnixTimestamp64Milli({col}) FROM {tableName}"));
         Assert.That(unixMs, Is.EqualTo(expected));
     }
 }

--- a/ClickHouse.Driver.Tests/Types/VariantTests.cs
+++ b/ClickHouse.Driver.Tests/Types/VariantTests.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using ClickHouse.Driver.ADO;
 using ClickHouse.Driver.Tests.Attributes;
 using ClickHouse.Driver.Utility;
-using NUnit.Framework;
 using NUnit.Framework.Legacy;
 
 namespace ClickHouse.Driver.Tests.Types;
@@ -15,70 +14,58 @@ public class VariantTests : AbstractConnectionTestFixture
     [RequiredFeature(Feature.Variant)]
     public async Task Read_NoneDiscriminator_ShouldReturnDbNull()
     {
-        var targetTable = "test.test_variant_read_null";
-        try
-        {
-            await connection.ExecuteStatementAsync(
-                $"CREATE OR REPLACE TABLE {targetTable} (id UInt32, val Variant(String, UInt64)) ENGINE = Memory");
+        var targetTable = CreateTableName();
 
-            await connection.ExecuteStatementAsync(
-                $"INSERT INTO {targetTable} VALUES (1, 'hello'), (2, 42), (3, NULL)");
+        await connection.ExecuteStatementAsync(
+            $"CREATE OR REPLACE TABLE {targetTable} (id UInt32, val Variant(String, UInt64)) ENGINE = Memory");
 
-            using var reader = await connection.ExecuteReaderAsync(
-                $"SELECT id, val FROM {targetTable} ORDER BY id");
+        await connection.ExecuteStatementAsync(
+            $"INSERT INTO {targetTable} VALUES (1, 'hello'), (2, 42), (3, NULL)");
 
-            ClassicAssert.IsTrue(reader.Read());
-            Assert.That(reader.GetValue(0), Is.EqualTo(1u));
-            Assert.That(reader.GetValue(1), Is.EqualTo("hello"));
+        using var reader = await connection.ExecuteReaderAsync(
+            $"SELECT id, val FROM {targetTable} ORDER BY id");
 
-            ClassicAssert.IsTrue(reader.Read());
-            Assert.That(reader.GetValue(0), Is.EqualTo(2u));
-            Assert.That(reader.GetValue(1), Is.EqualTo((ulong)42));
+        ClassicAssert.IsTrue(reader.Read());
+        Assert.That(reader.GetValue(0), Is.EqualTo(1u));
+        Assert.That(reader.GetValue(1), Is.EqualTo("hello"));
 
-            ClassicAssert.IsTrue(reader.Read());
-            Assert.That(reader.GetValue(0), Is.EqualTo(3u));
-            Assert.That(reader.GetValue(1), Is.EqualTo(DBNull.Value));
+        ClassicAssert.IsTrue(reader.Read());
+        Assert.That(reader.GetValue(0), Is.EqualTo(2u));
+        Assert.That(reader.GetValue(1), Is.EqualTo((ulong)42));
 
-            ClassicAssert.IsFalse(reader.Read());
-        }
-        finally
-        {
-            await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {targetTable}");
-        }
+        ClassicAssert.IsTrue(reader.Read());
+        Assert.That(reader.GetValue(0), Is.EqualTo(3u));
+        Assert.That(reader.GetValue(1), Is.EqualTo(DBNull.Value));
+
+        ClassicAssert.IsFalse(reader.Read());
     }
 
     [Test]
     [RequiredFeature(Feature.Variant)]
     public async Task Write_Null_ShouldRoundTrip()
     {
-        var targetTable = "test.test_variant_write_null";
-        try
-        {
-            await client.ExecuteNonQueryAsync(
-                $"CREATE OR REPLACE TABLE {targetTable} (id UInt32, val Variant(String, UInt64)) ENGINE = Memory");
+        var targetTable = CreateTableName();
 
-            await client.InsertBinaryAsync(targetTable, ["id", "val"], [
-                new object[] { 1u, "hello" },
-                new object[] { 2u, null },
-            ]);
+        await client.ExecuteNonQueryAsync(
+            $"CREATE OR REPLACE TABLE {targetTable} (id UInt32, val Variant(String, UInt64)) ENGINE = Memory");
 
-            using var reader = await connection.ExecuteReaderAsync(
-                $"SELECT id, val FROM {targetTable} ORDER BY id");
+        await client.InsertBinaryAsync(targetTable, ["id", "val"], [
+            new object[] { 1u, "hello" },
+            new object[] { 2u, null },
+        ]);
 
-            ClassicAssert.IsTrue(reader.Read());
-            Assert.That(reader.GetValue(0), Is.EqualTo(1u));
-            Assert.That(reader.GetValue(1), Is.EqualTo("hello"));
+        using var reader = await connection.ExecuteReaderAsync(
+            $"SELECT id, val FROM {targetTable} ORDER BY id");
 
-            ClassicAssert.IsTrue(reader.Read());
-            Assert.That(reader.GetValue(0), Is.EqualTo(2u));
-            Assert.That(reader.GetValue(1), Is.EqualTo(DBNull.Value));
+        ClassicAssert.IsTrue(reader.Read());
+        Assert.That(reader.GetValue(0), Is.EqualTo(1u));
+        Assert.That(reader.GetValue(1), Is.EqualTo("hello"));
 
-            ClassicAssert.IsFalse(reader.Read());
-        }
-        finally
-        {
-            await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {targetTable}");
-        }
+        ClassicAssert.IsTrue(reader.Read());
+        Assert.That(reader.GetValue(0), Is.EqualTo(2u));
+        Assert.That(reader.GetValue(1), Is.EqualTo(DBNull.Value));
+
+        ClassicAssert.IsFalse(reader.Read());
     }
 
     [Test]
@@ -139,45 +126,39 @@ public class VariantTests : AbstractConnectionTestFixture
     [RequiredFeature(Feature.Variant)]
     public async Task InsertBinaryAsync_VariantIPv4IPv6_ShouldRoundTrip()
     {
-        var targetTable = "test.test_variant_ip";
-        try
-        {
-            await client.ExecuteNonQueryAsync(
-                $"CREATE OR REPLACE TABLE {targetTable} (id UInt32, addr Variant(IPv4, IPv6)) ENGINE = Memory");
+        var targetTable = CreateTableName();
 
-            var ipv4 = IPAddress.Parse("10.0.0.1");
-            var ipv6 = IPAddress.Parse("2001:db8::1");
+        await client.ExecuteNonQueryAsync(
+            $"CREATE OR REPLACE TABLE {targetTable} (id UInt32, addr Variant(IPv4, IPv6)) ENGINE = Memory");
 
-            await client.InsertBinaryAsync(targetTable, ["id", "addr"], [
-                new object[] { 1u, ipv4 },
-                new object[] { 2u, ipv6 },
-                new object[] { 3u, null },
-            ]);
+        var ipv4 = IPAddress.Parse("10.0.0.1");
+        var ipv6 = IPAddress.Parse("2001:db8::1");
 
-            using var reader = await connection.ExecuteReaderAsync(
-                $"SELECT id, addr, variantType(addr) FROM {targetTable} ORDER BY id");
+        await client.InsertBinaryAsync(targetTable, ["id", "addr"], [
+            new object[] { 1u, ipv4 },
+            new object[] { 2u, ipv6 },
+            new object[] { 3u, null },
+        ]);
 
-            ClassicAssert.IsTrue(reader.Read());
-            Assert.That(reader.GetValue(0), Is.EqualTo(1u));
-            Assert.That(reader.GetValue(1), Is.EqualTo(ipv4));
-            Assert.That(reader.GetString(2), Is.EqualTo("IPv4"));
+        using var reader = await connection.ExecuteReaderAsync(
+            $"SELECT id, addr, variantType(addr) FROM {targetTable} ORDER BY id");
 
-            ClassicAssert.IsTrue(reader.Read());
-            Assert.That(reader.GetValue(0), Is.EqualTo(2u));
-            Assert.That(reader.GetValue(1), Is.EqualTo(ipv6));
-            Assert.That(reader.GetString(2), Is.EqualTo("IPv6"));
+        ClassicAssert.IsTrue(reader.Read());
+        Assert.That(reader.GetValue(0), Is.EqualTo(1u));
+        Assert.That(reader.GetValue(1), Is.EqualTo(ipv4));
+        Assert.That(reader.GetString(2), Is.EqualTo("IPv4"));
 
-            ClassicAssert.IsTrue(reader.Read());
-            Assert.That(reader.GetValue(0), Is.EqualTo(3u));
-            Assert.That(reader.GetValue(1), Is.EqualTo(DBNull.Value));
-            Assert.That(reader.GetString(2), Is.EqualTo("None"));
+        ClassicAssert.IsTrue(reader.Read());
+        Assert.That(reader.GetValue(0), Is.EqualTo(2u));
+        Assert.That(reader.GetValue(1), Is.EqualTo(ipv6));
+        Assert.That(reader.GetString(2), Is.EqualTo("IPv6"));
 
-            ClassicAssert.IsFalse(reader.Read());
-        }
-        finally
-        {
-            await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {targetTable}");
-        }
+        ClassicAssert.IsTrue(reader.Read());
+        Assert.That(reader.GetValue(0), Is.EqualTo(3u));
+        Assert.That(reader.GetValue(1), Is.EqualTo(DBNull.Value));
+        Assert.That(reader.GetString(2), Is.EqualTo("None"));
+
+        ClassicAssert.IsFalse(reader.Read());
     }
 
     // Three-type variant: exercises the write path's O(1) lookup (VariantType builds the lookup for
@@ -187,47 +168,41 @@ public class VariantTests : AbstractConnectionTestFixture
     [RequiredFeature(Feature.Variant)]
     public async Task InsertBinaryAsync_ThreeTypeVariantIPv4IPv6String_ShouldRoundTrip()
     {
-        var targetTable = "test.test_variant_ip3";
-        try
-        {
-            await client.ExecuteNonQueryAsync(
-                $"CREATE OR REPLACE TABLE {targetTable} (id UInt32, val Variant(IPv4, IPv6, String)) ENGINE = Memory");
+        var targetTable = CreateTableName();
 
-            var ipv4 = IPAddress.Parse("10.0.0.1");
-            var ipv6 = IPAddress.Parse("2001:db8::1");
+        await client.ExecuteNonQueryAsync(
+            $"CREATE OR REPLACE TABLE {targetTable} (id UInt32, val Variant(IPv4, IPv6, String)) ENGINE = Memory");
 
-            await client.InsertBinaryAsync(targetTable, ["id", "val"], [
-                new object[] { 1u, ipv4 },
-                new object[] { 2u, ipv6 },
-                new object[] { 3u, "hello" },
-                new object[] { 4u, null },
-            ]);
+        var ipv4 = IPAddress.Parse("10.0.0.1");
+        var ipv6 = IPAddress.Parse("2001:db8::1");
 
-            using var reader = await connection.ExecuteReaderAsync(
-                $"SELECT id, val, variantType(val) FROM {targetTable} ORDER BY id");
+        await client.InsertBinaryAsync(targetTable, ["id", "val"], [
+            new object[] { 1u, ipv4 },
+            new object[] { 2u, ipv6 },
+            new object[] { 3u, "hello" },
+            new object[] { 4u, null },
+        ]);
 
-            ClassicAssert.IsTrue(reader.Read());
-            Assert.That(reader.GetValue(1), Is.EqualTo(ipv4));
-            Assert.That(reader.GetString(2), Is.EqualTo("IPv4"));
+        using var reader = await connection.ExecuteReaderAsync(
+            $"SELECT id, val, variantType(val) FROM {targetTable} ORDER BY id");
 
-            ClassicAssert.IsTrue(reader.Read());
-            Assert.That(reader.GetValue(1), Is.EqualTo(ipv6));
-            Assert.That(reader.GetString(2), Is.EqualTo("IPv6"));
+        ClassicAssert.IsTrue(reader.Read());
+        Assert.That(reader.GetValue(1), Is.EqualTo(ipv4));
+        Assert.That(reader.GetString(2), Is.EqualTo("IPv4"));
 
-            ClassicAssert.IsTrue(reader.Read());
-            Assert.That(reader.GetValue(1), Is.EqualTo("hello"));
-            Assert.That(reader.GetString(2), Is.EqualTo("String"));
+        ClassicAssert.IsTrue(reader.Read());
+        Assert.That(reader.GetValue(1), Is.EqualTo(ipv6));
+        Assert.That(reader.GetString(2), Is.EqualTo("IPv6"));
 
-            ClassicAssert.IsTrue(reader.Read());
-            Assert.That(reader.GetValue(1), Is.EqualTo(DBNull.Value));
-            Assert.That(reader.GetString(2), Is.EqualTo("None"));
+        ClassicAssert.IsTrue(reader.Read());
+        Assert.That(reader.GetValue(1), Is.EqualTo("hello"));
+        Assert.That(reader.GetString(2), Is.EqualTo("String"));
 
-            ClassicAssert.IsFalse(reader.Read());
-        }
-        finally
-        {
-            await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {targetTable}");
-        }
+        ClassicAssert.IsTrue(reader.Read());
+        Assert.That(reader.GetValue(1), Is.EqualTo(DBNull.Value));
+        Assert.That(reader.GetString(2), Is.EqualTo("None"));
+
+        ClassicAssert.IsFalse(reader.Read());
     }
 
     // Multi-type variant with distinct FrameworkTypes: exercises the general lookup path (3 types,
@@ -239,40 +214,34 @@ public class VariantTests : AbstractConnectionTestFixture
     [RequiredFeature(Feature.Variant)]
     public async Task InsertBinaryAsync_MultiTypeVariant_ShouldRoundTrip()
     {
-        var targetTable = "test.test_variant_multi";
-        try
-        {
-            await client.ExecuteNonQueryAsync(
-                $"CREATE OR REPLACE TABLE {targetTable} (id UInt32, val Variant(Int64, String, Array(Int64))) ENGINE = Memory");
+        var targetTable = CreateTableName();
 
-            var array = new long[] { 10, 20, 30 };
+        await client.ExecuteNonQueryAsync(
+            $"CREATE OR REPLACE TABLE {targetTable} (id UInt32, val Variant(Int64, String, Array(Int64))) ENGINE = Memory");
 
-            await client.InsertBinaryAsync(targetTable, ["id", "val"], [
-                new object[] { 1u, 42L },
-                new object[] { 2u, "hello" },
-                new object[] { 3u, array },
-            ]);
+        var array = new long[] { 10, 20, 30 };
 
-            using var reader = await connection.ExecuteReaderAsync(
-                $"SELECT id, val, variantType(val) FROM {targetTable} ORDER BY id");
+        await client.InsertBinaryAsync(targetTable, ["id", "val"], [
+            new object[] { 1u, 42L },
+            new object[] { 2u, "hello" },
+            new object[] { 3u, array },
+        ]);
 
-            ClassicAssert.IsTrue(reader.Read());
-            Assert.That(reader.GetValue(1), Is.EqualTo(42L));
-            Assert.That(reader.GetString(2), Is.EqualTo("Int64"));
+        using var reader = await connection.ExecuteReaderAsync(
+            $"SELECT id, val, variantType(val) FROM {targetTable} ORDER BY id");
 
-            ClassicAssert.IsTrue(reader.Read());
-            Assert.That(reader.GetValue(1), Is.EqualTo("hello"));
-            Assert.That(reader.GetString(2), Is.EqualTo("String"));
+        ClassicAssert.IsTrue(reader.Read());
+        Assert.That(reader.GetValue(1), Is.EqualTo(42L));
+        Assert.That(reader.GetString(2), Is.EqualTo("Int64"));
 
-            ClassicAssert.IsTrue(reader.Read());
-            Assert.That(reader.GetValue(1), Is.EqualTo(array));
-            Assert.That(reader.GetString(2), Is.EqualTo("Array(Int64)"));
+        ClassicAssert.IsTrue(reader.Read());
+        Assert.That(reader.GetValue(1), Is.EqualTo("hello"));
+        Assert.That(reader.GetString(2), Is.EqualTo("String"));
 
-            ClassicAssert.IsFalse(reader.Read());
-        }
-        finally
-        {
-            await connection.ExecuteStatementAsync($"DROP TABLE IF EXISTS {targetTable}");
-        }
+        ClassicAssert.IsTrue(reader.Read());
+        Assert.That(reader.GetValue(1), Is.EqualTo(array));
+        Assert.That(reader.GetString(2), Is.EqualTo("Array(Int64)"));
+
+        ClassicAssert.IsFalse(reader.Read());
     }
 }

--- a/ClickHouse.Driver.Tests/Utilities/TestTableNamingTests.cs
+++ b/ClickHouse.Driver.Tests/Utilities/TestTableNamingTests.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using ClickHouse.Driver.ADO.Parameters;
+using ClickHouse.Driver.Utility;
+
+namespace ClickHouse.Driver.Tests.Utilities;
+
+/// <summary>
+/// Guards the table-naming contract the rest of the suite relies on for isolation: every generated
+/// name must be unique, legal as an unquoted ClickHouse identifier, and attributable to its test.
+/// </summary>
+public class TestTableNamingTests : AbstractConnectionTestFixture
+{
+    private static readonly Regex UniqueSuffix = new(@"_net\d+_[0-9a-f]{12}$", RegexOptions.Compiled);
+
+    [Test]
+    public void CreateTableName_WithNoArguments_UsesCallingMemberName()
+    {
+        var name = TestUtilities.CreateTableName();
+
+        Assert.That(name, Does.StartWith($"test.{nameof(CreateTableName_WithNoArguments_UsesCallingMemberName)}_"));
+    }
+
+    [Test]
+    public void CreateTableName_WithNoArguments_AppendsFrameworkAndRandomToken()
+    {
+        var name = TestUtilities.CreateTableName();
+
+        Assert.That(UniqueSuffix.IsMatch(name), Is.True, $"'{name}' should end in _net<major>_<12 hex>");
+    }
+
+    [Test]
+    public void CreateTableName_CalledRepeatedly_ReturnsDistinctNames()
+    {
+        var names = Enumerable.Range(0, 1000).Select(_ => TestUtilities.CreateTableName()).ToList();
+
+        Assert.That(names.Distinct(), Has.Exactly(names.Count).Items);
+    }
+
+    [Test]
+    public void CreateTableName_WithDefaultDatabase_QualifiesWithTestDatabase()
+    {
+        Assert.That(TestUtilities.CreateTableName("t"), Does.StartWith("test."));
+    }
+
+    [Test]
+    public void CreateTableName_WithExplicitDatabase_QualifiesWithThatDatabase()
+    {
+        Assert.That(TestUtilities.CreateTableName("t", database: "test_secondary"), Does.StartWith("test_secondary.t_"));
+    }
+
+    [Test]
+    public void CreateTableName_WithNullDatabase_ReturnsUnqualifiedName()
+    {
+        var name = TestUtilities.CreateTableName("t", database: null);
+
+        Assert.That(name, Does.Not.Contain("."));
+        Assert.That(name, Does.StartWith("t_"));
+    }
+
+    // Prefixes carry parametrized case values (ClickHouse type names, timezone ids, column names),
+    // which routinely contain characters that are illegal in an unquoted identifier.
+    [TestCase("Nullable(Int32)", "NullableInt32")]
+    [TestCase("Europe/Berlin", "EuropeBerlin")]
+    [TestCase("with space", "withspace")]
+    [TestCase("Array(Tuple(String, UInt8))", "ArrayTupleStringUInt8")]
+    [TestCase("keep_underscores_1", "keep_underscores_1")]
+    // Non-ASCII letters are rejected by the server in an unquoted identifier, even though
+    // char.IsLetterOrDigit considers them letters.
+    [TestCase("Çay", "ay")]
+    [TestCase("emoji_🙂_tail", "emoji__tail")]
+    public void CreateTableName_WithUnsafeCharactersInPrefix_StripsThem(string prefix, string expected)
+    {
+        Assert.That(TestUtilities.CreateTableName(prefix), Does.StartWith($"test.{expected}_net"));
+    }
+
+    [TestCase("()-/")]
+    [TestCase("Добрый")]
+    public void CreateTableName_WithPrefixThatSanitizesToNothing_FallsBackToPlaceholder(string prefix)
+    {
+        Assert.That(TestUtilities.CreateTableName(prefix), Does.StartWith("test.table_net"));
+    }
+
+    [Test]
+    public void CreateTableName_WithOverlongPrefix_TruncatesPrefixTo80Characters()
+    {
+        var name = TestUtilities.CreateTableName(new string('a', 200));
+
+        Assert.That(name, Does.StartWith("test." + new string('a', 80) + "_net"));
+    }
+
+    [TestCase("abc_123", "abc_123")]
+    [TestCase("a.b", "ab")]
+    [TestCase("", "")]
+    [TestCase(null, "")]
+    public void SanitizeTableName_WithVariousInput_KeepsOnlyIdentifierCharacters(string input, string expected)
+    {
+        Assert.That(TestUtilities.SanitizeTableName(input), Is.EqualTo(expected));
+    }
+
+    [TestCase("test.my_table", "my_table")]
+    [TestCase("test_secondary.my_table", "my_table")]
+    [TestCase("already_bare", "already_bare")]
+    [TestCase(null, null)]
+    public void BareTableName_WithVariousInput_StripsOnlyTheDatabaseQualifier(string input, string expected)
+    {
+        Assert.That(TestUtilities.BareTableName(input), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void BareTableName_WithGeneratedName_RoundTripsAgainstCreateTableName()
+    {
+        var qualified = TestUtilities.CreateTableName("round_trip", database: "test_secondary");
+
+        Assert.That(TestUtilities.BareTableName(qualified), Is.EqualTo(qualified["test_secondary.".Length..]));
+    }
+
+    // The whole scheme is worthless if the server rejects the names it produces, so exercise a
+    // generated name against a real server rather than trusting the character filter.
+    [Test]
+    public async Task CreateTableName_WithAwkwardPrefix_ProducesNameTheServerAccepts()
+    {
+        var table = CreateTableName("Map(String, Array(Nullable(DateTime64(3, 'UTC'))))");
+
+        await connection.ExecuteStatementAsync($"CREATE TABLE {table} (value Int32) ENGINE Memory");
+        await connection.ExecuteStatementAsync($"INSERT INTO {table} VALUES (42)");
+
+        Assert.That(await connection.ExecuteScalarAsync($"SELECT value FROM {table}"), Is.EqualTo(42));
+    }
+
+    // Names handed out by the fixture must be dropped on teardown; without that, randomization would
+    // trade flakiness for unbounded table growth in the shared `test` database.
+    [Test]
+    public async Task CreateTableName_OnFixtureTearDown_DropsRegisteredTables()
+    {
+        var fixture = new TearDownProbeFixture();
+        var table = fixture.CreateProbeTable();
+
+        await fixture.CreateAsync(table);
+        Assert.That(await TableExistsAsync(table), Is.True, "table should exist before teardown");
+
+        fixture.Dispose();
+
+        Assert.That(await TableExistsAsync(table), Is.False, "teardown should have dropped the table");
+    }
+
+    private async Task<bool> TableExistsAsync(string qualifiedName)
+    {
+        var parts = qualifiedName.Split('.');
+        var parameters = new ClickHouseParameterCollection();
+        parameters.AddParameter("db", parts[0]);
+        parameters.AddParameter("name", parts[1]);
+
+        var count = await client.ExecuteScalarAsync(
+            "SELECT count() FROM system.tables WHERE database = {db:String} AND name = {name:String}",
+            parameters);
+
+        return Convert.ToUInt64(count, CultureInfo.InvariantCulture) > 0;
+    }
+
+    /// <summary>
+    /// Stands in for a real fixture so the teardown drop can be observed without ending this one.
+    /// </summary>
+    private sealed class TearDownProbeFixture : AbstractConnectionTestFixture
+    {
+        public string CreateProbeTable() => CreateTableName("teardown_probe");
+
+        public Task CreateAsync(string table) =>
+            connection.ExecuteStatementAsync($"CREATE TABLE {table} (value Int32) ENGINE Memory");
+    }
+}

--- a/ClickHouse.Driver.Tests/Utilities/TestTableNamingTests.cs
+++ b/ClickHouse.Driver.Tests/Utilities/TestTableNamingTests.cs
@@ -32,6 +32,29 @@ public class TestTableNamingTests : AbstractConnectionTestFixture
         Assert.That(UniqueSuffix.IsMatch(name), Is.True, $"'{name}' should end in _net<major>_<12 hex>");
     }
 
+    // The moniker must track the compiled target framework, not Environment.Version, which reports the
+    // *runtime* version: under roll-forward (a net6.0 build on the .NET 10 runtime, when 6.0 is absent)
+    // every suite reports the same major and tables get attributed to the wrong one.
+    // The expectation is spelled out per target framework on purpose — deriving it from
+    // TargetFrameworkAttribute here would just re-read the same source the implementation uses, and
+    // would pass either way.
+    [Test]
+    public void CreateTableName_WithNoArguments_UsesCompiledTargetFrameworkNotRuntimeVersion()
+    {
+#if NET6_0
+        const string expected = "net6";
+#elif NET8_0
+        const string expected = "net8";
+#elif NET9_0
+        const string expected = "net9";
+#elif NET10_0
+        const string expected = "net10";
+#else
+#error Unhandled target framework — add it here and to the moniker expectation above.
+#endif
+        Assert.That(TestUtilities.CreateTableName(), Does.Contain($"_{expected}_"));
+    }
+
     [Test]
     public void CreateTableName_CalledRepeatedly_ReturnsDistinctNames()
     {

--- a/ClickHouse.Driver.Tests/Utilities/TestUtilities.cs
+++ b/ClickHouse.Driver.Tests/Utilities/TestUtilities.cs
@@ -4,7 +4,9 @@ using System.Data.Common;
 using System.Linq;
 using System.Net;
 using System.Numerics;
+using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Runtime.Versioning;
 using System.Text;
 using System.Threading.Tasks;
 using ClickHouse.Driver.ADO;
@@ -89,11 +91,27 @@ public static class TestUtilities
     public const string TestDatabase = "test";
 
     /// <summary>
-    /// Identifies the process running the test. The suites for net6.0/net8.0/net9.0/net10.0 run
-    /// concurrently against a single shared server, so the target framework moniker keeps those
-    /// four runs from colliding with each other.
+    /// Identifies which of the concurrently running net6.0/net8.0/net9.0/net10.0 suites produced a
+    /// name. Uniqueness itself comes from the random token in <see cref="CreateTableName"/>, not from
+    /// this; the moniker is here so a table observed on the shared server can be attributed to a suite.
     /// </summary>
-    private static readonly string TargetFrameworkMoniker = $"net{Environment.Version.Major}";
+    private static readonly string TargetFrameworkMoniker = GetTargetFrameworkMoniker();
+
+    /// <remarks>
+    /// Reads the assembly's compiled-in target framework rather than <see cref="Environment.Version"/>,
+    /// which reports the *runtime* version. Those differ under roll-forward — a net6.0 build runs on the
+    /// .NET 10 runtime when 6.0 is absent — and every suite would then report the same major, so the
+    /// moniker would point at the wrong one.
+    /// </remarks>
+    private static string GetTargetFrameworkMoniker()
+    {
+        // ".NETCoreApp,Version=v9.0" -> "net9"
+        var frameworkName = typeof(TestUtilities).Assembly
+            .GetCustomAttribute<TargetFrameworkAttribute>()?.FrameworkName;
+        var major = frameworkName?.Split("Version=v").ElementAtOrDefault(1)?.Split('.').FirstOrDefault();
+
+        return string.IsNullOrEmpty(major) ? "netunknown" : $"net{major}";
+    }
 
     /// <summary>
     /// Strips everything that is not valid in an unquoted ClickHouse identifier. Note that this

--- a/ClickHouse.Driver.Tests/Utilities/TestUtilities.cs
+++ b/ClickHouse.Driver.Tests/Utilities/TestUtilities.cs
@@ -84,6 +84,89 @@ public static class TestUtilities
     }
 
     /// <summary>
+    /// The database that tests should create their tables in.
+    /// </summary>
+    public const string TestDatabase = "test";
+
+    /// <summary>
+    /// Identifies the process running the test. The suites for net6.0/net8.0/net9.0/net10.0 run
+    /// concurrently against a single shared server, so the target framework moniker keeps those
+    /// four runs from colliding with each other.
+    /// </summary>
+    private static readonly string TargetFrameworkMoniker = $"net{Environment.Version.Major}";
+
+    /// <summary>
+    /// Strips everything that is not valid in an unquoted ClickHouse identifier. Note that this
+    /// also removes the <c>.</c> separator, so it must be applied to a bare name rather than to
+    /// an already database-qualified one.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately ASCII-only rather than <see cref="char.IsLetterOrDigit(char)"/>: that is
+    /// Unicode-aware and would keep letters like <c>Ç</c>, which the server rejects in an unquoted
+    /// identifier (<c>Code: 62, Unrecognized token</c>).
+    /// </remarks>
+    public static string SanitizeTableName(string input)
+    {
+        var builder = new StringBuilder(input?.Length ?? 0);
+        foreach (var c in input ?? string.Empty)
+        {
+            if (c is (>= 'a' and <= 'z') or (>= 'A' and <= 'Z') or (>= '0' and <= '9') or '_')
+                builder.Append(c);
+        }
+
+        return builder.ToString();
+    }
+
+    /// <summary>
+    /// Builds a unique, database-qualified table name for a test.
+    /// </summary>
+    /// <remarks>
+    /// Tests share a single ClickHouse server across concurrently executing target frameworks, so a
+    /// fixed table name lets one test truncate, drop or read another test's data. Every name produced
+    /// here carries the target framework moniker and a random token, which keeps parallel suites,
+    /// repeated runs and parametrized test cases apart.
+    /// </remarks>
+    /// <param name="prefix">
+    /// Readable part of the name, to make it possible to tell which test owns a table. Defaults to
+    /// the calling member's name. Sanitized, so interpolating test-case values into it is safe.
+    /// </param>
+    /// <param name="database">
+    /// Database to qualify the name with, <see cref="TestDatabase"/> by default. Pass <c>null</c>
+    /// for an unqualified name, for the rare test that has to use the connection's own database.
+    /// </param>
+    /// <param name="testName">Do not pass explicitly; filled in by the compiler.</param>
+    public static string CreateTableName(string prefix = null, string database = TestDatabase, [CallerMemberName] string testName = null)
+    {
+        var name = SanitizeTableName(prefix ?? testName);
+        if (name.Length == 0)
+            name = "table";
+
+        // Keep names short enough to stay readable in server logs and error messages.
+        if (name.Length > 80)
+            name = name[..80];
+
+        var token = Guid.NewGuid().ToString("N")[..12];
+        var unique = $"{name}_{TargetFrameworkMoniker}_{token}";
+        return database is null ? unique : $"{database}.{unique}";
+    }
+
+    /// <summary>
+    /// Strips the database qualifier from a name produced by <see cref="CreateTableName"/>.
+    /// </summary>
+    /// <remarks>
+    /// Needed in two situations. First, the server stores the unqualified name, so assertions against
+    /// <c>system.tables</c>/<c>system.columns</c>/<c>DESCRIBE</c> have to compare against this.
+    /// Second, an API whose database resolution is under test (<c>InsertOptions.Database</c>,
+    /// <c>QueryOptions.Database</c>) must be given the bare name — a qualified one resolves the
+    /// database by itself, making the override a no-op and the assertion vacuous.
+    /// </remarks>
+    public static string BareTableName(string qualifiedName)
+    {
+        var separator = qualifiedName?.IndexOf('.') ?? -1;
+        return separator < 0 ? qualifiedName : qualifiedName[(separator + 1)..];
+    }
+
+    /// <summary>
     /// Equality assertion with special handling for certain object types
     /// </summary>
     /// <param name="expected"></param>


### PR DESCRIPTION
## Summary

The `net6/8/9/10` suites run **simultaneously against one shared ClickHouse server**, so a fixed table name lets one suite drop, truncate or read another's table. ~195 call sites across 26 files used fixed or only partially-randomized names — `BulkCopyTests` alone had 36 fixed names.

Adds `TestUtilities.CreateTableName()`, returning `test.<testmethod>_net<major>_<12 hex>`: the framework moniker separates the four concurrent suites, the random token separates repeat runs and parametrized cases. `AbstractConnectionTestFixture` gains a tracking overload that registers each name and drops it in `[OneTimeTearDown]`, so migrated fixtures need no manual cleanup. Classes that can't derive from the fixture use the static helper plus their own teardown.

Because every name is now unique, this also deletes the scaffolding that only existed to clear a fixed name: ~52 `try/finally` drop wrappers, ~36 `DROP`/`TRUNCATE` preambles, and 5 duplicate private helpers.

`AGENTS.md` guidance is rewritten. The previous text was actively misleading — it recommended hand-rolling `SanitizeTableName($"...{Guid.NewGuid():N}")` and cited `BulkCopyTests` as the example to copy, while that file had no randomization at all. Plausibly how the drift accumulated.

### `CREATE TABLE` vs `IF NOT EXISTS`

Deliberately **not** blanket-adding `IF NOT EXISTS`. On a guaranteed-unique name a plain `CREATE TABLE` cannot collide, so `IF NOT EXISTS` is dead — and if the naming scheme ever regresses it would silently bind a test to a foreign table with a possibly different schema instead of failing loudly. Verified the tripwire fires: a duplicate plain `CREATE TABLE` returns `Code: 57 TABLE_ALREADY_EXISTS`. It survives only where a fixture deliberately shares one table and resets it in `[SetUp]` (`DapperContribTests`). Every `DROP TABLE` keeps `IF EXISTS`.

### Cases that needed more than a string swap

| Case | Handling |
|---|---|
| **Dapper.Contrib** | Name comes from a `[Table]` attribute (compile-time constant) — routed through `SqlMapperExtensions.TableNameMapper`, fixture-scoped since Contrib caches per type. |
| **linq2db** | Name comes from the mapping class — `CreateTableAsync(tableName:, databaseName:)`. The database must be a *separate* argument; linq2db's ClickHouse builder ignores a dotted name. |
| **Temporary tables** | `database: null` — cannot be qualified, and die with their session, so no teardown drop (an unqualified `DROP` from a fresh session would hit the persistent default database). |
| **`RolesTests`** | `database: null` — must resolve against the database the roles hold `GRANT`s on. |
| **`InsertOptions.Database` / `QueryOptions.Database`** | API gets the **bare** name, qualified one kept for `CREATE`/`SELECT`. A qualified name resolves the database itself, making the override a no-op and voiding the assertion. |

Also fixes **five latent intra-fixture collisions** the sweep exposed, where two tests — or ten `[TestCase]`s — already shared a single table.

## Verification

- net9.0: **9636 total / 9494 passed / 142 skipped / 0 failed**, against a `main` baseline of **9609 / 9467 / 142 / 0** — exactly +27 (the new utility tests), skips unchanged. Confirms nothing was lost or silently disabled.
- Assertion counts and `[Test]`/`[TestCase]` counts are **identical per file** before and after; every removed `await` is accounted for by a removed cleanup statement.
- The `Database`-override fix is mutation-verified: flipping `"test"` → `"default"` now fails exactly the 10 tests that set it, where previously deleting the line changed nothing.
- A solo full-suite run leaves **zero** tables in the shared `test` database.
- Clean build on `net6.0`/`net8.0`/`net9.0`/`net10.0`; `IntegrationTests` pass on `net10.0`.

## Checklist

- [x] Unit and integration tests covering the common scenarios were added
- [ ] ~A human-readable description of the changes was provided to include in CHANGELOG~ — test-only, no client behavioral change

🤖 Generated with [Claude Code](https://claude.com/claude-code)