### PR TITLE
fix(types): render valid Enum type declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Unreleased
 
 **Bug Fixes:**
 * Fixed JSON typed paths whose names start with `max_dynamic_paths` or `max_dynamic_types` being mistaken for JSON settings and decoded as dynamic values.
+* Fixed enum type names rendering as invalid ClickHouse syntax. Enum labels are now quoted and escaped, and the declaration includes its closing parenthesis.
 * Fixed `InsertOptions.WithColumnTypes()` and `InsertOptions.WithQueryId()` silently dropping some caller-set options (such as `AcceptEncoding`) when copying.
 * Fixed `ClickHouseServerException` carrying a blank `Message` and an `ErrorCode` of `-1` when the server — or an upstream component such as a load balancer or the ClickHouse Cloud edge — returned a non-2xx HTTP response with an empty (or whitespace-only) body. The exception now reports the HTTP status code and reason phrase, and uses the `X-ClickHouse-Exception-Code` response header as the error code when the server sets it (issue #440). Non-empty error bodies are unaffected.
 * Fixed `ClickHouseDataReader.GetSchemaTable()` leaving `NumericScale` unset (`DBNull`) for `DateTime64(N)` and `Time64(N)` columns (including their `Nullable(...)` variants). The schema table now reports the fractional-seconds precision `N` in `NumericScale`, matching how `Decimal` columns are already reported (issue #438).

--- a/ClickHouse.Driver.IntegrationTests/EnumTypeTests.cs
+++ b/ClickHouse.Driver.IntegrationTests/EnumTypeTests.cs
@@ -1,0 +1,23 @@
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tests;
+using NUnit.Framework;
+
+namespace ClickHouse.Driver.IntegrationTests;
+
+public class EnumTypeTests
+{
+    [Test]
+    public async Task GetDataTypeName_Enum16Column_RoundTripsThroughServer()
+    {
+        using var client = TestUtilities.GetTestClickHouseClient();
+        using var reader = await client.ExecuteReaderAsync(
+            "SELECT CAST('Low' AS Enum16('Low' = -32768, 'High' = 32767)) AS value");
+
+        Assert.That(reader.Read(), Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(reader.GetDataTypeName(0), Is.EqualTo("Enum16('Low' = -32768, 'High' = 32767)"));
+            Assert.That(reader.GetString(0), Is.EqualTo("Low"));
+        });
+    }
+}

--- a/ClickHouse.Driver.Tests/Types/EnumTypeTests.cs
+++ b/ClickHouse.Driver.Tests/Types/EnumTypeTests.cs
@@ -91,4 +91,32 @@ public class EnumTypeTests
         Assert.That(type.Lookup("a=b"), Is.EqualTo(1));
         Assert.That(type.Lookup(1), Is.EqualTo("a=b"));
     }
+
+    [Test]
+    public void ToString_WithEscapedEnumLabels_ReturnsParseableTypeDeclaration()
+    {
+        var type = (EnumType)TypeConverter.ParseClickHouseType(
+            "Enum8('DateTime(\\'UTC\\')' = -1, 'a=b' = 1)",
+            TypeSettings.Default);
+
+        var rendered = type.ToString();
+        var reparsed = (EnumType)TypeConverter.ParseClickHouseType(rendered, TypeSettings.Default);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(rendered, Is.EqualTo("Enum8('DateTime(\\'UTC\\')' = -1, 'a=b' = 1)"));
+            Assert.That(reparsed.Lookup("DateTime('UTC')"), Is.EqualTo(-1));
+            Assert.That(reparsed.Lookup("a=b"), Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void ToString_WithEnum16Type_ReturnsCompleteTypeDeclaration()
+    {
+        var type = (EnumType)TypeConverter.ParseClickHouseType(
+            "Enum16('Low' = -32768, 'High' = 32767)",
+            TypeSettings.Default);
+
+        Assert.That(type.ToString(), Is.EqualTo("Enum16('Low' = -32768, 'High' = 32767)"));
+    }
 }

--- a/ClickHouse.Driver/Types/Enum16Type.cs
+++ b/ClickHouse.Driver/Types/Enum16Type.cs
@@ -14,8 +14,6 @@ internal class Enum16Type : EnumType
 
     public override string Name => "Enum16";
 
-    public override string ToString() => "Enum16";
-
     public override object Read(ExtendedBinaryReader reader) => Lookup(reader.ReadInt16());
 
     public override void Write(ExtendedBinaryWriter writer, object value)

--- a/ClickHouse.Driver/Types/EnumType.cs
+++ b/ClickHouse.Driver/Types/EnumType.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using ClickHouse.Driver.Formats;
 using ClickHouse.Driver.Types.Grammar;
+using ClickHouse.Driver.Utility;
 
 namespace ClickHouse.Driver.Types;
 
@@ -57,7 +58,8 @@ internal class EnumType : ParameterizedType
 
     public string Lookup(int value) => reverseValues.TryGetValue(value, out var key) ? key : throw new KeyNotFoundException($"Enum value {value} not found");
 
-    public override string ToString() => $"{Name}({string.Join(",", Values.Select(kvp => kvp.Key + "=" + kvp.Value))}";
+    public override string ToString() =>
+        $"{Name}({string.Join(", ", Values.Select(kvp => $"{kvp.Key.Escape().QuoteSingle()} = {kvp.Value.ToString(CultureInfo.InvariantCulture)}"))})";
 
     public override object Read(ExtendedBinaryReader reader) => throw new NotImplementedException();
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -27,6 +27,7 @@ Unreleased
 
 **Bug Fixes:**
 * Fixed JSON typed paths whose names start with `max_dynamic_paths` or `max_dynamic_types` being mistaken for JSON settings and decoded as dynamic values.
+* Fixed enum type names rendering as invalid ClickHouse syntax. Enum labels are now quoted and escaped, and the declaration includes its closing parenthesis.
 * Fixed `InsertOptions.WithColumnTypes()` and `InsertOptions.WithQueryId()` silently dropping some caller-set options (such as `AcceptEncoding`) when copying.
 * Fixed `ClickHouseServerException` carrying a blank `Message` and an `ErrorCode` of `-1` when the server — or an upstream component such as a load balancer or the ClickHouse Cloud edge — returned a non-2xx HTTP response with an empty (or whitespace-only) body. The exception now reports the HTTP status code and reason phrase, and uses the `X-ClickHouse-Exception-Code` response header as the error code when the server sets it (issue #440). Non-empty error bodies are unaffected.
 * Fixed `ClickHouseDataReader.GetSchemaTable()` leaving `NumericScale` unset (`DBNull`) for `DateTime64(N)` and `Time64(N)` columns (including their `Nullable(...)` variants). The schema table now reports the fractional-seconds precision `N` in `NumericScale`, matching how `Decimal` columns are already reported (issue #438).


### PR DESCRIPTION
## Summary

`EnumType.ToString()` currently omits the closing parenthesis and renders labels without ClickHouse quoting or escaping. This produces malformed type names through APIs such as `GetDataTypeName()`.

Render enum declarations using the existing ClickHouse string escaping helpers, invariant integer formatting, and canonical spacing.

## Tests

Added a parser-renderer-parser regression covering escaped quotes and labels containing `=`.