### PR TITLE
TCP N5a: Add the read-side mirror of WritableElementTypes to IColumnCodec

### DIFF
--- a/ClickHouse.Driver.Tcp.Tests/Integration/ColumnReadProjectionIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ColumnReadProjectionIntegrationTests.cs
@@ -1,0 +1,213 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Format;
+using ClickHouse.Driver.Tcp.Types;
+using ClickHouse.Driver.Tcp.Types.Codecs;
+
+namespace ClickHouse.Driver.Tcp.Tests.Integration;
+
+/// <summary>
+/// Checks <see cref="IColumnCodec.TryProjectRead"/> against a real server: the projection of a decoded column must
+/// agree with the instant the server itself means by that value. The unit tests pin the arithmetic against
+/// hand-computed constants; these pin it against the server's own timezone and scale handling, which is the part
+/// a hand-computed constant could agree with only by luck.
+///
+/// <para>
+/// Every case names its timezone explicitly in the type, so the assertions do not depend on the container's
+/// session timezone.
+/// </para>
+/// </summary>
+[TestFixture]
+[Category("Integration")]
+public class ColumnReadProjectionIntegrationTests
+{
+    private static readonly CancellationToken None = CancellationToken.None;
+
+    /// <summary>
+    /// Projects one row of a decoded column to <typeparamref name="T"/> through the column's own codec, the way a
+    /// compiled POCO scatter will. The value is taken boxed and unboxed inside the expression, so the projection
+    /// under test is the same expression tree a plan would inline.
+    /// </summary>
+    private static T ProjectRow<T>(IColumn column, int row)
+    {
+        IColumnCodec codec = ColumnCodecRegistry.Default.Resolve(
+            column.TypeName,
+            new ResolveContext { ServerTimezone = "UTC" });
+
+        ParameterExpression boxed = Expression.Parameter(typeof(object), "boxed");
+        Assert.That(
+            codec.TryProjectRead(Expression.Convert(boxed, codec.ElementType), typeof(T), out Expression projected),
+            Is.True,
+            $"the '{column.TypeName}' codec does not project to {typeof(T)}");
+
+        var project = Expression.Lambda<Func<object, T>>(projected, boxed).Compile();
+
+        return project(column.GetValue(row));
+    }
+
+    [Test]
+    public async Task StreamAsync_DateTimeWithTimezone_ProjectsTheInstantTheServerMeans()
+    {
+        await using var client = TcpServerFixture.CreateClient();
+
+        uint canonical = 0;
+        DateTimeOffset asOffset = default;
+        DateTime asDateTime = default;
+
+        await foreach (Block block in client.StreamAsync(
+            "SELECT toDateTime(1700000000, 'Europe/Berlin')",
+            cancellationToken: None))
+        {
+            IColumn column = block[0];
+            canonical = ((IColumn<uint>)column).Values[0];
+            asOffset = ProjectRow<DateTimeOffset>(column, 0);
+            asDateTime = ProjectRow<DateTime>(column, 0);
+        }
+
+        Assert.Multiple(() =>
+        {
+            // The canonical read is the raw epoch second count, unchanged by the timezone.
+            Assert.That(canonical, Is.EqualTo(1_700_000_000u));
+
+            // 2023-11-14T22:13:20Z is 23:13:20 +01:00 in Berlin (winter, so standard time).
+            Assert.That(asOffset.UtcDateTime, Is.EqualTo(new DateTime(2023, 11, 14, 22, 13, 20, DateTimeKind.Utc)));
+            Assert.That(asOffset.Offset, Is.EqualTo(TimeSpan.FromHours(1)));
+
+            // A non-zero offset presents the wall clock in the column's zone, as Unspecified (HTTP-driver parity).
+            Assert.That(asDateTime, Is.EqualTo(new DateTime(2023, 11, 14, 23, 13, 20)));
+            Assert.That(asDateTime.Kind, Is.EqualTo(DateTimeKind.Unspecified));
+        });
+    }
+
+    [Test]
+    public async Task StreamAsync_DateTimeInUtc_ProjectsToUtcKind()
+    {
+        await using var client = TcpServerFixture.CreateClient();
+
+        DateTime asDateTime = default;
+
+        await foreach (Block block in client.StreamAsync(
+            "SELECT toDateTime(1700000000, 'UTC')",
+            cancellationToken: None))
+        {
+            asDateTime = ProjectRow<DateTime>(block[0], 0);
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(asDateTime, Is.EqualTo(new DateTime(2023, 11, 14, 22, 13, 20)));
+            Assert.That(asDateTime.Kind, Is.EqualTo(DateTimeKind.Utc));
+        });
+    }
+
+    /// <summary>
+    /// A daylight-saving date, where the offset differs from the zone's standard offset. A projection that used a
+    /// fixed base offset instead of resolving it per instant would pass the winter case above and fail here.
+    /// </summary>
+    [Test]
+    public async Task StreamAsync_DateTimeInDaylightSaving_ResolvesTheOffsetForThatInstant()
+    {
+        await using var client = TcpServerFixture.CreateClient();
+
+        DateTimeOffset asOffset = default;
+
+        await foreach (Block block in client.StreamAsync(
+            "SELECT toDateTime(1689000000, 'Europe/Berlin')",
+            cancellationToken: None))
+        {
+            asOffset = ProjectRow<DateTimeOffset>(block[0], 0);
+        }
+
+        Assert.Multiple(() =>
+        {
+            // 2023-07-10T14:40:00Z falls in CEST, so Berlin is +02:00 rather than its standard +01:00.
+            Assert.That(asOffset.UtcDateTime, Is.EqualTo(new DateTime(2023, 7, 10, 14, 40, 0, DateTimeKind.Utc)));
+            Assert.That(asOffset.Offset, Is.EqualTo(TimeSpan.FromHours(2)));
+        });
+    }
+
+    [Test]
+    [TestCase("fromUnixTimestamp64Milli(1700000000123, 'UTC')", 1_700_000_000_123L, "2023-11-14T22:13:20.1230000Z")]
+    [TestCase("fromUnixTimestamp64Nano(1700000000123456789, 'UTC')", 1_700_000_000_123_456_789L, "2023-11-14T22:13:20.1234567Z")]
+    public async Task StreamAsync_DateTime64_ProjectsAtTheColumnScale(string expression, long expectedCount, string expectedInstant)
+    {
+        await using var client = TcpServerFixture.CreateClient();
+
+        long canonical = 0;
+        DateTimeOffset asOffset = default;
+
+        await foreach (Block block in client.StreamAsync($"SELECT {expression}", cancellationToken: None))
+        {
+            IColumn column = block[0];
+            canonical = ((IColumn<long>)column).Values[0];
+            asOffset = ProjectRow<DateTimeOffset>(column, 0);
+        }
+
+        Assert.Multiple(() =>
+        {
+            // The canonical read keeps the exact wire count, including the nanosecond digits a DateTimeOffset cannot
+            // hold; the projection is the lossy calendar view of it (sub-100 ns digits truncate toward zero).
+            Assert.That(canonical, Is.EqualTo(expectedCount));
+            Assert.That(asOffset.UtcDateTime, Is.EqualTo(DateTimeOffset.Parse(expectedInstant).UtcDateTime));
+        });
+    }
+
+    [Test]
+    public async Task StreamAsync_NullableDateTime_ProjectsValueRowsAndKeepsNulls()
+    {
+        await using var client = TcpServerFixture.CreateClient();
+
+        var projected = new DateTime?[2];
+
+        await foreach (Block block in client.StreamAsync(
+            "SELECT CAST(number = 0 ? NULL : 1700000000, 'Nullable(DateTime(\\'UTC\\'))') FROM system.numbers LIMIT 2",
+            cancellationToken: None))
+        {
+            for (int row = 0; row < block.RowCount; row++)
+            {
+                projected[row] = ProjectRow<DateTime?>(block[0], row);
+            }
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(projected[0], Is.Null);
+            Assert.That(projected[1], Is.EqualTo(new DateTime(2023, 11, 14, 22, 13, 20, DateTimeKind.Utc)));
+        });
+    }
+
+    [Test]
+    public async Task StreamAsync_LowCardinalityNullableDateTime_ProjectsThroughBothWrappers()
+    {
+        await using var client = TcpServerFixture.CreateClient();
+
+        var projected = new DateTimeOffset?[2];
+
+        // The server refuses a LowCardinality over a small fixed-width type unless this is set; it says nothing
+        // about how the column decodes, which is what is under test here.
+        var options = new ClickHouseTcpQueryOptions
+        {
+            Settings = new Dictionary<string, string> { ["allow_suspicious_low_cardinality_types"] = "1" },
+        };
+
+        await foreach (Block block in client.StreamAsync(
+            "SELECT CAST(number = 0 ? NULL : 1700000000, 'LowCardinality(Nullable(DateTime(\\'UTC\\')))') FROM system.numbers LIMIT 2",
+            options,
+            None))
+        {
+            for (int row = 0; row < block.RowCount; row++)
+            {
+                projected[row] = ProjectRow<DateTimeOffset?>(block[0], row);
+            }
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(projected[0], Is.Null);
+            Assert.That(projected[1]?.UtcDateTime, Is.EqualTo(new DateTime(2023, 11, 14, 22, 13, 20, DateTimeKind.Utc)));
+        });
+    }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ColumnReadProjectionIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ColumnReadProjectionIntegrationTests.cs
@@ -10,14 +10,11 @@ using ClickHouse.Driver.Tcp.Types.Codecs;
 namespace ClickHouse.Driver.Tcp.Tests.Integration;
 
 /// <summary>
-/// Checks <see cref="IColumnCodec.TryProjectRead"/> against a real server: the projection of a decoded column must
-/// agree with the instant the server itself means by that value. The unit tests pin the arithmetic against
-/// hand-computed constants; these pin it against the server's own timezone and scale handling, which is the part
-/// a hand-computed constant could agree with only by luck.
-///
+/// Checks <see cref="IColumnCodec.TryProjectRead"/> against a real server: a projection must agree with the instant
+/// the server itself means by that value. The unit tests pin the arithmetic against hand-computed constants; these
+/// pin it against the server's own timezone and scale handling, which a constant could match only by luck.
 /// <para>
-/// Every case names its timezone explicitly in the type, so the assertions do not depend on the container's
-/// session timezone.
+/// Every case names its timezone in the type, so no assertion depends on the container's session timezone.
 /// </para>
 /// </summary>
 [TestFixture]

--- a/ClickHouse.Driver.Tcp.Tests/Types/ColumnReadProjectionTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/ColumnReadProjectionTests.cs
@@ -1,0 +1,805 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Protocol;
+using ClickHouse.Driver.Tcp.Types;
+using ClickHouse.Driver.Tcp.Types.Codecs;
+
+namespace ClickHouse.Driver.Tcp.Tests.Types;
+
+/// <summary>
+/// Covers <see cref="IColumnCodec.TryProjectRead"/> — the authority on which readings a codec offers — and the
+/// diagnostics-only <see cref="IColumnCodec.ReadableElementTypes"/>. These are API-surface and expression-shape
+/// concerns a server round-trip cannot observe: which <see cref="DateTimeKind"/> a projection carries, whether the
+/// emitted expression evaluates its source exactly once, and which targets are refused.
+/// </summary>
+[TestFixture]
+public class ColumnReadProjectionTests
+{
+    private static IColumnCodec Codec(string type, string serverTimezone = "UTC")
+        => ColumnCodecRegistry.Default.Resolve(type, new ResolveContext { ServerTimezone = serverTimezone });
+
+    /// <summary>Compiles a codec's projection into a delegate so its runtime result can be asserted.</summary>
+    private static Func<TSource, TTarget> Project<TSource, TTarget>(IColumnCodec codec)
+    {
+        ParameterExpression source = Expression.Parameter(typeof(TSource), "v");
+
+        Assert.That(codec.TryProjectRead(source, typeof(TTarget), out Expression body), Is.True,
+            $"{codec.TypeName} does not project to {typeof(TTarget)}");
+        Assert.That(body.Type, Is.EqualTo(typeof(TTarget)), "the projection must yield the requested type");
+
+        return Expression.Lambda<Func<TSource, TTarget>>(body, source).Compile();
+    }
+
+    [Test]
+    public void ReadableElementTypes_CodecWithoutAlternates_IsJustTheElementType()
+    {
+        IColumnCodec codec = Codec("UInt64");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(codec.ReadableElementTypes, Is.EqualTo(new[] { typeof(ulong) }));
+            Assert.That(codec.ElementType, Is.EqualTo(typeof(ulong)));
+        });
+    }
+
+    [Test]
+    public void TryProjectRead_CanonicalElementType_IsTheIdentity()
+    {
+        IColumnCodec codec = Codec("UInt64");
+        ParameterExpression source = Expression.Parameter(typeof(ulong), "v");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(codec.TryProjectRead(source, typeof(ulong), out Expression projected), Is.True);
+            Assert.That(projected, Is.SameAs(source));
+        });
+    }
+
+    /// <summary>
+    /// A target the codec does not offer is answered, not thrown: the caller decides what an unmappable member means,
+    /// and only it knows the column and property names worth naming. A refusal must also leave no projection behind,
+    /// so a caller that ignores the bool cannot use a stale one.
+    /// </summary>
+    [Test]
+    public void TryProjectRead_TypeNotOffered_ReturnsFalseAndNoProjection()
+    {
+        IColumnCodec codec = Codec("UInt64");
+        ParameterExpression source = Expression.Parameter(typeof(ulong), "v");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(codec.TryProjectRead(source, typeof(DateTime), out Expression projected), Is.False);
+            Assert.That(projected, Is.Null);
+        });
+    }
+
+    /// <summary>
+    /// A source expression of the wrong type is a caller mistake, distinct from a target the codec does not offer, so
+    /// it still throws rather than being reported as "no such projection".
+    /// </summary>
+    [Test]
+    public void TryProjectRead_SourceOfWrongType_ThrowsArgumentException()
+    {
+        IColumnCodec codec = Codec("DateTime('UTC')");
+        ParameterExpression wrong = Expression.Parameter(typeof(long), "v");
+
+        var ex = Assert.Throws<ArgumentException>(
+            () => codec.TryProjectRead(wrong, typeof(DateTimeOffset), out Expression _));
+        Assert.That(ex.Message, Does.Contain("System.UInt32").And.Contain("System.Int64"));
+    }
+
+    /// <summary>
+    /// Keeps the diagnostic list honest in the one direction that stays true: every type a codec advertises must
+    /// actually be projectable, so the failure message a caller is shown never names a reading that does not exist.
+    /// The converse is deliberately not asserted — <see cref="IColumnCodec.TryProjectRead"/> is the authority, and a
+    /// composite that lifts its children will answer for shapes too numerous to enumerate.
+    /// </summary>
+    [Test]
+    public void ReadableElementTypes_EveryRegisteredType_LeadsWithElementTypeAndIsProjectable()
+    {
+        string[] types =
+        {
+            "UInt8", "Int32", "UInt64", "Int128", "Float32", "Float64", "Bool", "String", "FixedString(4)",
+            "Date", "Date32", "DateTime", "DateTime('Europe/Berlin')", "DateTime64(3)", "DateTime64(9, 'UTC')",
+            "Time", "Time64(3)", "UUID", "IPv4", "IPv6", "Decimal(9, 2)", "Decimal(38, 10)", "Enum8('a' = 1)",
+            "Nullable(Int32)", "Nullable(String)", "Nullable(DateTime)", "Nullable(Time64(3))",
+            "LowCardinality(String)", "LowCardinality(UInt32)", "LowCardinality(Nullable(DateTime))",
+            "Array(Int32)", "Map(String, Int32)", "Tuple(Int32, String)", "Variant(Int32, String)", "Dynamic",
+        };
+
+        Assert.Multiple(() =>
+        {
+            foreach (string type in types)
+            {
+                IColumnCodec codec = Codec(type);
+                IReadOnlyList<Type> readable = codec.ReadableElementTypes;
+
+                Assert.That(readable, Is.Not.Empty, $"{type} advertises no readable types");
+                Assert.That(readable[0], Is.EqualTo(codec.ElementType), $"{type} must lead with its element type");
+                Assert.That(readable.Distinct().Count(), Is.EqualTo(readable.Count), $"{type} lists a duplicate");
+
+                foreach (Type target in readable)
+                {
+                    ParameterExpression source = Expression.Parameter(codec.ElementType, "v");
+                    Expression projected = null;
+                    bool offered = false;
+                    try
+                    {
+                        offered = codec.TryProjectRead(source, target, out projected);
+                    }
+                    catch (Exception ex)
+                    {
+                        Assert.Fail($"{type} advertises {target} but threw projecting it: {ex.Message}");
+                    }
+
+                    Assert.That(offered, Is.True, $"{type} advertises {target} but does not project it");
+                    Assert.That(projected?.Type, Is.EqualTo(target), $"{type} projected {target} as {projected?.Type}");
+                }
+            }
+        });
+    }
+
+    /// <summary>
+    /// Pins each projecting codec's readable list to literal types, so dropping a projection fails here rather than
+    /// silently agreeing with a matching change to the writable list.
+    /// </summary>
+    [Test]
+    public void ReadableElementTypes_ProjectingCodecs_AreTheExpectedLiteralTypes()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                Codec("DateTime('UTC')").ReadableElementTypes,
+                Is.EqualTo(new[] { typeof(uint), typeof(DateTimeOffset), typeof(DateTime) }));
+            Assert.That(
+                Codec("DateTime64(3, 'UTC')").ReadableElementTypes,
+                Is.EqualTo(new[] { typeof(long), typeof(DateTimeOffset), typeof(DateTime) }));
+            Assert.That(Codec("Time").ReadableElementTypes, Is.EqualTo(new[] { typeof(int), typeof(TimeSpan) }));
+            Assert.That(Codec("Time64(3)").ReadableElementTypes, Is.EqualTo(new[] { typeof(long), typeof(TimeSpan) }));
+        });
+    }
+
+    [Test]
+    public void ReadableElementTypes_DateTimeFamily_MirrorsTheWritableList()
+    {
+        Assert.Multiple(() =>
+        {
+            foreach (string type in new[] { "DateTime", "DateTime64(3)", "Time", "Time64(3)" })
+            {
+                IColumnCodec codec = Codec(type);
+                Assert.That(
+                    codec.ReadableElementTypes,
+                    Is.EqualTo(codec.WritableElementTypes),
+                    $"{type} should read back every CLR spelling it accepts on write");
+            }
+        });
+    }
+
+    [Test]
+    public void TryProjectRead_DateTimeToOffset_PresentsTheInstantInTheColumnTimezone()
+    {
+        // 1700000000 = 2023-11-14T22:13:20Z, which is 23:13:20 +01:00 in Berlin (winter, no DST).
+        Func<uint, DateTimeOffset> project = Project<uint, DateTimeOffset>(Codec("DateTime('Europe/Berlin')"));
+
+        DateTimeOffset result = project(1_700_000_000);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.UtcDateTime, Is.EqualTo(new DateTime(2023, 11, 14, 22, 13, 20, DateTimeKind.Utc)));
+            Assert.That(result.Offset, Is.EqualTo(TimeSpan.FromHours(1)));
+        });
+    }
+
+    [Test]
+    public void TryProjectRead_DateTimeToDateTime_UtcColumnYieldsUtcKind()
+    {
+        Func<uint, DateTime> project = Project<uint, DateTime>(Codec("DateTime('UTC')"));
+
+        DateTime result = project(1_700_000_000);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(new DateTime(2023, 11, 14, 22, 13, 20)));
+            Assert.That(result.Kind, Is.EqualTo(DateTimeKind.Utc));
+        });
+    }
+
+    /// <summary>
+    /// The <see cref="DateTimeKind"/> rule is chosen to match the HTTP driver's <c>ToDateTime</c>: a non-zero
+    /// offset yields the wall clock in the column's timezone as <see cref="DateTimeKind.Unspecified"/>, so a POCO
+    /// reading the same column through either client sees the same value.
+    /// </summary>
+    [Test]
+    public void TryProjectRead_DateTimeToDateTime_OffsetColumnYieldsUnspecifiedWallClock()
+    {
+        Func<uint, DateTime> project = Project<uint, DateTime>(Codec("DateTime('Europe/Berlin')"));
+
+        DateTime result = project(1_700_000_000);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(new DateTime(2023, 11, 14, 23, 13, 20)));
+            Assert.That(result.Kind, Is.EqualTo(DateTimeKind.Unspecified));
+        });
+    }
+
+    [Test]
+    [TestCase(3, 1_700_000_000_123L, "2023-11-14T22:13:20.1230000Z")]
+    [TestCase(9, 1_700_000_000_123_456_789L, "2023-11-14T22:13:20.1234567Z")]
+    [TestCase(0, 1_700_000_000L, "2023-11-14T22:13:20.0000000Z")]
+    public void TryProjectRead_DateTime64ToOffset_HonorsTheColumnScale(int scale, long count, string expected)
+    {
+        Func<long, DateTimeOffset> project = Project<long, DateTimeOffset>(Codec($"DateTime64({scale}, 'UTC')"));
+
+        // Scale 9 is finer than a .NET tick, so the sub-100 ns digits truncate toward zero.
+        Assert.That(project(count).UtcDateTime, Is.EqualTo(DateTimeOffset.Parse(expected).UtcDateTime));
+    }
+
+    [Test]
+    public void TryProjectRead_DateTime64ToDateTime_AppliesTheSameKindRuleAsDateTime()
+    {
+        Func<long, DateTime> utc = Project<long, DateTime>(Codec("DateTime64(3, 'UTC')"));
+        Func<long, DateTime> berlin = Project<long, DateTime>(Codec("DateTime64(3, 'Europe/Berlin')"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(utc(1_700_000_000_123L), Is.EqualTo(new DateTime(2023, 11, 14, 22, 13, 20, 123)));
+            Assert.That(utc(1_700_000_000_123L).Kind, Is.EqualTo(DateTimeKind.Utc));
+
+            Assert.That(berlin(1_700_000_000_123L), Is.EqualTo(new DateTime(2023, 11, 14, 23, 13, 20, 123)));
+            Assert.That(berlin(1_700_000_000_123L).Kind, Is.EqualTo(DateTimeKind.Unspecified));
+        });
+    }
+
+    /// <summary>
+    /// A raw count can be decodable yet name an instant outside the .NET calendar. The projection reports that as an
+    /// <see cref="OverflowException"/> pointing at the raw values, rather than letting a bare arithmetic exception
+    /// escape — the canonical read still returns the exact count.
+    /// </summary>
+    [Test]
+    public void TryProjectRead_DateTime64BeyondTheCalendarRange_ThrowsOverflowPointingAtTheRawValues()
+    {
+        Func<long, DateTimeOffset> project = Project<long, DateTimeOffset>(Codec("DateTime64(0, 'UTC')"));
+
+        var ex = Assert.Throws<OverflowException>(() => project(long.MaxValue));
+        Assert.That(ex.Message, Does.Contain("Values"));
+    }
+
+    [Test]
+    [TestCase("DateTime('UTC')", typeof(TimeSpan))]
+    [TestCase("DateTime64(3, 'UTC')", typeof(TimeSpan))]
+    [TestCase("Time", typeof(DateTime))]
+    [TestCase("Time64(3)", typeof(DateTime))]
+    [TestCase("Nullable(DateTime('UTC'))", typeof(TimeSpan?))]
+    [TestCase("LowCardinality(Nullable(DateTime('UTC')))", typeof(TimeSpan?))]
+    public void TryProjectRead_ProjectingCodecAskedForAnUnofferedType_ReturnsFalse(string type, Type unoffered)
+    {
+        IColumnCodec codec = Codec(type);
+        ParameterExpression source = Expression.Parameter(codec.ElementType, "v");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(codec.ReadableElementTypes, Does.Not.Contain(unoffered));
+            Assert.That(codec.TryProjectRead(source, unoffered, out Expression _), Is.False);
+        });
+    }
+
+    /// <summary>
+    /// A nullable surface refuses a bare value-typed target, because it has nowhere to put a null row. Asked for a
+    /// plain <c>uint</c>, <c>Nullable(DateTime)</c> must decline rather than silently hand back the inner's
+    /// non-nullable reading and drop the nulls.
+    /// </summary>
+    [Test]
+    [TestCase("Nullable(DateTime('UTC'))", typeof(uint))]
+    [TestCase("Nullable(DateTime('UTC'))", typeof(DateTime))]
+    [TestCase("Nullable(Time64(3))", typeof(TimeSpan))]
+    [TestCase("LowCardinality(Nullable(DateTime('UTC')))", typeof(DateTimeOffset))]
+    public void TryProjectRead_NullableSurfaceAskedForABareValueType_ReturnsFalse(string type, Type bare)
+    {
+        IColumnCodec codec = Codec(type);
+        ParameterExpression source = Expression.Parameter(codec.ElementType, "v");
+
+        Assert.That(codec.TryProjectRead(source, bare, out Expression _), Is.False);
+    }
+
+    [Test]
+    public void TryProjectRead_TimeToTimeSpan_IsExactWholeSeconds()
+    {
+        Func<int, TimeSpan> project = Project<int, TimeSpan>(Codec("Time"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(project(3661), Is.EqualTo(new TimeSpan(1, 1, 1)));
+            Assert.That(project(-3661), Is.EqualTo(new TimeSpan(1, 1, 1).Negate()));
+            Assert.That(project(0), Is.EqualTo(TimeSpan.Zero));
+        });
+    }
+
+    [Test]
+    [TestCase(3, 3_661_500L, "01:01:01.5000000")]
+    [TestCase(9, -1_000_000_001L, "-00:00:01.0000000")]
+    public void TryProjectRead_Time64ToTimeSpan_HonorsTheColumnScale(int scale, long count, string expected)
+    {
+        Func<long, TimeSpan> project = Project<long, TimeSpan>(Codec($"Time64({scale})"));
+
+        Assert.That(project(count), Is.EqualTo(TimeSpan.Parse(expected)));
+    }
+
+    [Test]
+    public void ReadableElementTypes_NullableOfProjectingInner_LiftsEveryInnerType()
+    {
+        IColumnCodec codec = Codec("Nullable(DateTime('UTC'))");
+
+        Assert.That(
+            codec.ReadableElementTypes,
+            Is.EqualTo(new[] { typeof(uint?), typeof(DateTimeOffset?), typeof(DateTime?) }));
+    }
+
+    [Test]
+    public void TryProjectRead_NullableOfDateTime_ProjectsValueAndPreservesNull()
+    {
+        Func<uint?, DateTime?> project = Project<uint?, DateTime?>(Codec("Nullable(DateTime('UTC'))"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(project(1_700_000_000), Is.EqualTo(new DateTime(2023, 11, 14, 22, 13, 20, DateTimeKind.Utc)));
+            Assert.That(project(null), Is.Null);
+        });
+    }
+
+    [Test]
+    public void ReadableElementTypes_NullableOfReferenceInner_StaysUnwrapped()
+    {
+        IColumnCodec codec = Codec("Nullable(String)");
+
+        // A reference inner's nulls are already CLR nulls, so the surface type is the bare inner type.
+        Assert.That(codec.ReadableElementTypes, Is.EqualTo(new[] { typeof(string) }));
+    }
+
+    [Test]
+    public void ReadableElementTypes_LowCardinalityOfNullableDateTime_LiftsThroughBothWrappers()
+    {
+        IColumnCodec codec = Codec("LowCardinality(Nullable(DateTime('UTC')))");
+
+        Assert.That(
+            codec.ReadableElementTypes,
+            Is.EqualTo(new[] { typeof(uint?), typeof(DateTimeOffset?), typeof(DateTime?) }));
+    }
+
+    [Test]
+    public void TryProjectRead_LowCardinalityOfNullableDateTime_ProjectsValueAndPreservesNull()
+    {
+        Func<uint?, DateTimeOffset?> project =
+            Project<uint?, DateTimeOffset?>(Codec("LowCardinality(Nullable(DateTime('UTC')))"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(project(1_700_000_000)?.UtcDateTime, Is.EqualTo(new DateTime(2023, 11, 14, 22, 13, 20, DateTimeKind.Utc)));
+            Assert.That(project(null), Is.Null);
+        });
+    }
+
+    [Test]
+    public void ReadableElementTypes_LowCardinalityOfNonProjectingInner_IsJustTheInnerType()
+    {
+        IColumnCodec codec = Codec("LowCardinality(String)");
+
+        Assert.That(codec.ReadableElementTypes, Is.EqualTo(new[] { typeof(string) }));
+    }
+
+    /// <summary>
+    /// A non-nullable <c>LowCardinality</c> surfaces the inner type unchanged, so its projection is the inner's own,
+    /// applied with no lifting. Exercises the delegation arm that the nullable cases skip.
+    /// </summary>
+    [Test]
+    public void TryProjectRead_LowCardinalityOfProjectingInner_DelegatesToTheInnerUnlifted()
+    {
+        IColumnCodec codec = Codec("LowCardinality(DateTime('Europe/Berlin'))");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                codec.ReadableElementTypes,
+                Is.EqualTo(new[] { typeof(uint), typeof(DateTimeOffset), typeof(DateTime) }));
+
+            Func<uint, DateTimeOffset> project = Project<uint, DateTimeOffset>(codec);
+            Assert.That(project(1_700_000_000).Offset, Is.EqualTo(TimeSpan.FromHours(1)));
+            Assert.That(
+                project(1_700_000_000).UtcDateTime,
+                Is.EqualTo(new DateTime(2023, 11, 14, 22, 13, 20, DateTimeKind.Utc)));
+        });
+    }
+
+    /// <summary>
+    /// Every advertised type must project to exactly itself through both wrappers. The wrappers recover the inner
+    /// spelling by undoing their own wrap on the target, so this pins that the wrap really is invertible for every
+    /// shape the registry produces.
+    /// </summary>
+    [Test]
+    public void TryProjectRead_WrappedCodecs_ProjectEveryAdvertisedTypeToExactlyThatType()
+    {
+        string[] wrapped =
+        {
+            "Nullable(DateTime('UTC'))", "Nullable(DateTime64(3, 'UTC'))", "Nullable(Time)", "Nullable(Time64(3))",
+            "Nullable(String)", "Nullable(Int32)", "Nullable(UUID)",
+            "LowCardinality(String)", "LowCardinality(UInt32)", "LowCardinality(DateTime('UTC'))",
+            "LowCardinality(Nullable(String))", "LowCardinality(Nullable(DateTime('UTC')))",
+        };
+
+        Assert.Multiple(() =>
+        {
+            foreach (string type in wrapped)
+            {
+                IColumnCodec codec = Codec(type);
+                foreach (Type target in codec.ReadableElementTypes)
+                {
+                    ParameterExpression source = Expression.Parameter(codec.ElementType, "v");
+                    Assert.That(codec.TryProjectRead(source, target, out Expression projected), Is.True,
+                        $"{type} advertises {target} but does not project it");
+                    Assert.That(projected.Type, Is.EqualTo(target), $"{type} projected {target} as {projected.Type}");
+                }
+            }
+        });
+    }
+
+    /// <summary>
+    /// The lifted projection splices its source in twice (once for the presence test, once for the value), so it must
+    /// bind it to a local first. A caller's source is typically a span access or a method call, and evaluating it
+    /// twice per row would be a silent correctness and throughput bug that no value-level assertion catches.
+    /// </summary>
+    [Test]
+    public void TryProjectRead_NullableLifting_EvaluatesItsSourceExactlyOnce()
+    {
+        var counter = new EvaluationCounter();
+        IColumnCodec codec = Codec("Nullable(DateTime('UTC'))");
+
+        // A source expression with an observable side effect, standing in for a span access.
+        Expression source = Expression.Call(
+            Expression.Constant(counter),
+            typeof(EvaluationCounter).GetMethod(nameof(EvaluationCounter.Next)));
+
+        Assert.That(codec.TryProjectRead(source, typeof(DateTime?), out Expression projected), Is.True);
+        DateTime? result = Expression.Lambda<Func<DateTime?>>(projected).Compile()();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(counter.Count, Is.EqualTo(1), "the source expression was evaluated more than once");
+            Assert.That(result, Is.EqualTo(new DateTime(2023, 11, 14, 22, 13, 20, DateTimeKind.Utc)));
+        });
+    }
+
+    [Test]
+    public void TryProjectRead_NullableOfNonProjectingInner_OffersOnlyTheCanonicalType()
+    {
+        IColumnCodec codec = Codec("Nullable(Int32)");
+        ParameterExpression source = Expression.Parameter(typeof(int?), "v");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(codec.ReadableElementTypes, Is.EqualTo(new[] { typeof(int?) }));
+            Assert.That(codec.TryProjectRead(source, typeof(long?), out Expression _), Is.False);
+        });
+    }
+
+    /// <summary>
+    /// Enum columns surface the raw ordinal and accept only the ordinal on write, so mirroring the write list
+    /// leaves them with no alternate reading. Pinned so that adding label projection later is a deliberate,
+    /// visible choice rather than an accident.
+    /// </summary>
+    [Test]
+    public void ReadableElementTypes_Enum_OffersOnlyTheRawOrdinal()
+    {
+        IColumnCodec codec = Codec("Enum8('a' = 1, 'b' = 2)");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(codec.ReadableElementTypes, Is.EqualTo(new[] { typeof(sbyte) }));
+            Assert.That(codec.ReadableElementTypes, Is.EqualTo(codec.WritableElementTypes));
+        });
+    }
+
+    /// <summary>
+    /// The lifting rule reads the source shape and the target shape independently, each from the type in front of it.
+    /// No registered type pair distinguishes that from inferring one out of the other — every codec's readings share
+    /// their value/reference-ness with its <see cref="IColumnCodec.ElementType"/> — so a stand-in codec supplies the
+    /// pair that does: a reference-typed element with a value-typed reading, which is what a <c>FixedString(16)</c>
+    /// read as a <see cref="Guid"/> would be. Lifting such a source by testing it for <c>HasValue</c>, or handing it
+    /// to the inner unlifted, both produce a wrong answer here.
+    /// </summary>
+    [Test]
+    public void TryLiftOverAbsent_ReferenceSourceWithValueTypedReading_LiftsAndKeepsAbsentAbsent()
+    {
+        var inner = new LengthOfStringCodec();
+        ParameterExpression source = Expression.Parameter(typeof(string), "v");
+
+        Assert.That(
+            ColumnValueProjections.TryLiftOverAbsent(source, inner, typeof(int), typeof(int?), out Expression projected),
+            Is.True);
+        Assert.That(projected.Type, Is.EqualTo(typeof(int?)));
+
+        Func<string, int?> project = Expression.Lambda<Func<string, int?>>(projected, source).Compile();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(project("abcd"), Is.EqualTo(4));
+            Assert.That(project(string.Empty), Is.EqualTo(0));
+            Assert.That(project(null), Is.Null, "an absent reference row must stay absent, not become default(int)");
+        });
+    }
+
+    /// <summary>
+    /// An absent row short-circuits: the inner projection never runs for it. Worth pinning separately from the value
+    /// assertion, because a lift that evaluated the projection eagerly and then discarded it would still return the
+    /// right answer while running per-row work — and, for a projection that throws on a null, would not.
+    /// </summary>
+    [Test]
+    public void TryLiftOverAbsent_AbsentRow_DoesNotRunTheInnerProjection()
+    {
+        var inner = new LengthOfStringCodec();
+        ParameterExpression source = Expression.Parameter(typeof(string), "v");
+
+        Assert.That(
+            ColumnValueProjections.TryLiftOverAbsent(source, inner, typeof(int), typeof(int?), out Expression projected),
+            Is.True);
+
+        Func<string, int?> project = Expression.Lambda<Func<string, int?>>(projected, source).Compile();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(project(null), Is.Null);
+            Assert.That(inner.Invocations, Is.Zero, "the inner projection must not run for an absent row");
+
+            Assert.That(project("abc"), Is.EqualTo(3));
+            Assert.That(inner.Invocations, Is.EqualTo(1), "a present row must run it exactly once");
+        });
+    }
+
+    /// <summary>A lift over an inner that does not offer the reading is declined, not built.</summary>
+    [Test]
+    public void TryLiftOverAbsent_InnerDoesNotOfferTheReading_ReturnsFalseAndNoProjection()
+    {
+        var inner = new LengthOfStringCodec();
+        ParameterExpression source = Expression.Parameter(typeof(string), "v");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                ColumnValueProjections.TryLiftOverAbsent(source, inner, typeof(Guid), typeof(Guid?), out Expression projected),
+                Is.False);
+            Assert.That(projected, Is.Null);
+        });
+    }
+
+    /// <summary>
+    /// The arm where the surfaced target already is the inner's spelling, so no <c>Convert</c> is spliced in. Reached
+    /// only by a reference-typed reading, which every registered type resolves through the wrapper's identity check
+    /// instead.
+    /// </summary>
+    [Test]
+    public void TryLiftOverAbsent_TargetAlreadyTheInnerSpelling_SplicesNoConversion()
+    {
+        var inner = new LengthOfStringCodec();
+        ParameterExpression source = Expression.Parameter(typeof(string), "v");
+
+        Assert.That(
+            ColumnValueProjections.TryLiftOverAbsent(source, inner, typeof(string), typeof(string), out Expression projected),
+            Is.True);
+        Assert.That(projected.Type, Is.EqualTo(typeof(string)));
+
+        Func<string, string> project = Expression.Lambda<Func<string, string>>(projected, source).Compile();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(project("abc"), Is.EqualTo("abc"));
+            Assert.That(project(null), Is.Null);
+        });
+    }
+
+    /// <summary>
+    /// The wrapper's own half of the rule, which no registered type can reach: asked for a reading whose inner
+    /// spelling is a value type over a <b>reference-typed</b> inner element, <c>Nullable</c> must still lift. Deciding
+    /// that from the inner codec's canonical type — which is reference-typed here, so "no lift" — hands back a bare
+    /// <c>int</c> where an <c>int?</c> was asked for, and a null row becomes <c>default(int)</c>. Built over a stand-in
+    /// inner through <see cref="NullableColumnCodec.Over"/>, because the registry cannot produce this shape.
+    /// </summary>
+    [Test]
+    public void TryProjectRead_NullableOverReferenceInnerWithValueTypedReading_StillLifts()
+    {
+        IColumnCodec codec = NullableColumnCodec.Over(new LengthOfStringCodec());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(codec.ElementType, Is.EqualTo(typeof(string)), "a reference inner surfaces unwrapped");
+            Assert.That(codec.ReadableElementTypes, Is.EqualTo(new[] { typeof(string), typeof(int?) }));
+        });
+
+        Func<string, int?> project = Project<string, int?>(codec);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(project("abcd"), Is.EqualTo(4));
+            Assert.That(project(null), Is.Null, "a null row must stay null, not become default(int)");
+        });
+    }
+
+    /// <summary>
+    /// The same shape through <c>LowCardinality(Nullable(T))</c>, whose surface rule is the same wrap and so needs the
+    /// same unwrap.
+    /// </summary>
+    [Test]
+    public void TryProjectRead_LowCardinalityNullableOverReferenceInnerWithValueTypedReading_StillLifts()
+    {
+        IColumnCodec codec = LowCardinalityColumnCodec.Over(new LengthOfStringCodec(), nullable: true);
+
+        Func<string, int?> project = Project<string, int?>(codec);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(project("abcd"), Is.EqualTo(4));
+            Assert.That(project(null), Is.Null);
+        });
+    }
+
+    /// <summary>
+    /// The reference-typed-target arm of the wrapper's unwrap: a reading that is neither the canonical element type nor
+    /// a <see cref="Nullable{T}"/> is passed through as the inner's own spelling. Also unreachable through the
+    /// registry, since no registered codec offers a second reference reading.
+    /// </summary>
+    [Test]
+    public void TryProjectRead_NullableAskedForANonCanonicalReferenceReading_PassesTheTargetThrough()
+    {
+        IColumnCodec codec = NullableColumnCodec.Over(new ReversedStringCodec());
+
+        Func<string, char[]> project = Project<string, char[]>(codec);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(project("abc"), Is.EqualTo(new[] { 'c', 'b', 'a' }));
+            Assert.That(project(null), Is.Null, "the inner projection must not run on a null reference");
+        });
+    }
+
+    /// <summary>The same reference-target arm through <c>LowCardinality(Nullable(T))</c>.</summary>
+    [Test]
+    public void TryProjectRead_LowCardinalityNullableAskedForANonCanonicalReferenceReading_PassesTheTargetThrough()
+    {
+        IColumnCodec codec = LowCardinalityColumnCodec.Over(new ReversedStringCodec(), nullable: true);
+
+        Func<string, char[]> project = Project<string, char[]>(codec);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(project("abc"), Is.EqualTo(new[] { 'c', 'b', 'a' }));
+            Assert.That(project(null), Is.Null);
+        });
+    }
+
+    private sealed class EvaluationCounter
+    {
+        public int Count { get; private set; }
+
+        public uint? Next()
+        {
+            Count++;
+            return 1_700_000_000;
+        }
+    }
+
+    /// <summary>
+    /// A stand-in codec whose element type is a reference type but which offers a value-typed reading — the shape no
+    /// registered codec has yet, and the one the independent source/target lifting rule exists for. Only the read
+    /// projection is implemented; nothing else is reached by these tests.
+    /// </summary>
+    private sealed class LengthOfStringCodec : IColumnCodec
+    {
+        private static readonly MethodInfo LengthOf =
+            typeof(LengthOfStringCodec).GetMethod(nameof(Length), BindingFlags.Public | BindingFlags.Static);
+
+        private static readonly MethodInfo CountOne =
+            typeof(LengthOfStringCodec).GetMethod(nameof(Count), BindingFlags.Public | BindingFlags.Instance);
+
+        public int Invocations { get; private set; }
+
+        public string TypeName => "LengthOfString";
+
+        public Type ElementType => typeof(string);
+
+        public IReadOnlyList<Type> ReadableElementTypes => new[] { typeof(string), typeof(int) };
+
+        public object NullPlaceholder => string.Empty;
+
+        public static int Length(string value) => value.Length;
+
+        public bool TryProjectRead(Expression value, Type targetType, out Expression projected)
+        {
+            ColumnValueProjections.RequireSourceType(value, typeof(string), TypeName);
+
+            if (targetType == typeof(string))
+            {
+                projected = value;
+                return true;
+            }
+
+            if (targetType == typeof(int))
+            {
+                // Routed through an instance counter so a test can assert the projection never runs for an absent row.
+                projected = Expression.Block(
+                    Expression.Call(Expression.Constant(this), CountOne),
+                    Expression.Call(LengthOf, value));
+                return true;
+            }
+
+            projected = null;
+            return false;
+        }
+
+        public void Count() => Invocations++;
+
+        public ValueTask<IColumn> ReadColumnAsync(ClickHouseBinaryReader reader, string columnName, string columnType, int rowCount, CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public bool CanWrite(IColumn column) => false;
+
+        public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
+            => throw new NotSupportedException();
+    }
+
+    /// <summary>
+    /// A second stand-in, offering a <b>reference</b>-typed reading other than its canonical one — the shape that
+    /// reaches the wrappers' reference-target arm. Its projection dereferences its argument, so a lift that failed to
+    /// guard the null would throw rather than return null.
+    /// </summary>
+    private sealed class ReversedStringCodec : IColumnCodec
+    {
+        private static readonly MethodInfo ReverseOf =
+            typeof(ReversedStringCodec).GetMethod(nameof(Reverse), BindingFlags.Public | BindingFlags.Static);
+
+        public string TypeName => "ReversedString";
+
+        public Type ElementType => typeof(string);
+
+        public IReadOnlyList<Type> ReadableElementTypes => new[] { typeof(string), typeof(char[]) };
+
+        public object NullPlaceholder => string.Empty;
+
+        public static char[] Reverse(string value)
+        {
+            char[] chars = value.ToCharArray();
+            Array.Reverse(chars);
+            return chars;
+        }
+
+        public bool TryProjectRead(Expression value, Type targetType, out Expression projected)
+        {
+            ColumnValueProjections.RequireSourceType(value, typeof(string), TypeName);
+
+            if (targetType == typeof(string))
+            {
+                projected = value;
+                return true;
+            }
+
+            if (targetType == typeof(char[]))
+            {
+                projected = Expression.Call(ReverseOf, value);
+                return true;
+            }
+
+            projected = null;
+            return false;
+        }
+
+        public ValueTask<IColumn> ReadColumnAsync(ClickHouseBinaryReader reader, string columnName, string columnType, int rowCount, CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public bool CanWrite(IColumn column) => false;
+
+        public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
+            => throw new NotSupportedException();
+    }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Types/ColumnReadProjectionTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/ColumnReadProjectionTests.cs
@@ -79,6 +79,36 @@ public class ColumnReadProjectionTests
     }
 
     /// <summary>
+    /// A codec with no absence concept refuses a <see cref="Nullable{T}"/> target, even for a reading it offers bare.
+    /// This is a gap, not a rule: widening a non-nullable column into a nullable member loses nothing. Closing it
+    /// belongs in the caller — one unwrap-and-widen step where <see cref="IColumnCodec.TryProjectRead"/> is consumed,
+    /// not a nullable arm in every codec. Pinned so that closing it is a visible change.
+    /// </summary>
+    [TestCase("UInt64", typeof(ulong?))]
+    [TestCase("Date", typeof(DateOnly?))]
+    [TestCase("UUID", typeof(Guid?))]
+    [TestCase("DateTime('UTC')", typeof(DateTime?))]
+    [TestCase("DateTime('UTC')", typeof(DateTimeOffset?))]
+    [TestCase("DateTime64(3, 'UTC')", typeof(DateTime?))]
+    [TestCase("Time", typeof(TimeSpan?))]
+    [TestCase("Time64(3)", typeof(TimeSpan?))]
+    public void TryProjectRead_NullableTargetOnCodecWithoutNulls_ReturnsFalse(string type, Type nullableTarget)
+    {
+        IColumnCodec codec = Codec(type);
+        ParameterExpression source = Expression.Parameter(codec.ElementType, "v");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                codec.TryProjectRead(source, Nullable.GetUnderlyingType(nullableTarget), out Expression _), Is.True,
+                "the test case must name a reading the codec actually offers bare");
+
+            Assert.That(codec.TryProjectRead(source, nullableTarget, out Expression projected), Is.False);
+            Assert.That(projected, Is.Null);
+        });
+    }
+
+    /// <summary>
     /// A source expression of the wrong type is a caller mistake, distinct from a target the codec does not offer, so
     /// it still throws rather than being reported as "no such projection".
     /// </summary>
@@ -504,12 +534,10 @@ public class ColumnReadProjectionTests
     }
 
     /// <summary>
-    /// The lifting rule reads the source shape and the target shape independently, each from the type in front of it.
-    /// No registered type pair distinguishes that from inferring one out of the other — every codec's readings share
-    /// their value/reference-ness with its <see cref="IColumnCodec.ElementType"/> — so a stand-in codec supplies the
-    /// pair that does: a reference-typed element with a value-typed reading, which is what a <c>FixedString(16)</c>
-    /// read as a <see cref="Guid"/> would be. Lifting such a source by testing it for <c>HasValue</c>, or handing it
-    /// to the inner unlifted, both produce a wrong answer here.
+    /// The lifting rule reads source and target shapes independently. No registered pair distinguishes that from
+    /// inferring one out of the other, so a stand-in codec supplies the pair that does: a reference-typed element
+    /// with a value-typed reading, as <c>FixedString(16)</c> read as a <see cref="Guid"/> would be. Testing such a
+    /// source for <c>HasValue</c>, or handing it to the inner unlifted, both answer wrongly here.
     /// </summary>
     [Test]
     public void TryLiftOverAbsent_ReferenceSourceWithValueTypedReading_LiftsAndKeepsAbsentAbsent()
@@ -601,11 +629,10 @@ public class ColumnReadProjectionTests
     }
 
     /// <summary>
-    /// The wrapper's own half of the rule, which no registered type can reach: asked for a reading whose inner
-    /// spelling is a value type over a <b>reference-typed</b> inner element, <c>Nullable</c> must still lift. Deciding
-    /// that from the inner codec's canonical type — which is reference-typed here, so "no lift" — hands back a bare
-    /// <c>int</c> where an <c>int?</c> was asked for, and a null row becomes <c>default(int)</c>. Built over a stand-in
-    /// inner through <see cref="NullableColumnCodec.Over"/>, because the registry cannot produce this shape.
+    /// The wrapper's own half of the rule, which no registered type reaches: asked for a value-typed reading over a
+    /// <b>reference-typed</b> inner element, <c>Nullable</c> must still lift. Deciding that from the inner's canonical
+    /// type — reference-typed here, so "no lift" — returns a bare <c>int</c> where an <c>int?</c> was asked for, and a
+    /// null row becomes <c>default(int)</c>. Built over a stand-in via <see cref="NullableColumnCodec.Over"/>.
     /// </summary>
     [Test]
     public void TryProjectRead_NullableOverReferenceInnerWithValueTypedReading_StillLifts()

--- a/ClickHouse.Driver.Tcp.Tests/Types/DateTimeColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/DateTimeColumnCodecTests.cs
@@ -260,6 +260,29 @@ public class DateTimeColumnCodecTests
     }
 
     [Test]
+    public async Task WriteColumn_LocalKind_EncodesTheInstantAndIgnoresTheColumnTimezone()
+    {
+        // A Kind=Local value names an instant, resolved against the host machine's timezone, so the column's own
+        // timezone takes no part: two columns five hours apart encode it identically, and so does the Kind=Utc
+        // value naming the same instant. A wall-clock reading would differ between the two columns. Both
+        // assertions hold whatever zone the host is in.
+        const string utcType = "DateTime('UTC')";
+        const string offsetType = "DateTime('Fixed/UTC+05:00:00')";
+        var local = new DateTime(2024, 1, 15, 10, 30, 0, DateTimeKind.Local);
+        DateTime utc = local.ToUniversalTime();
+
+        byte[] inUtcColumn = await WriteAsync(w => Codec(utcType).WriteColumn(w, new ArrayColumn<DateTime>("c", utcType, new[] { local })));
+        byte[] inOffsetColumn = await WriteAsync(w => Codec(offsetType).WriteColumn(w, new ArrayColumn<DateTime>("c", offsetType, new[] { local })));
+        byte[] fromUtcKind = await WriteAsync(w => Codec(offsetType).WriteColumn(w, new ArrayColumn<DateTime>("c", offsetType, new[] { utc })));
+
+        Assert.Multiple(() =>
+        {
+            CollectionAssert.AreEqual(inUtcColumn, inOffsetColumn, "the column timezone takes no part");
+            CollectionAssert.AreEqual(fromUtcKind, inOffsetColumn, "Local is the instant, not a wall clock in the column timezone");
+        });
+    }
+
+    [Test]
     public void Create_UnknownTimezone_Throws()
         => Assert.Throws<FormatException>(() => Codec("DateTime('Not/AZone')"));
 

--- a/ClickHouse.Driver.Tcp/Types/Codecs/DateTime64ColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/DateTime64ColumnCodec.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 using ClickHouse.Driver.Tcp.Protocol;
@@ -38,6 +39,9 @@ internal sealed class DateTime64ColumnCodec : IColumnCodec
 
     /// <inheritdoc/>
     public IReadOnlyList<Type> WritableElementTypes { get; } = new[] { typeof(long), typeof(DateTimeOffset), typeof(DateTime) };
+
+    /// <inheritdoc/>
+    public IReadOnlyList<Type> ReadableElementTypes { get; } = new[] { typeof(long), typeof(DateTimeOffset), typeof(DateTime) };
 
     /// <inheritdoc/>
     public object NullPlaceholder => 0L;
@@ -88,6 +92,33 @@ internal sealed class DateTime64ColumnCodec : IColumnCodec
     /// <inheritdoc/>
     public ValueTask<IColumn> ReadColumnAsync(ClickHouseBinaryReader reader, string columnName, string columnType, int rowCount, CancellationToken cancellationToken)
         => DateTime64Column.ReadAsync(reader, columnName, columnType, scale, timeZone, rowCount, cancellationToken);
+
+    /// <inheritdoc/>
+    public bool TryProjectRead(Expression value, Type targetType, out Expression projected)
+    {
+        ColumnValueProjections.RequireSourceType(value, typeof(long), TypeName);
+
+        if (targetType == typeof(long))
+        {
+            projected = value;
+            return true;
+        }
+
+        if (targetType == typeof(DateTimeOffset))
+        {
+            projected = ColumnValueProjections.Call(nameof(ColumnValueProjections.DateTime64ToOffset), value, scale, timeZone);
+            return true;
+        }
+
+        if (targetType == typeof(DateTime))
+        {
+            projected = ColumnValueProjections.Call(nameof(ColumnValueProjections.DateTime64ToDateTime), value, scale, timeZone);
+            return true;
+        }
+
+        projected = null;
+        return false;
+    }
 
     /// <inheritdoc/>
     public bool CanWrite(IColumn column) => column is IColumn<long> or IColumn<DateTimeOffset> or IColumn<DateTime>;

--- a/ClickHouse.Driver.Tcp/Types/Codecs/DateTimeColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/DateTimeColumnCodec.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 using ClickHouse.Driver.Tcp.Protocol;
@@ -31,6 +32,9 @@ internal sealed class DateTimeColumnCodec : IColumnCodec
 
     /// <inheritdoc/>
     public IReadOnlyList<Type> WritableElementTypes { get; } = new[] { typeof(uint), typeof(DateTimeOffset), typeof(DateTime) };
+
+    /// <inheritdoc/>
+    public IReadOnlyList<Type> ReadableElementTypes { get; } = new[] { typeof(uint), typeof(DateTimeOffset), typeof(DateTime) };
 
     /// <inheritdoc/>
     public object NullPlaceholder => 0u;
@@ -70,6 +74,33 @@ internal sealed class DateTimeColumnCodec : IColumnCodec
     /// <inheritdoc/>
     public ValueTask<IColumn> ReadColumnAsync(ClickHouseBinaryReader reader, string columnName, string columnType, int rowCount, CancellationToken cancellationToken)
         => DateTimeColumn.ReadAsync(reader, columnName, columnType, timeZone, rowCount, cancellationToken);
+
+    /// <inheritdoc/>
+    public bool TryProjectRead(Expression value, Type targetType, out Expression projected)
+    {
+        ColumnValueProjections.RequireSourceType(value, typeof(uint), TypeName);
+
+        if (targetType == typeof(uint))
+        {
+            projected = value;
+            return true;
+        }
+
+        if (targetType == typeof(DateTimeOffset))
+        {
+            projected = ColumnValueProjections.Call(nameof(ColumnValueProjections.DateTimeToOffset), value, timeZone);
+            return true;
+        }
+
+        if (targetType == typeof(DateTime))
+        {
+            projected = ColumnValueProjections.Call(nameof(ColumnValueProjections.DateTimeToDateTime), value, timeZone);
+            return true;
+        }
+
+        projected = null;
+        return false;
+    }
 
     /// <inheritdoc/>
     public bool CanWrite(IColumn column) => column is IColumn<uint> or IColumn<DateTimeOffset> or IColumn<DateTime>;

--- a/ClickHouse.Driver.Tcp/Types/Codecs/DateTimeColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/DateTimeColumnCodec.cs
@@ -142,8 +142,9 @@ internal sealed class DateTimeColumnCodec : IColumnCodec
         }
     }
 
-    // Reduces a DateTime to the UTC instant to encode. Utc and Local already denote an instant. An Unspecified
-    // value has no offset, so its wall-clock is read in the column's timezone.
+    // Reduces a DateTime to the UTC instant to encode. Utc and Local already denote an instant; a Local value
+    // resolves against the host machine's timezone, under the BCL's daylight-saving rules and not the ones below.
+    // An Unspecified value has no offset, so its wall-clock is read in the column's timezone.
     internal static DateTime ToUtc(DateTime value, TimeZoneInfo timeZone)
     {
         if (value.Kind != DateTimeKind.Unspecified)

--- a/ClickHouse.Driver.Tcp/Types/Codecs/LowCardinalityColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/LowCardinalityColumnCodec.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Buffers;
+using System.Collections.Generic;
+using System.Linq.Expressions;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -132,6 +134,26 @@ internal sealed class LowCardinalityColumnCodec : IColumnCodec
     public Type ElementType => shape.SurfaceElementType;
 
     /// <summary>
+    /// The inner codec's readings on this codec's surface — so <c>LowCardinality(Nullable(DateTime))</c> reports
+    /// <c>uint?</c>, <c>DateTimeOffset?</c> and <c>DateTime?</c>. Diagnostics only, and only ever read on a failure
+    /// path, so it is built per call rather than cached.
+    /// </summary>
+    public IReadOnlyList<Type> ReadableElementTypes
+    {
+        get
+        {
+            IReadOnlyList<Type> innerTypes = inner.ReadableElementTypes;
+            var surfaced = new Type[innerTypes.Count];
+            for (int i = 0; i < innerTypes.Count; i++)
+            {
+                surfaced[i] = LowCardinalityShapes.For(innerTypes[i], nullable).SurfaceElementType;
+            }
+
+            return surfaced;
+        }
+    }
+
+    /// <summary>
     /// The placeholder for an absent value: for a nullable inner it is <see langword="null"/> itself (the reserved
     /// NULL dictionary slot), otherwise the inner codec's placeholder. Relevant only if a composite nests a
     /// <c>LowCardinality</c> and asks for its placeholder; the server rejects <c>Nullable(LowCardinality(...))</c>,
@@ -174,6 +196,16 @@ internal sealed class LowCardinalityColumnCodec : IColumnCodec
         IColumnCodec inner = registry.ResolveNode(innerNode, in context);
         return new LowCardinalityColumnCodec(node.ToString(), inner, nullable);
     }
+
+    /// <summary>
+    /// Wraps an inner codec directly, bypassing the registry — see <see cref="NullableColumnCodec.Over"/> for why this
+    /// exists.
+    /// </summary>
+    /// <param name="inner">The inner codec to wrap.</param>
+    /// <param name="nullable">Whether to surface the inner as nullable, as <c>LowCardinality(Nullable(T))</c> does.</param>
+    /// <returns>The codec.</returns>
+    internal static LowCardinalityColumnCodec Over(IColumnCodec inner, bool nullable)
+        => new(nullable ? $"LowCardinality(Nullable({inner.TypeName}))" : $"LowCardinality({inner.TypeName})", inner, nullable);
 
     /// <inheritdoc/>
     public ValueTask ReadStatePrefixAsync(ClickHouseBinaryReader reader, CancellationToken cancellationToken)
@@ -335,6 +367,42 @@ internal sealed class LowCardinalityColumnCodec : IColumnCodec
         }
 
         return (int)key;
+    }
+
+    /// <inheritdoc/>
+    public bool TryProjectRead(Expression value, Type targetType, out Expression projected)
+    {
+        ColumnValueProjections.RequireSourceType(value, ElementType, TypeName);
+
+        if (targetType == ElementType)
+        {
+            projected = value;
+            return true;
+        }
+
+        // A non-nullable LowCardinality is fully transparent on reads: its surface is the inner element type
+        // unchanged, so the target is already the inner's own spelling and there is nothing to lift.
+        if (!nullable)
+        {
+            return inner.TryProjectRead(value, targetType, out projected);
+        }
+
+        projected = null;
+
+        // A nullable inner wraps the inner spelling exactly as Nullable(T) does, so the same unwrap applies — see
+        // NullableColumnCodec.TryProjectRead.
+        Type innerTarget = Nullable.GetUnderlyingType(targetType);
+        if (innerTarget is null)
+        {
+            if (targetType.IsValueType)
+            {
+                return false;
+            }
+
+            innerTarget = targetType;
+        }
+
+        return ColumnValueProjections.TryLiftOverAbsent(value, inner, innerTarget, targetType, out projected);
     }
 
     /// <inheritdoc/>

--- a/ClickHouse.Driver.Tcp/Types/Codecs/NullableColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/NullableColumnCodec.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 using ClickHouse.Driver.Tcp.Protocol;
@@ -67,6 +68,26 @@ internal sealed class NullableColumnCodec : IColumnCodec
     public Type ElementType => canonicalShape.NullableElementType;
 
     /// <summary>
+    /// The inner codec's readings, each made nullable through the same shape rule reads use — so
+    /// <c>Nullable(DateTime)</c> reports <c>uint?</c>, <c>DateTimeOffset?</c> and <c>DateTime?</c>. Diagnostics only,
+    /// and only ever read on a failure path, so it is built per call rather than cached.
+    /// </summary>
+    public IReadOnlyList<Type> ReadableElementTypes
+    {
+        get
+        {
+            IReadOnlyList<Type> innerTypes = inner.ReadableElementTypes;
+            var lifted = new Type[innerTypes.Count];
+            for (int i = 0; i < innerTypes.Count; i++)
+            {
+                lifted[i] = NullableShapes.For(innerTypes[i]).NullableElementType;
+            }
+
+            return lifted;
+        }
+    }
+
+    /// <summary>
     /// The placeholder for an absent <c>Nullable(T)</c> value is <see langword="null"/> itself — a null-marked
     /// row. Relevant only if a future composite nests a <c>Nullable</c> and asks for its placeholder.
     /// </summary>
@@ -94,6 +115,16 @@ internal sealed class NullableColumnCodec : IColumnCodec
         IColumnCodec inner = registry.ResolveNode(innerNode, in context);
         return new NullableColumnCodec(node.ToString(), inner);
     }
+
+    /// <summary>
+    /// Wraps an inner codec directly, bypassing the registry. Exists so a test can build this wrapper over a stand-in
+    /// inner whose read surface no registered type has — the read lifting rule is written for shapes the registry
+    /// cannot yet produce, and this is the only way to reach them.
+    /// </summary>
+    /// <param name="inner">The inner codec to wrap.</param>
+    /// <returns>The codec.</returns>
+    internal static NullableColumnCodec Over(IColumnCodec inner)
+        => new($"Nullable({inner.TypeName})", inner);
 
     /// <inheritdoc/>
     public ValueTask ReadStatePrefixAsync(ClickHouseBinaryReader reader, CancellationToken cancellationToken)
@@ -128,6 +159,39 @@ internal sealed class NullableColumnCodec : IColumnCodec
             innerColumn?.Dispose();
             throw;
         }
+    }
+
+    /// <inheritdoc/>
+    public bool TryProjectRead(Expression value, Type targetType, out Expression projected)
+    {
+        ColumnValueProjections.RequireSourceType(value, ElementType, TypeName);
+
+        if (targetType == ElementType)
+        {
+            projected = value;
+            return true;
+        }
+
+        projected = null;
+
+        // Undo this surface's wrap on the target to recover the inner's spelling. The wrap is invertible, so the
+        // target alone decides it — see ColumnValueProjections.TryLiftOverAbsent for why nothing may be inferred from
+        // the inner codec's canonical type instead.
+        Type innerTarget = Nullable.GetUnderlyingType(targetType);
+        if (innerTarget is null)
+        {
+            // A bare value-typed target has nowhere to put a null row, so this surface cannot offer it — that is what
+            // stops Nullable(Int64) from claiming it can produce a plain long.
+            if (targetType.IsValueType)
+            {
+                return false;
+            }
+
+            // A reference-typed target holds the null itself, and the surface left it unwrapped.
+            innerTarget = targetType;
+        }
+
+        return ColumnValueProjections.TryLiftOverAbsent(value, inner, innerTarget, targetType, out projected);
     }
 
     /// <inheritdoc/>

--- a/ClickHouse.Driver.Tcp/Types/Codecs/Time64ColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/Time64ColumnCodec.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 using ClickHouse.Driver.Tcp.Protocol;
@@ -37,6 +38,9 @@ internal sealed class Time64ColumnCodec : IColumnCodec
 
     /// <inheritdoc/>
     public IReadOnlyList<Type> WritableElementTypes { get; } = new[] { typeof(long), typeof(TimeSpan) };
+
+    /// <inheritdoc/>
+    public IReadOnlyList<Type> ReadableElementTypes { get; } = new[] { typeof(long), typeof(TimeSpan) };
 
     /// <inheritdoc/>
     public object NullPlaceholder => 0L;
@@ -79,6 +83,27 @@ internal sealed class Time64ColumnCodec : IColumnCodec
     /// <inheritdoc/>
     public ValueTask<IColumn> ReadColumnAsync(ClickHouseBinaryReader reader, string columnName, string columnType, int rowCount, CancellationToken cancellationToken)
         => Time64Column.ReadAsync(reader, columnName, columnType, scale, rowCount, cancellationToken);
+
+    /// <inheritdoc/>
+    public bool TryProjectRead(Expression value, Type targetType, out Expression projected)
+    {
+        ColumnValueProjections.RequireSourceType(value, typeof(long), TypeName);
+
+        if (targetType == typeof(long))
+        {
+            projected = value;
+            return true;
+        }
+
+        if (targetType == typeof(TimeSpan))
+        {
+            projected = ColumnValueProjections.Call(nameof(ColumnValueProjections.Time64ToTimeSpan), value, scale);
+            return true;
+        }
+
+        projected = null;
+        return false;
+    }
 
     /// <inheritdoc/>
     public bool CanWrite(IColumn column) => column is IColumn<long> or IColumn<TimeSpan>;

--- a/ClickHouse.Driver.Tcp/Types/Codecs/TimeColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/TimeColumnCodec.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 using ClickHouse.Driver.Tcp.Protocol;
@@ -34,6 +35,9 @@ internal sealed class TimeColumnCodec : IColumnCodec
     public IReadOnlyList<Type> WritableElementTypes { get; } = new[] { typeof(int), typeof(TimeSpan) };
 
     /// <inheritdoc/>
+    public IReadOnlyList<Type> ReadableElementTypes { get; } = new[] { typeof(int), typeof(TimeSpan) };
+
+    /// <inheritdoc/>
     public object NullPlaceholder => 0;
 
     /// <inheritdoc/>
@@ -55,6 +59,27 @@ internal sealed class TimeColumnCodec : IColumnCodec
     /// <inheritdoc/>
     public ValueTask<IColumn> ReadColumnAsync(ClickHouseBinaryReader reader, string columnName, string columnType, int rowCount, CancellationToken cancellationToken)
         => TimeColumn.ReadAsync(reader, columnName, columnType, rowCount, cancellationToken);
+
+    /// <inheritdoc/>
+    public bool TryProjectRead(Expression value, Type targetType, out Expression projected)
+    {
+        ColumnValueProjections.RequireSourceType(value, typeof(int), TypeName);
+
+        if (targetType == typeof(int))
+        {
+            projected = value;
+            return true;
+        }
+
+        if (targetType == typeof(TimeSpan))
+        {
+            projected = ColumnValueProjections.Call(nameof(ColumnValueProjections.TimeToTimeSpan), value);
+            return true;
+        }
+
+        projected = null;
+        return false;
+    }
 
     /// <inheritdoc/>
     public bool CanWrite(IColumn column) => column is IColumn<int> or IColumn<TimeSpan>;

--- a/ClickHouse.Driver.Tcp/Types/ColumnValueProjections.cs
+++ b/ClickHouse.Driver.Tcp/Types/ColumnValueProjections.cs
@@ -6,15 +6,10 @@ using ClickHouse.Driver.Tcp.Types.Codecs;
 namespace ClickHouse.Driver.Tcp.Types;
 
 /// <summary>
-/// The read-side value conversions shared by the date/time and time codecs' <see cref="IColumnCodec.TryProjectRead"/>
-/// and by the columns' own <c>GetDateTimeOffset</c>/<c>GetTimeSpan</c> accessors, so a raw wire count has exactly
-/// one calendar reading no matter which surface asks for it.
-///
-/// <para>
-/// Every method is <see langword="static"/> and takes the column's scale and timezone as plain arguments, so a
-/// codec can inline a call to one into a compiled projection expression (passing them as captured constants)
-/// without a delegate hop.
-/// </para>
+/// The read-side conversions shared by the date/time codecs' <see cref="IColumnCodec.TryProjectRead"/> and by the
+/// columns' own <c>GetDateTimeOffset</c>/<c>GetTimeSpan</c>, so a raw wire count has one calendar reading whichever
+/// surface asks. Static, taking scale and timezone as plain arguments, so a codec can inline a call with them as
+/// constants instead of paying a delegate hop.
 /// </summary>
 internal static class ColumnValueProjections
 {
@@ -24,29 +19,24 @@ internal static class ColumnValueProjections
     private static readonly long UnixEpochTicks = DateTime.UnixEpoch.Ticks;
 
     /// <summary>
-    /// Presents an instant as a <see cref="DateTime"/>: a zero offset yields <see cref="DateTimeKind.Utc"/>, and any
-    /// other offset yields the wall clock in the column's timezone as <see cref="DateTimeKind.Unspecified"/>.
-    ///
+    /// Presents an instant as a <see cref="DateTime"/>: a zero offset yields <see cref="DateTimeKind.Utc"/>, any
+    /// other offset the wall clock in the column's timezone as <see cref="DateTimeKind.Unspecified"/>.
     /// <para>
-    /// This matches the HTTP driver's <c>AbstractDateTimeType.ToDateTime</c> for a column whose type names a
-    /// timezone. For a <b>bare</b> <c>DateTime</c>/<c>DateTime64</c> the two clients deliberately differ: HTTP
-    /// presents it in UTC because its type object carries no zone, whereas this client resolves the session
-    /// timezone (<see cref="DateTimeZones.Resolve"/>) and so agrees with what the server itself would display. That
-    /// is the chosen behavior, not an oversight — do not "fix" it toward HTTP: it keeps the whole TCP read path
-    /// honoring <c>session_timezone</c>. The cost is that a bare column read through the two clients can differ by
-    /// the session offset.
+    /// Deliberate divergence from HTTP, do not "fix": on a bare <c>DateTime</c>/<c>DateTime64</c> HTTP presents UTC,
+    /// while this client resolves <c>session_timezone</c> and so matches what the server displays. The cost is that
+    /// one column read through the two clients can differ by the session offset.
     /// </para>
     /// </summary>
-    /// <param name="presented">The instant, already converted into the column's timezone.</param>
-    /// <returns>The <see cref="DateTime"/> reading of <paramref name="presented"/>.</returns>
+    /// <param name="presented">The instant, already in the column's timezone.</param>
+    /// <returns>The <see cref="DateTime"/> reading.</returns>
     public static DateTime PresentAsDateTime(DateTimeOffset presented) => presented.Offset == TimeSpan.Zero
         ? presented.UtcDateTime
         : presented.DateTime;
 
     /// <summary>
     /// Projects a <c>DateTime</c> column's raw epoch-second count onto the .NET calendar. The wire value is a UTC
-    /// instant; the timezone only decides the offset it is presented with, resolved from the instant so both
-    /// daylight-saving transitions and historical base-offset changes are honored.
+    /// instant; the timezone only decides the presented offset, resolved from the instant so that both daylight-saving
+    /// transitions and historical base-offset changes are honored.
     /// </summary>
     /// <param name="seconds">The raw epoch-second count.</param>
     /// <param name="timeZone">The column's timezone.</param>
@@ -54,10 +44,7 @@ internal static class ColumnValueProjections
     public static DateTimeOffset DateTimeToOffset(uint seconds, TimeZoneInfo timeZone)
         => TimeZoneInfo.ConvertTime(DateTimeOffset.FromUnixTimeSeconds(seconds), timeZone);
 
-    /// <summary>
-    /// <see cref="DateTimeToOffset"/> presented as a <see cref="DateTime"/> (see
-    /// <see cref="PresentAsDateTime"/> for the <see cref="DateTimeKind"/> rule).
-    /// </summary>
+    /// <summary><see cref="DateTimeToOffset"/> as a <see cref="DateTime"/>; see <see cref="PresentAsDateTime"/>.</summary>
     /// <param name="seconds">The raw epoch-second count.</param>
     /// <param name="timeZone">The column's timezone.</param>
     /// <returns>The instant as a <see cref="DateTime"/>.</returns>
@@ -65,21 +52,18 @@ internal static class ColumnValueProjections
         => PresentAsDateTime(DateTimeToOffset(seconds, timeZone));
 
     /// <summary>
-    /// Projects a <c>DateTime64</c> column's raw count at <paramref name="scale"/> onto the .NET calendar and
-    /// presents it in the column's timezone. Sub-100 ns digits at scale 8/9 are truncated toward zero; the exact
-    /// value stays in the column's raw values.
+    /// Projects a <c>DateTime64</c> count at <paramref name="scale"/> onto the .NET calendar, presented in the
+    /// column's timezone. Scale 8/9 sub-100 ns digits truncate toward zero; the exact value stays in the raw values.
     /// </summary>
     /// <param name="count">The raw count at <c>10^-<paramref name="scale"/></c> seconds since the epoch.</param>
     /// <param name="scale">The column's fractional-second scale (0–9).</param>
     /// <param name="timeZone">The column's timezone.</param>
     /// <returns>The instant, presented in <paramref name="timeZone"/>.</returns>
-    /// <exception cref="OverflowException"><paramref name="count"/> is decodable but outside the range a
-    /// <see cref="DateTimeOffset"/> can present.</exception>
+    /// <exception cref="OverflowException">The count is decodable but outside <see cref="DateTimeOffset"/>'s range.</exception>
     public static DateTimeOffset DateTime64ToOffset(long count, int scale, TimeZoneInfo timeZone)
     {
-        // Projecting the count onto the .NET calendar overflows for counts outside DateTimeOffset's range even
-        // though the raw count itself is decodable. Surface that as an actionable message pointing at the raw
-        // values rather than a bare arithmetic exception.
+        // A count can be decodable yet outside DateTimeOffset's range. Point at the raw values rather than let a bare
+        // arithmetic exception surface.
         try
         {
             long dotNetTicks = FixedPointScaling.ShiftDecimalPlaces(count, DotNetTickScale - scale);
@@ -94,30 +78,23 @@ internal static class ColumnValueProjections
         }
     }
 
-    /// <summary>
-    /// <see cref="DateTime64ToOffset"/> presented as a <see cref="DateTime"/> (see
-    /// <see cref="PresentAsDateTime"/> for the <see cref="DateTimeKind"/> rule).
-    /// </summary>
+    /// <summary><see cref="DateTime64ToOffset"/> as a <see cref="DateTime"/>; see <see cref="PresentAsDateTime"/>.</summary>
     /// <param name="count">The raw count at <c>10^-<paramref name="scale"/></c> seconds since the epoch.</param>
     /// <param name="scale">The column's fractional-second scale (0–9).</param>
     /// <param name="timeZone">The column's timezone.</param>
     /// <returns>The instant as a <see cref="DateTime"/>.</returns>
-    /// <exception cref="OverflowException"><paramref name="count"/> is decodable but outside the range a
-    /// <see cref="DateTimeOffset"/> can present.</exception>
+    /// <exception cref="OverflowException">The count is decodable but outside <see cref="DateTimeOffset"/>'s range.</exception>
     public static DateTime DateTime64ToDateTime(long count, int scale, TimeZoneInfo timeZone)
         => PresentAsDateTime(DateTime64ToOffset(count, scale, timeZone));
 
-    /// <summary>
-    /// Projects a <c>Time</c> column's raw second count to a <see cref="TimeSpan"/>. Exact — <c>Time</c> is a
-    /// whole-second duration.
-    /// </summary>
+    /// <summary>Projects a <c>Time</c> column's raw second count to a <see cref="TimeSpan"/>. Exact — whole seconds.</summary>
     /// <param name="seconds">The raw signed second count.</param>
     /// <returns>The duration.</returns>
     public static TimeSpan TimeToTimeSpan(int seconds) => TimeSpan.FromTicks(seconds * TimeSpan.TicksPerSecond);
 
     /// <summary>
-    /// Projects a <c>Time64</c> column's raw count at <paramref name="scale"/> to a <see cref="TimeSpan"/>.
-    /// Sub-100 ns digits at scale 8/9 are truncated toward zero; the exact value stays in the column's raw values.
+    /// Projects a <c>Time64</c> count at <paramref name="scale"/> to a <see cref="TimeSpan"/>. Scale 8/9 sub-100 ns
+    /// digits truncate toward zero; the exact value stays in the raw values.
     /// </summary>
     /// <param name="count">The raw signed count at <c>10^-<paramref name="scale"/></c> seconds.</param>
     /// <param name="scale">The column's fractional-second scale (0–9).</param>
@@ -126,9 +103,8 @@ internal static class ColumnValueProjections
         => TimeSpan.FromTicks(FixedPointScaling.ShiftDecimalPlaces(count, DotNetTickScale - scale));
 
     /// <summary>
-    /// Confirms the expression a codec was handed to project really yields its canonical
-    /// <see cref="IColumnCodec.ElementType"/>. A mismatch here would otherwise surface much later as an opaque
-    /// expression-tree or cast failure, so it is caught where the caller's mistake is.
+    /// Confirms a codec was handed an expression of its canonical <see cref="IColumnCodec.ElementType"/>. Catches the
+    /// caller's mistake here, instead of as an opaque expression-tree failure much later.
     /// </summary>
     /// <param name="value">The expression to check.</param>
     /// <param name="elementType">The codec's canonical element type.</param>
@@ -147,38 +123,29 @@ internal static class ColumnValueProjections
 
     /// <summary>
     /// Lifts an inner codec's projection over a source that can be absent: an absent row yields
-    /// <c>default(targetType)</c> — null for both a <see cref="Nullable{T}"/> and a reference type — and a present one
-    /// is projected and re-wrapped. Shared by the transparent wrappers (<c>Nullable</c>,
-    /// <c>LowCardinality(Nullable(T))</c>), whose surfaces differ but whose lifting rule does not.
-    ///
+    /// <c>default(targetType)</c> — null for both a <see cref="Nullable{T}"/> and a reference type. Shared by the
+    /// transparent wrappers (<c>Nullable</c>, <c>LowCardinality(Nullable(T))</c>), whose surfaces differ but whose
+    /// lifting rule does not.
     /// <para>
-    /// The source shape and the target shape are read independently, each from the type in front of it: whether the
-    /// source needs unwrapping is decided by <paramref name="value"/>'s own type, and whether the result needs
-    /// wrapping by <paramref name="targetType"/>. Neither is inferred from the other. They happen to agree for every
-    /// type pair that exists today — every codec's readings share their value/reference-ness with its
-    /// <see cref="IColumnCodec.ElementType"/> — but a codec that broke that (a <c>FixedString(16)</c> read as a
-    /// <see cref="Guid"/>, say) would otherwise silently turn a null row into <c>default(Guid)</c>.
+    /// Source and target shapes are read independently, each from the type in front of it, never one from the other.
+    /// They agree for every pair that exists today, but a reference-typed element with a value-typed reading
+    /// (<c>FixedString(16)</c> as a <see cref="Guid"/>) would otherwise turn a null row into <c>default(Guid)</c>.
     /// </para>
     /// </summary>
-    /// <param name="value">An expression of the wrapper's surface element type: either
-    /// <c>Nullable&lt;inner element&gt;</c> or, for a reference-typed inner, the inner element type itself.</param>
+    /// <param name="value">An expression of the wrapper's surface element type.</param>
     /// <param name="inner">The inner codec, asked to project the present value.</param>
     /// <param name="innerTarget">The inner codec's own spelling of the target type.</param>
     /// <param name="targetType">The surfaced target type, which must be able to hold an absent row.</param>
-    /// <param name="projected">An expression of type <paramref name="targetType"/>, or null when the inner offers no
-    /// projection to <paramref name="innerTarget"/>.</param>
+    /// <param name="projected">An expression of type <paramref name="targetType"/>, or null when the inner declines.</param>
     /// <returns>Whether the inner offered the projection.</returns>
     public static bool TryLiftOverAbsent(Expression value, IColumnCodec inner, Type innerTarget, Type targetType, out Expression projected)
     {
-        // Bind the source to a local first: it is spliced in twice (the presence test and the value) and may be an
-        // arbitrary expression — a span access or a method call — that must not be evaluated twice.
+        // Spliced in twice (the presence test and the value), and may be a span access or a call, so bind it once.
         ParameterExpression source = Expression.Variable(value.Type, "surfaceValue");
 
-        // A value-typed surface arrives as Nullable<U>, so presence is HasValue and the inner is handed Value. A
-        // reference-typed one is its own inner type already, so presence is a null test and it passes straight through.
-        // ReferenceNotEqual, not NotEqual: the latter binds a user-defined op_Inequality when the type declares one
-        // (String does), which would put a call per row where a reference comparison belongs and would break outright
-        // on an operator that dereferences its arguments or does not return bool.
+        // A value-typed surface arrives as Nullable<U>; a reference-typed one is its own inner type already.
+        // ReferenceNotEqual, not NotEqual: the latter binds a user-defined op_Inequality where the type declares one
+        // (String does), costing a call per row and breaking on an operator that dereferences its arguments.
         bool wrapped = Nullable.GetUnderlyingType(value.Type) is not null;
         Expression isPresent = wrapped
             ? Expression.Property(source, "HasValue")
@@ -202,8 +169,8 @@ internal static class ColumnValueProjections
     }
 
     /// <summary>
-    /// Builds a call to one of this class's projection methods, with the column's per-column state (scale,
-    /// timezone) passed as constants — the shape every codec's <see cref="IColumnCodec.TryProjectRead"/> returns.
+    /// Builds a call to one of this class's projection methods, with the per-column state (scale, timezone) as
+    /// constants — the shape every codec's <see cref="IColumnCodec.TryProjectRead"/> returns.
     /// </summary>
     /// <param name="method">The projection method name on this class.</param>
     /// <param name="value">The expression yielding the raw value; becomes the first argument.</param>
@@ -217,8 +184,7 @@ internal static class ColumnValueProjections
         ParameterInfo[] parameters = target.GetParameters();
         if (parameters.Length != constants.Length + 1)
         {
-            // Caught here rather than as an Expression.Call argument error, which would name the reflected method
-            // instead of the codec that miscalled it.
+            // Named here because Expression.Call's own error names the reflected method, not the codec that miscalled it.
             throw new InvalidOperationException(
                 $"Projection method '{method}' takes {parameters.Length} arguments, but was given {constants.Length + 1}.");
         }
@@ -227,8 +193,7 @@ internal static class ColumnValueProjections
         arguments[0] = value;
         for (int i = 0; i < constants.Length; i++)
         {
-            // Typed against the parameter rather than inferred from the value, so a null constant still binds and an
-            // implicitly-convertible one is not pinned to its own type.
+            // Typed against the parameter, so a null constant still binds and a convertible one is not pinned.
             arguments[i + 1] = Expression.Constant(constants[i], parameters[i + 1].ParameterType);
         }
 

--- a/ClickHouse.Driver.Tcp/Types/ColumnValueProjections.cs
+++ b/ClickHouse.Driver.Tcp/Types/ColumnValueProjections.cs
@@ -1,0 +1,237 @@
+using System;
+using System.Linq.Expressions;
+using System.Reflection;
+using ClickHouse.Driver.Tcp.Types.Codecs;
+
+namespace ClickHouse.Driver.Tcp.Types;
+
+/// <summary>
+/// The read-side value conversions shared by the date/time and time codecs' <see cref="IColumnCodec.TryProjectRead"/>
+/// and by the columns' own <c>GetDateTimeOffset</c>/<c>GetTimeSpan</c> accessors, so a raw wire count has exactly
+/// one calendar reading no matter which surface asks for it.
+///
+/// <para>
+/// Every method is <see langword="static"/> and takes the column's scale and timezone as plain arguments, so a
+/// codec can inline a call to one into a compiled projection expression (passing them as captured constants)
+/// without a delegate hop.
+/// </para>
+/// </summary>
+internal static class ColumnValueProjections
+{
+    // The .NET tick scale: one tick is 100 ns, i.e. 10^-7 s.
+    private const int DotNetTickScale = 7;
+
+    private static readonly long UnixEpochTicks = DateTime.UnixEpoch.Ticks;
+
+    /// <summary>
+    /// Presents an instant as a <see cref="DateTime"/>: a zero offset yields <see cref="DateTimeKind.Utc"/>, and any
+    /// other offset yields the wall clock in the column's timezone as <see cref="DateTimeKind.Unspecified"/>.
+    ///
+    /// <para>
+    /// This matches the HTTP driver's <c>AbstractDateTimeType.ToDateTime</c> for a column whose type names a
+    /// timezone. For a <b>bare</b> <c>DateTime</c>/<c>DateTime64</c> the two clients deliberately differ: HTTP
+    /// presents it in UTC because its type object carries no zone, whereas this client resolves the session
+    /// timezone (<see cref="DateTimeZones.Resolve"/>) and so agrees with what the server itself would display. That
+    /// is the chosen behavior, not an oversight — do not "fix" it toward HTTP: it keeps the whole TCP read path
+    /// honoring <c>session_timezone</c>. The cost is that a bare column read through the two clients can differ by
+    /// the session offset.
+    /// </para>
+    /// </summary>
+    /// <param name="presented">The instant, already converted into the column's timezone.</param>
+    /// <returns>The <see cref="DateTime"/> reading of <paramref name="presented"/>.</returns>
+    public static DateTime PresentAsDateTime(DateTimeOffset presented) => presented.Offset == TimeSpan.Zero
+        ? presented.UtcDateTime
+        : presented.DateTime;
+
+    /// <summary>
+    /// Projects a <c>DateTime</c> column's raw epoch-second count onto the .NET calendar. The wire value is a UTC
+    /// instant; the timezone only decides the offset it is presented with, resolved from the instant so both
+    /// daylight-saving transitions and historical base-offset changes are honored.
+    /// </summary>
+    /// <param name="seconds">The raw epoch-second count.</param>
+    /// <param name="timeZone">The column's timezone.</param>
+    /// <returns>The instant, presented in <paramref name="timeZone"/>.</returns>
+    public static DateTimeOffset DateTimeToOffset(uint seconds, TimeZoneInfo timeZone)
+        => TimeZoneInfo.ConvertTime(DateTimeOffset.FromUnixTimeSeconds(seconds), timeZone);
+
+    /// <summary>
+    /// <see cref="DateTimeToOffset"/> presented as a <see cref="DateTime"/> (see
+    /// <see cref="PresentAsDateTime"/> for the <see cref="DateTimeKind"/> rule).
+    /// </summary>
+    /// <param name="seconds">The raw epoch-second count.</param>
+    /// <param name="timeZone">The column's timezone.</param>
+    /// <returns>The instant as a <see cref="DateTime"/>.</returns>
+    public static DateTime DateTimeToDateTime(uint seconds, TimeZoneInfo timeZone)
+        => PresentAsDateTime(DateTimeToOffset(seconds, timeZone));
+
+    /// <summary>
+    /// Projects a <c>DateTime64</c> column's raw count at <paramref name="scale"/> onto the .NET calendar and
+    /// presents it in the column's timezone. Sub-100 ns digits at scale 8/9 are truncated toward zero; the exact
+    /// value stays in the column's raw values.
+    /// </summary>
+    /// <param name="count">The raw count at <c>10^-<paramref name="scale"/></c> seconds since the epoch.</param>
+    /// <param name="scale">The column's fractional-second scale (0–9).</param>
+    /// <param name="timeZone">The column's timezone.</param>
+    /// <returns>The instant, presented in <paramref name="timeZone"/>.</returns>
+    /// <exception cref="OverflowException"><paramref name="count"/> is decodable but outside the range a
+    /// <see cref="DateTimeOffset"/> can present.</exception>
+    public static DateTimeOffset DateTime64ToOffset(long count, int scale, TimeZoneInfo timeZone)
+    {
+        // Projecting the count onto the .NET calendar overflows for counts outside DateTimeOffset's range even
+        // though the raw count itself is decodable. Surface that as an actionable message pointing at the raw
+        // values rather than a bare arithmetic exception.
+        try
+        {
+            long dotNetTicks = FixedPointScaling.ShiftDecimalPlaces(count, DotNetTickScale - scale);
+            var utc = new DateTimeOffset(UnixEpochTicks + dotNetTicks, TimeSpan.Zero);
+            return TimeZoneInfo.ConvertTime(utc, timeZone);
+        }
+        catch (Exception ex) when (ex is OverflowException or ArgumentOutOfRangeException)
+        {
+            throw new OverflowException(
+                $"A DateTime64 count of {count} at scale {scale} is outside the range presentable as a DateTimeOffset in timezone '{timeZone.Id}'; read the raw count via Values instead.",
+                ex);
+        }
+    }
+
+    /// <summary>
+    /// <see cref="DateTime64ToOffset"/> presented as a <see cref="DateTime"/> (see
+    /// <see cref="PresentAsDateTime"/> for the <see cref="DateTimeKind"/> rule).
+    /// </summary>
+    /// <param name="count">The raw count at <c>10^-<paramref name="scale"/></c> seconds since the epoch.</param>
+    /// <param name="scale">The column's fractional-second scale (0–9).</param>
+    /// <param name="timeZone">The column's timezone.</param>
+    /// <returns>The instant as a <see cref="DateTime"/>.</returns>
+    /// <exception cref="OverflowException"><paramref name="count"/> is decodable but outside the range a
+    /// <see cref="DateTimeOffset"/> can present.</exception>
+    public static DateTime DateTime64ToDateTime(long count, int scale, TimeZoneInfo timeZone)
+        => PresentAsDateTime(DateTime64ToOffset(count, scale, timeZone));
+
+    /// <summary>
+    /// Projects a <c>Time</c> column's raw second count to a <see cref="TimeSpan"/>. Exact — <c>Time</c> is a
+    /// whole-second duration.
+    /// </summary>
+    /// <param name="seconds">The raw signed second count.</param>
+    /// <returns>The duration.</returns>
+    public static TimeSpan TimeToTimeSpan(int seconds) => TimeSpan.FromTicks(seconds * TimeSpan.TicksPerSecond);
+
+    /// <summary>
+    /// Projects a <c>Time64</c> column's raw count at <paramref name="scale"/> to a <see cref="TimeSpan"/>.
+    /// Sub-100 ns digits at scale 8/9 are truncated toward zero; the exact value stays in the column's raw values.
+    /// </summary>
+    /// <param name="count">The raw signed count at <c>10^-<paramref name="scale"/></c> seconds.</param>
+    /// <param name="scale">The column's fractional-second scale (0–9).</param>
+    /// <returns>The duration.</returns>
+    public static TimeSpan Time64ToTimeSpan(long count, int scale)
+        => TimeSpan.FromTicks(FixedPointScaling.ShiftDecimalPlaces(count, DotNetTickScale - scale));
+
+    /// <summary>
+    /// Confirms the expression a codec was handed to project really yields its canonical
+    /// <see cref="IColumnCodec.ElementType"/>. A mismatch here would otherwise surface much later as an opaque
+    /// expression-tree or cast failure, so it is caught where the caller's mistake is.
+    /// </summary>
+    /// <param name="value">The expression to check.</param>
+    /// <param name="elementType">The codec's canonical element type.</param>
+    /// <param name="typeName">The codec's type name, for the message.</param>
+    /// <exception cref="ArgumentException"><paramref name="value"/> is not of type <paramref name="elementType"/>.</exception>
+    public static void RequireSourceType(Expression value, Type elementType, string typeName)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        if (value.Type != elementType)
+        {
+            throw new ArgumentException(
+                $"The '{typeName}' codec projects from its element type {elementType}, but was given an expression of type {value.Type}.",
+                nameof(value));
+        }
+    }
+
+    /// <summary>
+    /// Lifts an inner codec's projection over a source that can be absent: an absent row yields
+    /// <c>default(targetType)</c> — null for both a <see cref="Nullable{T}"/> and a reference type — and a present one
+    /// is projected and re-wrapped. Shared by the transparent wrappers (<c>Nullable</c>,
+    /// <c>LowCardinality(Nullable(T))</c>), whose surfaces differ but whose lifting rule does not.
+    ///
+    /// <para>
+    /// The source shape and the target shape are read independently, each from the type in front of it: whether the
+    /// source needs unwrapping is decided by <paramref name="value"/>'s own type, and whether the result needs
+    /// wrapping by <paramref name="targetType"/>. Neither is inferred from the other. They happen to agree for every
+    /// type pair that exists today — every codec's readings share their value/reference-ness with its
+    /// <see cref="IColumnCodec.ElementType"/> — but a codec that broke that (a <c>FixedString(16)</c> read as a
+    /// <see cref="Guid"/>, say) would otherwise silently turn a null row into <c>default(Guid)</c>.
+    /// </para>
+    /// </summary>
+    /// <param name="value">An expression of the wrapper's surface element type: either
+    /// <c>Nullable&lt;inner element&gt;</c> or, for a reference-typed inner, the inner element type itself.</param>
+    /// <param name="inner">The inner codec, asked to project the present value.</param>
+    /// <param name="innerTarget">The inner codec's own spelling of the target type.</param>
+    /// <param name="targetType">The surfaced target type, which must be able to hold an absent row.</param>
+    /// <param name="projected">An expression of type <paramref name="targetType"/>, or null when the inner offers no
+    /// projection to <paramref name="innerTarget"/>.</param>
+    /// <returns>Whether the inner offered the projection.</returns>
+    public static bool TryLiftOverAbsent(Expression value, IColumnCodec inner, Type innerTarget, Type targetType, out Expression projected)
+    {
+        // Bind the source to a local first: it is spliced in twice (the presence test and the value) and may be an
+        // arbitrary expression — a span access or a method call — that must not be evaluated twice.
+        ParameterExpression source = Expression.Variable(value.Type, "surfaceValue");
+
+        // A value-typed surface arrives as Nullable<U>, so presence is HasValue and the inner is handed Value. A
+        // reference-typed one is its own inner type already, so presence is a null test and it passes straight through.
+        // ReferenceNotEqual, not NotEqual: the latter binds a user-defined op_Inequality when the type declares one
+        // (String does), which would put a call per row where a reference comparison belongs and would break outright
+        // on an operator that dereferences its arguments or does not return bool.
+        bool wrapped = Nullable.GetUnderlyingType(value.Type) is not null;
+        Expression isPresent = wrapped
+            ? Expression.Property(source, "HasValue")
+            : Expression.ReferenceNotEqual(source, Expression.Constant(null, value.Type));
+        Expression present = wrapped ? Expression.Property(source, "Value") : source;
+
+        if (!inner.TryProjectRead(present, innerTarget, out Expression innerProjection))
+        {
+            projected = null;
+            return false;
+        }
+
+        projected = Expression.Block(
+            new[] { source },
+            Expression.Assign(source, value),
+            Expression.Condition(
+                isPresent,
+                innerProjection.Type == targetType ? innerProjection : Expression.Convert(innerProjection, targetType),
+                Expression.Default(targetType)));
+        return true;
+    }
+
+    /// <summary>
+    /// Builds a call to one of this class's projection methods, with the column's per-column state (scale,
+    /// timezone) passed as constants — the shape every codec's <see cref="IColumnCodec.TryProjectRead"/> returns.
+    /// </summary>
+    /// <param name="method">The projection method name on this class.</param>
+    /// <param name="value">The expression yielding the raw value; becomes the first argument.</param>
+    /// <param name="constants">The remaining arguments, embedded as constants.</param>
+    /// <returns>The call expression.</returns>
+    public static Expression Call(string method, Expression value, params object[] constants)
+    {
+        MethodInfo target = typeof(ColumnValueProjections).GetMethod(method, BindingFlags.Public | BindingFlags.Static)
+            ?? throw new InvalidOperationException($"No projection method '{method}'.");
+
+        ParameterInfo[] parameters = target.GetParameters();
+        if (parameters.Length != constants.Length + 1)
+        {
+            // Caught here rather than as an Expression.Call argument error, which would name the reflected method
+            // instead of the codec that miscalled it.
+            throw new InvalidOperationException(
+                $"Projection method '{method}' takes {parameters.Length} arguments, but was given {constants.Length + 1}.");
+        }
+
+        var arguments = new Expression[constants.Length + 1];
+        arguments[0] = value;
+        for (int i = 0; i < constants.Length; i++)
+        {
+            // Typed against the parameter rather than inferred from the value, so a null constant still binds and an
+            // implicitly-convertible one is not pinned to its own type.
+            arguments[i + 1] = Expression.Constant(constants[i], parameters[i + 1].ParameterType);
+        }
+
+        return Expression.Call(target, arguments);
+    }
+}

--- a/ClickHouse.Driver.Tcp/Types/DateTime64Column.cs
+++ b/ClickHouse.Driver.Tcp/Types/DateTime64Column.cs
@@ -4,7 +4,6 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using ClickHouse.Driver.Tcp.Protocol;
-using ClickHouse.Driver.Tcp.Types.Codecs;
 
 namespace ClickHouse.Driver.Tcp.Types;
 
@@ -23,9 +22,6 @@ namespace ClickHouse.Driver.Tcp.Types;
 /// </summary>
 internal sealed class DateTime64Column : IColumn<long>
 {
-    private const int DotNetTickScale = 7; // .NET tick = 100 ns = 10^-7 s.
-    private static readonly long UnixEpochTicks = DateTime.UnixEpoch.Ticks;
-
     private readonly int scale;
     private readonly TimeZoneInfo timeZone;
     private readonly int length;
@@ -159,22 +155,5 @@ internal sealed class DateTime64Column : IColumn<long>
     // Projects a raw count onto the .NET calendar and presents it in the column's timezone. Sub-100 ns digits at
     // scale 8/9 are truncated toward zero here; the exact value stays in Values. The offset is resolved from the
     // instant so both daylight-saving transitions and historical base-offset changes are honored.
-    private DateTimeOffset ToDateTimeOffset(long count)
-    {
-        // Projecting the count onto the .NET calendar overflows for counts outside DateTimeOffset's range even
-        // though the raw count itself is decodable. Surface that as an actionable message pointing at Values
-        // rather than a bare arithmetic exception.
-        try
-        {
-            long dotNetTicks = FixedPointScaling.ShiftDecimalPlaces(count, DotNetTickScale - scale);
-            var utc = new DateTimeOffset(UnixEpochTicks + dotNetTicks, TimeSpan.Zero);
-            return TimeZoneInfo.ConvertTime(utc, timeZone);
-        }
-        catch (Exception ex) when (ex is OverflowException or ArgumentOutOfRangeException)
-        {
-            throw new OverflowException(
-                $"A DateTime64 count of {count} at scale {scale} is outside the range presentable as a DateTimeOffset in timezone '{timeZone.Id}'; read the raw count via Values instead.",
-                ex);
-        }
-    }
+    private DateTimeOffset ToDateTimeOffset(long count) => ColumnValueProjections.DateTime64ToOffset(count, scale, timeZone);
 }

--- a/ClickHouse.Driver.Tcp/Types/DateTimeColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/DateTimeColumn.cs
@@ -144,11 +144,5 @@ internal sealed class DateTimeColumn : IColumn<uint>
         return new DateTimeColumn(name, typeName, timeZone, rented, byteCount, pooled: true);
     }
 
-    // The wire value is a UTC instant; the timezone only decides the offset it is presented with. The offset is
-    // resolved from the instant so both daylight-saving transitions and historical base-offset changes are honored.
-    private DateTimeOffset ToDateTimeOffset(uint seconds)
-    {
-        DateTimeOffset utc = DateTimeOffset.FromUnixTimeSeconds(seconds);
-        return TimeZoneInfo.ConvertTime(utc, timeZone);
-    }
+    private DateTimeOffset ToDateTimeOffset(uint seconds) => ColumnValueProjections.DateTimeToOffset(seconds, timeZone);
 }

--- a/ClickHouse.Driver.Tcp/Types/IColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/IColumnCodec.cs
@@ -29,11 +29,10 @@ internal interface IColumnCodec
     /// for <c>String</c>, <see cref="uint"/> — the raw epoch-second count — for <c>DateTime</c>). Composite codecs
     /// consult a child codec's element type to build the right typed wrapper column (e.g. <c>Nullable(T)</c>
     /// surfaces <c>T?</c> for a value-type inner and the nullable reference for a reference-type inner).
-    ///
     /// <para>
-    /// This is the one type the column is *decoded* into. A codec may accept more CLR types than this on the
-    /// write path (<see cref="WritableElementTypes"/>, which leads with this type) and may project to more on the
-    /// read path (<see cref="TryProjectRead"/>).
+    /// The one type the column is <em>decoded</em> into. A codec may accept more on the write path
+    /// (<see cref="WritableElementTypes"/>, which leads with this type) and project to more on the read path
+    /// (<see cref="TryProjectRead"/>).
     /// </para>
     /// </summary>
     Type ElementType { get; }
@@ -49,45 +48,35 @@ internal interface IColumnCodec
     IReadOnlyList<Type> WritableElementTypes => new[] { ElementType };
 
     /// <summary>
-    /// The readings this codec offers, canonical <see cref="ElementType"/> first — <b>for diagnostics only</b>.
-    /// Defaults to just <see cref="ElementType"/>; a codec whose canonical type is a raw wire count lists the
-    /// calendar readings it can also offer (e.g. <c>DateTime</c> surfaces <see cref="uint"/> epoch seconds and can
-    /// also project <see cref="System.DateTimeOffset"/> and <see cref="System.DateTime"/>).
-    ///
+    /// The readings this codec offers, canonical <see cref="ElementType"/> first — <b>for diagnostics only</b>, to
+    /// tell a caller what a column can be read as once nothing matched. Defaults to just <see cref="ElementType"/>.
     /// <para>
-    /// <b>Do not use this to decide whether a projection is available</b> — ask <see cref="TryProjectRead"/>, which
-    /// is the authority. This list is not exhaustive and cannot be: a composite's readable set is the cartesian
-    /// product of its children's (a seven-field tuple of <c>DateTime64</c>s would be 3^7 entries), so a composite
-    /// that lifts its children answers <see cref="TryProjectRead"/> for shapes it does not enumerate here. Only ever
-    /// read on a failure path, to tell a caller what a column can be read as — so this is also not a hot property,
-    /// and it may allocate.
+    /// <b>Do not use this to decide whether a projection exists</b> — ask <see cref="TryProjectRead"/>, the authority.
+    /// This list cannot be exhaustive: a composite that lifts its children answers for their cartesian product, which
+    /// is too large to enumerate. Only read on a failure path, so it is not hot and may allocate.
     /// </para>
     /// </summary>
     IReadOnlyList<Type> ReadableElementTypes => new[] { ElementType };
 
     /// <summary>
-    /// Builds an expression projecting <paramref name="value"/> — an expression of type <see cref="ElementType"/> —
-    /// to <paramref name="targetType"/>. The identity for <see cref="ElementType"/> itself. This is the authority on
-    /// which readings exist: it answers the one type a caller asks about, rather than making the caller search
-    /// <see cref="ReadableElementTypes"/>, so a codec cannot advertise a projection it does not have and a composite
-    /// can recurse into its children without enumerating their cartesian product.
-    ///
+    /// Projects <paramref name="value"/> to <paramref name="targetType"/>; the identity for <see cref="ElementType"/>.
+    /// The authority on which readings exist: it answers the one type a caller asks about instead of publishing a list
+    /// to search, so a codec cannot advertise a projection it does not have, and a composite can recurse into its
+    /// children without enumerating their cartesian product.
     /// <para>
-    /// An <em>expression</em> rather than a delegate, so a caller compiling a per-column read loop can inline the
-    /// conversion into it; returning a <c>Func&lt;,&gt;</c> would cost an indirect call per row and defeat the
-    /// point. Any per-column state the conversion needs (scale, timezone) is embedded as a constant, so the
-    /// returned expression closes over nothing.
+    /// An <em>expression</em>, not a delegate, so a compiled per-column read loop can inline the conversion; a
+    /// <c>Func&lt;,&gt;</c> would cost an indirect call per row. Scale and timezone are embedded as constants, so the
+    /// result closes over nothing.
     /// </para>
     /// </summary>
-    /// <param name="value">An expression of type <see cref="ElementType"/> yielding one decoded value. Some
-    /// projections reference it more than once, so a caller must pass a variable or another repeatable expression.</param>
-    /// <param name="targetType">The CLR type to project to. Must not be null; implementations are not required to
-    /// agree on what a null does, so a caller with a possibly-absent target must check before asking.</param>
-    /// <param name="projected">An expression of type <paramref name="targetType"/>, or null when this codec offers
-    /// no projection to it.</param>
+    /// <param name="value">An expression of type <see cref="ElementType"/>. Spliced more than once by some
+    /// projections, so it must be a variable or another repeatable expression.</param>
+    /// <param name="targetType">The CLR type to project to. Must not be null — a caller with a possibly-absent target
+    /// checks before asking, as implementations need not agree on what a null does.</param>
+    /// <param name="projected">An expression of type <paramref name="targetType"/>, or null when none is offered.</param>
     /// <returns>Whether a projection to <paramref name="targetType"/> exists.</returns>
-    /// <exception cref="ArgumentException"><paramref name="value"/> is not of type <see cref="ElementType"/>. A
-    /// caller mistake, distinct from a target this codec simply does not offer.</exception>
+    /// <exception cref="ArgumentException"><paramref name="value"/> is not of type <see cref="ElementType"/> — a
+    /// caller mistake, distinct from a target this codec does not offer.</exception>
     bool TryProjectRead(Expression value, Type targetType, out Expression projected)
     {
         ColumnValueProjections.RequireSourceType(value, ElementType, TypeName);

--- a/ClickHouse.Driver.Tcp/Types/IColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/IColumnCodec.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 using ClickHouse.Driver.Tcp.Protocol;
@@ -25,11 +26,15 @@ internal interface IColumnCodec
     /// <summary>
     /// The CLR element type the decoded column surfaces — the <c>T</c> of the <see cref="IColumn{T}"/> that
     /// <see cref="ReadColumnAsync"/> produces (e.g. <see cref="ulong"/> for <c>UInt64</c>, <see cref="string"/>
-    /// for <c>String</c>, <see cref="System.DateTimeOffset"/> for <c>DateTime</c>). Composite codecs consult a
-    /// child codec's element type to build the right typed wrapper column (e.g. <c>Nullable(T)</c> surfaces
-    /// <c>T?</c> for a value-type inner and the nullable reference for a reference-type inner). A codec may still
-    /// <see cref="CanWrite"/> more CLR types than this on the write path (see <see cref="WritableElementTypes"/>);
-    /// this is the one it reads back.
+    /// for <c>String</c>, <see cref="uint"/> — the raw epoch-second count — for <c>DateTime</c>). Composite codecs
+    /// consult a child codec's element type to build the right typed wrapper column (e.g. <c>Nullable(T)</c>
+    /// surfaces <c>T?</c> for a value-type inner and the nullable reference for a reference-type inner).
+    ///
+    /// <para>
+    /// This is the one type the column is *decoded* into. A codec may accept more CLR types than this on the
+    /// write path (<see cref="WritableElementTypes"/>, which leads with this type) and may project to more on the
+    /// read path (<see cref="TryProjectRead"/>).
+    /// </para>
     /// </summary>
     Type ElementType { get; }
 
@@ -42,6 +47,53 @@ internal interface IColumnCodec
     /// <see cref="CanWrite"/> and <see cref="NullPlaceholderAs"/>.
     /// </summary>
     IReadOnlyList<Type> WritableElementTypes => new[] { ElementType };
+
+    /// <summary>
+    /// The readings this codec offers, canonical <see cref="ElementType"/> first — <b>for diagnostics only</b>.
+    /// Defaults to just <see cref="ElementType"/>; a codec whose canonical type is a raw wire count lists the
+    /// calendar readings it can also offer (e.g. <c>DateTime</c> surfaces <see cref="uint"/> epoch seconds and can
+    /// also project <see cref="System.DateTimeOffset"/> and <see cref="System.DateTime"/>).
+    ///
+    /// <para>
+    /// <b>Do not use this to decide whether a projection is available</b> — ask <see cref="TryProjectRead"/>, which
+    /// is the authority. This list is not exhaustive and cannot be: a composite's readable set is the cartesian
+    /// product of its children's (a seven-field tuple of <c>DateTime64</c>s would be 3^7 entries), so a composite
+    /// that lifts its children answers <see cref="TryProjectRead"/> for shapes it does not enumerate here. Only ever
+    /// read on a failure path, to tell a caller what a column can be read as — so this is also not a hot property,
+    /// and it may allocate.
+    /// </para>
+    /// </summary>
+    IReadOnlyList<Type> ReadableElementTypes => new[] { ElementType };
+
+    /// <summary>
+    /// Builds an expression projecting <paramref name="value"/> — an expression of type <see cref="ElementType"/> —
+    /// to <paramref name="targetType"/>. The identity for <see cref="ElementType"/> itself. This is the authority on
+    /// which readings exist: it answers the one type a caller asks about, rather than making the caller search
+    /// <see cref="ReadableElementTypes"/>, so a codec cannot advertise a projection it does not have and a composite
+    /// can recurse into its children without enumerating their cartesian product.
+    ///
+    /// <para>
+    /// An <em>expression</em> rather than a delegate, so a caller compiling a per-column read loop can inline the
+    /// conversion into it; returning a <c>Func&lt;,&gt;</c> would cost an indirect call per row and defeat the
+    /// point. Any per-column state the conversion needs (scale, timezone) is embedded as a constant, so the
+    /// returned expression closes over nothing.
+    /// </para>
+    /// </summary>
+    /// <param name="value">An expression of type <see cref="ElementType"/> yielding one decoded value. Some
+    /// projections reference it more than once, so a caller must pass a variable or another repeatable expression.</param>
+    /// <param name="targetType">The CLR type to project to. Must not be null; implementations are not required to
+    /// agree on what a null does, so a caller with a possibly-absent target must check before asking.</param>
+    /// <param name="projected">An expression of type <paramref name="targetType"/>, or null when this codec offers
+    /// no projection to it.</param>
+    /// <returns>Whether a projection to <paramref name="targetType"/> exists.</returns>
+    /// <exception cref="ArgumentException"><paramref name="value"/> is not of type <see cref="ElementType"/>. A
+    /// caller mistake, distinct from a target this codec simply does not offer.</exception>
+    bool TryProjectRead(Expression value, Type targetType, out Expression projected)
+    {
+        ColumnValueProjections.RequireSourceType(value, ElementType, TypeName);
+        projected = targetType == ElementType ? value : null;
+        return projected is not null;
+    }
 
     /// <summary>
     /// A value of <see cref="ElementType"/> to encode where a row has no value of its own — the placeholder

--- a/ClickHouse.Driver.Tcp/Types/Time64Column.cs
+++ b/ClickHouse.Driver.Tcp/Types/Time64Column.cs
@@ -4,7 +4,6 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using ClickHouse.Driver.Tcp.Protocol;
-using ClickHouse.Driver.Tcp.Types.Codecs;
 
 namespace ClickHouse.Driver.Tcp.Types;
 
@@ -29,8 +28,6 @@ namespace ClickHouse.Driver.Tcp.Types;
 /// </summary>
 internal sealed class Time64Column : IColumn<long>
 {
-    private const int DotNetTickScale = 7; // .NET tick = 100 ns = 10^-7 s.
-
     private readonly int scale;
     private readonly int length;
     private readonly bool pooled;
@@ -152,7 +149,5 @@ internal sealed class Time64Column : IColumn<long>
         return new Time64Column(name, typeName, scale, rented, byteCount, pooled: true);
     }
 
-    // Scales a raw count to .NET's 100 ns ticks. Sub-100 ns digits at scale 8/9 are truncated toward zero; the
-    // exact value stays in Values.
-    private TimeSpan ToTimeSpan(long count) => TimeSpan.FromTicks(FixedPointScaling.ShiftDecimalPlaces(count, DotNetTickScale - scale));
+    private TimeSpan ToTimeSpan(long count) => ColumnValueProjections.Time64ToTimeSpan(count, scale);
 }

--- a/ClickHouse.Driver.Tcp/Types/TimeColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/TimeColumn.cs
@@ -66,7 +66,7 @@ internal sealed class TimeColumn : IColumn<int>
     /// <summary>Returns a row as a <see cref="TimeSpan"/> (exact — <c>Time</c> is a whole-second duration).</summary>
     /// <param name="row">The zero-based row index.</param>
     /// <returns>The duration.</returns>
-    public TimeSpan GetTimeSpan(int row) => TimeSpan.FromSeconds(Values[row]);
+    public TimeSpan GetTimeSpan(int row) => ColumnValueProjections.TimeToTimeSpan(Values[row]);
 
     /// <summary>
     /// Projects every row to a <see cref="TimeSpan"/>, as a freshly allocated array the caller owns (it outlives
@@ -79,7 +79,7 @@ internal sealed class TimeColumn : IColumn<int>
         var result = new TimeSpan[seconds.Length];
         for (int i = 0; i < seconds.Length; i++)
         {
-            result[i] = TimeSpan.FromSeconds(seconds[i]);
+            result[i] = ColumnValueProjections.TimeToTimeSpan(seconds[i]);
         }
 
         return result;


### PR DESCRIPTION
Stacked on #462 (`tcp/epic-n1-client`) — review that first; this PR's diff is the last commit only.

First step of the Branch 2 POCO epic (N5a/N5/N9), landed on its own because it changes an `internal` interface every codec implements.

## Why

A codec already declares what it accepts on the **write** path — `WritableElementTypes` (preference-ordered), `CanWrite` as the membership test, `NullPlaceholderAs`, and the type switch inside `WriteColumn`. `DateTimeColumnCodec` even already holds the `TimeZoneInfo` and the `ToUtc`/`ToUnixSeconds` helpers.

The **read** path had no counterpart, because a codec decodes to exactly one canonical type — and for the date/time family that type is the raw wire count:

| type | canonical `IColumn<T>` |
|---|---|
| `DateTime` | `uint` (epoch seconds) |
| `DateTime64(s)` | `long` (raw count at scale) |
| `Time` / `Time64(s)` | `int` / `long` |

So `public DateTime CreatedAt { get; set; }` — the most common POCO member there is — has no match at all. Rather than invent a third home for knowledge the write path already keeps on the codec, this adds the read half.

## What

**`TryProjectRead(Expression value, Type targetType, out Expression projected)`** — the authority on which readings exist. It answers the one type a caller asks about rather than publishing a list the caller must search.

That direction is the design decision worth reviewing. On write the codec **chooses** among whatever CLR type the caller's column happens to hold, so an ordered list earns its keep. On read the target is **dictated** by the POCO member, so there is nothing to choose — the plan always arrives holding one concrete type and one question. Making the contract interrogative buys three things:

1. **A codec cannot advertise a projection it does not have.** Ask-then-build was two traversals that could disagree; now there is one.
2. **Composites become expressible later.** A composite's readable *set* is the cartesian product of its children's — `Tuple(DateTime, DateTime64, Time)` is 18, a seven-field tuple of `DateTime64`s is 3⁷ = 2187 — so no enumeration can express it, and any bounded subset is arbitrary. A predicate recurses into children in linear time. (Not done here; see below.)
3. **The wrappers stop guessing.** See "the latent bug" below.

An `Expression`, not a `Func<,>`, so the compiled per-column read loop the POCO reader will emit can *inline* the conversion; a delegate would cost an indirect call per row. Scale and timezone are embedded as constants, so the result closes over nothing.

**`ReadableElementTypes` stays, demoted to diagnostics.** It is what tells a caller what a column *can* be read as once nothing matched (`Array(DateTime)` reads as `uint[]`, so a `DateTime[]` member is told what does work). It is documented as neither authoritative nor exhaustive, and it is now built per call instead of cached, because it is only ever read on a failure path — which deleted a lazily-built cache, two fields and a race-tolerance comment from each wrapper. Both wrappers now hold only `readonly` state.

The conversions move into a new `ColumnValueProjections` that `DateTimeColumn`, `DateTime64Column`, `TimeColumn` and `Time64Column` now share instead of each keeping a private copy, so a raw count has one calendar reading whichever surface asks for it.

### The latent bug this removes

Both wrappers used to build a lifted surface→inner type pairing, search it, and then decide whether to lift. They now **unwrap the target** instead. The wrap is invertible — a value type becomes `Nullable<T>`, a reference type stays itself, and `Nullable<Nullable<T>>` does not exist — so the target alone decides both the inner spelling and whether a lift is needed, and the source shape is read from the source's own type. Nothing is inferred from the inner codec's canonical type.

That matters because the old discriminator was `innerTarget.IsValueType` against a source typed as the *canonical* surface. The moment a reference-typed inner offered a value-typed reading — `FixedString(16)` as a `Guid` being the plausible one — `ProjectNullable` would splice `Expression.Property(source, "HasValue")` onto a `byte[]`-typed source and **throw at expression-build time**. Unreachable today, and the previous revision of this PR shipped a guard test that could not fail.

It can now. Two stand-in codecs in the tests supply the shapes the registry cannot produce — a reference-typed element with a value-typed reading, and one with a second reference-typed reading — reached through a new `internal Over(inner)` factory on each wrapper. Deciding the lift from the inner codec's canonical type fails 2 of them; hardcoding the source unwrap fails 3.

### Deliberately excluded

**Enum.** `EnumColumnCodec<T>` does not override `WritableElementTypes` either — write takes only the raw ordinal — so offering a `string` label on read would be a read-only asymmetry rather than a mirror. Pinned by a test so adding it later is a visible choice.

**Composites.** `Array`/`Map`/`Tuple`/`Nested` do not lift their children, so `Array(DateTime)` reads only as `uint[]`. This is faithful: their **write** contracts do not lift either (`ArrayColumnCodec.CanWrite` is `column is IColumn<TElement[]>` over the child's canonical `ElementType`), so the gap is symmetric today. Lifting read alone would give "I can read `DateTime[]` out but cannot insert it back", so it waits for a write-side projection to match. The interrogative contract is what makes it possible; it is not attempted here. (Note: this gap is closed in a later PR).

## `DateTime` Kind semantics

`PresentAsDateTime` follows the HTTP driver's `AbstractDateTimeType.ToDateTime`: a zero offset yields `Kind=Utc`, any other offset the wall clock in the column's zone as `Kind=Unspecified`.

For a **bare `DateTime`/`DateTime64`** the two clients deliberately differ: HTTP presents it in UTC because its type object carries no zone, whereas this client resolves `session_timezone` and so agrees with what the server itself would display. That was weighed and chosen — keeping the whole TCP read path honoring `session_timezone` beat cross-client parity, at the cost of a POCO moved from the HTTP client shifting by the session offset on bare columns. Columns whose type names a timezone match HTTP exactly. Recorded in the `PresentAsDateTime` doc comment so it is not later "fixed" toward HTTP.

Adjacent and pre-existing: reads use the session timezone while writes use `ResolveContext.ForWrite`, which carries none, so `ToUtc` reads an `Unspecified` `DateTime` as a UTC wall clock. A round trip through a bare column on a non-UTC session is therefore not the identity.

## Tests

Nothing consumes this yet, so the tests carry the PR.

- **Values derived independently**, not from the implementation: `1700000000` = `2023-11-14T22:13:20Z`, Berlin `+01:00` in November and `+02:00` for a July instant (a fixed-base-offset implementation passes the first and fails the second), scale-9 `…123456789` truncating to `.1234567`, `Time64(9)` `-1000000001` → `-00:00:01` showing truncation toward zero.
- **Invariant sweep** over 36 registered types: every codec leads its readable list with `ElementType`, lists no duplicate, and can project each type it advertises. Deliberately one-directional — the converse stops being assertable once a composite answers for shapes it does not enumerate.
- **Refusals**, which only a predicate can express: a nullable surface asked for a bare value type must decline rather than drop the nulls.
- **Single evaluation** — the lift splices its source twice, so it binds a local first. Verified by mutation.
- **Integration** — projections checked against a real server's own timezone and scale handling, including a DST instant and `LowCardinality(Nullable(DateTime))`.

Coverage: every line added is covered. `IColumnCodec` and `DateTime64ColumnCodec` at 100%, `DateTimeColumnCodec` 99.0%, `LowCardinalityColumnCodec` 96.2%, `ColumnValueProjections` 95.3%, `NullableColumnCodec` 93.3%; the remaining uncovered lines in those files are all pre-existing. Full TCP suite green against a real server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
