### PR TITLE
fix(types): preserve JSON paths starting with setting names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Unreleased
 * `ClickHouseClient.MemoryStreamManager` is now `[Obsolete]`. Since binary inserts stream directly into the request body (see above), this property is no longer used and has no effect; it will be removed in a future version.
 
 **Bug Fixes:**
+* Fixed JSON typed paths whose names start with `max_dynamic_paths` or `max_dynamic_types` being mistaken for JSON settings and decoded as dynamic values.
 * Fixed `InsertOptions.WithColumnTypes()` and `InsertOptions.WithQueryId()` silently dropping some caller-set options (such as `AcceptEncoding`) when copying.
 * Fixed `ClickHouseServerException` carrying a blank `Message` and an `ErrorCode` of `-1` when the server — or an upstream component such as a load balancer or the ClickHouse Cloud edge — returned a non-2xx HTTP response with an empty (or whitespace-only) body. The exception now reports the HTTP status code and reason phrase, and uses the `X-ClickHouse-Exception-Code` response header as the error code when the server sets it (issue #440). Non-empty error bodies are unaffected.
 * Fixed `ClickHouseDataReader.GetSchemaTable()` leaving `NumericScale` unset (`DBNull`) for `DateTime64(N)` and `Time64(N)` columns (including their `Nullable(...)` variants). The schema table now reports the fractional-seconds precision `N` in `NumericScale`, matching how `Decimal` columns are already reported (issue #438).

--- a/ClickHouse.Driver.Tests/Types/JsonTypeTests.cs
+++ b/ClickHouse.Driver.Tests/Types/JsonTypeTests.cs
@@ -243,6 +243,27 @@ public class JsonTypeTests : AbstractConnectionTestFixture
             "code",
             "ABC1234567"
         ).SetName("FixedString(10)");
+
+        yield return new TestCaseData(
+            "max_dynamic_paths_used UInt64",
+            "{\"max_dynamic_paths_used\": 18446744073709551615}",
+            "max_dynamic_paths_used",
+            ulong.MaxValue
+        ).SetName("PathStartingWithMaxDynamicPaths");
+
+        yield return new TestCaseData(
+            "max_dynamic_paths UInt64",
+            "{\"max_dynamic_paths\": 18446744073709551615}",
+            "max_dynamic_paths",
+            ulong.MaxValue
+        ).SetName("PathNamedMaxDynamicPaths");
+
+        yield return new TestCaseData(
+            "max_dynamic_types_seen String",
+            "{\"max_dynamic_types_seen\": \"String value\"}",
+            "max_dynamic_types_seen",
+            "String value"
+        ).SetName("PathStartingWithMaxDynamicTypes");
     }
     
     [Test]
@@ -251,6 +272,7 @@ public class JsonTypeTests : AbstractConnectionTestFixture
     [TestCase("level1_int Int64, nested.level2_string String, skip path.to.ignore")]
     [TestCase("level1_int Int64, nested.level2_string String, SKIP path.to.skip, SKIP REGEXP 'regex.path.*'")]
     [TestCase("max_dynamic_paths=10, level1_int Int64, nested.level2_string String")]
+    [TestCase("max_dynamic_paths = 10, level1_int Int64, nested.level2_string String")]
     [TestCase("max_dynamic_paths=10, level1_int Int64, nested.level2_string String, SKIP path.to.skip")]
     [TestCase("max_dynamic_types=3, level1_int Int64, nested.level2_string String")]
     [TestCase("max_dynamic_paths=0")]

--- a/ClickHouse.Driver.Tests/Types/JsonTypeTests.cs
+++ b/ClickHouse.Driver.Tests/Types/JsonTypeTests.cs
@@ -307,6 +307,17 @@ public class JsonTypeTests : AbstractConnectionTestFixture
     }
 
     [Test]
+    [TestCase("JSON(max_dynamic_paths = 10, a String)")]
+    [TestCase("JSON(max_dynamic_paths  =  10, a String)")]
+    [TestCase("JSON(max_dynamic_types =3, a String)")]
+    public void ShouldExcludeSettingsFromHintedPathsWhenParsingSpacedAssignments(string typeString)
+    {
+        var type = (JsonType)TypeConverter.ParseClickHouseType(typeString, TypeSettings.Default);
+
+        Assert.That(type.HintedTypes.Keys, Is.EquivalentTo(new[] { "a" }));
+    }
+
+    [Test]
     [TestCaseSource(nameof(JsonTypeTestCases))]
     public async Task ShouldParseJsonWithTypedPath(string typeDefinition, string jsonData, string pathName, object expectedValue)
     {

--- a/ClickHouse.Driver/Types/JsonType.cs
+++ b/ClickHouse.Driver/Types/JsonType.cs
@@ -20,13 +20,6 @@ namespace ClickHouse.Driver.Types;
 
 internal class JsonType : ParameterizedType
 {
-    private static readonly string[] JsonSettingNames =
-    [
-        "max_dynamic_paths",
-        "max_dynamic_types",
-        "skip "
-    ];
-
     /// <summary>
     /// Shared DynamicType instance for writing unhinted values.
     /// </summary>
@@ -110,7 +103,7 @@ internal class JsonType : ParameterizedType
         TypeSettings settings)
     {
         var hintedTypes = node.ChildNodes
-            .Where(childNode => !JsonSettingNames.Any(jsonSettingName => childNode.Value.StartsWith(jsonSettingName, StringComparison.OrdinalIgnoreCase)))
+            .Where(childNode => !IsJsonSetting(childNode.Value))
             .Select(childNode =>
             {
                 var hintParts = childNode.Value.Split(' ');
@@ -141,6 +134,20 @@ internal class JsonType : ParameterizedType
         {
             TypeSettings = settings,
         };
+    }
+
+    private static bool IsJsonSetting(string value) =>
+        IsAssignment(value, "max_dynamic_paths")
+        || IsAssignment(value, "max_dynamic_types")
+        || value.StartsWith("skip ", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsAssignment(string value, string settingName)
+    {
+        if (!value.StartsWith(settingName, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        var remainder = value.AsSpan(settingName.Length).TrimStart();
+        return !remainder.IsEmpty && remainder[0] == '=';
     }
 
     public override string ToString() => Name;

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -26,6 +26,7 @@ Unreleased
 * `ClickHouseClient.MemoryStreamManager` is now `[Obsolete]`. Since binary inserts stream directly into the request body (see above), this property is no longer used and has no effect; it will be removed in a future version.
 
 **Bug Fixes:**
+* Fixed JSON typed paths whose names start with `max_dynamic_paths` or `max_dynamic_types` being mistaken for JSON settings and decoded as dynamic values.
 * Fixed `InsertOptions.WithColumnTypes()` and `InsertOptions.WithQueryId()` silently dropping some caller-set options (such as `AcceptEncoding`) when copying.
 * Fixed `ClickHouseServerException` carrying a blank `Message` and an `ErrorCode` of `-1` when the server — or an upstream component such as a load balancer or the ClickHouse Cloud edge — returned a non-2xx HTTP response with an empty (or whitespace-only) body. The exception now reports the HTTP status code and reason phrase, and uses the `X-ClickHouse-Exception-Code` response header as the error code when the server sets it (issue #440). Non-empty error bodies are unaffected.
 * Fixed `ClickHouseDataReader.GetSchemaTable()` leaving `NumericScale` unset (`DBNull`) for `DateTime64(N)` and `Time64(N)` columns (including their `Nullable(...)` variants). The schema table now reports the fractional-seconds precision `N` in `NumericScale`, matching how `Decimal` columns are already reported (issue #438).


### PR DESCRIPTION
## Summary

JSON type parsing filtered `max_dynamic_paths` and `max_dynamic_types` using prefix matching. This caused valid typed paths such as `max_dynamic_paths_used UInt64` to be discarded as settings.

Recognize these entries as settings only when followed by an assignment, while leaving `SKIP` handling unchanged.

## Tests

- Added real-server coverage for exact and prefixed path names
- Covered both affected setting names and preserved spaced assignment parsing
- `dotnet test ClickHouse.Driver.Tests --framework net10.0 --property WarningLevel=0 --filter "Name~ShouldSelectDataWithComplexHintedJsonType|Name~PathStartingWithMaxDynamic|Name~PathNamedMaxDynamicPaths"`
- `dotnet build ClickHouse.Driver.sln --framework net10.0 --property WarningLevel=0`

## Checklist

- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG