### PR TITLE
TCP N5a: Add the per-type half of the POCO mapping (attributes, descriptor, registry)

### DIFF
--- a/ClickHouse.Driver.Tcp.Tests/Poco/PocoTypeDescriptorTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Poco/PocoTypeDescriptorTests.cs
@@ -72,12 +72,11 @@ public class PocoTypeDescriptorTests
     }
 
     [Test]
-    public void Build_StaticProperty_IsNotMapped()
+    public void Build_StaticProperty_IsNotMappedWhileTheInstanceOneIs()
     {
-        InvalidOperationException error = Assert.Throws<InvalidOperationException>(
-            () => PocoTypeDescriptor<StaticOnlyPoco>.Build());
+        PocoTypeDescriptor<StaticAndInstancePoco> descriptor = PocoTypeDescriptor<StaticAndInstancePoco>.Build();
 
-        Assert.That(error.Message, Does.Contain("no public instance properties"));
+        Assert.That(ColumnNames(descriptor), Is.EquivalentTo(new[] { "Instance" }));
     }
 
     [Test]
@@ -97,6 +96,55 @@ public class PocoTypeDescriptorTests
 
         Assert.That(descriptor.Members.Count, Is.EqualTo(1));
         Assert.That(descriptor.Members[0].MemberType, Is.EqualTo(typeof(long)), "the derived declaration should win");
+    }
+
+    [Test]
+    public void Build_Interface_MapsThePropertiesItInheritsFromItsBaseInterfaces()
+    {
+        // GetProperties walks a class's base types but stops dead on an interface, which has no base type. Missing
+        // this would silently drop BaseValue and insert a server default into its column.
+        PocoTypeDescriptor<IDerivedShape> descriptor = PocoTypeDescriptor<IDerivedShape>.Build();
+
+        Assert.That(ColumnNames(descriptor), Is.EquivalentTo(new[] { "BaseValue", "DerivedValue" }));
+    }
+
+    [Test]
+    public void Build_InterfaceRedeclaringAnInheritedProperty_KeepsTheDerivedDeclaration()
+    {
+        PocoTypeDescriptor<IShadowingShape> descriptor = PocoTypeDescriptor<IShadowingShape>.Build();
+
+        Assert.That(descriptor.Members.Count, Is.EqualTo(1));
+        Assert.That(descriptor.Members[0].MemberType, Is.EqualTo(typeof(long)));
+    }
+
+    [Test]
+    public void Build_InterfaceInheritingOneNameFromTwoUnrelatedInterfaces_ThrowsRatherThanPickingOne()
+    {
+        // C# needs a cast to read such a property, so there is no declaration to prefer. Only interfaces can get
+        // here — a class hierarchy is one chain.
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(
+            () => PocoTypeDescriptor<IAmbiguousShape>.Build());
+
+        Assert.That(error.Message, Does.Contain("ILeftShape"));
+        Assert.That(error.Message, Does.Contain("IRightShape"));
+        Assert.That(error.Message, Does.Contain("neither inherits the other"));
+    }
+
+    [Test]
+    public void Build_NotMappedOnAVirtualBaseProperty_ExcludesTheOverride()
+    {
+        // GetCustomAttribute<T> walks base property definitions, so the attribute carries to the override. Pinned
+        // because PropertyInfo.GetCustomAttributes(type, inherit: true) does not do the same, and swapping the two
+        // APIs would silently change this.
+        PocoTypeDescriptor<OverridingPoco> descriptor = PocoTypeDescriptor<OverridingPoco>.Build();
+
+        Assert.That(ColumnNames(descriptor), Does.Not.Contain("Excluded"));
+    }
+
+    [Test]
+    public void Build_ColumnAttributeOnAVirtualBaseProperty_RenamesTheOverride()
+    {
+        Assert.That(Member<OverridingPoco>("renamed_column").MemberName, Is.EqualTo("Renamed"));
     }
 
     [Test]
@@ -122,8 +170,9 @@ public class PocoTypeDescriptorTests
         InvalidOperationException error = Assert.Throws<InvalidOperationException>(
             () => PocoTypeDescriptor<DuplicateColumnPoco>.Build());
 
-        Assert.That(error.Message, Does.Contain("Value"));
-        Assert.That(error.Message, Does.Contain("Other"));
+        // Asserted as the whole phrase: 'Value' is also the column name, so a bare substring check would pass
+        // without the first property ever being named.
+        Assert.That(error.Message, Does.Contain("both 'Value' and 'Other'"));
     }
 
     [Test]
@@ -150,8 +199,18 @@ public class PocoTypeDescriptorTests
         InvalidOperationException error = Assert.Throws<InvalidOperationException>(
             () => PocoTypeDescriptor<AllNotMappedPoco>.Build());
 
-        Assert.That(error.Message, Does.Contain("all 2"));
+        Assert.That(error.Message, Does.Contain("every mappable property (2)"));
         Assert.That(error.Message, Does.Contain("[ClickHouseTcpNotMapped]"));
+    }
+
+    [Test]
+    public void Build_EveryPropertyNotMappedAlongsideAnIndexer_CountsOnlyTheMappableOnes()
+    {
+        // The count is over what could have been mapped, so the indexer must not inflate it.
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(
+            () => PocoTypeDescriptor<NotMappedWithIndexerPoco>.Build());
+
+        Assert.That(error.Message, Does.Contain("every mappable property (1)"));
     }
 
     [Test]
@@ -197,6 +256,16 @@ public class PocoTypeDescriptorTests
     public void Build_SetterOnlyProperty_IsSettableButNotGettable()
     {
         PocoMember member = Member<AccessorsPoco>("SetterOnly");
+
+        Assert.That(member.CanGet, Is.False);
+        Assert.That(member.CanSet, Is.True);
+    }
+
+    [Test]
+    public void Build_PrivateGetter_IsNotGettableSoItCannotBeAnInsertSource()
+    {
+        // The insert-side mirror of the private-setter case: reflection reports a getter, but not a public one.
+        PocoMember member = Member<AccessorsPoco>("PrivateGetter");
 
         Assert.That(member.CanGet, Is.False);
         Assert.That(member.CanSet, Is.True);
@@ -304,6 +373,14 @@ public class PocoTypeDescriptorTests
     {
         Assert.That(Match<CaseCollidingPoco>("Value").MemberName, Is.EqualTo("Value"));
         Assert.That(Match<CaseCollidingPoco>("value").MemberName, Is.EqualTo("Lowercase"));
+    }
+
+    [Test]
+    public void TryMatchColumn_ColumnMatchingOneMemberExactlyWhileTheUnderscoreTierIsAmbiguous_PrefersTheExactMatch()
+    {
+        // The tightest tier holds every member, so an exact name wins even when the loosest tier would collide
+        // three ways.
+        Assert.That(Match<ExactBeatsUnderscorePoco>("userid").MemberName, Is.EqualTo("Compact"));
     }
 
     [Test]
@@ -417,9 +494,11 @@ public class PocoTypeDescriptorTests
         public int this[int index] => index;
     }
 
-    private class StaticOnlyPoco
+    private class StaticAndInstancePoco
     {
-        public static int Value { get; set; }
+        public static int Static { get; set; }
+
+        public int Instance { get; set; }
     }
 
     private class EmptyPoco
@@ -433,6 +512,14 @@ public class PocoTypeDescriptorTests
 
         [ClickHouseTcpNotMapped]
         public int Second { get; set; }
+    }
+
+    private class NotMappedWithIndexerPoco
+    {
+        [ClickHouseTcpNotMapped]
+        public int Dropped { get; set; }
+
+        public int this[int index] => index;
     }
 
     private class InheritedBase
@@ -470,6 +557,8 @@ public class PocoTypeDescriptorTests
         public int InitOnly { get; init; }
 
         public int PrivateSetter { get; private set; }
+
+        public int PrivateGetter { private get; set; }
 
         public int SetterOnly
         {
@@ -510,6 +599,60 @@ public class PocoTypeDescriptorTests
         int Value { get; set; }
     }
 
+    private interface IBaseShape
+    {
+        int BaseValue { get; set; }
+    }
+
+    private interface IDerivedShape : IBaseShape
+    {
+        int DerivedValue { get; set; }
+    }
+
+    private interface IShadowedShape
+    {
+        int Value { get; set; }
+    }
+
+    private interface IShadowingShape : IShadowedShape
+    {
+        new long Value { get; set; }
+    }
+
+    private interface ILeftShape
+    {
+        int Value { get; set; }
+    }
+
+    private interface IRightShape
+    {
+        int Value { get; set; }
+    }
+
+    private interface IAmbiguousShape : ILeftShape, IRightShape
+    {
+    }
+
+    private abstract class OverriddenBase
+    {
+        [ClickHouseTcpNotMapped]
+        public virtual int Excluded { get; set; }
+
+        [ClickHouseTcpColumn(Name = "renamed_column")]
+        public virtual int Renamed { get; set; }
+
+        public virtual int Plain { get; set; }
+    }
+
+    private class OverridingPoco : OverriddenBase
+    {
+        public override int Excluded { get; set; }
+
+        public override int Renamed { get; set; }
+
+        public override int Plain { get; set; }
+    }
+
     private class SnakeCasePoco
     {
         public int UserId { get; set; }
@@ -521,6 +664,19 @@ public class PocoTypeDescriptorTests
 
         [ClickHouseTcpColumn(Name = "value")]
         public int Lowercase { get; set; }
+    }
+
+    // Three column names that all collapse to 'userid' once underscores go, one of which is that name exactly.
+    private class ExactBeatsUnderscorePoco
+    {
+        [ClickHouseTcpColumn(Name = "userid")]
+        public int Compact { get; set; }
+
+        [ClickHouseTcpColumn(Name = "user_id")]
+        public int Snake { get; set; }
+
+        [ClickHouseTcpColumn(Name = "us_erid")]
+        public int Odd { get; set; }
     }
 
     // Column names that differ only in where their underscores fall: distinct at the case tier, indistinguishable

--- a/ClickHouse.Driver.Tcp.Tests/Poco/PocoTypeDescriptorTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Poco/PocoTypeDescriptorTests.cs
@@ -1,0 +1,536 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using ClickHouse.Driver.Tcp.Poco;
+
+namespace ClickHouse.Driver.Tcp.Tests.Poco;
+
+/// <summary>
+/// The per-type half of the POCO mapping: which properties are discovered, what column name each matches on, how a
+/// column name finds its property through the matcher's tiers, and which failures are refused at build time.
+///
+/// <para>
+/// All of this is unreachable from a server round trip — it is decided before a single column type is known — so it
+/// belongs here rather than in the integration suite.
+/// </para>
+/// </summary>
+[TestFixture]
+public class PocoTypeDescriptorTests
+{
+    [Test]
+    public void Build_PublicInstanceProperties_MapsEachToItsOwnName()
+    {
+        PocoTypeDescriptor<SimplePoco> descriptor = PocoTypeDescriptor<SimplePoco>.Build();
+
+        Assert.That(ColumnNames(descriptor), Is.EquivalentTo(new[] { "Id", "Name" }));
+        Assert.That(descriptor.PocoType, Is.EqualTo(typeof(SimplePoco)));
+    }
+
+    [Test]
+    public void Build_NotMappedProperty_LeavesItOutOfTheMemberSet()
+    {
+        PocoTypeDescriptor<PartlyMappedPoco> descriptor = PocoTypeDescriptor<PartlyMappedPoco>.Build();
+
+        Assert.That(ColumnNames(descriptor), Is.EquivalentTo(new[] { "Kept" }));
+    }
+
+    [Test]
+    public void Build_ColumnAttributeWithAName_MatchesOnThatNameInsteadOfThePropertyName()
+    {
+        PocoTypeDescriptor<RenamedPoco> descriptor = PocoTypeDescriptor<RenamedPoco>.Build();
+
+        Assert.That(ColumnNames(descriptor), Is.EquivalentTo(new[] { "event_time" }));
+        Assert.That(descriptor.Members[0].MemberName, Is.EqualTo("Timestamp"));
+    }
+
+    [Test]
+    public void Build_ColumnAttributeWithoutAName_FallsBackToThePropertyName()
+    {
+        // The attribute may be present for a future property, so a null Name is not an error.
+        PocoTypeDescriptor<AttributeWithoutNamePoco> descriptor = PocoTypeDescriptor<AttributeWithoutNamePoco>.Build();
+
+        Assert.That(ColumnNames(descriptor), Is.EquivalentTo(new[] { "Value" }));
+    }
+
+    [Test]
+    public void Build_BlankColumnAttributeName_ThrowsNamingTheProperty()
+    {
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(
+            () => PocoTypeDescriptor<BlankColumnNamePoco>.Build());
+
+        Assert.That(error.Message, Does.Contain("BlankColumnNamePoco.Value"));
+        Assert.That(error.Message, Does.Contain("empty or whitespace"));
+    }
+
+    [Test]
+    public void Build_Indexer_IsNotMapped()
+    {
+        PocoTypeDescriptor<IndexerPoco> descriptor = PocoTypeDescriptor<IndexerPoco>.Build();
+
+        Assert.That(ColumnNames(descriptor), Is.EquivalentTo(new[] { "Value" }));
+    }
+
+    [Test]
+    public void Build_StaticProperty_IsNotMapped()
+    {
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(
+            () => PocoTypeDescriptor<StaticOnlyPoco>.Build());
+
+        Assert.That(error.Message, Does.Contain("no public instance properties"));
+    }
+
+    [Test]
+    public void Build_InheritedProperty_IsMappedAlongsideTheDeclaredOne()
+    {
+        PocoTypeDescriptor<InheritedPoco> descriptor = PocoTypeDescriptor<InheritedPoco>.Build();
+
+        Assert.That(ColumnNames(descriptor), Is.EquivalentTo(new[] { "BaseValue", "DerivedValue" }));
+    }
+
+    [Test]
+    public void Build_ShadowedProperty_KeepsOnlyTheMostDerivedDeclaration()
+    {
+        // Reflection reports a `new` property once per declaring type. Left alone, the two would look like two
+        // properties competing for one column and fail the exact-duplicate check.
+        PocoTypeDescriptor<ShadowingPoco> descriptor = PocoTypeDescriptor<ShadowingPoco>.Build();
+
+        Assert.That(descriptor.Members.Count, Is.EqualTo(1));
+        Assert.That(descriptor.Members[0].MemberType, Is.EqualTo(typeof(long)), "the derived declaration should win");
+    }
+
+    [Test]
+    public void KeepMostDerived_BaseDeclarationComingFirst_StillKeepsTheDerivedOne()
+    {
+        // Reflection does not contract the order it reports a `new`-shadowed property in, so the pass must not
+        // depend on the derived declaration arriving first — which is the only order Build can observe here.
+        var baseFirst = new List<PropertyInfo>
+        {
+            DeclaredProperty(typeof(ShadowedBase), "Value"),
+            DeclaredProperty(typeof(ShadowingPoco), "Value"),
+        };
+
+        List<PropertyInfo> kept = PocoTypeDescriptor.KeepMostDerived(baseFirst);
+
+        Assert.That(kept.Count, Is.EqualTo(1));
+        Assert.That(kept[0].DeclaringType, Is.EqualTo(typeof(ShadowingPoco)));
+    }
+
+    [Test]
+    public void Build_TwoPropertiesMappedToOneColumn_ThrowsNamingBoth()
+    {
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(
+            () => PocoTypeDescriptor<DuplicateColumnPoco>.Build());
+
+        Assert.That(error.Message, Does.Contain("Value"));
+        Assert.That(error.Message, Does.Contain("Other"));
+    }
+
+    [Test]
+    public void Build_TypeWithNoProperties_ThrowsSayingThereAreNone()
+    {
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(
+            () => PocoTypeDescriptor<EmptyPoco>.Build());
+
+        Assert.That(error.Message, Does.Contain("no public instance properties"));
+    }
+
+    [Test]
+    public void Build_TypeWhoseOnlyPropertyIsAnIndexer_ThrowsSayingIndexersAreNeverMapped()
+    {
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(
+            () => PocoTypeDescriptor<IndexerOnlyPoco>.Build());
+
+        Assert.That(error.Message, Does.Contain("indexers"));
+    }
+
+    [Test]
+    public void Build_EveryPropertyNotMapped_ThrowsSayingTheyAreAllExcluded()
+    {
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(
+            () => PocoTypeDescriptor<AllNotMappedPoco>.Build());
+
+        Assert.That(error.Message, Does.Contain("all 2"));
+        Assert.That(error.Message, Does.Contain("[ClickHouseTcpNotMapped]"));
+    }
+
+    [Test]
+    public void Build_ReadWriteProperty_IsUsableInBothDirections()
+    {
+        PocoMember member = Member<SimplePoco>("Id");
+
+        Assert.That(member.CanGet, Is.True);
+        Assert.That(member.CanSet, Is.True);
+    }
+
+    [Test]
+    public void Build_GetterOnlyProperty_IsGettableButNotSettable()
+    {
+        PocoMember member = Member<AccessorsPoco>("GetterOnly");
+
+        Assert.That(member.CanGet, Is.True);
+        Assert.That(member.CanSet, Is.False);
+        Assert.That(member.DescribeWhyNotSettable(), Is.EqualTo("it has no setter"));
+    }
+
+    [Test]
+    public void Build_InitOnlyProperty_IsNotSettableBecauseAssigningItWouldDefeatTheImmutability()
+    {
+        PocoMember member = Member<AccessorsPoco>("InitOnly");
+
+        Assert.That(member.CanGet, Is.True);
+        Assert.That(member.CanSet, Is.False);
+        Assert.That(member.DescribeWhyNotSettable(), Is.EqualTo("its setter is init-only"));
+    }
+
+    [Test]
+    public void Build_PrivateSetter_IsNotSettable()
+    {
+        PocoMember member = Member<AccessorsPoco>("PrivateSetter");
+
+        Assert.That(member.CanGet, Is.True);
+        Assert.That(member.CanSet, Is.False);
+        Assert.That(member.DescribeWhyNotSettable(), Is.EqualTo("its setter is not public"));
+    }
+
+    [Test]
+    public void Build_SetterOnlyProperty_IsSettableButNotGettable()
+    {
+        PocoMember member = Member<AccessorsPoco>("SetterOnly");
+
+        Assert.That(member.CanGet, Is.False);
+        Assert.That(member.CanSet, Is.True);
+    }
+
+    [TestCase("Required", false, null)]
+    [TestCase("Optional", true, typeof(int))]
+    [TestCase("Text", true, null)]
+    public void Build_MemberType_RecordsWhetherNullFitsAndWhatTheNullableUnderlyingTypeIs(
+        string columnName, bool canAssignNull, Type nullableUnderlying)
+    {
+        PocoMember member = Member<NullabilityPoco>(columnName);
+
+        Assert.That(member.CanAssignNull, Is.EqualTo(canAssignNull));
+        Assert.That(member.NullableUnderlyingType, Is.EqualTo(nullableUnderlying));
+    }
+
+    [Test]
+    public void Activator_ClassWithAParameterlessConstructor_CreatesDistinctInstances()
+    {
+        PocoTypeDescriptor<SimplePoco> descriptor = PocoTypeDescriptor<SimplePoco>.Build();
+
+        Assert.That(descriptor.CanActivate, Is.True);
+        SimplePoco first = descriptor.Activator();
+        SimplePoco second = descriptor.Activator();
+        Assert.That(first, Is.Not.Null);
+        Assert.That(second, Is.Not.SameAs(first));
+    }
+
+    [Test]
+    public void Build_ImmutableTypeWithNoParameterlessConstructor_StillBuildsSoItCanBeInserted()
+    {
+        // The descriptor is shared with the insert path, which never constructs a T. Refusing the type here would
+        // make an immutable POCO uninsertable for a constructor only the query path needs.
+        PocoTypeDescriptor<ImmutablePoco> descriptor = PocoTypeDescriptor<ImmutablePoco>.Build();
+
+        Assert.That(ColumnNames(descriptor), Is.EquivalentTo(new[] { "Id" }));
+        Assert.That(descriptor.CanActivate, Is.False);
+
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => _ = descriptor.Activator);
+        Assert.That(error.Message, Does.Contain("no public parameterless constructor"));
+    }
+
+    [Test]
+    public void Activator_AbstractClass_IsBlockedForBeingAbstractRatherThanForLackingAConstructor()
+    {
+        // The declared public constructor makes GetConstructor succeed, so only the IsAbstract check catches this;
+        // otherwise it would compile and fail when the delegate first ran.
+        PocoTypeDescriptor<AbstractPocoWithConstructor> descriptor = PocoTypeDescriptor<AbstractPocoWithConstructor>.Build();
+
+        Assert.That(descriptor.CanActivate, Is.False);
+        Assert.That(
+            Assert.Throws<InvalidOperationException>(() => _ = descriptor.Activator).Message,
+            Does.Contain("it is abstract"));
+    }
+
+    [Test]
+    public void Activator_Interface_IsBlockedAndSaysSo()
+    {
+        PocoTypeDescriptor<IPocoShape> descriptor = PocoTypeDescriptor<IPocoShape>.Build();
+
+        Assert.That(descriptor.CanActivate, Is.False);
+        Assert.That(
+            Assert.Throws<InvalidOperationException>(() => _ = descriptor.Activator).Message,
+            Does.Contain("it is an interface"));
+    }
+
+    [Test]
+    public void TryMatchColumn_ExactName_MatchesThatMember()
+    {
+        Assert.That(Match<SimplePoco>("Name").MemberName, Is.EqualTo("Name"));
+    }
+
+    [Test]
+    public void TryMatchColumn_NameDifferingOnlyInCase_MatchesThatMember()
+    {
+        Assert.That(Match<SimplePoco>("name").MemberName, Is.EqualTo("Name"));
+    }
+
+    [Test]
+    public void TryMatchColumn_SnakeCaseColumn_MatchesThePascalCaseProperty()
+    {
+        // The reason most POCOs need no attribute at all.
+        Assert.That(Match<SnakeCasePoco>("user_id").MemberName, Is.EqualTo("UserId"));
+    }
+
+    [Test]
+    public void TryMatchColumn_SnakeCaseColumnInAnotherCase_StillMatchesThePascalCaseProperty()
+    {
+        // Both looser tiers at once: the underscores go, and what is left is compared case-insensitively.
+        Assert.That(Match<SnakeCasePoco>("USER_ID").MemberName, Is.EqualTo("UserId"));
+    }
+
+    [Test]
+    public void TryMatchColumn_UnknownColumn_ReturnsFalseSoTheColumnCanBeSkipped()
+    {
+        PocoTypeDescriptor<SimplePoco> descriptor = PocoTypeDescriptor<SimplePoco>.Build();
+
+        Assert.That(descriptor.TryMatchColumn("absent", out PocoMember member), Is.False);
+        Assert.That(member, Is.Null);
+    }
+
+    [Test]
+    public void TryMatchColumn_ColumnMatchingOneMemberExactlyAndAnotherByCase_PrefersTheExactMatch()
+    {
+        Assert.That(Match<CaseCollidingPoco>("Value").MemberName, Is.EqualTo("Value"));
+        Assert.That(Match<CaseCollidingPoco>("value").MemberName, Is.EqualTo("Lowercase"));
+    }
+
+    [Test]
+    public void TryMatchColumn_ColumnMatchingSeveralMembersOnlyByCase_ThrowsNamingThem()
+    {
+        PocoTypeDescriptor<CaseCollidingPoco> descriptor = PocoTypeDescriptor<CaseCollidingPoco>.Build();
+
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(
+            () => descriptor.TryMatchColumn("VALUE", out _));
+
+        Assert.That(error.Message, Does.Contain("VALUE"));
+        Assert.That(error.Message, Does.Contain("Value"));
+        Assert.That(error.Message, Does.Contain("Lowercase"));
+        Assert.That(error.Message, Does.Contain("[ClickHouseTcpColumn(Name = \"VALUE\")]"));
+    }
+
+    [Test]
+    public void TryMatchColumn_ColumnMatchingSeveralMembersOnlyOnceUnderscoresAreIgnored_Throws()
+    {
+        PocoTypeDescriptor<UnderscoreCollidingPoco> descriptor = PocoTypeDescriptor<UnderscoreCollidingPoco>.Build();
+
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(
+            () => descriptor.TryMatchColumn("userid", out _));
+
+        Assert.That(error.Message, Does.Contain("UserId"));
+        Assert.That(error.Message, Does.Contain("Alternate"));
+    }
+
+    [Test]
+    public void TryMatchColumn_ColumnResolvableByCaseWhileTheUnderscoreTierIsAmbiguous_NeverReachesTheAmbiguity()
+    {
+        // What earns the case tier its place: 'USER_ID' resolves there, even though ignoring underscores as well
+        // would have made it ambiguous.
+        Assert.That(Match<UnderscoreCollidingPoco>("USER_ID").MemberName, Is.EqualTo("UserId"));
+    }
+
+    [Test]
+    public void TryMatchColumn_ExplicitColumnName_StillMatchesThroughTheLooserTiers()
+    {
+        // One rule for every column name, whether it came from the attribute or the property.
+        Assert.That(Match<RenamedPoco>("EVENT_TIME").MemberName, Is.EqualTo("Timestamp"));
+    }
+
+    [Test]
+    public void TryMatchColumn_UnsettableMember_StillMatchesBecauseMatchingIsDirectionAgnostic()
+    {
+        // Whether the member can be written is the query plan's business; the descriptor serves both directions.
+        Assert.That(Match<ImmutablePoco>("id").MemberName, Is.EqualTo("Id"));
+    }
+
+    private static PropertyInfo DeclaredProperty(Type declaringType, string name)
+        => declaringType.GetProperty(name, BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+
+    private static PocoMember Match<T>(string columnName)
+        where T : class
+    {
+        Assert.That(PocoTypeDescriptor<T>.Build().TryMatchColumn(columnName, out PocoMember member), Is.True);
+        return member;
+    }
+
+    private static PocoMember Member<T>(string columnName)
+        where T : class
+        => PocoTypeDescriptor<T>.Build().Members.Single(member => member.ColumnName == columnName);
+
+    private static IEnumerable<string> ColumnNames<T>(PocoTypeDescriptor<T> descriptor)
+        where T : class
+        => descriptor.Members.Select(member => member.ColumnName);
+
+    private class SimplePoco
+    {
+        public long Id { get; set; }
+
+        public string Name { get; set; }
+    }
+
+    private class PartlyMappedPoco
+    {
+        public int Kept { get; set; }
+
+        [ClickHouseTcpNotMapped]
+        public int Dropped { get; set; }
+    }
+
+    private class RenamedPoco
+    {
+        [ClickHouseTcpColumn(Name = "event_time")]
+        public DateTime Timestamp { get; set; }
+    }
+
+    private class AttributeWithoutNamePoco
+    {
+        [ClickHouseTcpColumn]
+        public int Value { get; set; }
+    }
+
+    private class BlankColumnNamePoco
+    {
+        [ClickHouseTcpColumn(Name = "  ")]
+        public int Value { get; set; }
+    }
+
+    private class IndexerPoco
+    {
+        public int Value { get; set; }
+
+        public int this[int index] => index;
+    }
+
+    private class IndexerOnlyPoco
+    {
+        public int this[int index] => index;
+    }
+
+    private class StaticOnlyPoco
+    {
+        public static int Value { get; set; }
+    }
+
+    private class EmptyPoco
+    {
+    }
+
+    private class AllNotMappedPoco
+    {
+        [ClickHouseTcpNotMapped]
+        public int First { get; set; }
+
+        [ClickHouseTcpNotMapped]
+        public int Second { get; set; }
+    }
+
+    private class InheritedBase
+    {
+        public int BaseValue { get; set; }
+    }
+
+    private class InheritedPoco : InheritedBase
+    {
+        public int DerivedValue { get; set; }
+    }
+
+    private class ShadowedBase
+    {
+        public int Value { get; set; }
+    }
+
+    private class ShadowingPoco : ShadowedBase
+    {
+        public new long Value { get; set; }
+    }
+
+    private class DuplicateColumnPoco
+    {
+        public int Value { get; set; }
+
+        [ClickHouseTcpColumn(Name = "Value")]
+        public int Other { get; set; }
+    }
+
+    private class AccessorsPoco
+    {
+        public int GetterOnly => 1;
+
+        public int InitOnly { get; init; }
+
+        public int PrivateSetter { get; private set; }
+
+        public int SetterOnly
+        {
+            set => _ = value;
+        }
+    }
+
+    private class NullabilityPoco
+    {
+        public int Required { get; set; }
+
+        public int? Optional { get; set; }
+
+        public string Text { get; set; }
+    }
+
+    private class ImmutablePoco
+    {
+        public ImmutablePoco(long id) => Id = id;
+
+        public long Id { get; }
+    }
+
+    // The public parameterless constructor is the point: reflection finds it, so only the IsAbstract check stops
+    // the activator from compiling and then failing on first use.
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1012:Abstract types should not have public constructors", Justification = "The public constructor is what the test exercises.")]
+    private abstract class AbstractPocoWithConstructor
+    {
+        public AbstractPocoWithConstructor()
+        {
+        }
+
+        public int Value { get; set; }
+    }
+
+    private interface IPocoShape
+    {
+        int Value { get; set; }
+    }
+
+    private class SnakeCasePoco
+    {
+        public int UserId { get; set; }
+    }
+
+    private class CaseCollidingPoco
+    {
+        public int Value { get; set; }
+
+        [ClickHouseTcpColumn(Name = "value")]
+        public int Lowercase { get; set; }
+    }
+
+    // Column names that differ only in where their underscores fall: distinct at the case tier, indistinguishable
+    // once underscores are ignored.
+    private class UnderscoreCollidingPoco
+    {
+        [ClickHouseTcpColumn(Name = "user_id")]
+        public int UserId { get; set; }
+
+        [ClickHouseTcpColumn(Name = "us_erid")]
+        public int Alternate { get; set; }
+    }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Poco/PocoTypeRegistryTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Poco/PocoTypeRegistryTests.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Poco;
+
+namespace ClickHouse.Driver.Tcp.Tests.Poco;
+
+/// <summary>
+/// The caching contract around <see cref="PocoTypeDescriptor{T}"/>: one descriptor per type, keyed by the type
+/// itself, and a type that cannot be mapped reported to every caller rather than only the first.
+/// </summary>
+[TestFixture]
+public class PocoTypeRegistryTests
+{
+    [Test]
+    public void DescriptorFor_SameTypeTwice_ReturnsTheCachedDescriptor()
+    {
+        var registry = new PocoTypeRegistry();
+
+        Assert.That(registry.DescriptorFor<SimplePoco>(), Is.SameAs(registry.DescriptorFor<SimplePoco>()));
+    }
+
+    [Test]
+    public void DescriptorFor_DifferentTypes_ReturnsADescriptorPerType()
+    {
+        var registry = new PocoTypeRegistry();
+
+        PocoTypeDescriptor<SimplePoco> first = registry.DescriptorFor<SimplePoco>();
+        PocoTypeDescriptor<OtherPoco> second = registry.DescriptorFor<OtherPoco>();
+
+        Assert.That(first.PocoType, Is.EqualTo(typeof(SimplePoco)));
+        Assert.That(second.PocoType, Is.EqualTo(typeof(OtherPoco)));
+    }
+
+    [Test]
+    public void DescriptorFor_SeparateRegistries_DoNotShareDescriptors()
+    {
+        // Per-client caching: one client's compiles must not be reachable from another, so a caller can drop a
+        // client and, with it, everything it pinned.
+        Assert.That(new PocoTypeRegistry().DescriptorFor<SimplePoco>(), Is.Not.SameAs(new PocoTypeRegistry().DescriptorFor<SimplePoco>()));
+    }
+
+    [Test]
+    public void DescriptorFor_UnmappableType_ThrowsOnEveryCallRatherThanCachingTheFailure()
+    {
+        var registry = new PocoTypeRegistry();
+
+        Assert.Throws<InvalidOperationException>(() => registry.DescriptorFor<EmptyPoco>());
+        Assert.Throws<InvalidOperationException>(() => registry.DescriptorFor<EmptyPoco>());
+    }
+
+    [Test]
+    public async Task DescriptorFor_ConcurrentCallers_AllSeeOneDescriptor()
+    {
+        var registry = new PocoTypeRegistry();
+        var results = new PocoTypeDescriptor<SimplePoco>[16];
+
+        var racers = new Task[results.Length];
+        for (int i = 0; i < racers.Length; i++)
+        {
+            int slot = i;
+            racers[i] = Task.Run(() => results[slot] = registry.DescriptorFor<SimplePoco>());
+        }
+
+        await Task.WhenAll(racers).ConfigureAwait(false);
+
+        // A race may build twice, but only one build can win the dictionary, so every caller must be handed that
+        // one — otherwise two callers could hold descriptors whose compiled plans cache separately.
+        Assert.That(results, Is.All.SameAs(results[0]));
+    }
+
+    private class SimplePoco
+    {
+        public long Id { get; set; }
+    }
+
+    private class OtherPoco
+    {
+        public string Name { get; set; }
+    }
+
+    private class EmptyPoco
+    {
+    }
+}

--- a/ClickHouse.Driver.Tcp/Poco/ClickHouseTcpColumnAttribute.cs
+++ b/ClickHouse.Driver.Tcp/Poco/ClickHouseTcpColumnAttribute.cs
@@ -10,13 +10,6 @@ namespace ClickHouse.Driver.Tcp;
 /// then ignoring underscores — so <c>UserId</c> already finds a <c>user_id</c> column. Use the attribute only when
 /// the names differ by more than that.
 /// </para>
-///
-/// <para>
-/// This is deliberately not <c>ClickHouse.Driver.ClickHouseColumnAttribute</c>: the two clients are separate
-/// assemblies, and the native-TCP client cannot see the other one's types. The HTTP attribute also carries an
-/// explicit ClickHouse <c>Type</c>, which exists only to skip that client's schema-probe query; the native protocol
-/// sends the target types with the insert itself, so there is nothing here for such a property to do.
-/// </para>
 /// </summary>
 [AttributeUsage(AttributeTargets.Property)]
 public sealed class ClickHouseTcpColumnAttribute : Attribute

--- a/ClickHouse.Driver.Tcp/Poco/ClickHouseTcpColumnAttribute.cs
+++ b/ClickHouse.Driver.Tcp/Poco/ClickHouseTcpColumnAttribute.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace ClickHouse.Driver.Tcp;
+
+/// <summary>
+/// Maps a property to a differently-named ClickHouse column on the native-TCP client's POCO paths.
+///
+/// <para>
+/// Without this attribute a property is matched against the column of the same name, then case-insensitively,
+/// then ignoring underscores — so <c>UserId</c> already finds a <c>user_id</c> column. Use the attribute only when
+/// the names differ by more than that.
+/// </para>
+///
+/// <para>
+/// This is deliberately not <c>ClickHouse.Driver.ClickHouseColumnAttribute</c>: the two clients are separate
+/// assemblies, and the native-TCP client cannot see the other one's types. The HTTP attribute also carries an
+/// explicit ClickHouse <c>Type</c>, which exists only to skip that client's schema-probe query; the native protocol
+/// sends the target types with the insert itself, so there is nothing here for such a property to do.
+/// </para>
+/// </summary>
+[AttributeUsage(AttributeTargets.Property)]
+public sealed class ClickHouseTcpColumnAttribute : Attribute
+{
+    /// <summary>
+    /// The ClickHouse column name this property maps to. Leave unset to match on the property name.
+    /// </summary>
+    public string Name { get; set; }
+}

--- a/ClickHouse.Driver.Tcp/Poco/ClickHouseTcpNotMappedAttribute.cs
+++ b/ClickHouse.Driver.Tcp/Poco/ClickHouseTcpNotMappedAttribute.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace ClickHouse.Driver.Tcp;
+
+/// <summary>
+/// Excludes a property from the native-TCP client's POCO paths, in both directions: no column is matched to it on
+/// a query, and it is never read as an insert source.
+///
+/// <para>
+/// This is deliberately not <c>ClickHouse.Driver.ClickHouseNotMappedAttribute</c> — see
+/// <see cref="ClickHouseTcpColumnAttribute"/> for why the two clients carry their own attributes.
+/// </para>
+/// </summary>
+[AttributeUsage(AttributeTargets.Property)]
+public sealed class ClickHouseTcpNotMappedAttribute : Attribute
+{
+}

--- a/ClickHouse.Driver.Tcp/Poco/ClickHouseTcpNotMappedAttribute.cs
+++ b/ClickHouse.Driver.Tcp/Poco/ClickHouseTcpNotMappedAttribute.cs
@@ -5,11 +5,6 @@ namespace ClickHouse.Driver.Tcp;
 /// <summary>
 /// Excludes a property from the native-TCP client's POCO paths, in both directions: no column is matched to it on
 /// a query, and it is never read as an insert source.
-///
-/// <para>
-/// This is deliberately not <c>ClickHouse.Driver.ClickHouseNotMappedAttribute</c> — see
-/// <see cref="ClickHouseTcpColumnAttribute"/> for why the two clients carry their own attributes.
-/// </para>
 /// </summary>
 [AttributeUsage(AttributeTargets.Property)]
 public sealed class ClickHouseTcpNotMappedAttribute : Attribute

--- a/ClickHouse.Driver.Tcp/Poco/PocoMember.cs
+++ b/ClickHouse.Driver.Tcp/Poco/PocoMember.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Reflection;
+
+namespace ClickHouse.Driver.Tcp.Poco;
+
+/// <summary>
+/// One mapped property of a POCO type, resolved once per type by <see cref="PocoTypeDescriptor"/>.
+///
+/// <para>
+/// A member is kept whichever direction it can serve, because the descriptor is shared by both: a query needs a
+/// settable property (<see cref="CanSet"/>), an insert needs a gettable one (<see cref="CanGet"/>), and a type may
+/// well support only one — an immutable POCO with getter-only properties inserts but cannot be materialized. Each
+/// plan filters on the flag it needs, so a type is never rejected for lacking the direction it is not being used
+/// in.
+/// </para>
+/// </summary>
+internal sealed class PocoMember
+{
+    /// <summary>Builds the member metadata for one property.</summary>
+    /// <param name="property">The property, already known to be mapped (public, instance, not an indexer).</param>
+    /// <param name="columnName">The column name to match on: the attribute's name, or the property's.</param>
+    public PocoMember(PropertyInfo property, string columnName)
+    {
+        Property = property;
+        ColumnName = columnName;
+
+        Type memberType = property.PropertyType;
+        MemberType = memberType;
+        NullableUnderlyingType = Nullable.GetUnderlyingType(memberType);
+        CanAssignNull = !memberType.IsValueType || NullableUnderlyingType is not null;
+
+        MethodInfo getMethod = property.GetMethod;
+        CanGet = getMethod is not null && getMethod.IsPublic;
+
+        // An init-only setter is a real setter to reflection, and invoking it outside an object initializer works,
+        // but doing so would defeat the immutability the author asked for — so treat it as unsettable, the same
+        // call the HTTP client's POCO reader makes.
+        MethodInfo setMethod = property.SetMethod;
+        CanSet = setMethod is not null && setMethod.IsPublic && !IsInitOnly(setMethod);
+    }
+
+    /// <summary>The reflected property, used to compile the typed getter/setter access.</summary>
+    public PropertyInfo Property { get; }
+
+    /// <summary>The CLR property name, for diagnostics.</summary>
+    public string MemberName => Property.Name;
+
+    /// <summary>The CLR property type, e.g. <see cref="long"/> or <c>int?</c>.</summary>
+    public Type MemberType { get; }
+
+    /// <summary>The ClickHouse column name this member matches on, before the matcher's case/underscore tiers.</summary>
+    public string ColumnName { get; }
+
+    /// <summary>
+    /// The underlying type when <see cref="MemberType"/> is a <see cref="Nullable{T}"/>, otherwise null.
+    /// </summary>
+    public Type NullableUnderlyingType { get; }
+
+    /// <summary>
+    /// Whether null can be assigned — true for a reference type or a <see cref="Nullable{T}"/>. Decides whether a
+    /// <c>Nullable(T)</c> column can target this member without a null ever having nowhere to go.
+    /// </summary>
+    public bool CanAssignNull { get; }
+
+    /// <summary>Whether the property has a public getter, so it can be an insert source.</summary>
+    public bool CanGet { get; }
+
+    /// <summary>
+    /// Whether the property has a public, non-init setter, so a query can materialize into it.
+    /// </summary>
+    public bool CanSet { get; }
+
+    /// <summary>
+    /// Names why <see cref="CanSet"/> is false, for the message a query-side plan builder throws. Never called
+    /// when the member is settable.
+    /// </summary>
+    /// <returns>The reason, as a noun phrase.</returns>
+    public string DescribeWhyNotSettable()
+    {
+        MethodInfo setMethod = Property.SetMethod;
+        if (setMethod is null)
+        {
+            return "it has no setter";
+        }
+
+        return IsInitOnly(setMethod) ? "its setter is init-only" : "its setter is not public";
+    }
+
+    // C# marks an init-only setter with a required custom modifier on its return parameter; there is no
+    // dedicated reflection flag for it.
+    private static bool IsInitOnly(MethodInfo setMethod)
+        => Array.Exists(
+            setMethod.ReturnParameter.GetRequiredCustomModifiers(),
+            static modifier => modifier.FullName == "System.Runtime.CompilerServices.IsExternalInit");
+}

--- a/ClickHouse.Driver.Tcp/Poco/PocoTypeDescriptor.cs
+++ b/ClickHouse.Driver.Tcp/Poco/PocoTypeDescriptor.cs
@@ -11,7 +11,7 @@ namespace ClickHouse.Driver.Tcp.Poco;
 /// nothing here depends on the columns a particular query or table happens to have.
 ///
 /// <para>
-/// Matching is tiered, most specific first: the exact column name, then case-insensitively, then ignoring
+/// Matching is tiered, most specific first: the exact column name, then ignoring case, then ignoring case and
 /// underscores — so a <c>user_id</c> column reaches a <c>UserId</c> property with no attribute needed. A column
 /// that reaches more than one property at the tier it lands on is an error rather than a silent pick; a column that
 /// reaches none is simply not mapped, which the query path skips and the insert path reports.
@@ -25,12 +25,15 @@ internal abstract class PocoTypeDescriptor
 
     /// <summary>Builds the name lookups over an already-discovered member set.</summary>
     /// <param name="pocoType">The POCO type, for diagnostics.</param>
-    /// <param name="members">The mapped members, in declaration order.</param>
+    /// <param name="members">The mapped members.</param>
     /// <exception cref="InvalidOperationException">Two members map to the same column name.</exception>
     protected PocoTypeDescriptor(Type pocoType, PocoMember[] members)
     {
         PocoType = pocoType;
-        Members = members;
+
+        // Wrapped rather than handed over: the descriptor is cached and shared across threads, so no consumer
+        // should be able to reach the backing array.
+        Members = Array.AsReadOnly(members);
 
         byExactName = new Dictionary<string, PocoMember>(members.Length, StringComparer.Ordinal);
         foreach (PocoMember member in members)
@@ -52,7 +55,10 @@ internal abstract class PocoTypeDescriptor
     /// <summary>The POCO type this describes.</summary>
     public Type PocoType { get; }
 
-    /// <summary>The mapped members, in declaration order. Never empty.</summary>
+    /// <summary>
+    /// The mapped members. Never empty, and in no contracted order — reflection does not promise one, and for an
+    /// inherited property it reports the derived type first.
+    /// </summary>
     public IReadOnlyList<PocoMember> Members { get; }
 
     /// <summary>
@@ -83,17 +89,18 @@ internal abstract class PocoTypeDescriptor
     /// on.
     /// </summary>
     /// <param name="pocoType">The POCO type.</param>
-    /// <returns>The mapped members, in declaration order.</returns>
-    /// <exception cref="InvalidOperationException">Nothing is left to map, or a
-    /// <see cref="ClickHouseTcpColumnAttribute"/> carries a blank name.</exception>
+    /// <returns>The mapped members.</returns>
+    /// <exception cref="InvalidOperationException">Nothing is left to map, a
+    /// <see cref="ClickHouseTcpColumnAttribute"/> carries a blank name, or one name is declared by two unrelated
+    /// interfaces.</exception>
     protected static PocoMember[] DiscoverMembers(Type pocoType)
     {
-        PropertyInfo[] declared = pocoType.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+        List<PropertyInfo> visible = VisibleProperties(pocoType);
 
         // Indexers are dropped first because they all report the same name, so they would otherwise collapse into
         // one another in the shadowing pass below.
-        var candidates = new List<PropertyInfo>(declared.Length);
-        foreach (PropertyInfo property in declared)
+        var candidates = new List<PropertyInfo>(visible.Count);
+        foreach (PropertyInfo property in visible)
         {
             if (property.GetIndexParameters().Length == 0)
             {
@@ -116,13 +123,32 @@ internal abstract class PocoTypeDescriptor
 
         if (members.Count == 0)
         {
-            string reason = declared.Length == 0 ? "it declares no public instance properties"
+            string reason = visible.Count == 0 ? "it has no public instance properties"
                 : distinct.Count == 0 ? "its only public instance properties are indexers, which are never mapped"
-                : $"all {distinct.Count} of its public instance properties carry [ClickHouseTcpNotMapped]";
+                : $"every mappable property ({distinct.Count}) carries [ClickHouseTcpNotMapped]";
             throw new InvalidOperationException($"Type '{pocoType.Name}' has no properties to map to ClickHouse columns: {reason}.");
         }
 
         return members.ToArray();
+    }
+
+    // GetProperties walks a class's base types, but an interface has no base type: what an interface inherits sits
+    // on the interfaces it extends. An interface is a legal insert source, so collect those too. GetInterfaces
+    // returns the whole closure, each interface once, so a diamond yields no duplicates.
+    private static List<PropertyInfo> VisibleProperties(Type pocoType)
+    {
+        const BindingFlags Mapped = BindingFlags.Public | BindingFlags.Instance;
+        var properties = new List<PropertyInfo>(pocoType.GetProperties(Mapped));
+
+        if (pocoType.IsInterface)
+        {
+            foreach (Type inherited in pocoType.GetInterfaces())
+            {
+                properties.AddRange(inherited.GetProperties(Mapped));
+            }
+        }
+
+        return properties;
     }
 
     // A property declared with `new` is reported once per declaring type, so it would look like two properties
@@ -137,9 +163,19 @@ internal abstract class PocoTypeDescriptor
         {
             if (ordinalOf.TryGetValue(property.Name, out int at))
             {
-                if (kept[at].DeclaringType.IsAssignableFrom(property.DeclaringType))
+                PropertyInfo previous = kept[at];
+                if (previous.DeclaringType.IsAssignableFrom(property.DeclaringType))
                 {
                     kept[at] = property;
+                }
+                else if (!property.DeclaringType.IsAssignableFrom(previous.DeclaringType))
+                {
+                    // Only an interface can reach here, by extending two interfaces that each declare the name: a
+                    // class hierarchy is a single chain, so one declaration always wins. C# itself needs a cast to
+                    // read such a property, so there is no declaration to prefer.
+                    throw new InvalidOperationException(
+                        $"Property '{property.Name}' is declared by both '{previous.DeclaringType.Name}' and '{property.DeclaringType.Name}', and neither inherits the other, so the column it maps to is undecided. " +
+                        $"Map a type that declares the property once.");
                 }
 
                 continue;
@@ -255,7 +291,10 @@ internal sealed class PocoTypeDescriptor<T> : PocoTypeDescriptor
     /// </summary>
     public bool CanActivate => activator is not null;
 
-    /// <summary>A compiled <c>new T()</c>, as fast as the operator it stands in for.</summary>
+    /// <summary>
+    /// A compiled <c>new T()</c>, so a query pays one delegate call per row instead of
+    /// <see cref="System.Activator"/>'s reflection.
+    /// </summary>
     /// <exception cref="InvalidOperationException"><typeparamref name="T"/> cannot be instantiated.</exception>
     public Func<T> Activator => activator ?? throw new InvalidOperationException(
         $"Type '{typeof(T).Name}' cannot be materialized from a query result: {activationBlockedReason}.");
@@ -279,8 +318,9 @@ internal sealed class PocoTypeDescriptor<T> : PocoTypeDescriptor
         Type type = typeof(T);
 
         // IsAbstract covers interfaces too. An abstract class can report a public parameterless constructor, and
-        // Expression.New over it even builds, so without this the failure would surface only once the compiled
-        // delegate ran.
+        // Expression.New over it even builds — Compile is what refuses it, and only with "Can't compile a
+        // NewExpression with a constructor declared on an abstract class". Checking here turns that into a message
+        // that names the type, and keeps the type usable for insert instead of failing its whole descriptor.
         if (type.IsAbstract)
         {
             return (null, type.IsInterface ? "it is an interface" : "it is abstract");

--- a/ClickHouse.Driver.Tcp/Poco/PocoTypeDescriptor.cs
+++ b/ClickHouse.Driver.Tcp/Poco/PocoTypeDescriptor.cs
@@ -1,0 +1,294 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace ClickHouse.Driver.Tcp.Poco;
+
+/// <summary>
+/// The per-type half of a POCO mapping: which properties map to which column names, and how a column name coming
+/// off the wire finds its property. Built once per POCO type and shared by the query and insert plans, since
+/// nothing here depends on the columns a particular query or table happens to have.
+///
+/// <para>
+/// Matching is tiered, most specific first: the exact column name, then case-insensitively, then ignoring
+/// underscores — so a <c>user_id</c> column reaches a <c>UserId</c> property with no attribute needed. A column
+/// that reaches more than one property at the tier it lands on is an error rather than a silent pick; a column that
+/// reaches none is simply not mapped, which the query path skips and the insert path reports.
+/// </para>
+/// </summary>
+internal abstract class PocoTypeDescriptor
+{
+    private readonly Dictionary<string, PocoMember> byExactName;
+    private readonly Dictionary<string, PocoMember[]> byCaseInsensitiveName;
+    private readonly Dictionary<string, PocoMember[]> byUnderscoreFreeName;
+
+    /// <summary>Builds the name lookups over an already-discovered member set.</summary>
+    /// <param name="pocoType">The POCO type, for diagnostics.</param>
+    /// <param name="members">The mapped members, in declaration order.</param>
+    /// <exception cref="InvalidOperationException">Two members map to the same column name.</exception>
+    protected PocoTypeDescriptor(Type pocoType, PocoMember[] members)
+    {
+        PocoType = pocoType;
+        Members = members;
+
+        byExactName = new Dictionary<string, PocoMember>(members.Length, StringComparer.Ordinal);
+        foreach (PocoMember member in members)
+        {
+            if (!byExactName.TryAdd(member.ColumnName, member))
+            {
+                // Unlike the looser tiers, an exact collision can never be resolved by which column name arrives,
+                // so it fails the type outright rather than only the columns that would hit it.
+                throw new InvalidOperationException(
+                    $"Type '{pocoType.Name}' maps both '{byExactName[member.ColumnName].MemberName}' and '{member.MemberName}' to column '{member.ColumnName}'. " +
+                    $"Point one of them at a different column with [ClickHouseTcpColumn(Name = \"...\")], or exclude it with [ClickHouseTcpNotMapped].");
+            }
+        }
+
+        byCaseInsensitiveName = GroupByKey(members, static member => member.ColumnName);
+        byUnderscoreFreeName = GroupByKey(members, static member => WithoutUnderscores(member.ColumnName));
+    }
+
+    /// <summary>The POCO type this describes.</summary>
+    public Type PocoType { get; }
+
+    /// <summary>The mapped members, in declaration order. Never empty.</summary>
+    public IReadOnlyList<PocoMember> Members { get; }
+
+    /// <summary>
+    /// Finds the member a column maps to, through the tiers described on this class.
+    /// </summary>
+    /// <param name="columnName">The column name as the server sent it.</param>
+    /// <param name="member">The matched member, or null when the column maps to no member.</param>
+    /// <returns>Whether a member matched.</returns>
+    /// <exception cref="InvalidOperationException">The column reaches several members at the tier it lands on.</exception>
+    public bool TryMatchColumn(string columnName, out PocoMember member)
+    {
+        if (byExactName.TryGetValue(columnName, out member))
+        {
+            return true;
+        }
+
+        if (TryMatchTier(byCaseInsensitiveName, columnName, columnName, "differing only in case", out member))
+        {
+            return true;
+        }
+
+        return TryMatchTier(byUnderscoreFreeName, WithoutUnderscores(columnName), columnName, "differing only in case and underscores", out member);
+    }
+
+    /// <summary>
+    /// Reflects over a POCO type and resolves its mapped members: public instance properties, minus indexers and
+    /// anything carrying <see cref="ClickHouseTcpNotMappedAttribute"/>, each paired with the column name it matches
+    /// on.
+    /// </summary>
+    /// <param name="pocoType">The POCO type.</param>
+    /// <returns>The mapped members, in declaration order.</returns>
+    /// <exception cref="InvalidOperationException">Nothing is left to map, or a
+    /// <see cref="ClickHouseTcpColumnAttribute"/> carries a blank name.</exception>
+    protected static PocoMember[] DiscoverMembers(Type pocoType)
+    {
+        PropertyInfo[] declared = pocoType.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+
+        // Indexers are dropped first because they all report the same name, so they would otherwise collapse into
+        // one another in the shadowing pass below.
+        var candidates = new List<PropertyInfo>(declared.Length);
+        foreach (PropertyInfo property in declared)
+        {
+            if (property.GetIndexParameters().Length == 0)
+            {
+                candidates.Add(property);
+            }
+        }
+
+        List<PropertyInfo> distinct = KeepMostDerived(candidates);
+
+        var members = new List<PocoMember>(distinct.Count);
+        foreach (PropertyInfo property in distinct)
+        {
+            if (property.GetCustomAttribute<ClickHouseTcpNotMappedAttribute>() is not null)
+            {
+                continue;
+            }
+
+            members.Add(new PocoMember(property, ResolveColumnName(pocoType, property)));
+        }
+
+        if (members.Count == 0)
+        {
+            string reason = declared.Length == 0 ? "it declares no public instance properties"
+                : distinct.Count == 0 ? "its only public instance properties are indexers, which are never mapped"
+                : $"all {distinct.Count} of its public instance properties carry [ClickHouseTcpNotMapped]";
+            throw new InvalidOperationException($"Type '{pocoType.Name}' has no properties to map to ClickHouse columns: {reason}.");
+        }
+
+        return members.ToArray();
+    }
+
+    // A property declared with `new` is reported once per declaring type, so it would look like two properties
+    // competing for one column. Keep the most derived declaration, which is the one the compiler binds. Reflection
+    // does not contract an order, so neither does this; internal to let that be pinned directly.
+    internal static List<PropertyInfo> KeepMostDerived(List<PropertyInfo> properties)
+    {
+        var kept = new List<PropertyInfo>(properties.Count);
+        var ordinalOf = new Dictionary<string, int>(properties.Count, StringComparer.Ordinal);
+
+        foreach (PropertyInfo property in properties)
+        {
+            if (ordinalOf.TryGetValue(property.Name, out int at))
+            {
+                if (kept[at].DeclaringType.IsAssignableFrom(property.DeclaringType))
+                {
+                    kept[at] = property;
+                }
+
+                continue;
+            }
+
+            ordinalOf[property.Name] = kept.Count;
+            kept.Add(property);
+        }
+
+        return kept;
+    }
+
+    private static string ResolveColumnName(Type pocoType, PropertyInfo property)
+    {
+        string name = property.GetCustomAttribute<ClickHouseTcpColumnAttribute>()?.Name;
+        if (name is null)
+        {
+            return property.Name;
+        }
+
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            throw new InvalidOperationException(
+                $"Property '{pocoType.Name}.{property.Name}' has a [ClickHouseTcpColumn] name that is empty or whitespace. " +
+                $"Give it a column name, or leave Name unset to match on the property name.");
+        }
+
+        return name;
+    }
+
+    // Groups the members by a derived key, case-insensitively. Buckets hold every member that shares the key, so
+    // the lookup can tell "one match" from "ambiguous" and name the candidates either way.
+    private static Dictionary<string, PocoMember[]> GroupByKey(PocoMember[] members, Func<PocoMember, string> keyOf)
+    {
+        var buckets = new Dictionary<string, List<PocoMember>>(members.Length, StringComparer.OrdinalIgnoreCase);
+        foreach (PocoMember member in members)
+        {
+            string key = keyOf(member);
+            if (!buckets.TryGetValue(key, out List<PocoMember> bucket))
+            {
+                buckets[key] = bucket = new List<PocoMember>(1);
+            }
+
+            bucket.Add(member);
+        }
+
+        var grouped = new Dictionary<string, PocoMember[]>(buckets.Count, StringComparer.OrdinalIgnoreCase);
+        foreach (KeyValuePair<string, List<PocoMember>> bucket in buckets)
+        {
+            grouped[bucket.Key] = bucket.Value.ToArray();
+        }
+
+        return grouped;
+    }
+
+    private static string WithoutUnderscores(string name)
+        => name.IndexOf('_') < 0 ? name : name.Replace("_", string.Empty, StringComparison.Ordinal);
+
+    private bool TryMatchTier(
+        Dictionary<string, PocoMember[]> lookup,
+        string key,
+        string columnName,
+        string tier,
+        out PocoMember member)
+    {
+        member = null;
+        if (!lookup.TryGetValue(key, out PocoMember[] candidates))
+        {
+            return false;
+        }
+
+        if (candidates.Length > 1)
+        {
+            // Reached only when no member's column name matched exactly — an exact match would have won the tier
+            // above — so the caller has to say which one it means.
+            var names = new string[candidates.Length];
+            for (int i = 0; i < candidates.Length; i++)
+            {
+                names[i] = candidates[i].MemberName;
+            }
+
+            throw new InvalidOperationException(
+                $"Column '{columnName}' matches {candidates.Length} properties of '{PocoType.Name}' {tier} ({string.Join(", ", names)}), and none of them exactly. " +
+                $"Put [ClickHouseTcpColumn(Name = \"{columnName}\")] on the one it should map to.");
+        }
+
+        member = candidates[0];
+        return true;
+    }
+}
+
+/// <summary>
+/// The typed <see cref="PocoTypeDescriptor"/>, adding the one piece of the per-type mapping that needs
+/// <typeparamref name="T"/> itself: the compiled constructor a query materializes rows with.
+/// </summary>
+/// <typeparam name="T">The POCO type.</typeparam>
+internal sealed class PocoTypeDescriptor<T> : PocoTypeDescriptor
+    where T : class
+{
+    private readonly Func<T> activator;
+    private readonly string activationBlockedReason;
+
+    private PocoTypeDescriptor(PocoMember[] members, Func<T> activator, string activationBlockedReason)
+        : base(typeof(T), members)
+    {
+        this.activator = activator;
+        this.activationBlockedReason = activationBlockedReason;
+    }
+
+    /// <summary>
+    /// Whether <typeparamref name="T"/> can be instantiated, so a query can materialize into it. False for an
+    /// insert-only POCO, which needs no constructor of ours.
+    /// </summary>
+    public bool CanActivate => activator is not null;
+
+    /// <summary>A compiled <c>new T()</c>, as fast as the operator it stands in for.</summary>
+    /// <exception cref="InvalidOperationException"><typeparamref name="T"/> cannot be instantiated.</exception>
+    public Func<T> Activator => activator ?? throw new InvalidOperationException(
+        $"Type '{typeof(T).Name}' cannot be materialized from a query result: {activationBlockedReason}.");
+
+    /// <summary>Discovers <typeparamref name="T"/>'s members and compiles its constructor.</summary>
+    /// <returns>The descriptor.</returns>
+    /// <exception cref="InvalidOperationException"><typeparamref name="T"/> has nothing to map, or maps two
+    /// properties to one column.</exception>
+    public static PocoTypeDescriptor<T> Build()
+    {
+        PocoMember[] members = DiscoverMembers(typeof(T));
+        (Func<T> activator, string blockedReason) = CompileActivator();
+        return new PocoTypeDescriptor<T>(members, activator, blockedReason);
+    }
+
+    // Deliberately not fatal when T cannot be instantiated: the descriptor is shared with the insert path, which
+    // never constructs a T, so an immutable POCO has to stay usable there. The reason is kept for the query path
+    // to report if it does need one.
+    private static (Func<T> Activator, string BlockedReason) CompileActivator()
+    {
+        Type type = typeof(T);
+
+        // IsAbstract covers interfaces too. An abstract class can report a public parameterless constructor, and
+        // Expression.New over it even builds, so without this the failure would surface only once the compiled
+        // delegate ran.
+        if (type.IsAbstract)
+        {
+            return (null, type.IsInterface ? "it is an interface" : "it is abstract");
+        }
+
+        ConstructorInfo constructor = type.GetConstructor(Type.EmptyTypes);
+        return constructor is null
+            ? (null, "it has no public parameterless constructor")
+            : (Expression.Lambda<Func<T>>(Expression.New(constructor)).Compile(), null);
+    }
+}

--- a/ClickHouse.Driver.Tcp/Poco/PocoTypeRegistry.cs
+++ b/ClickHouse.Driver.Tcp/Poco/PocoTypeRegistry.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Concurrent;
+
+namespace ClickHouse.Driver.Tcp.Poco;
+
+/// <summary>
+/// Caches the POCO mapping work, so a type is reflected over and its constructor compiled once instead of once per
+/// query or insert. One registry lives per <see cref="ClickHouseTcpClient"/>: the client is meant to be held as a
+/// singleton, so the cost is amortized anyway, and a per-client cache cannot pin types loaded into an
+/// <see cref="System.Runtime.Loader.AssemblyLoadContext"/> the caller later wants to unload.
+///
+/// <para>
+/// Only the per-type level lives here. The compiled loops are per <c>(type, wire shape)</c> — the column types come
+/// from the server, not from the type — so they cache separately, keyed by the block or sample-block signature.
+/// </para>
+/// </summary>
+internal sealed class PocoTypeRegistry
+{
+    private readonly ConcurrentDictionary<Type, PocoTypeDescriptor> descriptors = new();
+
+    /// <summary>
+    /// Gets the descriptor for <typeparamref name="T"/>, building it on first use.
+    /// </summary>
+    /// <typeparam name="T">The POCO type.</typeparam>
+    /// <returns>The cached descriptor.</returns>
+    /// <exception cref="InvalidOperationException"><typeparamref name="T"/> cannot be mapped at all — see
+    /// <see cref="PocoTypeDescriptor{T}.Build"/>. Nothing is cached in that case, so the same failure is reported
+    /// every time rather than only to the first caller.</exception>
+    public PocoTypeDescriptor<T> DescriptorFor<T>()
+        where T : class
+        // Keyed by the Type object, not its name, so two same-named types from different assemblies stay distinct.
+        // A race can build twice; the build is pure, so the loser's copy is simply dropped.
+        => (PocoTypeDescriptor<T>)descriptors.GetOrAdd(typeof(T), static _ => PocoTypeDescriptor<T>.Build());
+}


### PR DESCRIPTION
Stacked on #548 (base branch `tcp/epic-n5-poco`). Steps 1–2 of the POCO epic (N5a). No behavior is reachable from the public API yet: nothing consumes the registry until `QueryAsync<T>` lands.

## What this is

A POCO mapping splits in two. What depends only on the CLR type — which properties map, to which column names, and how a name off the wire finds its property — is resolved once per type and shared by the query and insert paths. What depends on the column types is per `(type, wire shape)` and comes later. This is the first half.

## Name matching

Tiered, most specific first: the exact column name, then ignoring case, then ignoring case and underscores. So a `user_id` column reaches a `UserId` property with no attribute. A column that reaches several properties at the tier it lands on is an error, not a silent pick; a column that reaches none is simply unmapped.

Ambiguity is reported **per column, at match time**, not eagerly at build. An exact duplicate column name fails the build, since no arriving name could disambiguate it, but a case- or underscore-level collision fails only when a column actually lands on it — so a POCO holding both `Value` and a `value`-renamed member stays usable as long as the server sends exact names.

## Decisions worth review

**The attributes are `[ClickHouseTcpColumn]` / `[ClickHouseTcpNotMapped]`, not duplicates of the main driver's names.** Three reasons:

1. Both assemblies ship in the one `ClickHouse.Driver` package, so a same-named `ClickHouse.Driver.Tcp.ClickHouseColumnAttribute` would be a **CS0104 ambiguous reference** for any file importing both namespaces — which a user migrating client by client necessarily does.
2. Every other public TCP type is already `ClickHouseTcp*`-prefixed, so this is the convention rather than an exception to it.
3. The surfaces genuinely differ. The HTTP attribute's `Type` property exists only to skip that client's schema-probe query, and the native protocol sends the target types with the insert itself — so the TCP attribute carries `Name` alone, and a same-named duplicate would have had to grow a dead property or silently differ.

Cost: a POCO shared between both clients needs both attributes. Honoring the HTTP attribute by full-name reflection stays available later.

**One descriptor serves both directions**, rather than the HTTP client's separate insert and read mappings. `PocoMember` carries `CanGet` (public getter → insert source) and `CanSet` (public non-init setter → query target), and each future plan filters on the one it needs. So a type is never refused for lacking the direction it is not being used in: an immutable getter-only POCO with no parameterless constructor builds fine and stays insertable, and the query path checks `CanActivate`. Only a type with nothing mappable at all fails the build.

## Review findings already fixed in the second commit

- **An interface `T` lost every base-interface property.** `GetProperties` walks a class's base types, but an interface has no base type. `InsertAsync<IDerived>` would have written only what `IDerived` itself declares and let the server default the rest, silently. Discovery now also enumerates `GetInterfaces()`.
- That opened a case a class hierarchy cannot reach — one name declared by two unrelated interfaces, which C# itself needs a cast to read. It now throws instead of keeping whichever arrived first.
- Three comments were wrong, each verified against the BCL: `Expression.New` over an abstract class fails at `Compile()`, not at first invocation; `Members` is not in declaration order (reflection contracts none and reports inherited properties derived-first); a compiled `Func<T>` is not as fast as `new T()`, it beats `Activator.CreateInstance`.

## Verification

- 50 new unit tests; all four new files at **100% line coverage**.
- **1444/1444** TCP tests pass on net9.0 (was 1394 before this branch). Whole solution builds. No new analyzer warnings.
- Unit-only by design, per the AGENTS.md layering rule: none of this is reachable from a server round trip, since it is all decided before a column type is known.

CHANGELOG and RELEASENOTES are deliberately untouched — there is no user-visible behavior until the query and insert paths land. They come with the epic's final step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)