### PR TITLE
Stop collecting unused coverage in the Windows CI job

### DIFF
--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -43,10 +43,12 @@ jobs:
           dotnet-version: |
             10.x
 
+      # No coverage here: nothing in this job consumes it (codecov is fed by the Linux "Code
+      # Coverage" job), and coverlet's msbuild driver intermittently fails the job after tests pass.
       - name: Test
         run: dotnet test ClickHouse.Driver.Tests/ClickHouse.Driver.Tests.csproj
               --framework net10.0 --configuration Release --verbosity normal --logger GitHubActions
-              /clp:ErrorsOnly /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:SkipAutoProps=true
+              /clp:ErrorsOnly
         env:
           CLICKHOUSE_CONNECTION: Host=localhost;Port=8123;Username=default
           CLICKHOUSE_TEST_ENVIRONMENT: local_quick_setup


### PR DESCRIPTION
## What

Drop `/p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:SkipAutoProps=true` from the `Windows / Windows Tests` job. One file, workflow-only — no product or test code changes.

## Why

**Nothing consumes the coverage this job produces.** `tests-windows.yml`'s last step is `Test` — there is no `codecov-action` step and no artifact upload, so the report is computed and thrown away. Codecov is fed exclusively by the Linux `Code Coverage` job, and `reusable.yml` already treats these properties as coverage-only, adding them conditionally:

```yaml
${{ inputs.coverage && '/p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:SkipAutoProps=true' || '' }}
```

That made the Windows job the only job in the repo paying for coverage instrumentation while discarding the result — and absorbing the entire risk of coverlet's post-test coverage calculation.

**That risk is not theoretical.** [Run 31700578581](https://github.com/ClickHouse/clickhouse-cs/actions/runs/31700578581/job/94448457115) failed with all 10438 tests passing:

```
Test Run Successful.
Total tests: 10438
     Passed: 10282
    Skipped: 156
coverlet.msbuild.targets(72,5): error : Unable to read beyond the end of the stream.
   at System.IO.BinaryReader.ReadInt32()
   at Coverlet.Core.Coverage.CalculateCoverage() in Coverage.cs:line 420
```

`Coverage.cs:420` is the *first* `ReadInt32()` — it reads the hits file's length header, so EOF there means the file existed but was under 4 bytes. The guard just above only handles a *missing* file; an empty one falls through into an unguarded `BinaryReader` and becomes a hard error. With the msbuild driver the hits file is written only from the test host's `ProcessExit` handler, via a `FileStream` that defaults to `FileShare.Read` (readable the instant it is created, before any bytes land), and is read back by a later MSBuild task in a separate process — while vstest.console force-kills a test host that doesn't exit within 100 ms. Coverlet documents this under *"VSTest stops process execution early"* in [KnownIssues.md](https://github.com/coverlet-coverage/coverlet/blob/master/Documentation/KnownIssues.md), affected drivers: **msbuild (`dotnet test`)**.

Upstream refs: coverlet [#210](https://github.com/coverlet-coverage/coverlet/issues/210), [#736](https://github.com/coverlet-coverage/coverlet/issues/736), [#1086](https://github.com/coverlet-coverage/coverlet/issues/1086), [#1981](https://github.com/coverlet-coverage/coverlet/issues/1981), [#1983](https://github.com/coverlet-coverage/coverlet/issues/1983).

**Why not just upgrade coverlet.** [PR #1987](https://github.com/coverlet-coverage/coverlet/pull/1987) fixes it properly (atomic write + lock file), but it merged 2026-07-20, *after* the 10.0.1 release — so it is in no published package, and maintainers have signalled no near-term release. Meanwhile #1981 reports the 10.x line as *more* race-prone than 8.x, and [#1957](https://github.com/coverlet-coverage/coverlet/issues/1957) is this exact stack trace on `coverlet.msbuild` 10.0.1 + the .NET 10 SDK, closed as unfixable. Not collecting coverage we never read is the cheaper and more durable fix.

The existing `<ExcludeByFile>**/Vendor/**/*.cs</ExcludeByFile>` mitigation in `ClickHouse.Driver.Tests.csproj` is intentionally left alone — it still matters for the Linux coverage job.

## Testing

Ran the exact resulting command locally (net10.0, Release):

- [x] `Test Run Successful. Total tests: 10438, Passed: 10296, Skipped: 142`, 0 failed, 1.23 min. (142 skips locally vs 156 in the Windows job — the Windows job runs `local_quick_setup`, which feature-gates more tests.)
- [x] No `coverage.*.xml` artifact produced, and zero coverlet activity in the build log — confirming these properties were the only thing invoking coverlet in this job.
- [x] YAML parses; `/clp:ErrorsOnly`, `--framework net10.0` and the `env:` block are unchanged.
- [x] Nothing else references the Windows job's coverage — `codecov.yml` defines no flags, and no other workflow reads it.

No changelog fragment: workflow-only, no behavioral change in the client. (`changelog.yml` is path-filtered to `changelog.d/**`, `CHANGELOG.md`, `RELEASENOTES.md` and `scripts/changelog.cs`, so its gate does not apply.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)