### PR TITLE
TCP N5: POCO row read — QueryAsync<T> over a compiled per-column scatter

### DIFF
--- a/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpClientIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpClientIntegrationTests.cs
@@ -19,6 +19,11 @@ public class ClickHouseTcpClientIntegrationTests
 
     private static string UniqueTableName() => $"tcp_client_test_{Guid.NewGuid():N}";
 
+    private sealed class IdRow
+    {
+        public ulong Id { get; set; }
+    }
+
     [Test]
     public async Task StreamAsync_SelectLiteral_ReturnsSingleBlock()
     {
@@ -385,6 +390,7 @@ public class ClickHouseTcpClientIntegrationTests
                 await client.InsertAsync($"INSERT INTO {table} (id) VALUES", columns, cancellationToken: None);
 
                 var rows = await client.QueryAsync($"SELECT id FROM {table} ORDER BY id").ToListAsync();
+                var typed = await client.QueryAsync<IdRow>($"SELECT id FROM {table} ORDER BY id").ToListAsync();
 
                 var streamed = new List<ulong>();
                 await foreach (Block block in client.StreamAsync($"SELECT id FROM {table} ORDER BY id"))
@@ -395,6 +401,7 @@ public class ClickHouseTcpClientIntegrationTests
                 Assert.Multiple(() =>
                 {
                     CollectionAssert.AreEqual(ids, rows.Select(r => (ulong)r[0]));
+                    CollectionAssert.AreEqual(ids, typed.Select(row => row.Id));
                     CollectionAssert.AreEqual(ids, streamed);
                 });
             }

--- a/ClickHouse.Driver.Tcp.Tests/Integration/PocoReadIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/PocoReadIntegrationTests.cs
@@ -12,11 +12,8 @@ using ClickHouse.Driver.Tcp.Types;
 namespace ClickHouse.Driver.Tcp.Tests.Integration;
 
 /// <summary>
-/// <c>QueryAsync&lt;T&gt;</c> against a real server. Per-type coverage rides the round-trip corpus: each case
-/// already knows its ClickHouse type and the CLR type it reads back as, so it becomes a
-/// <see cref="Row{TValue}"/> assertion with no corpus of its own. The rest are the shapes the corpus cannot state —
-/// the calendar and enum readings a property asks for instead of the raw wire value, the session timezone, the
-/// attributes, and rows outliving the blocks they came from.
+/// Real-server coverage for <c>QueryAsync&lt;T&gt;</c>, including every round-trip corpus type and POCO-specific
+/// projections, mapping and lifetime behavior.
 /// </summary>
 [TestFixture]
 [Category("Integration")]
@@ -55,6 +52,229 @@ public class PocoReadIntegrationTests
             {
                 Assert.That(read[row], Is.EqualTo(expected.GetValue(row)), $"row {row}");
             }
+        }
+        finally
+        {
+            await client.ExecuteAsync($"DROP TABLE IF EXISTS {table}", cancellationToken: None);
+        }
+    }
+
+    [Test]
+    public async Task QueryAsync_OnePocoWithDeepCompositeColumns_MaterializesEveryProperty()
+    {
+        // The corpus proves these codecs and their constituent shapes one column at a time through Row<T>. This puts
+        // deeper compositions together in one plan, with independent offsets, state prefixes and null sentinels.
+        const string deepBytesType = "Array(Array(Array(Array(Array(UInt8)))))";
+        const string nullableDeepType = "Array(Array(Array(Nullable(UInt32))))";
+        const string mixedTupleType = "Tuple(Array(Nullable(Int32)), Map(String, Array(UInt16)), Tuple())";
+        const string mapOfTupleArraysType = "Map(String, Array(Tuple(Nullable(Int32), Array(String))))";
+        const string arrayOfMapsType = "Array(Map(String, Array(UInt64)))";
+        const string variantArrayType = "Array(Variant(Array(UInt64), String))";
+        const string dynamicTupleType = "Tuple(Dynamic, Array(Tuple(Dynamic, String)))";
+        const string nestedRecordsType = "Nested(label String, values Array(Nullable(Int32)), marker Tuple(UInt8, String))";
+
+        byte[][][][][][] deepBytes =
+        {
+            new byte[][][][][]
+            {
+                new byte[][][][]
+                {
+                    new byte[][][]
+                    {
+                        new byte[][] { new byte[] { 1, 2 }, Array.Empty<byte>() },
+                        Array.Empty<byte[]>(),
+                    },
+                    Array.Empty<byte[][]>(),
+                },
+                Array.Empty<byte[][][]>(),
+            },
+            Array.Empty<byte[][][][]>(),
+            new byte[][][][][]
+            {
+                new byte[][][][]
+                {
+                    new byte[][][]
+                    {
+                        new byte[][] { Array.Empty<byte>(), new byte[] { 3, 4, 5 } },
+                    },
+                },
+            },
+        };
+
+        uint?[][][][] nullableDeep =
+        {
+            new uint?[][][]
+            {
+                new uint?[][] { new uint?[] { 1, null }, Array.Empty<uint?>() },
+                Array.Empty<uint?[]>(),
+            },
+            Array.Empty<uint?[][]>(),
+            new uint?[][][]
+            {
+                new uint?[][] { new uint?[] { null, uint.MaxValue } },
+            },
+        };
+
+        (int?[] Numbers, KeyValuePair<string, ushort[]>[] Lookup, ValueTuple Empty)[] mixedTuples =
+        {
+            (
+                new int?[] { 1, null },
+                Pairs<string, ushort[]>(("filled", new ushort[] { 1, ushort.MaxValue }), ("empty", Array.Empty<ushort>())),
+                default),
+            (Array.Empty<int?>(), Array.Empty<KeyValuePair<string, ushort[]>>(), default),
+            (
+                new int?[] { int.MinValue, null },
+                Pairs<string, ushort[]>(("zero", new ushort[] { 0 })),
+                default),
+        };
+
+        KeyValuePair<string, (int?, string[])[]>[][] mapOfTupleArrays =
+        {
+            Pairs<string, (int?, string[])[]>(
+                ("filled", new (int?, string[])[] { (1, new[] { "a", string.Empty }), (null, Array.Empty<string>()) }),
+                ("empty", Array.Empty<(int?, string[])>())),
+            Array.Empty<KeyValuePair<string, (int?, string[])[]>>(),
+            Pairs<string, (int?, string[])[]>(
+                ("unicode", new (int?, string[])[] { (null, new[] { "héllo✓" }) })),
+        };
+
+        KeyValuePair<string, ulong[]>[][][] arrayOfMaps =
+        {
+            new KeyValuePair<string, ulong[]>[][]
+            {
+                Pairs<string, ulong[]>(("a", new ulong[] { 1, 2 })),
+                Array.Empty<KeyValuePair<string, ulong[]>>(),
+            },
+            Array.Empty<KeyValuePair<string, ulong[]>[]>(),
+            new KeyValuePair<string, ulong[]>[][]
+            {
+                Pairs<string, ulong[]>(("empty", Array.Empty<ulong>()), ("max", new[] { ulong.MaxValue })),
+            },
+        };
+
+        object[][] variantArrays =
+        {
+            new object[] { new ulong[] { 1, 2 }, "x", null, Array.Empty<ulong>() },
+            Array.Empty<object>(),
+            new object[] { string.Empty, null, new[] { ulong.MaxValue } },
+        };
+
+        (object Head, (object Value, string Label)[] Tail)[] dynamicTuples =
+        {
+            (42UL, new (object, string)[] { ("inner", "text"), (null, string.Empty) }),
+            (null, Array.Empty<(object, string)>()),
+            (
+                Pairs<string, uint>(("key", 7)),
+                new (object, string)[] { (new ulong[] { 1, 2 }, "array"), (7UL, "number") }),
+        };
+
+        object[][][] nestedRecords =
+        {
+            new object[][]
+            {
+                new object[] { "first", new int?[] { 1, null }, ((byte)1, "a") },
+                new object[] { "second", Array.Empty<int?>(), ((byte)2, string.Empty) },
+            },
+            Array.Empty<object[]>(),
+            new object[][]
+            {
+                new object[] { "third", new int?[] { null, int.MinValue }, ((byte)3, "héllo✓") },
+            },
+        };
+
+        IColumn[] columns =
+        {
+            PrimitiveColumn<byte>.FromValues("Id", "UInt8", new byte[] { 0, 1, 2 }),
+            new ArrayColumn<byte[][][][][]>("DeepBytes", deepBytesType, deepBytes),
+            new ArrayColumn<uint?[][][]>("NullableDeep", nullableDeepType, nullableDeep),
+            new ArrayColumn<(int?[], KeyValuePair<string, ushort[]>[], ValueTuple)>("MixedTuple", mixedTupleType, mixedTuples),
+            new ArrayColumn<KeyValuePair<string, (int?, string[])[]>[]>("MapOfTupleArrays", mapOfTupleArraysType, mapOfTupleArrays),
+            new ArrayColumn<KeyValuePair<string, ulong[]>[][]>("ArrayOfMaps", arrayOfMapsType, arrayOfMaps),
+            new ArrayColumn<object[]>("VariantArray", variantArrayType, variantArrays),
+            new ArrayColumn<(object, (object, string)[])>("DynamicTuple", dynamicTupleType, dynamicTuples),
+            new NestedColumn(
+                "NestedRecords",
+                nestedRecordsType,
+                new[] { "label", "values", "marker" },
+                new IColumn[]
+                {
+                    new ArrayColumn<string>("NestedRecords", "String", new[] { "first", "second", "third" }),
+                    new ArrayColumn<int?[]>("NestedRecords", "Array(Nullable(Int32))", new[]
+                    {
+                        new int?[] { 1, null },
+                        Array.Empty<int?>(),
+                        new int?[] { null, int.MinValue },
+                    }),
+                    new ArrayColumn<(byte, string)>("NestedRecords", "Tuple(UInt8, String)", new[]
+                    {
+                        ((byte)1, "a"),
+                        ((byte)2, string.Empty),
+                        ((byte)3, "héllo✓"),
+                    }),
+                },
+                new[] { 0, 2, 2, 3 },
+                rowCount: 3,
+                pooledOffsets: false,
+                ownsFields: false),
+        };
+
+        var settings = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["flatten_nested"] = "0",
+            ["allow_experimental_variant_type"] = "1",
+            ["allow_suspicious_variant_types"] = "1",
+            ["allow_experimental_dynamic_type"] = "1",
+            ["output_format_native_use_flattened_dynamic_and_json_serialization"] = "1",
+        };
+        var queryOptions = new ClickHouseTcpQueryOptions { Settings = settings };
+        var insertOptions = new ClickHouseTcpInsertOptions { Settings = settings };
+        string table = UniqueTableName();
+        string schema = string.Join(", ", new[]
+        {
+            "Id UInt8",
+            $"DeepBytes {deepBytesType}",
+            $"NullableDeep {nullableDeepType}",
+            $"MixedTuple {mixedTupleType}",
+            $"MapOfTupleArrays {mapOfTupleArraysType}",
+            $"ArrayOfMaps {arrayOfMapsType}",
+            $"VariantArray {variantArrayType}",
+            $"DynamicTuple {dynamicTupleType}",
+            $"NestedRecords {nestedRecordsType}",
+        });
+
+        await using var client = TcpServerFixture.CreateClient();
+        try
+        {
+            await client.ExecuteAsync($"CREATE TABLE {table} ({schema}) ENGINE = Memory", queryOptions, None);
+            await client.InsertAsync(
+                $"INSERT INTO {table} (Id, DeepBytes, NullableDeep, MixedTuple, MapOfTupleArrays, ArrayOfMaps, VariantArray, DynamicTuple, NestedRecords) VALUES",
+                columns,
+                insertOptions,
+                None);
+
+            List<CompositeStressRow> rows = await client
+                .QueryAsync<CompositeStressRow>($"SELECT * FROM {table} ORDER BY Id", queryOptions, None)
+                .ToListAsync();
+
+            Assert.That(rows, Has.Count.EqualTo(3));
+            Assert.Multiple(() =>
+            {
+                for (int row = 0; row < rows.Count; row++)
+                {
+                    Assert.That(rows[row].Id, Is.EqualTo((byte)row), $"row {row}: Id");
+                    Assert.That(rows[row].DeepBytes, Is.EqualTo(deepBytes[row]), $"row {row}: DeepBytes");
+                    Assert.That(rows[row].NullableDeep, Is.EqualTo(nullableDeep[row]), $"row {row}: NullableDeep");
+                    Assert.That(rows[row].MixedTuple.Item1, Is.EqualTo(mixedTuples[row].Numbers), $"row {row}: MixedTuple.Item1");
+                    Assert.That(rows[row].MixedTuple.Item2, Is.EqualTo(mixedTuples[row].Lookup), $"row {row}: MixedTuple.Item2");
+                    Assert.That(rows[row].MixedTuple.Item3, Is.EqualTo(mixedTuples[row].Empty), $"row {row}: MixedTuple.Item3");
+                    Assert.That(rows[row].MapOfTupleArrays, Is.EqualTo(mapOfTupleArrays[row]), $"row {row}: MapOfTupleArrays");
+                    Assert.That(rows[row].ArrayOfMaps, Is.EqualTo(arrayOfMaps[row]), $"row {row}: ArrayOfMaps");
+                    Assert.That(rows[row].VariantArray, Is.EqualTo(variantArrays[row]), $"row {row}: VariantArray");
+                    Assert.That(rows[row].DynamicTuple.Item1, Is.EqualTo(dynamicTuples[row].Head), $"row {row}: DynamicTuple.Item1");
+                    Assert.That(rows[row].DynamicTuple.Item2, Is.EqualTo(dynamicTuples[row].Tail), $"row {row}: DynamicTuple.Item2");
+                    Assert.That(rows[row].NestedRecords, Is.EqualTo(nestedRecords[row]), $"row {row}: NestedRecords");
+                }
+            });
         }
         finally
         {
@@ -409,6 +629,17 @@ public class PocoReadIntegrationTests
         throw new InvalidOperationException($"Column '{column.Name}' ({column.TypeName}) surfaces no IColumn<T>.");
     }
 
+    private static KeyValuePair<TKey, TValue>[] Pairs<TKey, TValue>(params (TKey Key, TValue Value)[] pairs)
+    {
+        var result = new KeyValuePair<TKey, TValue>[pairs.Length];
+        for (int i = 0; i < pairs.Length; i++)
+        {
+            result[i] = new KeyValuePair<TKey, TValue>(pairs[i].Key, pairs[i].Value);
+        }
+
+        return result;
+    }
+
     private static string UniqueTableName() => $"tcp_poco_test_{Guid.NewGuid():N}";
 
     private enum Level : sbyte
@@ -444,6 +675,27 @@ public class PocoReadIntegrationTests
         public DateTime Stamp { get; set; }
 
         public DateTimeOffset Offset { get; set; }
+    }
+
+    private sealed class CompositeStressRow
+    {
+        public byte Id { get; set; }
+
+        public byte[][][][][] DeepBytes { get; set; }
+
+        public uint?[][][] NullableDeep { get; set; }
+
+        public (int?[], KeyValuePair<string, ushort[]>[], ValueTuple) MixedTuple { get; set; }
+
+        public KeyValuePair<string, (int?, string[])[]>[] MapOfTupleArrays { get; set; }
+
+        public KeyValuePair<string, ulong[]>[][] ArrayOfMaps { get; set; }
+
+        public object[] VariantArray { get; set; }
+
+        public (object, (object, string)[]) DynamicTuple { get; set; }
+
+        public object[][] NestedRecords { get; set; }
     }
 
     private sealed class SeparatorRow

--- a/ClickHouse.Driver.Tcp.Tests/Integration/PocoReadIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/PocoReadIntegrationTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
@@ -165,6 +166,67 @@ public class PocoReadIntegrationTests
             Assert.That(rows[rowCount - 1].Id, Is.EqualTo((ulong)(rowCount - 1)));
             Assert.That(rows[rowCount - 1].Name, Is.EqualTo((rowCount - 1).ToString()));
         });
+    }
+
+    [Test]
+    public async Task QueryAsync_BlockLargerThanTheMaterializationWindow_YieldsEveryRowOnceInOrder()
+    {
+        // A block is materialized a window of rows at a time, not all at once, so a block that spans several
+        // windows is the case where a window could drop, repeat or misorder rows. The multi-block test above cannot
+        // reach it: there, every block boundary is also a window boundary.
+        const int rowCount = 5_000;
+        var options = new ClickHouseTcpQueryOptions
+        {
+            Settings = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                // One block holding every row: the row count is under max_block_size, and the byte-based cap that
+                // would otherwise split it first is disabled.
+                ["max_block_size"] = "8192",
+                ["preferred_block_size_bytes"] = "0",
+                ["max_threads"] = "1",
+            },
+        };
+
+        string sql = $"SELECT number AS Id, toString(number) AS Name FROM numbers({rowCount})";
+        await using var client = TcpServerFixture.CreateClient();
+
+        // The premise, asserted rather than assumed: if the server ever splits this differently, the row assertions
+        // below would still pass while no longer testing a window boundary inside a block.
+        int blocks = 0;
+        await foreach (Block _ in client.StreamAsync(sql, options, None))
+        {
+            blocks++;
+        }
+
+        List<Numbered> rows = await client.QueryAsync<Numbered>(sql, options, None).ToListAsync();
+
+        Assert.That(blocks, Is.EqualTo(1), "the query has to produce one block for this to test a window boundary");
+        Assert.That(rows, Has.Count.EqualTo(rowCount));
+        Assert.Multiple(() =>
+        {
+            for (int i = 0; i < rowCount; i++)
+            {
+                Assert.That(rows[i].Id, Is.EqualTo((ulong)i), $"Id at row {i}");
+                Assert.That(rows[i].Name, Is.EqualTo(i.ToString(CultureInfo.InvariantCulture)), $"Name at row {i}");
+            }
+        });
+    }
+
+    [Test]
+    public async Task QueryAsync_NullPastTheFirstWindow_NamesTheRowOfTheResult()
+    {
+        // The row a failure names is counted across the whole result. Reported from inside a window, so the offset
+        // of the window within its block has to be carried into the message.
+        const int nullAtRow = 1_500;
+        await using var client = TcpServerFixture.CreateClient();
+
+        InvalidOperationException error = Assert.ThrowsAsync<InvalidOperationException>(async () => await client
+            .QueryAsync<Numbered>(
+                $"SELECT if(number = {nullAtRow}, NULL, number) AS Id FROM numbers(3000)",
+                cancellationToken: None)
+            .ToListAsync());
+
+        Assert.That(error.Message, Does.Contain($"row {nullAtRow}").And.Contain("Numbered.Id"));
     }
 
     [Test]

--- a/ClickHouse.Driver.Tcp.Tests/Integration/PocoReadIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/PocoReadIntegrationTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Format;
 using ClickHouse.Driver.Tcp.Poco;
 using ClickHouse.Driver.Tcp.Tests.Utilities;
 using ClickHouse.Driver.Tcp.Types;
@@ -266,25 +267,37 @@ public class PocoReadIntegrationTests
     }
 
     [Test]
-    public async Task QueryAsync_EveryScatterTier_ReadsTheSameRows()
+    public async Task Materialize_EveryScatterTier_ReadsTheSameRows()
     {
         // The tiers are compared here as well as in the unit tests because these values come off a real server: the
-        // span tier's zero-copy read and the two per-row tiers have to agree on decoded storage, not just on columns
-        // a test built.
+        // span tier's zero-copy read and the per-row tier have to agree on decoded storage, not just on columns a
+        // test built. QueryAsync<T> leaves the tier to the runtime, so the plan is built directly to name one; each
+        // tier reads its own block, since materializing one block twice would let the first tier fill the caches
+        // the second reads.
         const string sql = "SELECT toUInt64(number) AS Id, toString(number) AS Name FROM numbers(3)";
+        await using var client = new ClickHouseTcpClient(TcpServerFixture.Options());
         var byTier = new Dictionary<PocoScatterTier, List<Numbered>>();
+
         foreach (PocoScatterTier tier in Enum.GetValues<PocoScatterTier>())
         {
-            await using var client = new ClickHouseTcpClient(TcpServerFixture.Options()) { ForcedPocoScatterTier = tier };
-            byTier[tier] = await client.QueryAsync<Numbered>(sql, cancellationToken: None).ToListAsync();
+            var read = new List<Numbered>();
+            await foreach (Block block in client.StreamAsync(sql, cancellationToken: None))
+            {
+                var rows = new Numbered[block.RowCount];
+                PocoReadPlan<Numbered>.Build(PocoTypeDescriptor<Numbered>.Build(), block, tier)
+                    .Materialize(block, rows, read.Count);
+                read.AddRange(rows);
+            }
+
+            byTier[tier] = read;
         }
 
         Assert.Multiple(() =>
         {
             foreach ((PocoScatterTier tier, List<Numbered> rows) in byTier)
             {
-                Assert.That(Array.ConvertAll(rows.ToArray(), row => row.Id), Is.EqualTo(new ulong[] { 0, 1, 2 }), $"{tier}: Id");
-                Assert.That(Array.ConvertAll(rows.ToArray(), row => row.Name), Is.EqualTo(new[] { "0", "1", "2" }), $"{tier}: Name");
+                Assert.That(rows.ConvertAll(row => row.Id), Is.EqualTo(new ulong[] { 0, 1, 2 }), $"{tier}: Id");
+                Assert.That(rows.ConvertAll(row => row.Name), Is.EqualTo(new[] { "0", "1", "2" }), $"{tier}: Name");
             }
         });
     }

--- a/ClickHouse.Driver.Tcp.Tests/Integration/PocoReadIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/PocoReadIntegrationTests.cs
@@ -1,0 +1,388 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Poco;
+using ClickHouse.Driver.Tcp.Tests.Utilities;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Tests.Integration;
+
+/// <summary>
+/// <c>QueryAsync&lt;T&gt;</c> against a real server. Per-type coverage rides the round-trip corpus: each case
+/// already knows its ClickHouse type and the CLR type it reads back as, so it becomes a
+/// <see cref="Row{TValue}"/> assertion with no corpus of its own. The rest are the shapes the corpus cannot state —
+/// the calendar and enum readings a property asks for instead of the raw wire value, the session timezone, the
+/// attributes, and rows outliving the blocks they came from.
+/// </summary>
+[TestFixture]
+[Category("Integration")]
+public class PocoReadIntegrationTests
+{
+    private static readonly CancellationToken None = CancellationToken.None;
+
+    private static readonly IReadOnlyDictionary<string, string> TimeSettings = new Dictionary<string, string>(StringComparer.Ordinal)
+    {
+        ["enable_time_time64_type"] = "1",
+        ["allow_experimental_time_time64_type"] = "1",
+    };
+
+    [TestCaseSource(typeof(InsertRoundTripCase), nameof(InsertRoundTripCase.Cases))]
+    public async Task QueryAsync_EveryCorpusType_MaterializesTheColumnIntoTheProperty(InsertRoundTripCase testCase)
+    {
+        await using var client = TcpServerFixture.CreateClient();
+        var options = new ClickHouseTcpQueryOptions { Settings = testCase.Settings };
+        string table = UniqueTableName();
+        try
+        {
+            await client.ExecuteAsync($"CREATE TABLE {table} (value {testCase.ClickHouseType}) ENGINE = Memory", options, None);
+
+            IColumn insert = testCase.BuildInsertColumn("value");
+            await client.InsertAsync(
+                $"INSERT INTO {table} (value) VALUES",
+                new[] { insert },
+                new ClickHouseTcpInsertOptions { Settings = testCase.Settings },
+                None);
+
+            IColumn expected = testCase.BuildExpectedColumn("value");
+            object[] read = await ReadColumnAsRowsAsync(client, $"SELECT value FROM {table}", options, ElementTypeOf(expected));
+
+            Assert.That(read, Has.Length.EqualTo(expected.RowCount), "row count");
+            for (int row = 0; row < expected.RowCount; row++)
+            {
+                Assert.That(read[row], Is.EqualTo(expected.GetValue(row)), $"row {row}");
+            }
+        }
+        finally
+        {
+            await client.ExecuteAsync($"DROP TABLE IF EXISTS {table}", cancellationToken: None);
+        }
+    }
+
+    [Test]
+    public async Task QueryAsync_CalendarAndEnumProperties_ReadTheProjectionsNotTheWireValues()
+    {
+        // The corpus reads each of these columns as its raw wire value (epoch seconds, a scaled count, an ordinal),
+        // which is a different assertion from the one a POCO makes: here every property asks for the reading a
+        // caller would actually declare.
+        await using var client = TcpServerFixture.CreateClient();
+        var options = new ClickHouseTcpQueryOptions { Settings = TimeSettings };
+        string table = UniqueTableName();
+        try
+        {
+            await client.ExecuteAsync(
+                $"CREATE TABLE {table} (Stamp DateTime('UTC'), Precise DateTime64(3, 'UTC'), Day Date, Clock Time, Fine Time64(3), Level Enum8('low' = -1, 'high' = 127)) ENGINE = Memory",
+                options,
+                None);
+
+            var stamp = new DateTime(2024, 1, 15, 10, 30, 0, DateTimeKind.Utc);
+            DateTimeOffset precise = DateTimeOffset.FromUnixTimeMilliseconds(1_700_000_000_123);
+            var day = new DateOnly(2024, 1, 15);
+            var clock = new TimeSpan(12, 34, 56);
+            var fine = new TimeSpan(0, 1, 2, 3, 456);
+
+            IColumn[] columns =
+            {
+                new ArrayColumn<DateTime>("Stamp", "DateTime('UTC')", new[] { stamp }),
+                new ArrayColumn<DateTimeOffset>("Precise", "DateTime64(3, 'UTC')", new[] { precise }),
+                new ArrayColumn<DateOnly>("Day", "Date", new[] { day }),
+                new ArrayColumn<TimeSpan>("Clock", "Time", new[] { clock }),
+                new ArrayColumn<TimeSpan>("Fine", "Time64(3)", new[] { fine }),
+                PrimitiveColumn<sbyte>.FromValues("Level", "Enum8('low' = -1, 'high' = 127)", new sbyte[] { 127 }),
+            };
+
+            await client.InsertAsync(
+                $"INSERT INTO {table} (Stamp, Precise, Day, Clock, Fine, Level) VALUES",
+                columns,
+                new ClickHouseTcpInsertOptions { Settings = TimeSettings },
+                None);
+
+            List<CalendarRow> rows = await client.QueryAsync<CalendarRow>($"SELECT * FROM {table}", options, None).ToListAsync();
+
+            Assert.That(rows, Has.Count.EqualTo(1));
+            Assert.Multiple(() =>
+            {
+                Assert.That(rows[0].Stamp, Is.EqualTo(stamp));
+                Assert.That(rows[0].Stamp.Kind, Is.EqualTo(DateTimeKind.Utc), "a zero offset presents as UTC");
+                Assert.That(rows[0].Precise, Is.EqualTo(precise));
+                Assert.That(rows[0].Day, Is.EqualTo(day));
+                Assert.That(rows[0].Clock, Is.EqualTo(clock));
+                Assert.That(rows[0].Fine, Is.EqualTo(fine));
+                Assert.That(rows[0].Level, Is.EqualTo(Level.High));
+            });
+        }
+        finally
+        {
+            await client.ExecuteAsync($"DROP TABLE IF EXISTS {table}", cancellationToken: None);
+        }
+    }
+
+    [Test]
+    public async Task QueryAsync_TimezoneLessDateTimeColumn_PresentsTheSessionTimezoneWallClock()
+    {
+        // D7: a bare DateTime column is presented in the session timezone, so a DateTime property carries that wall
+        // clock (as Unspecified, there being no offset to attach) while a DateTimeOffset property carries the offset.
+        // This is a deliberate difference from the HTTP client, which has no session timezone to resolve.
+        await using var client = TcpServerFixture.CreateClient();
+        var options = new ClickHouseTcpQueryOptions
+        {
+            Settings = new Dictionary<string, string> { ["session_timezone"] = "Asia/Kolkata" },
+        };
+
+        List<InstantRow> rows = await client
+            .QueryAsync<InstantRow>("SELECT toDateTime(1700000000) AS Stamp, toDateTime(1700000000) AS Offset", options, None)
+            .ToListAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(rows[0].Offset.ToUnixTimeSeconds(), Is.EqualTo(1_700_000_000));
+            Assert.That(rows[0].Offset.Offset, Is.EqualTo(new TimeSpan(5, 30, 0)));
+            Assert.That(rows[0].Stamp, Is.EqualTo(rows[0].Offset.DateTime));
+            Assert.That(rows[0].Stamp.Kind, Is.EqualTo(DateTimeKind.Unspecified));
+        });
+    }
+
+    [Test]
+    public async Task QueryAsync_ResultSpanningSeveralBlocks_KeepsEveryRowValidAfterItsBlock()
+    {
+        // The rows are accumulated and asserted after the enumeration ends, which is the ownership contract: every
+        // value a column surfaces is a copy, so a row outlives the borrowed block it came from. The row count is
+        // well past one block, so the plan is also reused across blocks rather than rebuilt.
+        const int rowCount = 200_000;
+        await using var client = TcpServerFixture.CreateClient();
+
+        List<Numbered> rows = await client
+            .QueryAsync<Numbered>($"SELECT number AS Id, toString(number) AS Name FROM numbers({rowCount})", cancellationToken: None)
+            .ToListAsync();
+
+        Assert.That(rows, Has.Count.EqualTo(rowCount));
+        Assert.Multiple(() =>
+        {
+            Assert.That(rows[0].Id, Is.EqualTo(0ul));
+            Assert.That(rows[0].Name, Is.EqualTo("0"));
+            Assert.That(rows[rowCount - 1].Id, Is.EqualTo((ulong)(rowCount - 1)));
+            Assert.That(rows[rowCount - 1].Name, Is.EqualTo((rowCount - 1).ToString()));
+        });
+    }
+
+    [Test]
+    public async Task QueryAsync_ColumnWithNoPropertyAndPropertyWithNoColumn_SkipsOneAndDefaultsTheOther()
+    {
+        await using var client = TcpServerFixture.CreateClient();
+
+        List<Numbered> rows = await client
+            .QueryAsync<Numbered>("SELECT toUInt64(7) AS Id, 'ignored' AS Untouched", cancellationToken: None)
+            .ToListAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(rows[0].Id, Is.EqualTo(7ul));
+            Assert.That(rows[0].Name, Is.Null, "no column maps to Name");
+        });
+    }
+
+    [Test]
+    public async Task QueryAsync_RenamedAndNotMappedProperties_HonorTheAttributes()
+    {
+        await using var client = TcpServerFixture.CreateClient();
+
+        List<AttributedRow> rows = await client
+            .QueryAsync<AttributedRow>("SELECT toDateTime(1700000000, 'UTC') AS event_time, 'x' AS Ignored", cancellationToken: None)
+            .ToListAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(rows[0].Timestamp, Is.EqualTo(DateTime.UnixEpoch.AddSeconds(1_700_000_000)));
+            Assert.That(rows[0].Ignored, Is.Null, "[ClickHouseTcpNotMapped] keeps the column from reaching the property");
+        });
+    }
+
+    [Test]
+    public async Task QueryAsync_ResultWithNoRows_YieldsNothing()
+    {
+        // A result with no rows carries no block at all (the connection drops zero-row blocks), so there is no header
+        // to compile a plan from: the sequence is simply empty, and nothing about T is validated.
+        await using var client = TcpServerFixture.CreateClient();
+
+        List<Numbered> rows = await client
+            .QueryAsync<Numbered>("SELECT toUInt64(1) AS Id FROM numbers(1) WHERE 0", cancellationToken: None)
+            .ToListAsync();
+
+        Assert.That(rows, Is.Empty);
+    }
+
+    [Test]
+    public async Task QueryAsync_EnumerationAbandonedEarly_LeavesTheClientUsable()
+    {
+        // Stopping mid-result has to release both the pooled row array and the connection; the second query is what
+        // proves the release happened, since a leaked connection would leave the client unable to run another query.
+        await using var client = TcpServerFixture.CreateClient();
+
+        var seen = new List<ulong>();
+        await foreach (Numbered row in client.QueryAsync<Numbered>("SELECT number AS Id FROM numbers(200000)", cancellationToken: None))
+        {
+            seen.Add(row.Id);
+            if (seen.Count == 5)
+            {
+                break;
+            }
+        }
+
+        List<Numbered> after = await client.QueryAsync<Numbered>("SELECT toUInt64(7) AS Id", cancellationToken: None).ToListAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(seen, Is.EqualTo(new ulong[] { 0, 1, 2, 3, 4 }));
+            Assert.That(after[0].Id, Is.EqualTo(7ul));
+        });
+    }
+
+    [Test]
+    public async Task QueryAsync_ColumnNameHoldingThePlanCacheSeparators_MapsToItsProperty()
+    {
+        // The premise of the plan cache's key: a column name is arbitrary text, tabs and newlines included, so a
+        // quoted alias really can spell what a naively joined key uses as its separators.
+        await using var client = TcpServerFixture.CreateClient();
+
+        List<SeparatorRow> rows = await client
+            .QueryAsync<SeparatorRow>("SELECT toInt32(42) AS `a\tb\nc`", cancellationToken: None)
+            .ToListAsync();
+
+        Assert.That(rows[0].Value, Is.EqualTo(42));
+    }
+
+    [Test]
+    public async Task QueryAsync_PropertyTheColumnCannotBeReadAs_ThrowsBeforeTheFirstRow()
+    {
+        // The plan is compiled from the result's first block, so the failure arrives on the first MoveNext rather
+        // than part-way through the rows.
+        await using var client = TcpServerFixture.CreateClient();
+
+        InvalidOperationException error = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await client.QueryAsync<Row<Guid>>("SELECT toInt32(1) AS value", cancellationToken: None).ToListAsync());
+
+        Assert.That(error.Message, Does.Contain("Int32").And.Contain("System.Guid"));
+    }
+
+    [Test]
+    public async Task QueryAsync_EveryScatterTier_ReadsTheSameRows()
+    {
+        // The tiers are compared here as well as in the unit tests because these values come off a real server: the
+        // span tier's zero-copy read and the two per-row tiers have to agree on decoded storage, not just on columns
+        // a test built.
+        const string sql = "SELECT toUInt64(number) AS Id, toString(number) AS Name FROM numbers(3)";
+        var byTier = new Dictionary<PocoScatterTier, List<Numbered>>();
+        foreach (PocoScatterTier tier in Enum.GetValues<PocoScatterTier>())
+        {
+            await using var client = new ClickHouseTcpClient(TcpServerFixture.Options()) { ForcedPocoScatterTier = tier };
+            byTier[tier] = await client.QueryAsync<Numbered>(sql, cancellationToken: None).ToListAsync();
+        }
+
+        Assert.Multiple(() =>
+        {
+            foreach ((PocoScatterTier tier, List<Numbered> rows) in byTier)
+            {
+                Assert.That(Array.ConvertAll(rows.ToArray(), row => row.Id), Is.EqualTo(new ulong[] { 0, 1, 2 }), $"{tier}: Id");
+                Assert.That(Array.ConvertAll(rows.ToArray(), row => row.Name), Is.EqualTo(new[] { "0", "1", "2" }), $"{tier}: Name");
+            }
+        });
+    }
+
+    /// <summary>
+    /// Reads a one-column result into <c>Row&lt;TValue&gt;</c> for a CLR type only known at runtime, which is what
+    /// lets the corpus drive the POCO path: each case's expected column names the type its rows come back as.
+    /// </summary>
+    /// <param name="client">The client to query with.</param>
+    /// <param name="sql">The one-column query.</param>
+    /// <param name="options">The per-query options the case needs.</param>
+    /// <param name="valueType">The CLR type of the column's values.</param>
+    /// <returns>Each row's value, in row order.</returns>
+    private static Task<object[]> ReadColumnAsRowsAsync(IClickHouseTcpClient client, string sql, ClickHouseTcpQueryOptions options, Type valueType)
+    {
+        MethodInfo reader = typeof(PocoReadIntegrationTests)
+            .GetMethod(nameof(ReadRowsAsync), BindingFlags.NonPublic | BindingFlags.Static)
+            .MakeGenericMethod(valueType);
+
+        return (Task<object[]>)reader.Invoke(null, new object[] { client, sql, options });
+    }
+
+    private static async Task<object[]> ReadRowsAsync<TValue>(IClickHouseTcpClient client, string sql, ClickHouseTcpQueryOptions options)
+    {
+        var values = new List<object>();
+        await foreach (Row<TValue> row in client.QueryAsync<Row<TValue>>(sql, options, None))
+        {
+            values.Add(row.Value);
+        }
+
+        return values.ToArray();
+    }
+
+    /// <summary>The <c>T</c> of the <see cref="IColumn{T}"/> a column surfaces.</summary>
+    /// <param name="column">The column.</param>
+    /// <returns>Its CLR element type.</returns>
+    private static Type ElementTypeOf(IColumn column)
+    {
+        foreach (Type implemented in column.GetType().GetInterfaces())
+        {
+            if (implemented.IsGenericType && implemented.GetGenericTypeDefinition() == typeof(IColumn<>))
+            {
+                return implemented.GetGenericArguments()[0];
+            }
+        }
+
+        throw new InvalidOperationException($"Column '{column.Name}' ({column.TypeName}) surfaces no IColumn<T>.");
+    }
+
+    private static string UniqueTableName() => $"tcp_poco_test_{Guid.NewGuid():N}";
+
+    private enum Level : sbyte
+    {
+        Low = -1,
+        High = 127,
+    }
+
+    private sealed class Numbered
+    {
+        public ulong Id { get; set; }
+
+        public string Name { get; set; }
+    }
+
+    private sealed class CalendarRow
+    {
+        public DateTime Stamp { get; set; }
+
+        public DateTimeOffset Precise { get; set; }
+
+        public DateOnly Day { get; set; }
+
+        public TimeSpan Clock { get; set; }
+
+        public TimeSpan Fine { get; set; }
+
+        public Level Level { get; set; }
+    }
+
+    private sealed class InstantRow
+    {
+        public DateTime Stamp { get; set; }
+
+        public DateTimeOffset Offset { get; set; }
+    }
+
+    private sealed class SeparatorRow
+    {
+        [ClickHouseTcpColumn(Name = "a\tb\nc")]
+        public int Value { get; set; }
+    }
+
+    private sealed class AttributedRow
+    {
+        [ClickHouseTcpColumn(Name = "event_time")]
+        public DateTime Timestamp { get; set; }
+
+        [ClickHouseTcpNotMapped]
+        public string Ignored { get; set; }
+    }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Poco/PocoReadPlanTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Poco/PocoReadPlanTests.cs
@@ -8,16 +8,7 @@ using ClickHouse.Driver.Tcp.Types;
 namespace ClickHouse.Driver.Tcp.Tests.Poco;
 
 /// <summary>
-/// The compiled read plan: which tier a column is scattered through, which (column type, property type) pairs are
-/// accepted, and which are refused. Per-type value coverage lives in the integration suite, driven off the
-/// round-trip corpus; what is here is what a server round trip cannot reach — the refusals, the tier choice and the
-/// parity between tiers, the plan cache key, and the shapes a real result cannot produce.
-///
-/// <para>
-/// A plan only needs a column's <see cref="IColumn.TypeName"/> and its <see cref="IColumn{T}"/> shape, so the
-/// blocks here are built from plain columns stamped with the type string under test — the same shape a decoded
-/// block presents.
-/// </para>
+/// Unit coverage for POCO read-plan validation, tier selection and parity, cache keys, and synthetic column shapes.
 /// </summary>
 [TestFixture]
 public class PocoReadPlanTests

--- a/ClickHouse.Driver.Tcp.Tests/Poco/PocoReadPlanTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Poco/PocoReadPlanTests.cs
@@ -68,6 +68,59 @@ public class PocoReadPlanTests
         Assert.That(rows[0].UserId, Is.EqualTo(42));
     }
 
+    [TestCase(true)]
+    [TestCase(false)]
+    public void Materialize_WindowStartingPastTheFirstRow_ReadsThatWindowIntoTheFirstRows(bool spanTier)
+    {
+        PocoScatterTier tier = spanTier ? PocoScatterTier.Span : PocoScatterTier.Indexer;
+        // The window's start has to rebase the column read while leaving the destination at 0, and a start of 0
+        // would not show that: a scatter ignoring the parameter passes. Both tiers source a value differently, so
+        // proving one says nothing about the other.
+        Block block = BlockOf(5, Ints("value", 10, 11, 12, 13, 14));
+        PocoReadPlan<Row<int>> plan = PocoReadPlan<Row<int>>.Build(PocoTypeDescriptor<Row<int>>.Build(), block, tier);
+        var rows = new Row<int>[2];
+
+        plan.Materialize(block, rows, start: 2, count: 2, rowOffset: 2);
+
+        Assert.That(Values(rows), Is.EqualTo(new[] { 12, 13 }));
+    }
+
+    [Test]
+    public void Materialize_WholeBlockInWindows_ProducesTheSameRowsAsOnePass()
+    {
+        // What the client's windowed loop does, against the single pass it replaced. A window that does not divide
+        // the block evenly is the interesting case: the last one is short.
+        Block block = BlockOf(7, Ints("value", 0, 1, 2, 3, 4, 5, 6));
+        PocoReadPlan<Row<int>> plan = PocoReadPlan<Row<int>>.Build(PocoTypeDescriptor<Row<int>>.Build(), block, null);
+        var windowed = new Row<int>[7];
+        var window = new Row<int>[3];
+
+        for (int start = 0; start < block.RowCount; start += window.Length)
+        {
+            int count = Math.Min(window.Length, block.RowCount - start);
+            plan.Materialize(block, window, start, count, start);
+            Array.Copy(window, 0, windowed, start, count);
+        }
+
+        Assert.That(Values(windowed), Is.EqualTo(Values(Materialize<Row<int>>(block))));
+    }
+
+    [Test]
+    public void Materialize_NullInALaterWindow_NamesTheRowOfTheResultRatherThanOfTheWindow()
+    {
+        // The row a caller counts is rowOffset plus the offset within the window, so a window that starts part-way
+        // into a block of a later block must still name the absolute row. Off-by-one here is invisible in the
+        // first window of the first block, where every candidate expression agrees.
+        Block block = BlockOf(5, new ArrayColumn<int?>("value", "Nullable(Int32)", new int?[] { 1, 2, 3, null, 5 }));
+        PocoReadPlan<Row<int>> plan = PocoReadPlan<Row<int>>.Build(PocoTypeDescriptor<Row<int>>.Build(), block, null);
+        var rows = new Row<int>[2];
+
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(
+            () => plan.Materialize(block, rows, start: 2, count: 2, rowOffset: 1002));
+
+        Assert.That(error.Message, Does.Contain("row 1003").And.Contain("Row`1.Value"));
+    }
+
     [Test]
     public void Materialize_ZeroRows_ConstructsNothing()
     {
@@ -379,28 +432,43 @@ public class PocoReadPlanTests
         PocoColumnScatter<Row<int>> scatter = PocoColumnScatterFactory.Create<Row<int>>(column, codec, member, PocoScatterTier.Indexer, preferInterpretation: true);
         var rows = new[] { new Row<int>(), new Row<int>() };
 
-        scatter(column, rows, rows.Length, rowOffset: 0);
+        scatter(column, rows, start: 0, rows.Length, rowOffset: 0);
 
         Assert.That(Values(rows), Is.EqualTo(new[] { 1, -2 }));
     }
 
     [Test]
-    public void SelectTier_NoForcedTier_PrefersTheSpanTierWhereverTreesCompile()
+    public void SelectTier_StoredValuesColumnAndNoForcedTier_PrefersTheSpanTierWhereverTreesCompile()
     {
         // The interpreter cannot hold a ReadOnlySpan<T>, so the span tier is only offered where a tree becomes IL.
         PocoScatterTier expected = RuntimeFeature.IsDynamicCodeCompiled ? PocoScatterTier.Span : PocoScatterTier.Indexer;
 
-        Assert.That(PocoColumnScatterFactory.SelectTier(null), Is.EqualTo(expected));
+        Assert.That(PocoColumnScatterFactory.SelectTier(null, Ints("value", 1)), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void SelectTier_ColumnThatBuildsItsValuesAndNoForcedTier_PrefersTheIndexerTier()
+    {
+        // Hoisting Values is the point of the span tier, but for a column that builds its values on access that one
+        // read materializes every row of the block and pins it, which is what the windowed materialization avoids.
+        var built = new StringColumn("value", "String", new byte[] { 0x61 }, new[] { 0, 1 }, 1, pooled: false);
+
+        Assert.That(PocoColumnScatterFactory.SelectTier(null, built), Is.EqualTo(PocoScatterTier.Indexer));
     }
 
     [Test]
     public void SelectTier_ForcedTier_IsHonored()
     {
+        // Forced over both column shapes: a forced tier outranks the column's own preference, which is what lets the
+        // parity harness compile the span tier for a column that would otherwise choose the indexer.
+        var built = new StringColumn("value", "String", new byte[] { 0x61 }, new[] { 0, 1 }, 1, pooled: false);
+
         Assert.Multiple(() =>
         {
             foreach (PocoScatterTier tier in Enum.GetValues<PocoScatterTier>())
             {
-                Assert.That(PocoColumnScatterFactory.SelectTier(tier), Is.EqualTo(tier), tier.ToString());
+                Assert.That(PocoColumnScatterFactory.SelectTier(tier, Ints("value", 1)), Is.EqualTo(tier), $"{tier} over stored values");
+                Assert.That(PocoColumnScatterFactory.SelectTier(tier, built), Is.EqualTo(tier), $"{tier} over built values");
             }
         });
     }

--- a/ClickHouse.Driver.Tcp.Tests/Poco/PocoReadPlanTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Poco/PocoReadPlanTests.cs
@@ -170,6 +170,32 @@ public class PocoReadPlanTests
     }
 
     [Test]
+    public void Build_EnumLabelSpellingATypeName_StillGetsTheOrdinaryAdvice()
+    {
+        // An enum label is arbitrary text that rides inside the type string, so a column can be perfectly well typed
+        // and still mention Nothing. Diagnosing it as an untyped NULL would send the caller after the wrong thing.
+        Block block = BlockOf(1, PrimitiveColumn<sbyte>.FromValues("value", "Enum8('Nothing' = 1)", new sbyte[] { 1 }));
+
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => Materialize<Row<Guid>>(block));
+
+        Assert.That(error.Message, Does.Not.Contain("untyped NULL").And.Contain("Give the property one of those types"));
+    }
+
+    [Test]
+    public void Materialize_NullInALaterBlock_NamesTheRowOfTheResultNotOfTheBlock()
+    {
+        // The scatter's counter restarts per block, so without the offset a NULL in the second block of a result
+        // reports as row 1 — pointing the caller at a row that is not the one that failed.
+        Block block = BlockOf(2, new ArrayColumn<int?>("value", "Nullable(Int32)", new int?[] { 1, null }));
+        PocoReadPlan<Row<int>> plan = PocoReadPlan<Row<int>>.Build(PocoTypeDescriptor<Row<int>>.Build(), block, forcedTier: null);
+
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(
+            () => plan.Materialize(block, new Row<int>[2], rowOffset: 65_536));
+
+        Assert.That(error.Message, Does.Contain("row 65537 of the result"));
+    }
+
+    [Test]
     public void Build_BlockWithNoColumns_ThrowsSayingSo()
     {
         InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => Materialize<IdName>(BlockOf(1)));
@@ -358,7 +384,7 @@ public class PocoReadPlanTests
                 PocoColumnScatter<Row<int>> scatter = PocoColumnScatterFactory.Create<Row<int>>(column, codec, member, tier, preferInterpretation: true);
                 var rows = new[] { new Row<int>(), new Row<int>() };
 
-                scatter(column, rows, rows.Length);
+                scatter(column, rows, rows.Length, rowOffset: 0);
 
                 Assert.That(Values(rows), Is.EqualTo(new[] { 1, -2 }), tier.ToString());
             }
@@ -436,8 +462,8 @@ public class PocoReadPlanTests
 
         var intRows = new Row<object>[1];
         var stringRows = new Row<object>[1];
-        intPlan.Materialize(ints, intRows);
-        stringPlan.Materialize(strings, stringRows);
+        intPlan.Materialize(ints, intRows, rowOffset: 0);
+        stringPlan.Materialize(strings, stringRows, rowOffset: 0);
 
         Assert.Multiple(() =>
         {
@@ -459,8 +485,8 @@ public class PocoReadPlanTests
 
         var spelledRows = new ThreeColumns[1];
         var threeRows = new ThreeColumns[1];
-        registry.ReadPlanFor<ThreeColumns>(spelled, forcedTier: null).Materialize(spelled, spelledRows);
-        registry.ReadPlanFor<ThreeColumns>(three, forcedTier: null).Materialize(three, threeRows);
+        registry.ReadPlanFor<ThreeColumns>(spelled, forcedTier: null).Materialize(spelled, spelledRows, rowOffset: 0);
+        registry.ReadPlanFor<ThreeColumns>(three, forcedTier: null).Materialize(three, threeRows, rowOffset: 0);
 
         Assert.Multiple(() =>
         {
@@ -482,8 +508,8 @@ public class PocoReadPlanTests
 
         var utcRows = new Row<DateTime>[1];
         var kolkataRows = new Row<DateTime>[1];
-        registry.ReadPlanFor<Row<DateTime>>(utc, forcedTier: null).Materialize(utc, utcRows);
-        registry.ReadPlanFor<Row<DateTime>>(kolkata, forcedTier: null).Materialize(kolkata, kolkataRows);
+        registry.ReadPlanFor<Row<DateTime>>(utc, forcedTier: null).Materialize(utc, utcRows, rowOffset: 0);
+        registry.ReadPlanFor<Row<DateTime>>(kolkata, forcedTier: null).Materialize(kolkata, kolkataRows, rowOffset: 0);
 
         Assert.That(kolkataRows[0].Value - utcRows[0].Value, Is.EqualTo(new TimeSpan(5, 30, 0)));
     }
@@ -552,7 +578,7 @@ public class PocoReadPlanTests
     {
         PocoReadPlan<T> plan = PocoReadPlan<T>.Build(PocoTypeDescriptor<T>.Build(), block, tier);
         var rows = new T[block.RowCount];
-        plan.Materialize(block, rows);
+        plan.Materialize(block, rows, rowOffset: 0);
         return rows;
     }
 

--- a/ClickHouse.Driver.Tcp.Tests/Poco/PocoReadPlanTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Poco/PocoReadPlanTests.cs
@@ -347,7 +347,7 @@ public class PocoReadPlanTests
     [Test]
     public void Materialize_EveryTier_ProducesTheSameRows()
     {
-        // The three tiers differ only in how one value is sourced, so they must agree — including on the
+        // The tiers differ only in how one value is sourced, so they must agree — including on the
         // conversions, which is why the block mixes a raw type, a projected one, a nullable and a composite. This
         // doubles as the proof that the span-free tier a runtime without dynamic code falls back to is equivalent.
         Assert.Multiple(() =>
@@ -367,7 +367,7 @@ public class PocoReadPlanTests
     }
 
     [Test]
-    public void Create_SpanFreeTiers_AlsoRunUnderTheExpressionInterpreter()
+    public void Create_IndexerTier_AlsoRunsUnderTheExpressionInterpreter()
     {
         // Why the indexer tier exists at all: a runtime without dynamic code interprets the tree instead of
         // compiling it, and an interpreted tree cannot hold a ReadOnlySpan<T>. A test host that has dynamic code
@@ -376,19 +376,12 @@ public class PocoReadPlanTests
         IColumn column = Ints("value", 1, -2);
         IColumnCodec codec = ColumnCodecRegistry.Default.Resolve("Int32", new ResolveContext());
         PocoMember member = PocoTypeDescriptor<Row<int>>.Build().Members[0];
+        PocoColumnScatter<Row<int>> scatter = PocoColumnScatterFactory.Create<Row<int>>(column, codec, member, PocoScatterTier.Indexer, preferInterpretation: true);
+        var rows = new[] { new Row<int>(), new Row<int>() };
 
-        Assert.Multiple(() =>
-        {
-            foreach (PocoScatterTier tier in new[] { PocoScatterTier.Indexer, PocoScatterTier.Boxed })
-            {
-                PocoColumnScatter<Row<int>> scatter = PocoColumnScatterFactory.Create<Row<int>>(column, codec, member, tier, preferInterpretation: true);
-                var rows = new[] { new Row<int>(), new Row<int>() };
+        scatter(column, rows, rows.Length, rowOffset: 0);
 
-                scatter(column, rows, rows.Length, rowOffset: 0);
-
-                Assert.That(Values(rows), Is.EqualTo(new[] { 1, -2 }), tier.ToString());
-            }
-        });
+        Assert.That(Values(rows), Is.EqualTo(new[] { 1, -2 }));
     }
 
     [Test]
@@ -397,44 +390,31 @@ public class PocoReadPlanTests
         // The interpreter cannot hold a ReadOnlySpan<T>, so the span tier is only offered where a tree becomes IL.
         PocoScatterTier expected = RuntimeFeature.IsDynamicCodeCompiled ? PocoScatterTier.Span : PocoScatterTier.Indexer;
 
-        Assert.That(PocoColumnScatterFactory.SelectTier(null, columnSurfacesElementType: true), Is.EqualTo(expected));
+        Assert.That(PocoColumnScatterFactory.SelectTier(null), Is.EqualTo(expected));
     }
 
     [Test]
-    public void SelectTier_ForcedTier_IsHonoredForATypedColumn()
+    public void SelectTier_ForcedTier_IsHonored()
     {
         Assert.Multiple(() =>
         {
             foreach (PocoScatterTier tier in Enum.GetValues<PocoScatterTier>())
             {
-                Assert.That(PocoColumnScatterFactory.SelectTier(tier, columnSurfacesElementType: true), Is.EqualTo(tier), tier.ToString());
+                Assert.That(PocoColumnScatterFactory.SelectTier(tier), Is.EqualTo(tier), tier.ToString());
             }
         });
     }
 
     [Test]
-    public void SelectTier_ColumnNotSurfacingItsElementType_FallsBackToBoxed()
+    public void Build_ColumnNotSurfacingItsElementType_ReportsTheCodecMismatch()
     {
-        Assert.Multiple(() =>
-        {
-            Assert.That(PocoColumnScatterFactory.SelectTier(null, columnSurfacesElementType: false), Is.EqualTo(PocoScatterTier.Boxed), "unforced");
-            foreach (PocoScatterTier tier in Enum.GetValues<PocoScatterTier>())
-            {
-                Assert.That(PocoColumnScatterFactory.SelectTier(tier, columnSurfacesElementType: false), Is.EqualTo(PocoScatterTier.Boxed), tier.ToString());
-            }
-        });
-    }
-
-    [Test]
-    public void Materialize_ColumnNotSurfacingItsElementType_ReadsItThroughGetValue()
-    {
-        // No decoded column has this shape, but the plan must not assume otherwise: the typed tiers would fail their
-        // cast, so the boxed path is what keeps such a column readable.
+        // No shipped codec produces such a column, but both tiers cast to IColumn<T>, so one would fail that cast
+        // inside compiled code on the first block. Reported at plan build, naming the column and the codec.
         Block block = BlockOf(2, new UntypedColumn("value", "Int32", 1, -2));
 
-        Row<int>[] rows = Materialize<Row<int>>(block);
+        var error = Assert.Throws<InvalidOperationException>(() => Materialize<Row<int>>(block));
 
-        Assert.That(Values(rows), Is.EqualTo(new[] { 1, -2 }));
+        Assert.That(error.Message, Does.Contain("value").And.Contain("IColumn<System.Int32>"));
     }
 
     [Test]
@@ -521,9 +501,9 @@ public class PocoReadPlanTests
         Block block = BlockOf(1, Ints("value", 1));
 
         PocoReadPlan<Row<int>> span = registry.ReadPlanFor<Row<int>>(block, PocoScatterTier.Span);
-        PocoReadPlan<Row<int>> boxed = registry.ReadPlanFor<Row<int>>(block, PocoScatterTier.Boxed);
+        PocoReadPlan<Row<int>> indexer = registry.ReadPlanFor<Row<int>>(block, PocoScatterTier.Indexer);
 
-        Assert.That(boxed, Is.Not.SameAs(span));
+        Assert.That(indexer, Is.Not.SameAs(span));
     }
 
     [Test]
@@ -584,7 +564,7 @@ public class PocoReadPlanTests
 
     private static TValue[] Values<TValue>(Row<TValue>[] rows) => Array.ConvertAll(rows, row => row.Value);
 
-    /// <summary>A column that surfaces its values only boxed, which forces the boxed tier.</summary>
+    /// <summary>A column that surfaces its values only boxed, which no tier can source through.</summary>
     private sealed class UntypedColumn : IColumn
     {
         private readonly object[] values;

--- a/ClickHouse.Driver.Tcp.Tests/Poco/PocoReadPlanTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Poco/PocoReadPlanTests.cs
@@ -1,0 +1,644 @@
+using System;
+using System.Runtime.CompilerServices;
+using ClickHouse.Driver.Tcp.Format;
+using ClickHouse.Driver.Tcp.Poco;
+using ClickHouse.Driver.Tcp.Tests.Utilities;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Tests.Poco;
+
+/// <summary>
+/// The compiled read plan: which tier a column is scattered through, which (column type, property type) pairs are
+/// accepted, and which are refused. Per-type value coverage lives in the integration suite, driven off the
+/// round-trip corpus; what is here is what a server round trip cannot reach — the refusals, the tier choice and the
+/// parity between tiers, the plan cache key, and the shapes a real result cannot produce.
+///
+/// <para>
+/// A plan only needs a column's <see cref="IColumn.TypeName"/> and its <see cref="IColumn{T}"/> shape, so the
+/// blocks here are built from plain columns stamped with the type string under test — the same shape a decoded
+/// block presents.
+/// </para>
+/// </summary>
+[TestFixture]
+public class PocoReadPlanTests
+{
+    [Test]
+    public void Materialize_PropertyMatchingTheColumn_FillsEveryRow()
+    {
+        Block block = BlockOf(3, Ints("value", 1, -2, int.MaxValue));
+
+        Row<int>[] rows = Materialize<Row<int>>(block);
+
+        Assert.That(Values(rows), Is.EqualTo(new[] { 1, -2, int.MaxValue }));
+    }
+
+    [Test]
+    public void Materialize_ColumnMatchingNoProperty_LeavesItUnread()
+    {
+        // The extra column is not merely ignored: nothing reads it, so a column type the POCO cannot model does not
+        // stop the columns it can from being read.
+        Block block = BlockOf(2, Ints("Id", 7, 8), new ArrayColumn<object>("Extra", "Variant(Int32, String)", new object[] { 1, "x" }));
+
+        IdName[] rows = Materialize<IdName>(block);
+
+        Assert.That(Array.ConvertAll(rows, row => row.Id), Is.EqualTo(new[] { 7, 8 }));
+    }
+
+    [Test]
+    public void Materialize_PropertyMatchingNoColumn_LeavesItAtItsDefault()
+    {
+        Block block = BlockOf(2, Ints("Id", 7, 8));
+
+        IdName[] rows = Materialize<IdName>(block);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(Array.ConvertAll(rows, row => row.Id), Is.EqualTo(new[] { 7, 8 }));
+            Assert.That(Array.ConvertAll(rows, row => row.Name), Is.EqualTo(new string[] { null, null }));
+        });
+    }
+
+    [Test]
+    public void Materialize_UnderscoredColumnName_ReachesThePropertyThroughTheMatcher()
+    {
+        Block block = BlockOf(1, Ints("user_id", 42));
+
+        UserRow[] rows = Materialize<UserRow>(block);
+
+        Assert.That(rows[0].UserId, Is.EqualTo(42));
+    }
+
+    [Test]
+    public void Materialize_ZeroRows_ConstructsNothing()
+    {
+        Block block = BlockOf(0, Ints("value"));
+
+        Row<int>[] rows = Materialize<Row<int>>(block);
+
+        Assert.That(rows, Is.Empty);
+    }
+
+    [Test]
+    public void Build_TypeWithoutAParameterlessConstructor_ThrowsNamingTheReason()
+    {
+        Block block = BlockOf(1, Ints("Value", 1));
+
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => Materialize<ConstructorOnlyPoco>(block));
+
+        Assert.That(error.Message, Does.Contain("ConstructorOnlyPoco").And.Contain("no public parameterless constructor"));
+    }
+
+    [Test]
+    public void Build_ColumnMappedToAGetterOnlyProperty_ThrowsNamingTheProperty()
+    {
+        Block block = BlockOf(1, Ints("Value", 1));
+
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => Materialize<GetterOnlyPoco>(block));
+
+        Assert.That(error.Message, Does.Contain("'Value'").And.Contain("GetterOnlyPoco.Value").And.Contain("no setter"));
+    }
+
+    [Test]
+    public void Build_ColumnMappedToAnInitOnlyProperty_ThrowsNamingTheSetter()
+    {
+        Block block = BlockOf(1, Ints("Value", 1));
+
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => Materialize<InitOnlyPoco>(block));
+
+        Assert.That(error.Message, Does.Contain("InitOnlyPoco.Value").And.Contain("init-only"));
+    }
+
+    [Test]
+    public void Build_TwoColumnsReachingOneProperty_ThrowsNamingBoth()
+    {
+        // Neither name matches exactly, so both land on UserId through the looser tiers; whichever scattered last
+        // would win silently.
+        Block block = BlockOf(1, Ints("user_id", 1), Ints("userid", 2));
+
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => Materialize<UserRow>(block));
+
+        Assert.That(error.Message, Does.Contain("'user_id'").And.Contain("'userid'").And.Contain("UserRow.UserId"));
+    }
+
+    [Test]
+    public void Build_NoColumnReachingAnyProperty_ThrowsRatherThanReturningDefaults()
+    {
+        Block block = BlockOf(1, Ints("something_else", 1));
+
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => Materialize<IdName>(block));
+
+        Assert.That(error.Message, Does.Contain("something_else").And.Contain("Id").And.Contain("Name"));
+    }
+
+    [Test]
+    public void Build_WiderNumericProperty_ThrowsRatherThanWidening()
+    {
+        // D6c: an Int32 column does not fill a long property, however lossless the conversion would be.
+        Block block = BlockOf(1, Ints("value", 1));
+
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => Materialize<Row<long>>(block));
+
+        Assert.That(error.Message, Does.Contain("Int32").And.Contain("System.Int64"));
+    }
+
+    [Test]
+    public void Build_WiderNumericPropertyAcrossTheNullableCombinations_ThrowsRatherThanWidening()
+    {
+        // Each nullable combination is its own arm of the resolution, and only the plain one is covered above. Left
+        // untested, replacing any of these three checks with a bare cast would start widening int into long silently.
+        Block nullableColumn = BlockOf(1, new ArrayColumn<int?>("value", "Nullable(Int32)", new int?[] { 1 }));
+        Block plainColumn = BlockOf(1, Ints("value", 1));
+
+        Assert.Multiple(() =>
+        {
+            Assert.Throws<InvalidOperationException>(() => Materialize<Row<long>>(nullableColumn), "Nullable(Int32) -> long");
+            Assert.Throws<InvalidOperationException>(() => Materialize<Row<long?>>(plainColumn), "Int32 -> long?");
+            Assert.Throws<InvalidOperationException>(() => Materialize<Row<long?>>(nullableColumn), "Nullable(Int32) -> long?");
+        });
+    }
+
+    [Test]
+    public void Build_UntypedNullColumn_ThrowsTellingTheCallerToTypeItInTheQuery()
+    {
+        // `SELECT NULL AS Name` yields Nullable(Nothing), which reads only as object — so the usual "give the property
+        // one of these types" advice is useless: the property is fine, the column has no type.
+        Block block = BlockOf(1, new ArrayColumn<object>("value", "Nullable(Nothing)", new object[] { null }));
+
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => Materialize<Row<string>>(block));
+
+        Assert.That(error.Message, Does.Contain("Nullable(Nothing)").And.Contain("untyped NULL").And.Contain("CAST(NULL AS Nullable(String))"));
+    }
+
+    [Test]
+    public void Build_BlockWithNoColumns_ThrowsSayingSo()
+    {
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => Materialize<IdName>(BlockOf(1)));
+
+        Assert.That(error.Message, Does.Contain("no columns"));
+    }
+
+    [Test]
+    public void Build_CompositePropertyNeedingElementProjection_ThrowsNamingWhatTheColumnReadsAs()
+    {
+        // A composite does not lift its child's readable types, so Array(DateTime) reads as uint[] and nothing else.
+        // The message has to say so, since DateTime[] is the shape a caller would reasonably expect.
+        Block block = BlockOf(1, new ArrayColumn<uint[]>("value", "Array(DateTime)", new[] { new uint[] { 1, 2 } }));
+
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => Materialize<Row<DateTime[]>>(block));
+
+        Assert.That(error.Message, Does.Contain("Array(DateTime)").And.Contain("System.UInt32[]").And.Contain("System.DateTime[]"));
+    }
+
+    [Test]
+    public void Materialize_NullableColumnIntoANullableProperty_KeepsTheNulls()
+    {
+        Block block = BlockOf(3, new ArrayColumn<int?>("value", "Nullable(Int32)", new int?[] { 1, null, -3 }));
+
+        Row<int?>[] rows = Materialize<Row<int?>>(block);
+
+        Assert.That(Values(rows), Is.EqualTo(new int?[] { 1, null, -3 }));
+    }
+
+    [Test]
+    public void Materialize_NullableColumnWithNoNullsIntoANonNullableProperty_FillsEveryRow()
+    {
+        Block block = BlockOf(2, new ArrayColumn<int?>("value", "Nullable(Int32)", new int?[] { 1, -3 }));
+
+        Row<int>[] rows = Materialize<Row<int>>(block);
+
+        Assert.That(Values(rows), Is.EqualTo(new[] { 1, -3 }));
+    }
+
+    [Test]
+    public void Materialize_NullReachingANonNullableProperty_ThrowsNamingTheRow()
+    {
+        // D6a: assigning default would make a NULL indistinguishable from a stored zero.
+        Block block = BlockOf(3, new ArrayColumn<int?>("value", "Nullable(Int32)", new int?[] { 1, null, 3 }));
+
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => Materialize<Row<int>>(block));
+
+        Assert.That(error.Message, Does.Contain("'value'").And.Contain("Nullable(Int32)").And.Contain("row 1").And.Contain("Row`1.Value"));
+    }
+
+    [Test]
+    public void Materialize_NonNullableColumnIntoANullableProperty_Lifts()
+    {
+        Block block = BlockOf(2, Ints("value", 1, -2));
+
+        Row<int?>[] rows = Materialize<Row<int?>>(block);
+
+        Assert.That(Values(rows), Is.EqualTo(new int?[] { 1, -2 }));
+    }
+
+    [Test]
+    public void Materialize_NullablePropertyOverAProjectedColumn_ProjectsThenLifts()
+    {
+        // Both halves at once: the codec's own conversion, then the lift a nullable property needs. Neither the
+        // corpus nor the plain lift case reaches this pair.
+        Block block = BlockOf(1, PrimitiveColumn<uint>.FromValues("value", "DateTime('UTC')", new uint[] { 1_700_000_000 }));
+
+        Row<DateTime?>[] rows = Materialize<Row<DateTime?>>(block);
+
+        Assert.That(rows[0].Value, Is.EqualTo(DateTime.UnixEpoch.AddSeconds(1_700_000_000)));
+    }
+
+    [Test]
+    public void Materialize_NullableEnumPropertyOverANonNullableColumn_CastsThenLifts()
+    {
+        Block block = BlockOf(2, PrimitiveColumn<sbyte>.FromValues("value", "Enum8('low' = -1, 'high' = 127)", new sbyte[] { -1, 127 }));
+
+        Row<Level?>[] rows = Materialize<Row<Level?>>(block);
+
+        Assert.That(Values(rows), Is.EqualTo(new Level?[] { Level.Low, Level.High }));
+    }
+
+    [Test]
+    public void Materialize_ObjectProperty_BoxesWhateverTheColumnSurfaces()
+    {
+        Block block = BlockOf(2, Ints("value", 1, -2));
+
+        Row<object>[] rows = Materialize<Row<object>>(block);
+
+        Assert.That(Values(rows), Is.EqualTo(new object[] { 1, -2 }));
+    }
+
+    [Test]
+    public void Materialize_EnumProperty_CastsTheOrdinal()
+    {
+        // D6b: the cast is blind, so an ordinal the CLR enum does not name arrives as that ordinal rather than
+        // being rejected. 5 is not a Level member.
+        Block block = BlockOf(3, PrimitiveColumn<sbyte>.FromValues("value", "Enum8('low' = -1, 'high' = 127)", new sbyte[] { -1, 127, 5 }));
+
+        Row<Level>[] rows = Materialize<Row<Level>>(block);
+
+        Assert.That(Values(rows), Is.EqualTo(new[] { Level.Low, Level.High, (Level)5 }));
+    }
+
+    [Test]
+    public void Materialize_NullableEnumProperty_KeepsTheNullsAndCastsTheRest()
+    {
+        Block block = BlockOf(3, new ArrayColumn<sbyte?>("value", "Nullable(Enum8('low' = -1, 'high' = 127))", new sbyte?[] { -1, null, 127 }));
+
+        Row<Level?>[] rows = Materialize<Row<Level?>>(block);
+
+        Assert.That(Values(rows), Is.EqualTo(new Level?[] { Level.Low, null, Level.High }));
+    }
+
+    [Test]
+    public void Materialize_EnumPropertyOverANullableColumnWithANull_ThrowsNamingTheRow()
+    {
+        Block block = BlockOf(2, new ArrayColumn<sbyte?>("value", "Nullable(Enum8('low' = -1))", new sbyte?[] { -1, null }));
+
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => Materialize<Row<Level>>(block));
+
+        Assert.That(error.Message, Does.Contain("row 1"));
+    }
+
+    [Test]
+    public void Materialize_DateTimePropertyOverADateTimeColumn_ProjectsThroughTheCodec()
+    {
+        // The column's canonical CLR type is the raw epoch second count, so this is the codec's projection being
+        // inlined into the scatter — the single most common POCO shape there is.
+        Block block = BlockOf(1, PrimitiveColumn<uint>.FromValues("value", "DateTime('UTC')", new uint[] { 1_700_000_000 }));
+
+        Row<DateTime>[] rows = Materialize<Row<DateTime>>(block);
+
+        Assert.That(rows[0].Value, Is.EqualTo(DateTime.UnixEpoch.AddSeconds(1_700_000_000)));
+    }
+
+    [Test]
+    public void Materialize_RawPropertyOverADateTimeColumn_StillReadsTheWireValue()
+    {
+        Block block = BlockOf(1, PrimitiveColumn<uint>.FromValues("value", "DateTime('UTC')", new uint[] { 1_700_000_000 }));
+
+        Row<uint>[] rows = Materialize<Row<uint>>(block);
+
+        Assert.That(rows[0].Value, Is.EqualTo(1_700_000_000u));
+    }
+
+    // The tiers are cases of one loop rather than [TestCase]s, because the enum is internal and a public test
+    // method cannot take it as a parameter. Iterating the enum also covers a tier added later for free.
+    [Test]
+    public void Materialize_EveryTier_ProducesTheSameRows()
+    {
+        // The three tiers differ only in how one value is sourced, so they must agree — including on the
+        // conversions, which is why the block mixes a raw type, a projected one, a nullable and a composite. This
+        // doubles as the proof that the span-free tier a runtime without dynamic code falls back to is equivalent.
+        Assert.Multiple(() =>
+        {
+            foreach (PocoScatterTier tier in Enum.GetValues<PocoScatterTier>())
+            {
+                MixedRow[] rows = Materialize<MixedRow>(MixedBlock(), tier);
+
+                Assert.That(Array.ConvertAll(rows, row => row.Id), Is.EqualTo(new[] { 1, 2 }), $"{tier}: Id");
+                Assert.That(Array.ConvertAll(rows, row => row.Name), Is.EqualTo(new[] { "a", "b" }), $"{tier}: Name");
+                Assert.That(Array.ConvertAll(rows, row => row.Stamp), Is.EqualTo(new[] { DateTime.UnixEpoch.AddSeconds(1_700_000_000), DateTime.UnixEpoch }), $"{tier}: Stamp");
+                Assert.That(Array.ConvertAll(rows, row => row.Score), Is.EqualTo(new double?[] { 1.5, null }), $"{tier}: Score");
+                Assert.That(Array.ConvertAll(rows, row => row.Tags), Is.EqualTo(new[] { new[] { "x", "y" }, Array.Empty<string>() }), $"{tier}: Tags");
+                Assert.That(Array.ConvertAll(rows, row => row.Level), Is.EqualTo(new[] { Level.Low, Level.High }), $"{tier}: Level");
+            }
+        });
+    }
+
+    [Test]
+    public void Create_SpanFreeTiers_AlsoRunUnderTheExpressionInterpreter()
+    {
+        // Why the indexer tier exists at all: a runtime without dynamic code interprets the tree instead of
+        // compiling it, and an interpreted tree cannot hold a ReadOnlySpan<T>. A test host that has dynamic code
+        // never takes that path, so the interpreter is asked for explicitly here — otherwise the fallback ships
+        // untested and only fails on NativeAOT.
+        IColumn column = Ints("value", 1, -2);
+        IColumnCodec codec = ColumnCodecRegistry.Default.Resolve("Int32", new ResolveContext());
+        PocoMember member = PocoTypeDescriptor<Row<int>>.Build().Members[0];
+
+        Assert.Multiple(() =>
+        {
+            foreach (PocoScatterTier tier in new[] { PocoScatterTier.Indexer, PocoScatterTier.Boxed })
+            {
+                PocoColumnScatter<Row<int>> scatter = PocoColumnScatterFactory.Create<Row<int>>(column, codec, member, tier, preferInterpretation: true);
+                var rows = new[] { new Row<int>(), new Row<int>() };
+
+                scatter(column, rows, rows.Length);
+
+                Assert.That(Values(rows), Is.EqualTo(new[] { 1, -2 }), tier.ToString());
+            }
+        });
+    }
+
+    [Test]
+    public void SelectTier_NoForcedTier_PrefersTheSpanTierWhereverTreesCompile()
+    {
+        // The interpreter cannot hold a ReadOnlySpan<T>, so the span tier is only offered where a tree becomes IL.
+        PocoScatterTier expected = RuntimeFeature.IsDynamicCodeCompiled ? PocoScatterTier.Span : PocoScatterTier.Indexer;
+
+        Assert.That(PocoColumnScatterFactory.SelectTier(null, columnSurfacesElementType: true), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void SelectTier_ForcedTier_IsHonoredForATypedColumn()
+    {
+        Assert.Multiple(() =>
+        {
+            foreach (PocoScatterTier tier in Enum.GetValues<PocoScatterTier>())
+            {
+                Assert.That(PocoColumnScatterFactory.SelectTier(tier, columnSurfacesElementType: true), Is.EqualTo(tier), tier.ToString());
+            }
+        });
+    }
+
+    [Test]
+    public void SelectTier_ColumnNotSurfacingItsElementType_FallsBackToBoxed()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(PocoColumnScatterFactory.SelectTier(null, columnSurfacesElementType: false), Is.EqualTo(PocoScatterTier.Boxed), "unforced");
+            foreach (PocoScatterTier tier in Enum.GetValues<PocoScatterTier>())
+            {
+                Assert.That(PocoColumnScatterFactory.SelectTier(tier, columnSurfacesElementType: false), Is.EqualTo(PocoScatterTier.Boxed), tier.ToString());
+            }
+        });
+    }
+
+    [Test]
+    public void Materialize_ColumnNotSurfacingItsElementType_ReadsItThroughGetValue()
+    {
+        // No decoded column has this shape, but the plan must not assume otherwise: the typed tiers would fail their
+        // cast, so the boxed path is what keeps such a column readable.
+        Block block = BlockOf(2, new UntypedColumn("value", "Int32", 1, -2));
+
+        Row<int>[] rows = Materialize<Row<int>>(block);
+
+        Assert.That(Values(rows), Is.EqualTo(new[] { 1, -2 }));
+    }
+
+    [Test]
+    public void ReadPlanFor_SameHeader_ReturnsTheCachedPlan()
+    {
+        var registry = new PocoTypeRegistry();
+
+        PocoReadPlan<Row<int>> first = registry.ReadPlanFor<Row<int>>(BlockOf(1, Ints("value", 1)), forcedTier: null);
+        PocoReadPlan<Row<int>> second = registry.ReadPlanFor<Row<int>>(BlockOf(1, Ints("value", 2)), forcedTier: null);
+
+        Assert.That(second, Is.SameAs(first));
+    }
+
+    [Test]
+    public void ReadPlanFor_SameColumnNameDifferentType_CompilesItsOwnPlan()
+    {
+        // The regression the HTTP client's box-free path hit: keying on anything less exact than the server's own
+        // type string lets one shape's plan be handed to another, which then casts the wrong column type.
+        var registry = new PocoTypeRegistry();
+        Block ints = BlockOf(1, Ints("value", 42));
+        Block strings = BlockOf(1, new ArrayColumn<string>("value", "String", new[] { "x" }));
+
+        PocoReadPlan<Row<object>> intPlan = registry.ReadPlanFor<Row<object>>(ints, forcedTier: null);
+        PocoReadPlan<Row<object>> stringPlan = registry.ReadPlanFor<Row<object>>(strings, forcedTier: null);
+
+        var intRows = new Row<object>[1];
+        var stringRows = new Row<object>[1];
+        intPlan.Materialize(ints, intRows);
+        stringPlan.Materialize(strings, stringRows);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(stringPlan, Is.Not.SameAs(intPlan));
+            Assert.That(intRows[0].Value, Is.EqualTo(42));
+            Assert.That(stringRows[0].Value, Is.EqualTo("x"));
+        });
+    }
+
+    [Test]
+    public void ReadPlanFor_ColumnNameHoldingTheKeySeparators_DoesNotCollideWithAnotherHeader()
+    {
+        // A column name is arbitrary text — `SELECT 1 AS "a<tab>b"` is a legal alias — so a key joined on separators
+        // alone lets one header spell another. The collision is silent: the wrong plan scatters the columns it was
+        // built for, leaving the rest of the block unread, or indexes past it.
+        var registry = new PocoTypeRegistry();
+        Block spelled = BlockOf(1, Ints("Id", 10), Ints("Name\tInt32\nScore", 20));
+        Block three = BlockOf(1, Ints("Id", 10), Ints("Name", 20), Ints("Score", 30));
+
+        var spelledRows = new ThreeColumns[1];
+        var threeRows = new ThreeColumns[1];
+        registry.ReadPlanFor<ThreeColumns>(spelled, forcedTier: null).Materialize(spelled, spelledRows);
+        registry.ReadPlanFor<ThreeColumns>(three, forcedTier: null).Materialize(three, threeRows);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(spelledRows[0].Score, Is.EqualTo(0), "the two-column header has no Score column");
+            Assert.That(threeRows[0].Id, Is.EqualTo(10));
+            Assert.That(threeRows[0].Name, Is.EqualTo(20));
+            Assert.That(threeRows[0].Score, Is.EqualTo(30));
+        });
+    }
+
+    [Test]
+    public void ReadPlanFor_SameHeaderDifferentSessionTimezone_CompilesItsOwnPlan()
+    {
+        // A DateTime column whose type string names no timezone is presented in the session timezone, which the
+        // header cannot show — so the header alone is not enough to key a plan on.
+        var registry = new PocoTypeRegistry();
+        Block utc = BlockOf(new ResolveContext { ServerTimezone = "UTC" }, 1, PrimitiveColumn<uint>.FromValues("value", "DateTime", new uint[] { 1_700_000_000 }));
+        Block kolkata = BlockOf(new ResolveContext { ServerTimezone = "Asia/Kolkata" }, 1, PrimitiveColumn<uint>.FromValues("value", "DateTime", new uint[] { 1_700_000_000 }));
+
+        var utcRows = new Row<DateTime>[1];
+        var kolkataRows = new Row<DateTime>[1];
+        registry.ReadPlanFor<Row<DateTime>>(utc, forcedTier: null).Materialize(utc, utcRows);
+        registry.ReadPlanFor<Row<DateTime>>(kolkata, forcedTier: null).Materialize(kolkata, kolkataRows);
+
+        Assert.That(kolkataRows[0].Value - utcRows[0].Value, Is.EqualTo(new TimeSpan(5, 30, 0)));
+    }
+
+    [Test]
+    public void ReadPlanFor_DifferentForcedTiers_CompileTheirOwnPlans()
+    {
+        var registry = new PocoTypeRegistry();
+        Block block = BlockOf(1, Ints("value", 1));
+
+        PocoReadPlan<Row<int>> span = registry.ReadPlanFor<Row<int>>(block, PocoScatterTier.Span);
+        PocoReadPlan<Row<int>> boxed = registry.ReadPlanFor<Row<int>>(block, PocoScatterTier.Boxed);
+
+        Assert.That(boxed, Is.Not.SameAs(span));
+    }
+
+    [Test]
+    public void ReadPlanFor_BuildFailure_IsNotCached()
+    {
+        var registry = new PocoTypeRegistry();
+        Block block = BlockOf(1, Ints("value", 1));
+
+        Assert.Throws<InvalidOperationException>(() => registry.ReadPlanFor<Row<long>>(block, forcedTier: null));
+        Assert.Throws<InvalidOperationException>(() => registry.ReadPlanFor<Row<long>>(block, forcedTier: null), "the failure must be reported to every caller, not only the first");
+    }
+
+    [Test]
+    public void MatchesHeader_ADifferentHeader_IsRejectedSoTheCacheIsConsulted()
+    {
+        Block block = BlockOf(1, Ints("value", 1));
+        PocoReadPlan<Row<int>> plan = PocoReadPlan<Row<int>>.Build(PocoTypeDescriptor<Row<int>>.Build(), block, forcedTier: null);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(plan.MatchesHeader(BlockOf(1, Ints("value", 2))), Is.True, "same shape");
+            Assert.That(plan.MatchesHeader(BlockOf(1, Ints("value", 1), Ints("other", 1))), Is.False, "column count");
+            Assert.That(plan.MatchesHeader(BlockOf(1, Ints("renamed", 1))), Is.False, "column name");
+            Assert.That(plan.MatchesHeader(BlockOf(1, PrimitiveColumn<long>.FromValues("value", "Int64", new long[] { 1 }))), Is.False, "column type");
+            Assert.That(
+                plan.MatchesHeader(BlockOf(new ResolveContext { ServerTimezone = "Asia/Kolkata" }, 1, Ints("value", 1))),
+                Is.False,
+                "session timezone");
+            Assert.That(plan.MatchesHeader(BlockOf(default, 1, Ints("value", 1))), Is.False, "no session timezone at all");
+        });
+    }
+
+    private static Block MixedBlock() => BlockOf(
+        2,
+        Ints("Id", 1, 2),
+        new ArrayColumn<string>("Name", "String", new[] { "a", "b" }),
+        PrimitiveColumn<uint>.FromValues("Stamp", "DateTime('UTC')", new uint[] { 1_700_000_000, 0 }),
+        new ArrayColumn<double?>("Score", "Nullable(Float64)", new double?[] { 1.5, null }),
+        new ArrayColumn<string[]>("Tags", "Array(String)", new[] { new[] { "x", "y" }, Array.Empty<string>() }),
+        PrimitiveColumn<sbyte>.FromValues("Level", "Enum8('low' = -1, 'high' = 127)", new sbyte[] { -1, 127 }));
+
+    private static Block BlockOf(int rowCount, params IColumn[] columns)
+        => BlockOf(new ResolveContext { ServerTimezone = "UTC" }, rowCount, columns);
+
+    private static Block BlockOf(ResolveContext context, int rowCount, params IColumn[] columns)
+        => new(string.Empty, BlockInfo.Default, rowCount, columns, ColumnCodecRegistry.Default, context);
+
+    private static IColumn Ints(string name, params int[] values) => PrimitiveColumn<int>.FromValues(name, "Int32", values);
+
+    private static T[] Materialize<T>(Block block, PocoScatterTier? tier = null)
+        where T : class
+    {
+        PocoReadPlan<T> plan = PocoReadPlan<T>.Build(PocoTypeDescriptor<T>.Build(), block, tier);
+        var rows = new T[block.RowCount];
+        plan.Materialize(block, rows);
+        return rows;
+    }
+
+    private static TValue[] Values<TValue>(Row<TValue>[] rows) => Array.ConvertAll(rows, row => row.Value);
+
+    /// <summary>A column that surfaces its values only boxed, which forces the boxed tier.</summary>
+    private sealed class UntypedColumn : IColumn
+    {
+        private readonly object[] values;
+
+        public UntypedColumn(string name, string typeName, params object[] values)
+        {
+            Name = name;
+            TypeName = typeName;
+            this.values = values;
+        }
+
+        public string Name { get; }
+
+        public string TypeName { get; }
+
+        public int RowCount => values.Length;
+
+        public object GetValue(int row) => values[row];
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private enum Level : sbyte
+    {
+        Low = -1,
+        High = 127,
+    }
+
+    private sealed class IdName
+    {
+        public int Id { get; set; }
+
+        public string Name { get; set; }
+    }
+
+    private sealed class UserRow
+    {
+        public int UserId { get; set; }
+    }
+
+    private sealed class ThreeColumns
+    {
+        public int Id { get; set; }
+
+        public int Name { get; set; }
+
+        public int Score { get; set; }
+    }
+
+    private sealed class MixedRow
+    {
+        public int Id { get; set; }
+
+        public string Name { get; set; }
+
+        public DateTime Stamp { get; set; }
+
+        public double? Score { get; set; }
+
+        public string[] Tags { get; set; }
+
+        public Level Level { get; set; }
+    }
+
+    private sealed class GetterOnlyPoco
+    {
+        public int Value => 5;
+    }
+
+    private sealed class InitOnlyPoco
+    {
+        public int Value { get; init; }
+    }
+
+    private sealed class ConstructorOnlyPoco
+    {
+        public ConstructorOnlyPoco(int value) => Value = value;
+
+        public int Value { get; set; }
+    }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Types/LowCardinalityColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/LowCardinalityColumnCodecTests.cs
@@ -472,4 +472,36 @@ public class LowCardinalityColumnCodecTests
             Assert.That(value.CanWrite(new ArrayColumn<uint>("c", "LowCardinality(Nullable(UInt32))", Array.Empty<uint>())), Is.False, "the bare (non-nullable) element type is not accepted");
         });
     }
+
+    [Test]
+    public void Indexer_RowsSharingADictionaryEntry_GetTheSameInstance()
+    {
+        // The indexer reads the dictionary through its Values, not its own indexer, so an entry that is built on
+        // access is built once for the block instead of once per row. A String dictionary is the case that matters:
+        // its indexer decodes UTF-8 per call, so reading a 65,536-row column row by row would otherwise allocate a
+        // string per row for a dictionary holding a handful of them.
+        using var dictionary = new StringColumn("c", "String", "alphabeta"u8.ToArray(), new[] { 0, 0, 5, 9 }, rowCount: 3, pooled: false);
+        using var column = new LowCardinalityColumn<string>("c", "LowCardinality(String)", dictionary, new[] { 1, 2, 1 }, rowCount: 3, pooledKeys: false);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(column[0], Is.EqualTo("alpha"));
+            Assert.That(column[2], Is.EqualTo("alpha"));
+            Assert.That(column[0], Is.SameAs(column[2]), "both rows hold the same dictionary entry");
+            Assert.That(column[1], Is.EqualTo("beta"));
+        });
+    }
+
+    [Test]
+    public void Indexer_MutableElementTypeSharingADictionaryEntry_AliasesRatherThanCopies()
+    {
+        // The consequence of the above for the one element type a caller can mutate: the byte[] of a
+        // LowCardinality(FixedString(N)) is shared, so writing through one row's array is visible from another.
+        // Pinned deliberately, matching what IColumn<T>.Values has always done for this shape; a reader that needs
+        // its own copy has to make one.
+        using var dictionary = new FixedStringColumn("c", "FixedString(2)", 2, "\0\0aabb"u8.ToArray(), rowCount: 3, pooled: false);
+        using var column = new LowCardinalityColumn<byte[]>("c", "LowCardinality(FixedString(2))", dictionary, new[] { 1, 2, 1 }, rowCount: 3, pooledKeys: false);
+
+        Assert.That(column[0], Is.SameAs(column[2]));
+    }
 }

--- a/ClickHouse.Driver.Tcp.Tests/Types/LowCardinalityColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/LowCardinalityColumnCodecTests.cs
@@ -504,4 +504,23 @@ public class LowCardinalityColumnCodecTests
 
         Assert.That(column[0], Is.SameAs(column[2]));
     }
+
+    [Test]
+    public void NullableReferenceIndexer_RowsSharingADictionaryEntry_GetTheSameInstanceAndKeepNullNull()
+    {
+        // The nullable-reference shape reads its dictionary the same way, and a round trip asserting equal values
+        // would still pass if it regressed to rebuilding an entry per row. Key 0 is the NULL marker here (two
+        // reserved slots), so the null has to survive the sharing.
+        using var dictionary = new StringColumn("c", "String", "alphabeta"u8.ToArray(), new[] { 0, 0, 0, 5, 9 }, rowCount: 4, pooled: false);
+        using var column = new NullableLowCardinalityReferenceColumn<string>(
+            "c", "LowCardinality(Nullable(String))", dictionary, new[] { 2, 0, 3, 2 }, rowCount: 4, pooledKeys: false);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(column[0], Is.EqualTo("alpha"));
+            Assert.That(column[1], Is.Null, "key 0 is the NULL marker");
+            Assert.That(column[2], Is.EqualTo("beta"));
+            Assert.That(column[3], Is.SameAs(column[0]), "both rows hold the same dictionary entry");
+        });
+    }
 }

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/Row.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/Row.cs
@@ -1,0 +1,13 @@
+namespace ClickHouse.Driver.Tcp.Tests.Utilities;
+
+/// <summary>
+/// A one-property POCO over a one-column result, so the POCO read path can be driven from the per-type corpus in
+/// <see cref="InsertRoundTripCase"/> instead of a corpus of its own: each case already knows its ClickHouse type and
+/// the CLR type it reads back as, which is exactly <c>Row&lt;that CLR type&gt;</c>.
+/// </summary>
+/// <typeparam name="TValue">The property type, matched against the column named <c>value</c> case-insensitively.</typeparam>
+public sealed class Row<TValue>
+{
+    /// <summary>The column's value for this row.</summary>
+    public TValue Value { get; set; }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/Row.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/Row.cs
@@ -1,9 +1,7 @@
 namespace ClickHouse.Driver.Tcp.Tests.Utilities;
 
 /// <summary>
-/// A one-property POCO over a one-column result, so the POCO read path can be driven from the per-type corpus in
-/// <see cref="InsertRoundTripCase"/> instead of a corpus of its own: each case already knows its ClickHouse type and
-/// the CLR type it reads back as, which is exactly <c>Row&lt;that CLR type&gt;</c>.
+/// A one-property POCO used to drive reads from <see cref="InsertRoundTripCase"/>.
 /// </summary>
 /// <typeparam name="TValue">The property type, matched against the column named <c>value</c> case-insensitively.</typeparam>
 public sealed class Row<TValue>

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClient.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClient.cs
@@ -73,18 +73,6 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
     public ClickHouseTcpClientOptions Options { get; }
 
     /// <summary>
-    /// Forces every POCO read on this client to compile at one <see cref="PocoScatterTier"/> instead of the tier the
-    /// runtime would choose. A test seam: production leaves it null.
-    ///
-    /// <para>
-    /// The runtime picks the tier, and a host that compiles expression trees always picks the span tier, so the
-    /// indexer tier a NativeAOT host falls back to would never run in CI. A test sets this to read one query at each
-    /// tier and check that the rows match.
-    /// </para>
-    /// </summary>
-    internal PocoScatterTier? ForcedPocoScatterTier { get; init; }
-
-    /// <summary>
     /// Runs a query and streams its result as a sequence of <see cref="Block"/>s — the low-level columnar tier,
     /// with no per-row materialization.
     /// </summary>
@@ -210,7 +198,7 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
             // check also covers the header changing mid-enumeration, which the cache then serves.
             if (plan is null || !plan.MatchesHeader(block))
             {
-                plan = pocoTypes.ReadPlanFor<T>(block, ForcedPocoScatterTier);
+                plan = pocoTypes.ReadPlanFor<T>(block, forcedTier: null);
             }
 
             T[] rows = ArrayPool<T>.Shared.Rent(block.RowCount);

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClient.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClient.cs
@@ -45,7 +45,9 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
     private readonly IConnectionSource source;
 
     // Per-client, as HTTP's registry is: the client is meant to be a singleton, so the reflection and the compiles
-    // are amortized anyway, and a per-client cache cannot pin a type whose AssemblyLoadContext the caller unloads.
+    // are amortized anyway. It does hold its Type keys and compiled delegates strongly, so it pins a collectible
+    // AssemblyLoadContext for as long as the client is reachable; scoping it to the client is what makes disposing
+    // the client release them, rather than holding them for the process. See PocoTypeRegistry.
     private readonly PocoTypeRegistry pocoTypes = new();
 
     /// <summary>Creates a client from options.</summary>
@@ -136,6 +138,14 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
     /// column in header order (pair with <see cref="Block.ColumnNames"/> — via <see cref="StreamAsync"/> — to
     /// address by name). Each returned array is owned and safe to retain past the enumeration.
     /// </summary>
+    /// <remarks>
+    /// One caveat on <em>sharing</em>, as opposed to lifetime: a <c>LowCardinality</c> column holds a dictionary of
+    /// distinct values and one key per row, and hands each row that dictionary entry rather than a copy of it. So do
+    /// not mutate an array-valued entry in place — with a <c>LowCardinality(FixedString(N))</c> the <c>byte[]</c> may
+    /// be another row's too. The aliasing is bounded to one block, since each block ships its own dictionary, which
+    /// makes it harder to catch rather than easier: a small result is a single block and aliases throughout, while a
+    /// large one aliases only within each block.
+    /// </remarks>
     /// <param name="sql">The SQL text.</param>
     /// <param name="options">Per-query options (query id, settings), or null for the client defaults.</param>
     /// <param name="cancellationToken">A token to observe for cancellation.</param>

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClient.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClient.cs
@@ -139,12 +139,8 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
     /// address by name). Each returned array is owned and safe to retain past the enumeration.
     /// </summary>
     /// <remarks>
-    /// One caveat on <em>sharing</em>, as opposed to lifetime: a <c>LowCardinality</c> column holds a dictionary of
-    /// distinct values and one key per row, and hands each row that dictionary entry rather than a copy of it. So do
-    /// not mutate an array-valued entry in place — with a <c>LowCardinality(FixedString(N))</c> the <c>byte[]</c> may
-    /// be another row's too. The aliasing is bounded to one block, since each block ships its own dictionary, which
-    /// makes it harder to catch rather than easier: a small result is a single block and aliases throughout, while a
-    /// large one aliases only within each block.
+    /// <c>LowCardinality</c> values may be shared within a block. In particular, do not mutate a
+    /// <c>LowCardinality(FixedString(N))</c> <c>byte[]</c> in place because another row may reference it.
     /// </remarks>
     /// <param name="sql">The SQL text.</param>
     /// <param name="options">Per-query options (query id, settings), or null for the client defaults.</param>
@@ -180,20 +176,11 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
     /// column maps to keeps its default.
     /// </summary>
     /// <remarks>
-    /// Unlike a <see cref="Block"/>, the rows are <b>owned</b>: no value borrows the block's storage, so an instance
-    /// stays valid after the enumeration moves on. One caveat on <em>sharing</em>, as opposed to lifetime: a
-    /// <c>LowCardinality</c> column may hand the same element instance to every row holding that dictionary entry, so
-    /// do not mutate an array-valued property in place — with a <c>LowCardinality(FixedString(N))</c> the
-    /// <c>byte[]</c> may be another row's too.
-    ///
-    /// <para>
-    /// The reading itself is box-free — the values go from the decoded column into the property through a compiled
-    /// per-column loop, with no boxed intermediate — for every property whose type the column reads as.
-    /// <typeparamref name="T"/> needs a public parameterless constructor and public setters; the mapping is compiled
-    /// from the first block of the result, so a mismatch is reported before the first row is handed out. A result with
-    /// no rows carries no block, and so yields nothing and reports nothing: use the block-level API if a shape has to
-    /// be validated against an empty result.
-    /// </para>
+    /// Rows own their values and remain valid after enumeration advances. <c>LowCardinality</c> elements may still
+    /// be shared within a block; do not mutate an array-valued property in place. <typeparamref name="T"/> must be
+    /// concrete with a public parameterless constructor; every property reached by a result column must have a
+    /// public, non-init setter. Mapping is validated on the first block, so an empty result yields nothing without
+    /// validating <typeparamref name="T"/>.
     /// </remarks>
     /// <typeparam name="T">The row type.</typeparam>
     /// <param name="sql">The SQL text.</param>

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClient.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClient.cs
@@ -73,10 +73,14 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
     public ClickHouseTcpClientOptions Options { get; }
 
     /// <summary>
-    /// Compiles the POCO scatters at one tier instead of the one the runtime calls for (except for a column that
-    /// surfaces no typed view, which is always read boxed). The parity harness: the three tiers differ only in how
-    /// they source a value, so the same query read at each must produce equal rows — which is also the proof that the
-    /// span-free tier a runtime without dynamic code falls back to behaves like the span tier it replaces.
+    /// Forces every POCO read on this client to compile at one <see cref="PocoScatterTier"/> instead of the tier the
+    /// runtime would choose. A test seam: production leaves it null.
+    ///
+    /// <para>
+    /// The runtime picks the tier, and a host that compiles expression trees always picks the span tier, so the
+    /// indexer tier a NativeAOT host falls back to would never run in CI. A test sets this to read one query at each
+    /// tier and check that the rows match.
+    /// </para>
     /// </summary>
     internal PocoScatterTier? ForcedPocoScatterTier { get; init; }
 

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClient.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClient.cs
@@ -30,6 +30,16 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
     // enables it on every operation so callers never have to know about it. A caller-supplied value wins.
     private const string FlattenedSerializationSetting = "output_format_native_use_flattened_dynamic_and_json_serialization";
 
+    // How many rows QueryAsync<T> materializes at once. A whole block would otherwise be alive together, and a
+    // block is server-sized: 65,409 rows by default, more if a caller raises max_block_size. Bounding it keeps the
+    // rows a streaming consumer drops inside gen0 instead of promoting them.
+    //
+    // Measured flat from 64 to 4096 rows and slower outside that, so this sits mid-plateau rather than at a
+    // measured optimum. Erring small on purpose: the cost of a smaller window is a per-window cast and loop setup
+    // per column, which did not register even on a two-column row of fixed-width values, while the cost of too
+    // large a window is the promotion this is here to avoid, against a gen0 budget that varies by host and GC mode.
+    private const int MaterializationWindowRows = 256;
+
     private static readonly ClickHouseTcpInsertOptions DefaultInsertOptions = new();
 
     private readonly IConnectionSource source;
@@ -201,17 +211,24 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
                 plan = pocoTypes.ReadPlanFor<T>(block, forcedTier: null);
             }
 
-            T[] rows = ArrayPool<T>.Shared.Rent(block.RowCount);
+            T[] rows = ArrayPool<T>.Shared.Rent(Math.Min(MaterializationWindowRows, block.RowCount));
             try
             {
-                // Materializing in one synchronous call is what lets the scatters hold a span: an iterator method
-                // cannot. The rows are handed out afterwards, when no span is live.
-                plan.Materialize(block, rows, produced);
-                produced += block.RowCount;
-                for (int i = 0; i < block.RowCount; i++)
+                // Strides by the constant rather than by the rented length, so the loop advances even for an empty
+                // block and cannot depend on how much the pool handed back.
+                for (int start = 0; start < block.RowCount; start += MaterializationWindowRows)
                 {
-                    yield return rows[i];
+                    // Materializing in one synchronous call is what lets the scatters hold a span: an iterator
+                    // method cannot. The rows are handed out afterwards, when no span is live.
+                    int count = Math.Min(MaterializationWindowRows, block.RowCount - start);
+                    plan.Materialize(block, rows, start, count, produced + start);
+                    for (int i = 0; i < count; i++)
+                    {
+                        yield return rows[i];
+                    }
                 }
+
+                produced += block.RowCount;
             }
             finally
             {

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClient.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClient.cs
@@ -199,6 +199,7 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
         where T : class
     {
         PocoReadPlan<T> plan = null;
+        long produced = 0;
         await foreach (Block block in StreamAsync(sql, options, cancellationToken).ConfigureAwait(false))
         {
             // The blocks of one result share a header, so the plan is resolved once per result in practice; the
@@ -213,7 +214,8 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
             {
                 // Materializing in one synchronous call is what lets the scatters hold a span: an iterator method
                 // cannot. The rows are handed out afterwards, when no span is live.
-                plan.Materialize(block, rows);
+                plan.Materialize(block, rows, produced);
+                produced += block.RowCount;
                 for (int i = 0; i < block.RowCount; i++)
                 {
                     yield return rows[i];

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClient.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClient.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
@@ -6,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using ClickHouse.Driver.Tcp.Client;
 using ClickHouse.Driver.Tcp.Format;
+using ClickHouse.Driver.Tcp.Poco;
 using ClickHouse.Driver.Tcp.Types;
 
 namespace ClickHouse.Driver.Tcp;
@@ -31,6 +33,10 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
     private static readonly ClickHouseTcpInsertOptions DefaultInsertOptions = new();
 
     private readonly IConnectionSource source;
+
+    // Per-client, as HTTP's registry is: the client is meant to be a singleton, so the reflection and the compiles
+    // are amortized anyway, and a per-client cache cannot pin a type whose AssemblyLoadContext the caller unloads.
+    private readonly PocoTypeRegistry pocoTypes = new();
 
     /// <summary>Creates a client from options.</summary>
     /// <param name="options">The client configuration (endpoint, credentials, timeouts, client-level settings).</param>
@@ -65,6 +71,14 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
     /// operation. Init-only, so it reflects construction and never changes.
     /// </summary>
     public ClickHouseTcpClientOptions Options { get; }
+
+    /// <summary>
+    /// Compiles the POCO scatters at one tier instead of the one the runtime calls for (except for a column that
+    /// surfaces no typed view, which is always read boxed). The parity harness: the three tiers differ only in how
+    /// they source a value, so the same query read at each must produce equal rows — which is also the proof that the
+    /// span-free tier a runtime without dynamic code falls back to behaves like the span tier it replaces.
+    /// </summary>
+    internal PocoScatterTier? ForcedPocoScatterTier { get; init; }
 
     /// <summary>
     /// Runs a query and streams its result as a sequence of <see cref="Block"/>s — the low-level columnar tier,
@@ -142,6 +156,73 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
                 }
 
                 yield return values;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Runs a query and streams its result one row at a time as <typeparamref name="T"/>, filling each property
+    /// from the column of the same name. Matching ignores case, and then underscores, so a <c>user_id</c> column
+    /// reaches a <c>UserId</c> property; <c>[ClickHouseTcpColumn]</c> renames a property and
+    /// <c>[ClickHouseTcpNotMapped]</c> excludes one. A column no property maps to is skipped, and a property no
+    /// column maps to keeps its default.
+    /// </summary>
+    /// <remarks>
+    /// Unlike a <see cref="Block"/>, the rows are <b>owned</b>: no value borrows the block's storage, so an instance
+    /// stays valid after the enumeration moves on. One caveat on <em>sharing</em>, as opposed to lifetime: a
+    /// <c>LowCardinality</c> column may hand the same element instance to every row holding that dictionary entry, so
+    /// do not mutate an array-valued property in place — with a <c>LowCardinality(FixedString(N))</c> the
+    /// <c>byte[]</c> may be another row's too.
+    ///
+    /// <para>
+    /// The reading itself is box-free — the values go from the decoded column into the property through a compiled
+    /// per-column loop, with no boxed intermediate — for every property whose type the column reads as.
+    /// <typeparamref name="T"/> needs a public parameterless constructor and public setters; the mapping is compiled
+    /// from the first block of the result, so a mismatch is reported before the first row is handed out. A result with
+    /// no rows carries no block, and so yields nothing and reports nothing: use the block-level API if a shape has to
+    /// be validated against an empty result.
+    /// </para>
+    /// </remarks>
+    /// <typeparam name="T">The row type.</typeparam>
+    /// <param name="sql">The SQL text.</param>
+    /// <param name="options">Per-query options (query id, settings), or null for the client defaults.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>An async stream of result rows.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="sql"/> is null.</exception>
+    /// <exception cref="InvalidOperationException"><typeparamref name="T"/> cannot be mapped to the result: it has
+    /// nothing to map or cannot be constructed, no column maps to a property, or a column cannot be read as its
+    /// property's type.</exception>
+    public async IAsyncEnumerable<T> QueryAsync<T>(
+        string sql,
+        ClickHouseTcpQueryOptions options = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        where T : class
+    {
+        PocoReadPlan<T> plan = null;
+        await foreach (Block block in StreamAsync(sql, options, cancellationToken).ConfigureAwait(false))
+        {
+            // The blocks of one result share a header, so the plan is resolved once per result in practice; the
+            // check also covers the header changing mid-enumeration, which the cache then serves.
+            if (plan is null || !plan.MatchesHeader(block))
+            {
+                plan = pocoTypes.ReadPlanFor<T>(block, ForcedPocoScatterTier);
+            }
+
+            T[] rows = ArrayPool<T>.Shared.Rent(block.RowCount);
+            try
+            {
+                // Materializing in one synchronous call is what lets the scatters hold a span: an iterator method
+                // cannot. The rows are handed out afterwards, when no span is live.
+                plan.Materialize(block, rows);
+                for (int i = 0; i < block.RowCount; i++)
+                {
+                    yield return rows[i];
+                }
+            }
+            finally
+            {
+                // Cleared, so the pool does not keep the rows it just handed to the caller alive.
+                ArrayPool<T>.Shared.Return(rows, clearArray: true);
             }
         }
     }

--- a/ClickHouse.Driver.Tcp/Client/IClickHouseTcpClient.cs
+++ b/ClickHouse.Driver.Tcp/Client/IClickHouseTcpClient.cs
@@ -53,9 +53,7 @@ public interface IClickHouseTcpClient : IAsyncDisposable
     /// column in header order. Each returned array is owned and safe to retain past the enumeration.
     /// </summary>
     /// <remarks>
-    /// Owned, but not unshared: a <c>LowCardinality</c> column hands each row its dictionary entry rather than a copy,
-    /// so an array-valued entry must not be mutated in place — with a <c>LowCardinality(FixedString(N))</c> the
-    /// <c>byte[]</c> may be another row's too. An implementation must honor that, since a consumer cannot tell.
+    /// <c>LowCardinality</c> values may be shared within a block; array-valued entries must not be mutated in place.
     /// </remarks>
     /// <param name="sql">The SQL text.</param>
     /// <param name="options">Per-query options (query id, settings), or null for the client defaults.</param>
@@ -73,10 +71,8 @@ public interface IClickHouseTcpClient : IAsyncDisposable
     /// skipped, and a property no column maps to keeps its default.
     /// </summary>
     /// <remarks>
-    /// Unlike a <see cref="Block"/>, the rows are <b>owned</b>: an instance stays valid after the enumeration moves
-    /// on, because no value borrows the block's storage. An implementation must honor that, since a consumer has no
-    /// way to copy what it is handed. Two rows may still share one element instance where the column's own
-    /// representation does (see <see cref="ClickHouseTcpClient.QueryAsync{T}"/>).
+    /// Rows remain valid after enumeration advances. Element instances may still be shared where the column's
+    /// representation does; see <see cref="ClickHouseTcpClient.QueryAsync{T}"/>.
     /// </remarks>
     /// <typeparam name="T">The row type.</typeparam>
     /// <param name="sql">The SQL text.</param>

--- a/ClickHouse.Driver.Tcp/Client/IClickHouseTcpClient.cs
+++ b/ClickHouse.Driver.Tcp/Client/IClickHouseTcpClient.cs
@@ -52,6 +52,11 @@ public interface IClickHouseTcpClient : IAsyncDisposable
     /// Runs a query and streams its result one row at a time as <c>object[]</c>, each entry the boxed value of a
     /// column in header order. Each returned array is owned and safe to retain past the enumeration.
     /// </summary>
+    /// <remarks>
+    /// Owned, but not unshared: a <c>LowCardinality</c> column hands each row its dictionary entry rather than a copy,
+    /// so an array-valued entry must not be mutated in place — with a <c>LowCardinality(FixedString(N))</c> the
+    /// <c>byte[]</c> may be another row's too. An implementation must honor that, since a consumer cannot tell.
+    /// </remarks>
     /// <param name="sql">The SQL text.</param>
     /// <param name="options">Per-query options (query id, settings), or null for the client defaults.</param>
     /// <param name="cancellationToken">A token to observe for cancellation.</param>

--- a/ClickHouse.Driver.Tcp/Client/IClickHouseTcpClient.cs
+++ b/ClickHouse.Driver.Tcp/Client/IClickHouseTcpClient.cs
@@ -63,6 +63,30 @@ public interface IClickHouseTcpClient : IAsyncDisposable
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Runs a query and streams its result one row at a time as <typeparamref name="T"/>, filling each property
+    /// from the column of the same name (ignoring case, and then underscores). A column no property maps to is
+    /// skipped, and a property no column maps to keeps its default.
+    /// </summary>
+    /// <remarks>
+    /// Unlike a <see cref="Block"/>, the rows are <b>owned</b>: an instance stays valid after the enumeration moves
+    /// on, because no value borrows the block's storage. An implementation must honor that, since a consumer has no
+    /// way to copy what it is handed. Two rows may still share one element instance where the column's own
+    /// representation does (see <see cref="ClickHouseTcpClient.QueryAsync{T}"/>).
+    /// </remarks>
+    /// <typeparam name="T">The row type.</typeparam>
+    /// <param name="sql">The SQL text.</param>
+    /// <param name="options">Per-query options (query id, settings), or null for the client defaults.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>An async stream of result rows.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="sql"/> is null.</exception>
+    /// <exception cref="InvalidOperationException"><typeparamref name="T"/> cannot be mapped to the result.</exception>
+    IAsyncEnumerable<T> QueryAsync<T>(
+        string sql,
+        ClickHouseTcpQueryOptions options = null,
+        CancellationToken cancellationToken = default)
+        where T : class;
+
+    /// <summary>
     /// Runs a statement that produces no result rows (DDL, or DML other than an <c>INSERT ... VALUES</c>) and
     /// returns once the server acknowledges it. Any result blocks are drained and discarded.
     /// </summary>

--- a/ClickHouse.Driver.Tcp/Format/Block.cs
+++ b/ClickHouse.Driver.Tcp/Format/Block.cs
@@ -26,12 +26,16 @@ public sealed class Block : IDisposable
     /// <param name="info">The block info prefix.</param>
     /// <param name="rowCount">The number of rows every column holds.</param>
     /// <param name="columns">The decoded columns, in header order.</param>
-    internal Block(string name, BlockInfo info, int rowCount, IReadOnlyList<IColumn> columns)
+    /// <param name="codecs">The registry the columns' codecs came from.</param>
+    /// <param name="context">The context they were resolved with.</param>
+    internal Block(string name, BlockInfo info, int rowCount, IReadOnlyList<IColumn> columns, ColumnCodecRegistry codecs, ResolveContext context)
     {
         Name = name;
         Info = info;
         RowCount = rowCount;
         Columns = columns;
+        Codecs = codecs;
+        Context = context;
     }
 
     /// <summary>The block name.</summary>
@@ -39,6 +43,17 @@ public sealed class Block : IDisposable
 
     /// <summary>The block info prefix.</summary>
     internal BlockInfo Info { get; }
+
+    /// <summary>
+    /// How to re-resolve a column's codec from its <see cref="IColumn.TypeName"/>, which the POCO read plan has to
+    /// do to reach the codec's read projections. Carried on the block, rather than assumed, so the plan resolves a
+    /// codec the way the read did — a <c>DateTime</c> column whose type string names no timezone otherwise projects
+    /// against the wrong zone.
+    /// </summary>
+    internal ColumnCodecRegistry Codecs { get; }
+
+    /// <summary>The context the columns' codecs were resolved with (the session timezone). See <see cref="Codecs"/>.</summary>
+    internal ResolveContext Context { get; }
 
     /// <summary>The number of rows in the block.</summary>
     public int RowCount { get; }

--- a/ClickHouse.Driver.Tcp/Format/Block.cs
+++ b/ClickHouse.Driver.Tcp/Format/Block.cs
@@ -45,10 +45,7 @@ public sealed class Block : IDisposable
     internal BlockInfo Info { get; }
 
     /// <summary>
-    /// How to re-resolve a column's codec from its <see cref="IColumn.TypeName"/>, which the POCO read plan has to
-    /// do to reach the codec's read projections. Carried on the block, rather than assumed, so the plan resolves a
-    /// codec the way the read did — a <c>DateTime</c> column whose type string names no timezone otherwise projects
-    /// against the wrong zone.
+    /// The registry used to resolve this block's codecs, retained for POCO read projections.
     /// </summary>
     internal ColumnCodecRegistry Codecs { get; }
 

--- a/ClickHouse.Driver.Tcp/Format/BlockReader.cs
+++ b/ClickHouse.Driver.Tcp/Format/BlockReader.cs
@@ -80,7 +80,7 @@ internal static class BlockReader
             throw;
         }
 
-        return new Block(name, info, rowCount, columns);
+        return new Block(name, info, rowCount, columns, registry, context);
     }
 
     /// <summary>

--- a/ClickHouse.Driver.Tcp/Poco/PocoColumnScatterFactory.cs
+++ b/ClickHouse.Driver.Tcp/Poco/PocoColumnScatterFactory.cs
@@ -16,10 +16,12 @@ namespace ClickHouse.Driver.Tcp.Poco;
 /// <typeparam name="T">The POCO type.</typeparam>
 /// <param name="column">The column to read, already known to the plan that built this delegate.</param>
 /// <param name="rows">The rows to scatter into; at least <paramref name="rowCount"/> long, each already constructed.</param>
+/// <param name="start">The first row of <paramref name="column"/> to read. <c>rows[i]</c> takes column row
+/// <c>start + i</c>, so a block can be materialized in several passes without the rows moving.</param>
 /// <param name="rowCount">The number of rows to fill.</param>
-/// <param name="rowOffset">How many rows of the result precede this block, so a failure can name the row a caller
+/// <param name="rowOffset">How many rows of the result precede <c>rows[0]</c>, so a failure can name the row a caller
 /// counts rather than the row within a block they never see. Read only on the failure path.</param>
-internal delegate void PocoColumnScatter<in T>(IColumn column, T[] rows, int rowCount, long rowOffset);
+internal delegate void PocoColumnScatter<in T>(IColumn column, T[] rows, int start, int rowCount, long rowOffset);
 
 /// <summary>
 /// Compiles the per-column scatter delegates a <see cref="PocoReadPlan{T}"/> is made of. One delegate handles one
@@ -54,10 +56,11 @@ internal static class PocoColumnScatterFactory
             throw NotSurfacingItsElementType(column, codec);
         }
 
-        PocoScatterTier tier = SelectTier(forcedTier);
+        PocoScatterTier tier = SelectTier(forcedTier, column);
 
         ParameterExpression columnParameter = Expression.Parameter(typeof(IColumn), "column");
         ParameterExpression rows = Expression.Parameter(typeof(T[]), "rows");
+        ParameterExpression start = Expression.Parameter(typeof(int), "start");
         ParameterExpression rowCount = Expression.Parameter(typeof(int), "rowCount");
         ParameterExpression rowOffset = Expression.Parameter(typeof(long), "rowOffset");
         ParameterExpression row = Expression.Variable(typeof(int), "row");
@@ -79,7 +82,7 @@ internal static class PocoColumnScatterFactory
 
         var locals = new List<ParameterExpression>(3) { row };
         var body = new List<Expression>(4);
-        Expression source = SourceOneValue(tier, columnParameter, typedColumn, elementType, row, locals, body);
+        Expression source = SourceOneValue(tier, columnParameter, typedColumn, elementType, Expression.Add(start, row), locals, body);
 
         // row = 0; while (row < rowCount) { value = <source>; rows[row].P = <projected>; row++; }
         LabelTarget done = Expression.Label("done");
@@ -95,19 +98,29 @@ internal static class PocoColumnScatterFactory
                 Expression.Break(done)),
             done));
 
-        return Expression.Lambda<PocoColumnScatter<T>>(Expression.Block(locals, body), columnParameter, rows, rowCount, rowOffset)
+        return Expression.Lambda<PocoColumnScatter<T>>(Expression.Block(locals, body), columnParameter, rows, start, rowCount, rowOffset)
             .Compile(preferInterpretation);
     }
 
     /// <summary>
-    /// Picks the tier to compile: the caller's, or the span tier wherever expression trees compile to IL. A tree
-    /// holding a <c>ReadOnlySpan&lt;T&gt;</c> compiles but cannot be <em>interpreted</em>, which is the path taken
-    /// when the runtime has no dynamic code (NativeAOT), so the span tier is not offered there.
+    /// Picks the tier to compile: the caller's, or one chosen from the runtime and the column.
+    ///
+    /// <para>
+    /// Two conditions have to hold for the span tier. A tree holding a <c>ReadOnlySpan&lt;T&gt;</c> compiles but
+    /// cannot be <em>interpreted</em>, which is the path taken when the runtime has no dynamic code (NativeAOT), so
+    /// the span tier is not offered there at all. And the column's <see cref="IColumn{T}.Values"/> has to be free to
+    /// read (<see cref="IStoredValuesColumn"/>): hoisting it out of the loop is the point of the tier, but for a
+    /// column that builds its values on access that one read materializes the whole block and pins it for the
+    /// block's lifetime, which is exactly what a windowed materialization is trying to avoid.
+    /// </para>
     /// </summary>
     /// <param name="forcedTier">A tier to use in place of the choice, or null to choose.</param>
+    /// <param name="column">The column to be read, consulted for whether its values are stored or built.</param>
     /// <returns>The tier to compile.</returns>
-    internal static PocoScatterTier SelectTier(PocoScatterTier? forcedTier)
-        => forcedTier ?? (RuntimeFeature.IsDynamicCodeCompiled ? PocoScatterTier.Span : PocoScatterTier.Indexer);
+    internal static PocoScatterTier SelectTier(PocoScatterTier? forcedTier, IColumn column)
+        => forcedTier ?? (RuntimeFeature.IsDynamicCodeCompiled && column is IStoredValuesColumn
+            ? PocoScatterTier.Span
+            : PocoScatterTier.Indexer);
 
     /// <summary>
     /// Builds the expression that yields the value at <paramref name="row"/>, adding whatever the tier hoists out
@@ -117,7 +130,7 @@ internal static class PocoColumnScatterFactory
     /// <param name="column">The scatter's column parameter.</param>
     /// <param name="typedColumn">The <see cref="IColumn{T}"/> type over the codec's element type.</param>
     /// <param name="elementType">The codec's element type.</param>
-    /// <param name="row">The loop counter.</param>
+    /// <param name="columnRow">The row of the column to read: the loop counter rebased by the scatter's start.</param>
     /// <param name="locals">The enclosing block's locals, added to by both tiers.</param>
     /// <param name="prologue">The statements before the loop, added to by both tiers.</param>
     /// <returns>An expression of type <paramref name="elementType"/>.</returns>
@@ -126,7 +139,7 @@ internal static class PocoColumnScatterFactory
         ParameterExpression column,
         Type typedColumn,
         Type elementType,
-        ParameterExpression row,
+        Expression columnRow,
         List<ParameterExpression> locals,
         List<Expression> prologue)
     {
@@ -140,13 +153,13 @@ internal static class PocoColumnScatterFactory
                 ParameterExpression values = Expression.Variable(typeof(ReadOnlySpan<>).MakeGenericType(elementType), "values");
                 locals.Add(values);
                 prologue.Add(Expression.Assign(values, Expression.Property(Expression.Convert(column, typedColumn), "Values")));
-                return Expression.Call(SpanAt.MakeGenericMethod(elementType), values, row);
+                return Expression.Call(SpanAt.MakeGenericMethod(elementType), values, columnRow);
 
             default:
                 ParameterExpression typed = Expression.Variable(typedColumn, "typed");
                 locals.Add(typed);
                 prologue.Add(Expression.Assign(typed, Expression.Convert(column, typedColumn)));
-                return Expression.MakeIndex(typed, typedColumn.GetProperty("Item", elementType, new[] { typeof(int) }), new[] { row });
+                return Expression.MakeIndex(typed, typedColumn.GetProperty("Item", elementType, new[] { typeof(int) }), new[] { columnRow });
         }
     }
 

--- a/ClickHouse.Driver.Tcp/Poco/PocoColumnScatterFactory.cs
+++ b/ClickHouse.Driver.Tcp/Poco/PocoColumnScatterFactory.cs
@@ -30,8 +30,6 @@ internal static class PocoColumnScatterFactory
 {
     private static readonly MethodInfo SpanAt = typeof(PocoSpan).GetMethod(nameof(PocoSpan.At), BindingFlags.Public | BindingFlags.Static);
 
-    private static readonly MethodInfo ColumnGetValue = typeof(IColumn).GetMethod(nameof(IColumn.GetValue));
-
     /// <summary>
     /// Compiles the scatter for one column into one property.
     /// </summary>
@@ -42,15 +40,21 @@ internal static class PocoColumnScatterFactory
     /// <param name="forcedTier">A tier to compile regardless of the runtime, or null to choose one.</param>
     /// <param name="preferInterpretation">Compiles the tree to an interpreter rather than to IL. Not used in
     /// production — the runtime decides that — but it is the only way to exercise the path a runtime without dynamic
-    /// code takes, which is the whole reason the span-free tiers exist.</param>
+    /// code takes, which is the whole reason the indexer tier exists.</param>
     /// <returns>The compiled scatter.</returns>
-    /// <exception cref="InvalidOperationException">The column's values cannot be read as the property's type.</exception>
+    /// <exception cref="InvalidOperationException">The column's values cannot be read as the property's type, or the
+    /// column does not surface its codec's element type.</exception>
     public static PocoColumnScatter<T> Create<T>(IColumn column, IColumnCodec codec, PocoMember member, PocoScatterTier? forcedTier, bool preferInterpretation = false)
         where T : class
     {
         Type elementType = codec.ElementType;
         Type typedColumn = typeof(IColumn<>).MakeGenericType(elementType);
-        PocoScatterTier tier = SelectTier(forcedTier, typedColumn.IsInstanceOfType(column));
+        if (!typedColumn.IsInstanceOfType(column))
+        {
+            throw NotSurfacingItsElementType(column, codec);
+        }
+
+        PocoScatterTier tier = SelectTier(forcedTier);
 
         ParameterExpression columnParameter = Expression.Parameter(typeof(IColumn), "column");
         ParameterExpression rows = Expression.Parameter(typeof(T[]), "rows");
@@ -100,20 +104,10 @@ internal static class PocoColumnScatterFactory
     /// holding a <c>ReadOnlySpan&lt;T&gt;</c> compiles but cannot be <em>interpreted</em>, which is the path taken
     /// when the runtime has no dynamic code (NativeAOT), so the span tier is not offered there.
     /// </summary>
-    /// <param name="forcedTier">A tier to use in place of the choice, or null to choose. A column that does not
-    /// surface its element type overrides it: neither typed tier can read one.</param>
-    /// <param name="columnSurfacesElementType">Whether the column implements <see cref="IColumn{T}"/> over its
-    /// codec's element type, which both typed tiers rely on.</param>
+    /// <param name="forcedTier">A tier to use in place of the choice, or null to choose.</param>
     /// <returns>The tier to compile.</returns>
-    internal static PocoScatterTier SelectTier(PocoScatterTier? forcedTier, bool columnSurfacesElementType)
-    {
-        if (!columnSurfacesElementType)
-        {
-            return PocoScatterTier.Boxed;
-        }
-
-        return forcedTier ?? (RuntimeFeature.IsDynamicCodeCompiled ? PocoScatterTier.Span : PocoScatterTier.Indexer);
-    }
+    internal static PocoScatterTier SelectTier(PocoScatterTier? forcedTier)
+        => forcedTier ?? (RuntimeFeature.IsDynamicCodeCompiled ? PocoScatterTier.Span : PocoScatterTier.Indexer);
 
     /// <summary>
     /// Builds the expression that yields the value at <paramref name="row"/>, adding whatever the tier hoists out
@@ -124,8 +118,8 @@ internal static class PocoColumnScatterFactory
     /// <param name="typedColumn">The <see cref="IColumn{T}"/> type over the codec's element type.</param>
     /// <param name="elementType">The codec's element type.</param>
     /// <param name="row">The loop counter.</param>
-    /// <param name="locals">The enclosing block's locals, added to by the typed tiers.</param>
-    /// <param name="prologue">The statements before the loop, added to by the typed tiers.</param>
+    /// <param name="locals">The enclosing block's locals, added to by both tiers.</param>
+    /// <param name="prologue">The statements before the loop, added to by both tiers.</param>
     /// <returns>An expression of type <paramref name="elementType"/>.</returns>
     private static Expression SourceOneValue(
         PocoScatterTier tier,
@@ -148,16 +142,27 @@ internal static class PocoColumnScatterFactory
                 prologue.Add(Expression.Assign(values, Expression.Property(Expression.Convert(column, typedColumn), "Values")));
                 return Expression.Call(SpanAt.MakeGenericMethod(elementType), values, row);
 
-            case PocoScatterTier.Indexer:
+            default:
                 ParameterExpression typed = Expression.Variable(typedColumn, "typed");
                 locals.Add(typed);
                 prologue.Add(Expression.Assign(typed, Expression.Convert(column, typedColumn)));
                 return Expression.MakeIndex(typed, typedColumn.GetProperty("Item", elementType, new[] { typeof(int) }), new[] { row });
-
-            default:
-                return Expression.Convert(Expression.Call(column, ColumnGetValue, row), elementType);
         }
     }
+
+    /// <summary>
+    /// The failure for a column that does not implement <see cref="IColumn{T}"/> over its own codec's element type.
+    /// Both tiers cast to that interface, so such a column would otherwise fail the cast inside compiled code, on
+    /// the first block rather than at plan build. No shipped codec produces one — a codec and the column it reads
+    /// are written together — so this reports the codec bug rather than the cast that follows from it.
+    /// </summary>
+    /// <param name="column">The column.</param>
+    /// <param name="codec">The column's codec.</param>
+    /// <returns>The exception to throw.</returns>
+    private static Exception NotSurfacingItsElementType(IColumn column, IColumnCodec codec)
+        => new InvalidOperationException(
+            $"Column '{column.Name}' ({column.TypeName}) was read as {column.GetType()}, which does not implement IColumn<{codec.ElementType}> " +
+            $"as its codec {codec.GetType()} declares. A POCO read sources every value through that interface, so the column cannot be read into a property.");
 
     /// <summary>
     /// The failure for a property the column cannot be read as (D6d): raised at plan build, so it names the shape

--- a/ClickHouse.Driver.Tcp/Poco/PocoColumnScatterFactory.cs
+++ b/ClickHouse.Driver.Tcp/Poco/PocoColumnScatterFactory.cs
@@ -1,0 +1,187 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Poco;
+
+/// <summary>
+/// Copies one decoded column into one property of every row of a materialized block — the compiled unit of a POCO
+/// read. Column-major rather than row-major: the block is already decoded, so the loop is taken over one column's
+/// values, which keeps the cast and the span access out of the per-row work.
+/// </summary>
+/// <typeparam name="T">The POCO type.</typeparam>
+/// <param name="column">The column to read, already known to the plan that built this delegate.</param>
+/// <param name="rows">The rows to scatter into; at least <paramref name="rowCount"/> long, each already constructed.</param>
+/// <param name="rowCount">The number of rows to fill.</param>
+internal delegate void PocoColumnScatter<in T>(IColumn column, T[] rows, int rowCount);
+
+/// <summary>
+/// Compiles the per-column scatter delegates a <see cref="PocoReadPlan{T}"/> is made of. One delegate handles one
+/// (column, property) pair for a whole block, with the value conversion (<see cref="PocoValueProjection"/>) inlined
+/// into the loop rather than called through a delegate per row.
+/// </summary>
+internal static class PocoColumnScatterFactory
+{
+    private static readonly MethodInfo SpanAt = typeof(PocoSpan).GetMethod(nameof(PocoSpan.At), BindingFlags.Public | BindingFlags.Static);
+
+    private static readonly MethodInfo ColumnGetValue = typeof(IColumn).GetMethod(nameof(IColumn.GetValue));
+
+    /// <summary>
+    /// Compiles the scatter for one column into one property.
+    /// </summary>
+    /// <typeparam name="T">The POCO type.</typeparam>
+    /// <param name="column">A column of the shape the plan was built for, for its name, type and runtime shape.</param>
+    /// <param name="codec">The column's codec, resolved the way the read resolved it.</param>
+    /// <param name="member">The property the column maps to; must be settable.</param>
+    /// <param name="forcedTier">A tier to compile regardless of the runtime, or null to choose one.</param>
+    /// <param name="preferInterpretation">Compiles the tree to an interpreter rather than to IL. Not used in
+    /// production — the runtime decides that — but it is the only way to exercise the path a runtime without dynamic
+    /// code takes, which is the whole reason the span-free tiers exist.</param>
+    /// <returns>The compiled scatter.</returns>
+    /// <exception cref="InvalidOperationException">The column's values cannot be read as the property's type.</exception>
+    public static PocoColumnScatter<T> Create<T>(IColumn column, IColumnCodec codec, PocoMember member, PocoScatterTier? forcedTier, bool preferInterpretation = false)
+        where T : class
+    {
+        Type elementType = codec.ElementType;
+        Type typedColumn = typeof(IColumn<>).MakeGenericType(elementType);
+        PocoScatterTier tier = SelectTier(forcedTier, typedColumn.IsInstanceOfType(column));
+
+        ParameterExpression columnParameter = Expression.Parameter(typeof(IColumn), "column");
+        ParameterExpression rows = Expression.Parameter(typeof(T[]), "rows");
+        ParameterExpression rowCount = Expression.Parameter(typeof(int), "rowCount");
+        ParameterExpression row = Expression.Variable(typeof(int), "row");
+        ParameterExpression value = Expression.Variable(elementType, "value");
+
+        var site = new PocoProjectionSite
+        {
+            ColumnName = column.Name,
+            ColumnType = column.TypeName,
+            PocoTypeName = typeof(T).Name,
+            MemberName = member.MemberName,
+            Row = row,
+        };
+
+        if (!PocoValueProjection.TryResolve(codec, value, member.MemberType, site, out Expression projected))
+        {
+            throw NotReadableAs(column, codec, member, typeof(T));
+        }
+
+        var locals = new List<ParameterExpression>(3) { row };
+        var body = new List<Expression>(4);
+        Expression source = SourceOneValue(tier, columnParameter, typedColumn, elementType, row, locals, body);
+
+        // row = 0; while (row < rowCount) { value = <source>; rows[row].P = <projected>; row++; }
+        LabelTarget done = Expression.Label("done");
+        body.Add(Expression.Assign(row, Expression.Constant(0)));
+        body.Add(Expression.Loop(
+            Expression.IfThenElse(
+                Expression.LessThan(row, rowCount),
+                Expression.Block(
+                    new[] { value },
+                    Expression.Assign(value, source),
+                    Expression.Assign(Expression.Property(Expression.ArrayIndex(rows, row), member.Property), projected),
+                    Expression.PostIncrementAssign(row)),
+                Expression.Break(done)),
+            done));
+
+        return Expression.Lambda<PocoColumnScatter<T>>(Expression.Block(locals, body), columnParameter, rows, rowCount)
+            .Compile(preferInterpretation);
+    }
+
+    /// <summary>
+    /// Picks the tier to compile: the caller's, or the span tier wherever expression trees compile to IL. A tree
+    /// holding a <c>ReadOnlySpan&lt;T&gt;</c> compiles but cannot be <em>interpreted</em>, which is the path taken
+    /// when the runtime has no dynamic code (NativeAOT), so the span tier is not offered there.
+    /// </summary>
+    /// <param name="forcedTier">A tier to use in place of the choice, or null to choose. A column that does not
+    /// surface its element type overrides it: neither typed tier can read one.</param>
+    /// <param name="columnSurfacesElementType">Whether the column implements <see cref="IColumn{T}"/> over its
+    /// codec's element type, which both typed tiers rely on.</param>
+    /// <returns>The tier to compile.</returns>
+    internal static PocoScatterTier SelectTier(PocoScatterTier? forcedTier, bool columnSurfacesElementType)
+    {
+        if (!columnSurfacesElementType)
+        {
+            return PocoScatterTier.Boxed;
+        }
+
+        return forcedTier ?? (RuntimeFeature.IsDynamicCodeCompiled ? PocoScatterTier.Span : PocoScatterTier.Indexer);
+    }
+
+    /// <summary>
+    /// Builds the expression that yields the value at <paramref name="row"/>, adding whatever the tier hoists out
+    /// of the loop (the span, or the cast column) to the enclosing block.
+    /// </summary>
+    /// <param name="tier">The tier to source through.</param>
+    /// <param name="column">The scatter's column parameter.</param>
+    /// <param name="typedColumn">The <see cref="IColumn{T}"/> type over the codec's element type.</param>
+    /// <param name="elementType">The codec's element type.</param>
+    /// <param name="row">The loop counter.</param>
+    /// <param name="locals">The enclosing block's locals, added to by the typed tiers.</param>
+    /// <param name="prologue">The statements before the loop, added to by the typed tiers.</param>
+    /// <returns>An expression of type <paramref name="elementType"/>.</returns>
+    private static Expression SourceOneValue(
+        PocoScatterTier tier,
+        ParameterExpression column,
+        Type typedColumn,
+        Type elementType,
+        ParameterExpression row,
+        List<ParameterExpression> locals,
+        List<Expression> prologue)
+    {
+        switch (tier)
+        {
+            case PocoScatterTier.Span:
+                // The span is read once: IColumn<T>.Values recomputes it per access, and it cannot be cached in a
+                // field, so hoisting it into a local is the whole point of the tier. For a jagged column
+                // (Array/Map/Nested) Values materializes the block's rows into a cache, which the indexer would do
+                // per row instead — the same work either way, plus one array of references here.
+                ParameterExpression values = Expression.Variable(typeof(ReadOnlySpan<>).MakeGenericType(elementType), "values");
+                locals.Add(values);
+                prologue.Add(Expression.Assign(values, Expression.Property(Expression.Convert(column, typedColumn), "Values")));
+                return Expression.Call(SpanAt.MakeGenericMethod(elementType), values, row);
+
+            case PocoScatterTier.Indexer:
+                ParameterExpression typed = Expression.Variable(typedColumn, "typed");
+                locals.Add(typed);
+                prologue.Add(Expression.Assign(typed, Expression.Convert(column, typedColumn)));
+                return Expression.MakeIndex(typed, typedColumn.GetProperty("Item", elementType, new[] { typeof(int) }), new[] { row });
+
+            default:
+                return Expression.Convert(Expression.Call(column, ColumnGetValue, row), elementType);
+        }
+    }
+
+    /// <summary>
+    /// The failure for a property the column cannot be read as (D6d): raised at plan build, so it names the shape
+    /// rather than surfacing as a cast failure part-way through a result.
+    /// </summary>
+    /// <param name="column">The column.</param>
+    /// <param name="codec">The column's codec, for the types it can be read as.</param>
+    /// <param name="member">The property that cannot be filled.</param>
+    /// <param name="pocoType">The POCO type.</param>
+    /// <returns>The exception to throw.</returns>
+    private static Exception NotReadableAs(IColumn column, IColumnCodec codec, PocoMember member, Type pocoType)
+    {
+        IReadOnlyList<Type> readable = codec.ReadableElementTypes;
+        var offered = new string[readable.Count];
+        for (int i = 0; i < readable.Count; i++)
+        {
+            offered[i] = readable[i].ToString();
+        }
+
+        // A bare NULL or empty-array literal comes back as Nothing (or a composite of it): the column carries no type
+        // of its own, so it reads only as object however nullable the property is. Changing the property cannot help,
+        // and no other ClickHouse type name contains the word — hence the remedy is to type the column in the query.
+        string remedy = column.TypeName.Contains("Nothing", StringComparison.Ordinal)
+            ? "That column is an untyped NULL, so it carries no type to read as anything else: give it one in the query (for example CAST(NULL AS Nullable(String))), or exclude the property with [ClickHouseTcpNotMapped]."
+            : "Give the property one of those types, exclude it with [ClickHouseTcpNotMapped], or read the column through the block-level API.";
+
+        return new InvalidOperationException(
+            $"Column '{column.Name}' ({column.TypeName}) maps to property '{pocoType.Name}.{member.MemberName}' of type {member.MemberType}, which it cannot be read as. " +
+            $"It reads as {string.Join(" or ", offered)}. {remedy}");
+    }
+}

--- a/ClickHouse.Driver.Tcp/Poco/PocoColumnScatterFactory.cs
+++ b/ClickHouse.Driver.Tcp/Poco/PocoColumnScatterFactory.cs
@@ -4,6 +4,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using ClickHouse.Driver.Tcp.Types;
+using ClickHouse.Driver.Tcp.Types.Codecs;
 
 namespace ClickHouse.Driver.Tcp.Poco;
 
@@ -16,7 +17,9 @@ namespace ClickHouse.Driver.Tcp.Poco;
 /// <param name="column">The column to read, already known to the plan that built this delegate.</param>
 /// <param name="rows">The rows to scatter into; at least <paramref name="rowCount"/> long, each already constructed.</param>
 /// <param name="rowCount">The number of rows to fill.</param>
-internal delegate void PocoColumnScatter<in T>(IColumn column, T[] rows, int rowCount);
+/// <param name="rowOffset">How many rows of the result precede this block, so a failure can name the row a caller
+/// counts rather than the row within a block they never see. Read only on the failure path.</param>
+internal delegate void PocoColumnScatter<in T>(IColumn column, T[] rows, int rowCount, long rowOffset);
 
 /// <summary>
 /// Compiles the per-column scatter delegates a <see cref="PocoReadPlan{T}"/> is made of. One delegate handles one
@@ -52,6 +55,7 @@ internal static class PocoColumnScatterFactory
         ParameterExpression columnParameter = Expression.Parameter(typeof(IColumn), "column");
         ParameterExpression rows = Expression.Parameter(typeof(T[]), "rows");
         ParameterExpression rowCount = Expression.Parameter(typeof(int), "rowCount");
+        ParameterExpression rowOffset = Expression.Parameter(typeof(long), "rowOffset");
         ParameterExpression row = Expression.Variable(typeof(int), "row");
         ParameterExpression value = Expression.Variable(elementType, "value");
 
@@ -61,7 +65,7 @@ internal static class PocoColumnScatterFactory
             ColumnType = column.TypeName,
             PocoTypeName = typeof(T).Name,
             MemberName = member.MemberName,
-            Row = row,
+            Row = Expression.Add(rowOffset, Expression.Convert(row, typeof(long))),
         };
 
         if (!PocoValueProjection.TryResolve(codec, value, member.MemberType, site, out Expression projected))
@@ -87,7 +91,7 @@ internal static class PocoColumnScatterFactory
                 Expression.Break(done)),
             done));
 
-        return Expression.Lambda<PocoColumnScatter<T>>(Expression.Block(locals, body), columnParameter, rows, rowCount)
+        return Expression.Lambda<PocoColumnScatter<T>>(Expression.Block(locals, body), columnParameter, rows, rowCount, rowOffset)
             .Compile(preferInterpretation);
     }
 
@@ -175,13 +179,40 @@ internal static class PocoColumnScatterFactory
 
         // A bare NULL or empty-array literal comes back as Nothing (or a composite of it): the column carries no type
         // of its own, so it reads only as object however nullable the property is. Changing the property cannot help,
-        // and no other ClickHouse type name contains the word — hence the remedy is to type the column in the query.
-        string remedy = column.TypeName.Contains("Nothing", StringComparison.Ordinal)
+        // so that case gets its own remedy.
+        string remedy = NamesTheNothingType(TypeParser.Parse(column.TypeName))
             ? "That column is an untyped NULL, so it carries no type to read as anything else: give it one in the query (for example CAST(NULL AS Nullable(String))), or exclude the property with [ClickHouseTcpNotMapped]."
             : "Give the property one of those types, exclude it with [ClickHouseTcpNotMapped], or read the column through the block-level API.";
 
         return new InvalidOperationException(
             $"Column '{column.Name}' ({column.TypeName}) maps to property '{pocoType.Name}.{member.MemberName}' of type {member.MemberType}, which it cannot be read as. " +
             $"It reads as {string.Join(" or ", offered)}. {remedy}");
+    }
+
+    /// <summary>
+    /// Whether a parsed type names <c>Nothing</c> anywhere in its tree. Walked as a tree, and matched exactly,
+    /// because a type <em>string</em> also carries arbitrary caller text: the label of an
+    /// <c>Enum8('Nothing' = 1)</c> and the field name of a named <c>Tuple</c> both live in it, so searching the text
+    /// would diagnose a perfectly well-typed column as an untyped NULL. A label arrives as one childless node whose
+    /// name is its raw token (quotes and ordinal included), so only a real type node matches.
+    /// </summary>
+    /// <param name="node">The parsed column type.</param>
+    /// <returns>Whether the type is, or contains, <c>Nothing</c>.</returns>
+    private static bool NamesTheNothingType(TypeNode node)
+    {
+        if (string.Equals(node.Name, NothingColumnCodec.Instance.TypeName, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        for (int i = 0; i < node.Arguments.Count; i++)
+        {
+            if (NamesTheNothingType(node.Arguments[i]))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/ClickHouse.Driver.Tcp/Poco/PocoColumnScatterFactory.cs
+++ b/ClickHouse.Driver.Tcp/Poco/PocoColumnScatterFactory.cs
@@ -9,24 +9,18 @@ using ClickHouse.Driver.Tcp.Types.Codecs;
 namespace ClickHouse.Driver.Tcp.Poco;
 
 /// <summary>
-/// Copies one decoded column into one property of every row of a materialized block — the compiled unit of a POCO
-/// read. Column-major rather than row-major: the block is already decoded, so the loop is taken over one column's
-/// values, which keeps the cast and the span access out of the per-row work.
+/// Copies one decoded column into one property across a range of POCO rows.
 /// </summary>
 /// <typeparam name="T">The POCO type.</typeparam>
-/// <param name="column">The column to read, already known to the plan that built this delegate.</param>
+/// <param name="column">The column to read.</param>
 /// <param name="rows">The rows to scatter into; at least <paramref name="rowCount"/> long, each already constructed.</param>
-/// <param name="start">The first row of <paramref name="column"/> to read. <c>rows[i]</c> takes column row
-/// <c>start + i</c>, so a block can be materialized in several passes without the rows moving.</param>
+/// <param name="start">The first column row to read; destination rows start at zero.</param>
 /// <param name="rowCount">The number of rows to fill.</param>
-/// <param name="rowOffset">How many rows of the result precede <c>rows[0]</c>, so a failure can name the row a caller
-/// counts rather than the row within a block they never see. Read only on the failure path.</param>
+/// <param name="rowOffset">The result-wide index of <c>rows[0]</c>, used in failures.</param>
 internal delegate void PocoColumnScatter<in T>(IColumn column, T[] rows, int start, int rowCount, long rowOffset);
 
 /// <summary>
-/// Compiles the per-column scatter delegates a <see cref="PocoReadPlan{T}"/> is made of. One delegate handles one
-/// (column, property) pair for a whole block, with the value conversion (<see cref="PocoValueProjection"/>) inlined
-/// into the loop rather than called through a delegate per row.
+/// Compiles a per-column loop with <see cref="PocoValueProjection"/> inlined into each assignment.
 /// </summary>
 internal static class PocoColumnScatterFactory
 {
@@ -40,9 +34,7 @@ internal static class PocoColumnScatterFactory
     /// <param name="codec">The column's codec, resolved the way the read resolved it.</param>
     /// <param name="member">The property the column maps to; must be settable.</param>
     /// <param name="forcedTier">A tier to compile regardless of the runtime, or null to choose one.</param>
-    /// <param name="preferInterpretation">Compiles the tree to an interpreter rather than to IL. Not used in
-    /// production — the runtime decides that — but it is the only way to exercise the path a runtime without dynamic
-    /// code takes, which is the whole reason the indexer tier exists.</param>
+    /// <param name="preferInterpretation">Whether to interpret the expression tree; used to test dynamic-code-free runtimes.</param>
     /// <returns>The compiled scatter.</returns>
     /// <exception cref="InvalidOperationException">The column's values cannot be read as the property's type, or the
     /// column does not surface its codec's element type.</exception>
@@ -103,16 +95,7 @@ internal static class PocoColumnScatterFactory
     }
 
     /// <summary>
-    /// Picks the tier to compile: the caller's, or one chosen from the runtime and the column.
-    ///
-    /// <para>
-    /// Two conditions have to hold for the span tier. A tree holding a <c>ReadOnlySpan&lt;T&gt;</c> compiles but
-    /// cannot be <em>interpreted</em>, which is the path taken when the runtime has no dynamic code (NativeAOT), so
-    /// the span tier is not offered there at all. And the column's <see cref="IColumn{T}.Values"/> has to be free to
-    /// read (<see cref="IStoredValuesColumn"/>): hoisting it out of the loop is the point of the tier, but for a
-    /// column that builds its values on access that one read materializes the whole block and pins it for the
-    /// block's lifetime, which is exactly what a windowed materialization is trying to avoid.
-    /// </para>
+    /// Uses the forced tier, or selects spans only when dynamic code is compiled and values are already stored.
     /// </summary>
     /// <param name="forcedTier">A tier to use in place of the choice, or null to choose.</param>
     /// <param name="column">The column to be read, consulted for whether its values are stored or built.</param>
@@ -123,8 +106,7 @@ internal static class PocoColumnScatterFactory
             : PocoScatterTier.Indexer);
 
     /// <summary>
-    /// Builds the expression that yields the value at <paramref name="row"/>, adding whatever the tier hoists out
-    /// of the loop (the span, or the cast column) to the enclosing block.
+    /// Builds one indexed read and adds its hoisted locals and prologue to the enclosing expression block.
     /// </summary>
     /// <param name="tier">The tier to source through.</param>
     /// <param name="column">The scatter's column parameter.</param>
@@ -164,10 +146,7 @@ internal static class PocoColumnScatterFactory
     }
 
     /// <summary>
-    /// The failure for a column that does not implement <see cref="IColumn{T}"/> over its own codec's element type.
-    /// Both tiers cast to that interface, so such a column would otherwise fail the cast inside compiled code, on
-    /// the first block rather than at plan build. No shipped codec produces one — a codec and the column it reads
-    /// are written together — so this reports the codec bug rather than the cast that follows from it.
+    /// Reports a column that does not implement <see cref="IColumn{T}"/> for its codec's element type.
     /// </summary>
     /// <param name="column">The column.</param>
     /// <param name="codec">The column's codec.</param>
@@ -178,8 +157,7 @@ internal static class PocoColumnScatterFactory
             $"as its codec {codec.GetType()} declares. A POCO read sources every value through that interface, so the column cannot be read into a property.");
 
     /// <summary>
-    /// The failure for a property the column cannot be read as (D6d): raised at plan build, so it names the shape
-    /// rather than surfacing as a cast failure part-way through a result.
+    /// Reports a property type the column cannot be read as.
     /// </summary>
     /// <param name="column">The column.</param>
     /// <param name="codec">The column's codec, for the types it can be read as.</param>
@@ -208,11 +186,7 @@ internal static class PocoColumnScatterFactory
     }
 
     /// <summary>
-    /// Whether a parsed type names <c>Nothing</c> anywhere in its tree. Walked as a tree, and matched exactly,
-    /// because a type <em>string</em> also carries arbitrary caller text: the label of an
-    /// <c>Enum8('Nothing' = 1)</c> and the field name of a named <c>Tuple</c> both live in it, so searching the text
-    /// would diagnose a perfectly well-typed column as an untyped NULL. A label arrives as one childless node whose
-    /// name is its raw token (quotes and ordinal included), so only a real type node matches.
+    /// Whether a parsed type contains a real <c>Nothing</c> node, excluding labels or field names with that text.
     /// </summary>
     /// <param name="node">The parsed column type.</param>
     /// <returns>Whether the type is, or contains, <c>Nothing</c>.</returns>

--- a/ClickHouse.Driver.Tcp/Poco/PocoReadPlan.cs
+++ b/ClickHouse.Driver.Tcp/Poco/PocoReadPlan.cs
@@ -182,7 +182,9 @@ internal sealed class PocoReadPlan<T>
     /// </summary>
     /// <param name="block">The block to materialize; must have the shape this plan was built for.</param>
     /// <param name="rows">The destination, at least <see cref="Block.RowCount"/> long.</param>
-    public void Materialize(Block block, T[] rows)
+    /// <param name="rowOffset">How many rows of the result precede this block, so a failure names the row the caller
+    /// counts. Only ever read on a failure path.</param>
+    public void Materialize(Block block, T[] rows, long rowOffset)
     {
         int rowCount = block.RowCount;
         for (int i = 0; i < rowCount; i++)
@@ -192,7 +194,7 @@ internal sealed class PocoReadPlan<T>
 
         for (int i = 0; i < scatters.Length; i++)
         {
-            scatters[i]?.Invoke(block[i], rows, rowCount);
+            scatters[i]?.Invoke(block[i], rows, rowCount, rowOffset);
         }
     }
 

--- a/ClickHouse.Driver.Tcp/Poco/PocoReadPlan.cs
+++ b/ClickHouse.Driver.Tcp/Poco/PocoReadPlan.cs
@@ -176,25 +176,45 @@ internal sealed class PocoReadPlan<T>
     }
 
     /// <summary>
-    /// Materializes a block's rows into <paramref name="rows"/>: one instance per row, then one scatter per mapped
-    /// column. Synchronous by necessity — the span tier holds a <see cref="ReadOnlySpan{T}"/>, which no async or
-    /// iterator method may.
+    /// A whole block in one pass. Convenient where the row count is known to be small, or where all of a block's
+    /// rows are wanted at once; a reader streaming a result of any size wants the windowed overload instead, so
+    /// that the rows it has handed on can be collected while it reads the rest.
     /// </summary>
     /// <param name="block">The block to materialize; must have the shape this plan was built for.</param>
     /// <param name="rows">The destination, at least <see cref="Block.RowCount"/> long.</param>
     /// <param name="rowOffset">How many rows of the result precede this block, so a failure names the row the caller
     /// counts. Only ever read on a failure path.</param>
     public void Materialize(Block block, T[] rows, long rowOffset)
+        => Materialize(block, rows, 0, block.RowCount, rowOffset);
+
+    /// <summary>
+    /// Materializes rows <c>[start, start + count)</c> of a block into <c>rows[0, count)</c>: one instance per row,
+    /// then one scatter per mapped column. Synchronous by necessity — the span tier holds a
+    /// <see cref="ReadOnlySpan{T}"/>, which no async or iterator method may.
+    ///
+    /// <para>
+    /// Taking a block in windows rather than whole bounds how many rows are reachable at once, which is otherwise
+    /// however many rows the server chose to put in a block. That matters because a generational collector charges
+    /// for what survives a collection rather than for what it frees, so rows held for a whole block are copied
+    /// forward instead of being dropped.
+    /// </para>
+    /// </summary>
+    /// <param name="block">The block to materialize; must have the shape this plan was built for.</param>
+    /// <param name="rows">The destination, at least <paramref name="count"/> long.</param>
+    /// <param name="start">The first row of the block to take.</param>
+    /// <param name="count">How many rows to take.</param>
+    /// <param name="rowOffset">How many rows of the result precede <c>rows[0]</c>, so a failure names the row the
+    /// caller counts. Only ever read on a failure path.</param>
+    public void Materialize(Block block, T[] rows, int start, int count, long rowOffset)
     {
-        int rowCount = block.RowCount;
-        for (int i = 0; i < rowCount; i++)
+        for (int i = 0; i < count; i++)
         {
             rows[i] = activator();
         }
 
         for (int i = 0; i < scatters.Length; i++)
         {
-            scatters[i]?.Invoke(block[i], rows, rowCount, rowOffset);
+            scatters[i]?.Invoke(block[i], rows, start, count, rowOffset);
         }
     }
 

--- a/ClickHouse.Driver.Tcp/Poco/PocoReadPlan.cs
+++ b/ClickHouse.Driver.Tcp/Poco/PocoReadPlan.cs
@@ -1,0 +1,212 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using ClickHouse.Driver.Tcp.Format;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Poco;
+
+/// <summary>
+/// The header identity a <see cref="PocoReadPlan{T}"/> is built against. Only the wire shape lives here, so it is
+/// shared by every POCO type rather than compiled once per type.
+/// </summary>
+internal static class PocoReadPlan
+{
+    /// <summary>
+    /// The cache key for a block's shape: the resolution context, then each column's name and ClickHouse type. The
+    /// type string is the server's own header text, so two types that print alike cannot collide.
+    ///
+    /// <para>
+    /// Every part is length-prefixed rather than merely separated, because a column name is arbitrary text — a
+    /// backtick- or double-quoted alias may itself contain any separator character. Joined on a delimiter alone, the
+    /// header <c>[a Int32, b Int32]</c> and a single column named with that delimiter sequence produce the same key,
+    /// and the cache then hands one shape's plan to the other: columns silently unread, or an index past the block's
+    /// columns. Length prefixes make the key injective, so the shape a plan was compiled for is the only shape that
+    /// can find it.
+    /// </para>
+    /// </summary>
+    /// <param name="block">The block whose header to key on.</param>
+    /// <returns>The key.</returns>
+    public static string SignatureOf(Block block)
+    {
+        var key = new StringBuilder();
+        Append(key, ContextKey(block.Context));
+        for (int i = 0; i < block.ColumnCount; i++)
+        {
+            IColumn column = block[i];
+            Append(key, column.Name);
+            Append(key, column.TypeName);
+        }
+
+        return key.ToString();
+    }
+
+    /// <summary>
+    /// The part of the key that is not in the header. A <c>DateTime</c> column whose type string names no timezone
+    /// resolves against the session timezone, so a plan built for one session timezone must not be reused for
+    /// another — the header alone cannot tell the two apart.
+    /// </summary>
+    /// <param name="context">The context the block's codecs were resolved with.</param>
+    /// <returns>The key part.</returns>
+    public static string ContextKey(in ResolveContext context) => context.ServerTimezone ?? string.Empty;
+
+    private static void Append(StringBuilder key, string part) => key.Append(part.Length).Append(':').Append(part);
+}
+
+/// <summary>
+/// The compiled read plan for one POCO type over one block shape: a scatter per mapped column, plus the
+/// constructor the rows come from. Built once per (type, block shape) and cached, because the column types come
+/// from the server and so cannot be known from the type alone.
+///
+/// <para>
+/// A column that maps to no property is left with no scatter and never read — nothing has to be consumed to stay
+/// aligned, the block being already decoded. A property no column maps to keeps its default.
+/// </para>
+/// </summary>
+/// <typeparam name="T">The POCO type.</typeparam>
+internal sealed class PocoReadPlan<T>
+    where T : class
+{
+    private readonly Func<T> activator;
+    private readonly string[] columnNames;
+    private readonly string[] columnTypes;
+    private readonly string contextKey;
+    private readonly PocoColumnScatter<T>[] scatters;
+
+    private PocoReadPlan(Func<T> activator, string[] columnNames, string[] columnTypes, string contextKey, PocoColumnScatter<T>[] scatters)
+    {
+        this.activator = activator;
+        this.columnNames = columnNames;
+        this.columnTypes = columnTypes;
+        this.contextKey = contextKey;
+        this.scatters = scatters;
+    }
+
+    /// <summary>
+    /// Compiles the plan for <paramref name="block"/>'s shape. Everything that can fail — an unsettable or
+    /// unreadable property, a type that cannot be constructed — fails here rather than part-way through a result.
+    /// </summary>
+    /// <param name="descriptor">The POCO type's mapping.</param>
+    /// <param name="block">A block of the shape to plan for; only its header and its columns' runtime shapes are read.</param>
+    /// <param name="forcedTier">A scatter tier to compile regardless of the runtime, or null to choose one.</param>
+    /// <returns>The plan.</returns>
+    /// <exception cref="InvalidOperationException"><typeparamref name="T"/> cannot be materialized, no column maps
+    /// to a property, two columns map to one property, a mapped property cannot be set, or a column cannot be read
+    /// as its property's type.</exception>
+    public static PocoReadPlan<T> Build(PocoTypeDescriptor<T> descriptor, Block block, PocoScatterTier? forcedTier)
+    {
+        // Read first: an insert-only POCO (no accessible parameterless constructor) fails here, naming the reason.
+        Func<T> activator = descriptor.Activator;
+
+        int columnCount = block.ColumnCount;
+        var names = new string[columnCount];
+        var types = new string[columnCount];
+        var scatters = new PocoColumnScatter<T>[columnCount];
+        var claimedBy = new Dictionary<string, string>(columnCount, StringComparer.Ordinal);
+
+        for (int i = 0; i < columnCount; i++)
+        {
+            IColumn column = block[i];
+            names[i] = column.Name;
+            types[i] = column.TypeName;
+
+            if (!descriptor.TryMatchColumn(column.Name, out PocoMember member))
+            {
+                continue;
+            }
+
+            if (!member.CanSet)
+            {
+                throw new InvalidOperationException(
+                    $"Column '{column.Name}' maps to property '{typeof(T).Name}.{member.MemberName}', which a query cannot fill: {member.DescribeWhyNotSettable()}. " +
+                    $"Give it a public setter, or exclude it with [ClickHouseTcpNotMapped].");
+            }
+
+            if (claimedBy.TryGetValue(member.MemberName, out string claimed))
+            {
+                // Two columns reaching one property through the matcher's looser tiers, e.g. 'user_id' and
+                // 'userId'. Whichever scattered last would win silently, so the caller has to disambiguate.
+                throw new InvalidOperationException(
+                    $"Columns '{claimed}' and '{column.Name}' both map to property '{typeof(T).Name}.{member.MemberName}'. " +
+                    $"Point one of them at a property of its own with [ClickHouseTcpColumn(Name = \"...\")], or select only one of them.");
+            }
+
+            claimedBy[member.MemberName] = column.Name;
+            IColumnCodec codec = block.Codecs.Resolve(column.TypeName, block.Context);
+            scatters[i] = PocoColumnScatterFactory.Create<T>(column, codec, member, forcedTier);
+        }
+
+        if (claimedBy.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"No column of the result maps to a property of '{typeof(T).Name}': the result has {Describe(names)}, and the type has {Describe(descriptor)}. " +
+                $"Every row would be left at its defaults, so this is reported rather than returned.");
+        }
+
+        return new PocoReadPlan<T>(activator, names, types, PocoReadPlan.ContextKey(block.Context), scatters);
+    }
+
+    /// <summary>
+    /// Whether <paramref name="block"/> has the shape this plan was compiled for, so an enumeration can reuse the
+    /// plan across the blocks of one result without going back to the cache. Compared column by column rather than
+    /// by the cache key, since every block builds its own header strings and no key has to be materialized to say
+    /// no.
+    /// </summary>
+    /// <param name="block">The block to check.</param>
+    /// <returns>Whether the plan applies to it.</returns>
+    public bool MatchesHeader(Block block)
+    {
+        if (block.ColumnCount != columnNames.Length
+            || !string.Equals(contextKey, PocoReadPlan.ContextKey(block.Context), StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        for (int i = 0; i < columnNames.Length; i++)
+        {
+            IColumn column = block[i];
+            if (!string.Equals(column.Name, columnNames[i], StringComparison.Ordinal)
+                || !string.Equals(column.TypeName, columnTypes[i], StringComparison.Ordinal))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Materializes a block's rows into <paramref name="rows"/>: one instance per row, then one scatter per mapped
+    /// column. Synchronous by necessity — the span tier holds a <see cref="ReadOnlySpan{T}"/>, which no async or
+    /// iterator method may.
+    /// </summary>
+    /// <param name="block">The block to materialize; must have the shape this plan was built for.</param>
+    /// <param name="rows">The destination, at least <see cref="Block.RowCount"/> long.</param>
+    public void Materialize(Block block, T[] rows)
+    {
+        int rowCount = block.RowCount;
+        for (int i = 0; i < rowCount; i++)
+        {
+            rows[i] = activator();
+        }
+
+        for (int i = 0; i < scatters.Length; i++)
+        {
+            scatters[i]?.Invoke(block[i], rows, rowCount);
+        }
+    }
+
+    private static string Describe(string[] columnNames)
+        => columnNames.Length == 0 ? "no columns" : $"columns {string.Join(", ", columnNames)}";
+
+    private static string Describe(PocoTypeDescriptor descriptor)
+    {
+        var names = new string[descriptor.Members.Count];
+        for (int i = 0; i < names.Length; i++)
+        {
+            names[i] = descriptor.Members[i].ColumnName;
+        }
+
+        return $"properties mapping to {string.Join(", ", names)}";
+    }
+}

--- a/ClickHouse.Driver.Tcp/Poco/PocoReadPlan.cs
+++ b/ClickHouse.Driver.Tcp/Poco/PocoReadPlan.cs
@@ -7,23 +7,13 @@ using ClickHouse.Driver.Tcp.Types;
 namespace ClickHouse.Driver.Tcp.Poco;
 
 /// <summary>
-/// The header identity a <see cref="PocoReadPlan{T}"/> is built against. Only the wire shape lives here, so it is
-/// shared by every POCO type rather than compiled once per type.
+/// Builds cache keys for result shapes used by <see cref="PocoReadPlan{T}"/>.
 /// </summary>
 internal static class PocoReadPlan
 {
     /// <summary>
-    /// The cache key for a block's shape: the resolution context, then each column's name and ClickHouse type. The
-    /// type string is the server's own header text, so two types that print alike cannot collide.
-    ///
-    /// <para>
-    /// Every part is length-prefixed rather than merely separated, because a column name is arbitrary text — a
-    /// backtick- or double-quoted alias may itself contain any separator character. Joined on a delimiter alone, the
-    /// header <c>[a Int32, b Int32]</c> and a single column named with that delimiter sequence produce the same key,
-    /// and the cache then hands one shape's plan to the other: columns silently unread, or an index past the block's
-    /// columns. Length prefixes make the key injective, so the shape a plan was compiled for is the only shape that
-    /// can find it.
-    /// </para>
+    /// Builds a length-prefixed key from the resolution context and each column's name and type. Length prefixes
+    /// prevent aliases containing separator characters from colliding with another header.
     /// </summary>
     /// <param name="block">The block whose header to key on.</param>
     /// <returns>The key.</returns>
@@ -42,9 +32,7 @@ internal static class PocoReadPlan
     }
 
     /// <summary>
-    /// The part of the key that is not in the header. A <c>DateTime</c> column whose type string names no timezone
-    /// resolves against the session timezone, so a plan built for one session timezone must not be reused for
-    /// another — the header alone cannot tell the two apart.
+    /// Builds the context part of the key, including the session timezone used by timezone-less types.
     /// </summary>
     /// <param name="context">The context the block's codecs were resolved with.</param>
     /// <returns>The key part.</returns>
@@ -54,14 +42,8 @@ internal static class PocoReadPlan
 }
 
 /// <summary>
-/// The compiled read plan for one POCO type over one block shape: a scatter per mapped column, plus the
-/// constructor the rows come from. Built once per (type, block shape) and cached, because the column types come
-/// from the server and so cannot be known from the type alone.
-///
-/// <para>
-/// A column that maps to no property is left with no scatter and never read — nothing has to be consumed to stay
-/// aligned, the block being already decoded. A property no column maps to keeps its default.
-/// </para>
+/// A compiled constructor and per-column scatter set for one POCO type and result shape. Unmapped columns are
+/// skipped; properties without columns retain their defaults.
 /// </summary>
 /// <typeparam name="T">The POCO type.</typeparam>
 internal sealed class PocoReadPlan<T>
@@ -83,8 +65,7 @@ internal sealed class PocoReadPlan<T>
     }
 
     /// <summary>
-    /// Compiles the plan for <paramref name="block"/>'s shape. Everything that can fail — an unsettable or
-    /// unreadable property, a type that cannot be constructed — fails here rather than part-way through a result.
+    /// Compiles the plan for <paramref name="block"/>'s shape, validating construction, mapping and conversions.
     /// </summary>
     /// <param name="descriptor">The POCO type's mapping.</param>
     /// <param name="block">A block of the shape to plan for; only its header and its columns' runtime shapes are read.</param>
@@ -147,10 +128,7 @@ internal sealed class PocoReadPlan<T>
     }
 
     /// <summary>
-    /// Whether <paramref name="block"/> has the shape this plan was compiled for, so an enumeration can reuse the
-    /// plan across the blocks of one result without going back to the cache. Compared column by column rather than
-    /// by the cache key, since every block builds its own header strings and no key has to be materialized to say
-    /// no.
+    /// Whether <paramref name="block"/> matches this plan's column names, types and resolution context.
     /// </summary>
     /// <param name="block">The block to check.</param>
     /// <returns>Whether the plan applies to it.</returns>
@@ -176,9 +154,7 @@ internal sealed class PocoReadPlan<T>
     }
 
     /// <summary>
-    /// A whole block in one pass. Convenient where the row count is known to be small, or where all of a block's
-    /// rows are wanted at once; a reader streaming a result of any size wants the windowed overload instead, so
-    /// that the rows it has handed on can be collected while it reads the rest.
+    /// Materializes a whole block into <paramref name="rows"/>.
     /// </summary>
     /// <param name="block">The block to materialize; must have the shape this plan was built for.</param>
     /// <param name="rows">The destination, at least <see cref="Block.RowCount"/> long.</param>
@@ -188,16 +164,8 @@ internal sealed class PocoReadPlan<T>
         => Materialize(block, rows, 0, block.RowCount, rowOffset);
 
     /// <summary>
-    /// Materializes rows <c>[start, start + count)</c> of a block into <c>rows[0, count)</c>: one instance per row,
-    /// then one scatter per mapped column. Synchronous by necessity — the span tier holds a
-    /// <see cref="ReadOnlySpan{T}"/>, which no async or iterator method may.
-    ///
-    /// <para>
-    /// Taking a block in windows rather than whole bounds how many rows are reachable at once, which is otherwise
-    /// however many rows the server chose to put in a block. That matters because a generational collector charges
-    /// for what survives a collection rather than for what it frees, so rows held for a whole block are copied
-    /// forward instead of being dropped.
-    /// </para>
+    /// Materializes block rows <c>[start, start + count)</c> into <c>rows[0, count)</c>. Keeping this synchronous
+    /// allows span-based scatters; callers may invoke it in windows to bound live rows.
     /// </summary>
     /// <param name="block">The block to materialize; must have the shape this plan was built for.</param>
     /// <param name="rows">The destination, at least <paramref name="count"/> long.</param>

--- a/ClickHouse.Driver.Tcp/Poco/PocoScatterTier.cs
+++ b/ClickHouse.Driver.Tcp/Poco/PocoScatterTier.cs
@@ -1,0 +1,38 @@
+namespace ClickHouse.Driver.Tcp.Poco;
+
+/// <summary>
+/// How a compiled scatter sources one value from a column. The three tiers differ only in that sourcing step — the
+/// value conversion and the property assignment are identical — so they must produce equal values, which is what
+/// the parity tests assert.
+///
+/// <para>
+/// Equal <em>values</em>, not identical references: a <c>LowCardinality</c> column's
+/// <see cref="Types.IColumn{T}.Values"/> hands every row sharing a dictionary entry the same element instance, while
+/// its indexer materializes one per row. That is observable only for a mutable element type, i.e. the
+/// <c>byte[]</c> of a <c>LowCardinality(FixedString(N))</c> — see the remarks on
+/// <see cref="ClickHouseTcpClient.QueryAsync{T}"/>.
+/// </para>
+/// </summary>
+internal enum PocoScatterTier
+{
+    /// <summary>
+    /// Reads <see cref="Types.IColumn{T}.Values"/> once and indexes the span per row, so nothing is boxed and a
+    /// column whose storage is its values (the fixed-width and calendar columns) is read with no copy at all. The
+    /// default wherever the runtime compiles expression trees to IL.
+    /// </summary>
+    Span,
+
+    /// <summary>
+    /// Reads <c>IColumn&lt;T&gt;[row]</c> per row: still box-free, and the default when
+    /// <see cref="System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeCompiled"/> is false (NativeAOT and
+    /// friends), where a tree is interpreted rather than compiled and cannot hold a <c>ReadOnlySpan&lt;T&gt;</c>.
+    /// </summary>
+    Indexer,
+
+    /// <summary>
+    /// Reads <see cref="Types.IColumn.GetValue"/> per row and unboxes: one box per cell, so it is not chosen for a
+    /// column that surfaces its element type generically. It is the fallback for a column that does not implement
+    /// <see cref="Types.IColumn{T}"/> over its codec's element type, and the third leg of the parity harness.
+    /// </summary>
+    Boxed,
+}

--- a/ClickHouse.Driver.Tcp/Poco/PocoScatterTier.cs
+++ b/ClickHouse.Driver.Tcp/Poco/PocoScatterTier.cs
@@ -1,40 +1,15 @@
 namespace ClickHouse.Driver.Tcp.Poco;
 
 /// <summary>
-/// How a compiled scatter sources one value from a column. The two tiers differ only in that sourcing step — the
-/// value conversion and the property assignment are identical — so they must produce equal values, which is what
-/// the parity tests assert.
-///
-/// <para>
-/// Equal <em>values</em>, not identical references, and the two are not the same claim for a reference-typed
-/// element. A <c>FixedString(N)</c> column builds a fresh <c>byte[]</c> per row either way, but not the
-/// <em>same</em> one: <see cref="Types.IColumn{T}.Values"/> caches the array it built, while the indexer copies the
-/// row's bytes out again on each access. So the two tiers hand out arrays with equal contents and different
-/// identities, which is why parity is asserted on values.
-/// </para>
-///
-/// <para>
-/// Within one <c>LowCardinality</c> column the opposite holds, on both tiers: every row sharing a dictionary entry
-/// gets that entry's own instance, because both the indexer and <see cref="Types.IColumn{T}.Values"/> read the
-/// dictionary through its <c>Values</c>. That is deliberate (it is what stops a <c>String</c> dictionary being
-/// decoded once per row) and it is observable for a mutable element type, i.e. the <c>byte[]</c> of a
-/// <c>LowCardinality(FixedString(N))</c> — see the remarks on <see cref="ClickHouseTcpClient.QueryAsync{T}"/> and
-/// on <see cref="ClickHouseTcpClient.QueryAsync(string, ClickHouseTcpQueryOptions, System.Threading.CancellationToken)"/>.
-/// </para>
+/// How a compiled scatter reads a column value. Both tiers use the same conversion and assignment logic.
 /// </summary>
 internal enum PocoScatterTier
 {
-    /// <summary>
-    /// Reads <see cref="Types.IColumn{T}.Values"/> once and indexes the span per row, so nothing is boxed and a
-    /// column whose storage is its values (the fixed-width and calendar columns) is read with no copy at all. The
-    /// default wherever the runtime compiles expression trees to IL.
-    /// </summary>
+    /// <summary>Hoists <see cref="Types.IColumn{T}.Values"/> and indexes its span.</summary>
     Span,
 
     /// <summary>
-    /// Reads <c>IColumn&lt;T&gt;[row]</c> per row: still box-free, and the default when
-    /// <see cref="System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeCompiled"/> is false (NativeAOT and
-    /// friends), where a tree is interpreted rather than compiled and cannot hold a <c>ReadOnlySpan&lt;T&gt;</c>.
+    /// Reads <c>IColumn&lt;T&gt;[row]</c>; used when spans would materialize values or expression trees are interpreted.
     /// </summary>
     Indexer,
 }

--- a/ClickHouse.Driver.Tcp/Poco/PocoScatterTier.cs
+++ b/ClickHouse.Driver.Tcp/Poco/PocoScatterTier.cs
@@ -1,7 +1,7 @@
 namespace ClickHouse.Driver.Tcp.Poco;
 
 /// <summary>
-/// How a compiled scatter sources one value from a column. The three tiers differ only in that sourcing step — the
+/// How a compiled scatter sources one value from a column. The two tiers differ only in that sourcing step — the
 /// value conversion and the property assignment are identical — so they must produce equal values, which is what
 /// the parity tests assert.
 ///
@@ -28,11 +28,4 @@ internal enum PocoScatterTier
     /// friends), where a tree is interpreted rather than compiled and cannot hold a <c>ReadOnlySpan&lt;T&gt;</c>.
     /// </summary>
     Indexer,
-
-    /// <summary>
-    /// Reads <see cref="Types.IColumn.GetValue"/> per row and unboxes: one box per cell, so it is not chosen for a
-    /// column that surfaces its element type generically. It is the fallback for a column that does not implement
-    /// <see cref="Types.IColumn{T}"/> over its codec's element type, and the third leg of the parity harness.
-    /// </summary>
-    Boxed,
 }

--- a/ClickHouse.Driver.Tcp/Poco/PocoScatterTier.cs
+++ b/ClickHouse.Driver.Tcp/Poco/PocoScatterTier.cs
@@ -6,11 +6,20 @@ namespace ClickHouse.Driver.Tcp.Poco;
 /// the parity tests assert.
 ///
 /// <para>
-/// Equal <em>values</em>, not identical references: a <c>LowCardinality</c> column's
-/// <see cref="Types.IColumn{T}.Values"/> hands every row sharing a dictionary entry the same element instance, while
-/// its indexer materializes one per row. That is observable only for a mutable element type, i.e. the
-/// <c>byte[]</c> of a <c>LowCardinality(FixedString(N))</c> — see the remarks on
-/// <see cref="ClickHouseTcpClient.QueryAsync{T}"/>.
+/// Equal <em>values</em>, not identical references, and the two are not the same claim for a reference-typed
+/// element. A <c>FixedString(N)</c> column builds a fresh <c>byte[]</c> per row either way, but not the
+/// <em>same</em> one: <see cref="Types.IColumn{T}.Values"/> caches the array it built, while the indexer copies the
+/// row's bytes out again on each access. So the two tiers hand out arrays with equal contents and different
+/// identities, which is why parity is asserted on values.
+/// </para>
+///
+/// <para>
+/// Within one <c>LowCardinality</c> column the opposite holds, on both tiers: every row sharing a dictionary entry
+/// gets that entry's own instance, because both the indexer and <see cref="Types.IColumn{T}.Values"/> read the
+/// dictionary through its <c>Values</c>. That is deliberate (it is what stops a <c>String</c> dictionary being
+/// decoded once per row) and it is observable for a mutable element type, i.e. the <c>byte[]</c> of a
+/// <c>LowCardinality(FixedString(N))</c> — see the remarks on <see cref="ClickHouseTcpClient.QueryAsync{T}"/> and
+/// on <see cref="ClickHouseTcpClient.QueryAsync(string, ClickHouseTcpQueryOptions, System.Threading.CancellationToken)"/>.
 /// </para>
 /// </summary>
 internal enum PocoScatterTier

--- a/ClickHouse.Driver.Tcp/Poco/PocoSpan.cs
+++ b/ClickHouse.Driver.Tcp/Poco/PocoSpan.cs
@@ -8,11 +8,7 @@ namespace ClickHouse.Driver.Tcp.Poco;
 internal static class PocoSpan
 {
     /// <summary>
-    /// Reads one element of a span. An expression tree cannot consume <see cref="ReadOnlySpan{T}"/>'s indexer
-    /// directly, because it returns <c>ref readonly T</c> and a tree has no way to express a managed reference
-    /// (<c>Expression of type 'System.Int32&amp;' cannot be used for return type 'System.Int32'</c>). Routing the
-    /// index through this method returns the element by value instead; the JIT inlines it away, so the compiled
-    /// scatter still reads straight out of the column's borrowed storage.
+    /// Reads a span element by value, which expression trees can represent unlike the span's ref-returning indexer.
     /// </summary>
     /// <typeparam name="T">The element type.</typeparam>
     /// <param name="span">The span to read from.</param>

--- a/ClickHouse.Driver.Tcp/Poco/PocoSpan.cs
+++ b/ClickHouse.Driver.Tcp/Poco/PocoSpan.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace ClickHouse.Driver.Tcp.Poco;
+
+/// <summary>
+/// Span access for the compiled POCO scatters.
+/// </summary>
+internal static class PocoSpan
+{
+    /// <summary>
+    /// Reads one element of a span. An expression tree cannot consume <see cref="ReadOnlySpan{T}"/>'s indexer
+    /// directly, because it returns <c>ref readonly T</c> and a tree has no way to express a managed reference
+    /// (<c>Expression of type 'System.Int32&amp;' cannot be used for return type 'System.Int32'</c>). Routing the
+    /// index through this method returns the element by value instead; the JIT inlines it away, so the compiled
+    /// scatter still reads straight out of the column's borrowed storage.
+    /// </summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="span">The span to read from.</param>
+    /// <param name="index">The zero-based element index.</param>
+    /// <returns>The element at that index.</returns>
+    public static T At<T>(ReadOnlySpan<T> span, int index) => span[index];
+}

--- a/ClickHouse.Driver.Tcp/Poco/PocoTypeRegistry.cs
+++ b/ClickHouse.Driver.Tcp/Poco/PocoTypeRegistry.cs
@@ -6,17 +6,24 @@ namespace ClickHouse.Driver.Tcp.Poco;
 
 /// <summary>
 /// Caches the POCO mapping work, so a type is reflected over and its constructor compiled once instead of once per
-/// query or insert. One registry lives per <see cref="ClickHouseTcpClient"/>: the client is meant to be held as a
-/// singleton, so the cost is amortized anyway, and a per-client cache cannot pin types loaded into an
-/// <see cref="System.Runtime.Loader.AssemblyLoadContext"/> the caller later wants to unload.
+/// query or insert. One registry lives per <see cref="ClickHouseTcpClient"/> rather than one per process: the client
+/// is meant to be held as a singleton, so the cost is amortized either way, and scoping the cache to the client is
+/// what lets dropping the client release it.
 ///
 /// <para>
 /// Two levels, because only half of a mapping is per-type. The descriptor is; the compiled loops are per
 /// <c>(type, wire shape)</c> — the column types come from the server, not from the type — so they cache under their
-/// own key, the block signature. Neither level evicts. The descriptors are bounded by the POCO types a program has,
-/// but the plans are bounded by the distinct result <em>shapes</em> it queries, which is caller-controlled (aliases,
-/// ad-hoc column lists): a long-lived client issuing endlessly varied shapes for one type accumulates a plan per
-/// shape. Worth a bound if that ever shows up; it is not the shape of the workloads this is for.
+/// own key, the block signature.
+/// </para>
+///
+/// <para>
+/// Neither level evicts, which has two consequences worth stating. The descriptors are bounded by the POCO types a
+/// program has, but the plans are bounded by the distinct result <em>shapes</em> it queries, and a shape is
+/// caller-controlled (aliases, ad-hoc column lists): a long-lived client issuing endlessly varied shapes for one type
+/// accumulates a plan per shape. And both levels hold their <see cref="Type"/> keys — plus compiled delegates over
+/// that type's members — for as long as the client lives, so a POCO loaded into a collectible
+/// <see cref="System.Runtime.Loader.AssemblyLoadContext"/> keeps that context loaded until the client is disposed.
+/// Neither is the shape of the workloads this is for; both want a weak or bounded cache if they ever show up.
 /// </para>
 /// </summary>
 internal sealed class PocoTypeRegistry

--- a/ClickHouse.Driver.Tcp/Poco/PocoTypeRegistry.cs
+++ b/ClickHouse.Driver.Tcp/Poco/PocoTypeRegistry.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using ClickHouse.Driver.Tcp.Format;
 
 namespace ClickHouse.Driver.Tcp.Poco;
 
@@ -10,13 +11,19 @@ namespace ClickHouse.Driver.Tcp.Poco;
 /// <see cref="System.Runtime.Loader.AssemblyLoadContext"/> the caller later wants to unload.
 ///
 /// <para>
-/// Only the per-type level lives here. The compiled loops are per <c>(type, wire shape)</c> — the column types come
-/// from the server, not from the type — so they cache separately, keyed by the block or sample-block signature.
+/// Two levels, because only half of a mapping is per-type. The descriptor is; the compiled loops are per
+/// <c>(type, wire shape)</c> — the column types come from the server, not from the type — so they cache under their
+/// own key, the block signature. Neither level evicts. The descriptors are bounded by the POCO types a program has,
+/// but the plans are bounded by the distinct result <em>shapes</em> it queries, which is caller-controlled (aliases,
+/// ad-hoc column lists): a long-lived client issuing endlessly varied shapes for one type accumulates a plan per
+/// shape. Worth a bound if that ever shows up; it is not the shape of the workloads this is for.
 /// </para>
 /// </summary>
 internal sealed class PocoTypeRegistry
 {
     private readonly ConcurrentDictionary<Type, PocoTypeDescriptor> descriptors = new();
+
+    private readonly ConcurrentDictionary<(Type PocoType, string Signature, PocoScatterTier? ForcedTier), object> readPlans = new();
 
     /// <summary>
     /// Gets the descriptor for <typeparamref name="T"/>, building it on first use.
@@ -31,4 +38,25 @@ internal sealed class PocoTypeRegistry
         // Keyed by the Type object, not its name, so two same-named types from different assemblies stay distinct.
         // A race can build twice; the build is pure, so the loser's copy is simply dropped.
         => (PocoTypeDescriptor<T>)descriptors.GetOrAdd(typeof(T), static _ => PocoTypeDescriptor<T>.Build());
+
+    /// <summary>
+    /// Gets the read plan for <typeparamref name="T"/> over <paramref name="block"/>'s shape, compiling it on first
+    /// use. Keyed by the block signature, so one type queried through several shapes keeps a plan per shape, and by
+    /// the forced tier, so a caller asking for a particular tier is never handed another tier's plan.
+    /// </summary>
+    /// <typeparam name="T">The POCO type.</typeparam>
+    /// <param name="block">A block of the shape to plan for.</param>
+    /// <param name="forcedTier">A scatter tier to compile regardless of the runtime, or null to choose one.</param>
+    /// <returns>The cached plan.</returns>
+    /// <exception cref="InvalidOperationException">The shape cannot be read into <typeparamref name="T"/> — see
+    /// <see cref="PocoReadPlan{T}.Build"/>. Nothing is cached in that case, so every caller is told, not just the
+    /// first.</exception>
+    public PocoReadPlan<T> ReadPlanFor<T>(Block block, PocoScatterTier? forcedTier)
+        where T : class
+    {
+        PocoTypeDescriptor<T> descriptor = DescriptorFor<T>();
+        return (PocoReadPlan<T>)readPlans.GetOrAdd(
+            (typeof(T), PocoReadPlan.SignatureOf(block), forcedTier),
+            _ => PocoReadPlan<T>.Build(descriptor, block, forcedTier));
+    }
 }

--- a/ClickHouse.Driver.Tcp/Poco/PocoTypeRegistry.cs
+++ b/ClickHouse.Driver.Tcp/Poco/PocoTypeRegistry.cs
@@ -5,26 +5,8 @@ using ClickHouse.Driver.Tcp.Format;
 namespace ClickHouse.Driver.Tcp.Poco;
 
 /// <summary>
-/// Caches the POCO mapping work, so a type is reflected over and its constructor compiled once instead of once per
-/// query or insert. One registry lives per <see cref="ClickHouseTcpClient"/> rather than one per process: the client
-/// is meant to be held as a singleton, so the cost is amortized either way, and scoping the cache to the client is
-/// what lets dropping the client release it.
-///
-/// <para>
-/// Two levels, because only half of a mapping is per-type. The descriptor is; the compiled loops are per
-/// <c>(type, wire shape)</c> — the column types come from the server, not from the type — so they cache under their
-/// own key, the block signature.
-/// </para>
-///
-/// <para>
-/// Neither level evicts, which has two consequences worth stating. The descriptors are bounded by the POCO types a
-/// program has, but the plans are bounded by the distinct result <em>shapes</em> it queries, and a shape is
-/// caller-controlled (aliases, ad-hoc column lists): a long-lived client issuing endlessly varied shapes for one type
-/// accumulates a plan per shape. And both levels hold their <see cref="Type"/> keys — plus compiled delegates over
-/// that type's members — for as long as the client lives, so a POCO loaded into a collectible
-/// <see cref="System.Runtime.Loader.AssemblyLoadContext"/> keeps that context loaded until the client is disposed.
-/// Neither is the shape of the workloads this is for; both want a weak or bounded cache if they ever show up.
-/// </para>
+/// Caches descriptors per POCO type and read plans per type and result shape. The per-client caches do not evict;
+/// disposing the client releases their type keys and compiled delegates.
 /// </summary>
 internal sealed class PocoTypeRegistry
 {
@@ -32,14 +14,10 @@ internal sealed class PocoTypeRegistry
 
     private readonly ConcurrentDictionary<(Type PocoType, string Signature, PocoScatterTier? ForcedTier), object> readPlans = new();
 
-    /// <summary>
-    /// Gets the descriptor for <typeparamref name="T"/>, building it on first use.
-    /// </summary>
+    /// <summary>Gets or builds the descriptor for <typeparamref name="T"/>.</summary>
     /// <typeparam name="T">The POCO type.</typeparam>
     /// <returns>The cached descriptor.</returns>
-    /// <exception cref="InvalidOperationException"><typeparamref name="T"/> cannot be mapped at all — see
-    /// <see cref="PocoTypeDescriptor{T}.Build"/>. Nothing is cached in that case, so the same failure is reported
-    /// every time rather than only to the first caller.</exception>
+    /// <exception cref="InvalidOperationException"><typeparamref name="T"/> cannot be mapped.</exception>
     public PocoTypeDescriptor<T> DescriptorFor<T>()
         where T : class
         // Keyed by the Type object, not its name, so two same-named types from different assemblies stay distinct.
@@ -47,17 +25,13 @@ internal sealed class PocoTypeRegistry
         => (PocoTypeDescriptor<T>)descriptors.GetOrAdd(typeof(T), static _ => PocoTypeDescriptor<T>.Build());
 
     /// <summary>
-    /// Gets the read plan for <typeparamref name="T"/> over <paramref name="block"/>'s shape, compiling it on first
-    /// use. Keyed by the block signature, so one type queried through several shapes keeps a plan per shape, and by
-    /// the forced tier, so a caller asking for a particular tier is never handed another tier's plan.
+    /// Gets or builds the read plan for <typeparamref name="T"/>, the block shape, and the requested tier.
     /// </summary>
     /// <typeparam name="T">The POCO type.</typeparam>
     /// <param name="block">A block of the shape to plan for.</param>
     /// <param name="forcedTier">A scatter tier to compile regardless of the runtime, or null to choose one.</param>
     /// <returns>The cached plan.</returns>
-    /// <exception cref="InvalidOperationException">The shape cannot be read into <typeparamref name="T"/> — see
-    /// <see cref="PocoReadPlan{T}.Build"/>. Nothing is cached in that case, so every caller is told, not just the
-    /// first.</exception>
+    /// <exception cref="InvalidOperationException">The shape cannot be read into <typeparamref name="T"/>.</exception>
     public PocoReadPlan<T> ReadPlanFor<T>(Block block, PocoScatterTier? forcedTier)
         where T : class
     {

--- a/ClickHouse.Driver.Tcp/Poco/PocoValueProjection.cs
+++ b/ClickHouse.Driver.Tcp/Poco/PocoValueProjection.cs
@@ -15,7 +15,7 @@ namespace ClickHouse.Driver.Tcp.Poco;
 /// The rules, first match winning:
 /// <list type="number">
 /// <item>the property type is the column's element type — the identity;</item>
-/// <item>the codec advertises the property type in <see cref="IColumnCodec.ReadableElementTypes"/> — its own
+/// <item>the codec offers a projection to the property type (<see cref="IColumnCodec.TryProjectRead"/>) — its own
 /// projection is inlined, which is what reads a <c>DateTime</c> column into a <see cref="DateTime"/> property
 /// rather than into the raw epoch seconds;</item>
 /// <item>a <c>Nullable(T)</c> column into a property that cannot hold null — projected through the nullable
@@ -67,9 +67,8 @@ internal static class PocoValueProjection
             return true;
         }
 
-        if (Offers(codec, target))
+        if (codec.TryProjectRead(value, target, out projected))
         {
-            projected = codec.ProjectRead(value, target);
             return true;
         }
 
@@ -84,9 +83,9 @@ internal static class PocoValueProjection
             Expression onNull = ThrowNull(site, target);
             Type lifted = typeof(Nullable<>).MakeGenericType(target);
 
-            if (Offers(codec, lifted))
+            if (codec.TryProjectRead(value, lifted, out Expression liftedProjection))
             {
-                projected = OverValue(codec.ProjectRead(value, lifted), target, onNull, static present => present);
+                projected = OverValue(liftedProjection, target, onNull, static present => present);
                 return true;
             }
 
@@ -146,24 +145,6 @@ internal static class PocoValueProjection
         => new InvalidOperationException(
             $"Column '{columnName}' ({columnType}) is NULL at row {row} of the result, but it maps to property '{pocoType}.{memberName}' of type {memberType}, which cannot hold null. " +
             $"Make that property nullable, or exclude the NULLs in the query.");
-
-    /// <summary>Whether the codec advertises a projection to <paramref name="target"/>.</summary>
-    /// <param name="codec">The codec.</param>
-    /// <param name="target">The type to look for.</param>
-    /// <returns>Whether the type is one of the codec's readable element types.</returns>
-    private static bool Offers(IColumnCodec codec, Type target)
-    {
-        IReadOnlyList<Type> readable = codec.ReadableElementTypes;
-        for (int i = 0; i < readable.Count; i++)
-        {
-            if (readable[i] == target)
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
 
     /// <summary>
     /// The conversions that need no codec: a CLR <c>enum</c> over its own ordinal type, and a target the source is

--- a/ClickHouse.Driver.Tcp/Poco/PocoValueProjection.cs
+++ b/ClickHouse.Driver.Tcp/Poco/PocoValueProjection.cs
@@ -7,51 +7,18 @@ using ClickHouse.Driver.Tcp.Types;
 namespace ClickHouse.Driver.Tcp.Poco;
 
 /// <summary>
-/// Resolves how one decoded column value becomes one POCO property value, as an <see cref="Expression"/> the
-/// scatter builder inlines into its per-row loop. Resolution happens once per (column, property) pair at plan
-/// build, so a shape that cannot work fails before the first row rather than mid-stream.
-///
-/// <para>
-/// The rules, first match winning:
-/// <list type="number">
-/// <item>the property type is the column's element type — the identity;</item>
-/// <item>the codec offers a projection to the property type (<see cref="IColumnCodec.TryProjectRead"/>) — its own
-/// projection is inlined, which is what reads a <c>DateTime</c> column into a <see cref="DateTime"/> property
-/// rather than into the raw epoch seconds;</item>
-/// <item>a <c>Nullable(T)</c> column into a property that cannot hold null — projected through the nullable
-/// surface, then required to have a value per row (D6a: a NULL throws, naming the row);</item>
-/// <item>a nullable property — the underlying types are matched by these same rules, and null stays null;</item>
-/// <item>a CLR <c>enum</c> property over the column's own ordinal type — a blind unchecked cast (D6b);</item>
-/// <item>a property type the element type is assignable to (<see cref="object"/>, or an interface the element
-/// type implements).</item>
-/// </list>
-/// </para>
-///
-/// <para>
-/// Numeric widening is deliberately absent (D6c): an <c>Int32</c> column does not fill a <see cref="long"/>
-/// property. Reflection assignability admits no numeric conversion, so the rules decline it by construction rather
-/// than by a special case.
-/// </para>
-///
-/// <para>
-/// One consequence of the last rule's position: an <see cref="object"/> property is assignable from any element type,
-/// so it takes the <em>raw</em> value rather than a projection — a <c>DateTime</c> column fills it with boxed epoch
-/// seconds, the same value the untyped <c>object[]</c> read produces. Declare the property as the type you want the
-/// reading in.
-/// </para>
+/// Builds the expression that converts a decoded column value into a POCO property value. It supports codec-owned
+/// projections, nullable lifting/unwrapping, enum ordinal casts and assignability; numeric widening is not allowed.
+/// An <see cref="object"/> target receives the column's raw element value.
 /// </summary>
 internal static class PocoValueProjection
 {
     private static readonly MethodInfo NullNotAssignableMethod =
         typeof(PocoValueProjection).GetMethod(nameof(NullNotAssignable), BindingFlags.Public | BindingFlags.Static);
 
-    /// <summary>
-    /// Builds the projection from one decoded value to one property value.
-    /// </summary>
-    /// <param name="codec">The column's codec, consulted for the conversions it owns. Only ever asked to project
-    /// <paramref name="value"/> itself, so the expression it receives is always of its element type.</param>
-    /// <param name="value">An expression of the codec's element type yielding one decoded value. Some rules
-    /// reference it twice, so the caller must pass a variable (or another repeatable expression).</param>
+    /// <summary>Builds the projection from one decoded value to one property value.</summary>
+    /// <param name="codec">The column's codec, consulted for codec-owned conversions.</param>
+    /// <param name="value">A repeatable expression yielding one decoded element.</param>
     /// <param name="target">The property type to produce.</param>
     /// <param name="site">The column/property names a failed projection reports at runtime.</param>
     /// <param name="projected">An expression of type <paramref name="target"/>, or null when no rule applies.</param>
@@ -131,8 +98,7 @@ internal static class PocoValueProjection
     }
 
     /// <summary>
-    /// The exception a scatter throws when a NULL row reaches a property that cannot hold one. Called from
-    /// compiled code, so the constant parts arrive as arguments rather than being formatted at build time.
+    /// Creates the exception thrown when a NULL reaches a property that cannot hold it.
     /// </summary>
     /// <param name="columnName">The column name.</param>
     /// <param name="columnType">The column's ClickHouse type.</param>
@@ -147,9 +113,7 @@ internal static class PocoValueProjection
             $"Make that property nullable, or exclude the NULLs in the query.");
 
     /// <summary>
-    /// The conversions that need no codec: a CLR <c>enum</c> over its own ordinal type, and a target the source is
-    /// assignable to. Both are exactly what the equivalent C# cast does, which is why neither needs the codec's
-    /// per-column state (scale, timezone, labels).
+    /// Whether a CLR enum ordinal cast or reference/value assignability can perform the conversion.
     /// </summary>
     /// <param name="from">The source type.</param>
     /// <param name="to">The target type.</param>
@@ -163,9 +127,7 @@ internal static class PocoValueProjection
         => value.Type == target ? value : Expression.Convert(value, target);
 
     /// <summary>
-    /// Runs <paramref name="fromValue"/> over a nullable expression's value, using <paramref name="onNull"/> for a
-    /// null row. The source is bound to a local first: it is referenced twice (<c>HasValue</c> and <c>Value</c>)
-    /// and may be a whole projection, which must not run twice.
+    /// Projects a nullable expression's value or evaluates <paramref name="onNull"/> when absent.
     /// </summary>
     /// <param name="nullable">An expression of some <see cref="Nullable{T}"/> type.</param>
     /// <param name="target">The type the result must have.</param>
@@ -197,8 +159,7 @@ internal static class PocoValueProjection
 }
 
 /// <summary>
-/// What a projection needs to name in a runtime failure: which column, which property, and which row. The row is
-/// an expression because it is the scatter's loop counter, not a constant.
+/// Column, property and row context for projection failures.
 /// </summary>
 internal readonly struct PocoProjectionSite
 {
@@ -215,8 +176,7 @@ internal readonly struct PocoProjectionSite
     public string MemberName { get; init; }
 
     /// <summary>
-    /// A <see cref="long"/> expression yielding the row being scattered, counted across the whole result rather than
-    /// within the block — a caller never sees the blocks, so a block-local index would name the wrong row.
+    /// A <see cref="long"/> expression yielding the row index across the whole result.
     /// </summary>
     public Expression Row { get; init; }
 }

--- a/ClickHouse.Driver.Tcp/Poco/PocoValueProjection.cs
+++ b/ClickHouse.Driver.Tcp/Poco/PocoValueProjection.cs
@@ -1,0 +1,238 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Poco;
+
+/// <summary>
+/// Resolves how one decoded column value becomes one POCO property value, as an <see cref="Expression"/> the
+/// scatter builder inlines into its per-row loop. Resolution happens once per (column, property) pair at plan
+/// build, so a shape that cannot work fails before the first row rather than mid-stream.
+///
+/// <para>
+/// The rules, first match winning:
+/// <list type="number">
+/// <item>the property type is the column's element type — the identity;</item>
+/// <item>the codec advertises the property type in <see cref="IColumnCodec.ReadableElementTypes"/> — its own
+/// projection is inlined, which is what reads a <c>DateTime</c> column into a <see cref="DateTime"/> property
+/// rather than into the raw epoch seconds;</item>
+/// <item>a <c>Nullable(T)</c> column into a property that cannot hold null — projected through the nullable
+/// surface, then required to have a value per row (D6a: a NULL throws, naming the row);</item>
+/// <item>a nullable property — the underlying types are matched by these same rules, and null stays null;</item>
+/// <item>a CLR <c>enum</c> property over the column's own ordinal type — a blind unchecked cast (D6b);</item>
+/// <item>a property type the element type is assignable to (<see cref="object"/>, or an interface the element
+/// type implements).</item>
+/// </list>
+/// </para>
+///
+/// <para>
+/// Numeric widening is deliberately absent (D6c): an <c>Int32</c> column does not fill a <see cref="long"/>
+/// property. Reflection assignability admits no numeric conversion, so the rules decline it by construction rather
+/// than by a special case.
+/// </para>
+///
+/// <para>
+/// One consequence of the last rule's position: an <see cref="object"/> property is assignable from any element type,
+/// so it takes the <em>raw</em> value rather than a projection — a <c>DateTime</c> column fills it with boxed epoch
+/// seconds, the same value the untyped <c>object[]</c> read produces. Declare the property as the type you want the
+/// reading in.
+/// </para>
+/// </summary>
+internal static class PocoValueProjection
+{
+    private static readonly MethodInfo NullNotAssignableMethod =
+        typeof(PocoValueProjection).GetMethod(nameof(NullNotAssignable), BindingFlags.Public | BindingFlags.Static);
+
+    /// <summary>
+    /// Builds the projection from one decoded value to one property value.
+    /// </summary>
+    /// <param name="codec">The column's codec, consulted for the conversions it owns. Only ever asked to project
+    /// <paramref name="value"/> itself, so the expression it receives is always of its element type.</param>
+    /// <param name="value">An expression of the codec's element type yielding one decoded value. Some rules
+    /// reference it twice, so the caller must pass a variable (or another repeatable expression).</param>
+    /// <param name="target">The property type to produce.</param>
+    /// <param name="site">The column/property names a failed projection reports at runtime.</param>
+    /// <param name="projected">An expression of type <paramref name="target"/>, or null when no rule applies.</param>
+    /// <returns>Whether a rule applied.</returns>
+    public static bool TryResolve(IColumnCodec codec, Expression value, Type target, PocoProjectionSite site, out Expression projected)
+    {
+        Type elementType = value.Type;
+        projected = null;
+
+        if (target == elementType)
+        {
+            projected = value;
+            return true;
+        }
+
+        if (Offers(codec, target))
+        {
+            projected = codec.ProjectRead(value, target);
+            return true;
+        }
+
+        Type sourceUnderlying = Nullable.GetUnderlyingType(elementType);
+        Type targetUnderlying = Nullable.GetUnderlyingType(target);
+
+        // A value-nullable column into a property with nowhere to put a null. Both spellings of the conversion are
+        // reachable: the codec may offer the lifted target (Nullable(DateTime) offers DateTime?), or the unwrapped
+        // value may convert on its own (Nullable(Enum8)'s sbyte into a CLR enum).
+        if (sourceUnderlying is not null && targetUnderlying is null && target.IsValueType)
+        {
+            Expression onNull = ThrowNull(site, target);
+            Type lifted = typeof(Nullable<>).MakeGenericType(target);
+
+            if (Offers(codec, lifted))
+            {
+                projected = OverValue(codec.ProjectRead(value, lifted), target, onNull, static present => present);
+                return true;
+            }
+
+            if (CanConvert(sourceUnderlying, target))
+            {
+                projected = OverValue(value, target, onNull, present => Cast(present, target));
+                return true;
+            }
+
+            return false;
+        }
+
+        // A nullable property: null stays null, whichever side the nullability came from.
+        if (targetUnderlying is not null)
+        {
+            if (sourceUnderlying is null)
+            {
+                if (!TryResolve(codec, value, targetUnderlying, site, out Expression present))
+                {
+                    return false;
+                }
+
+                projected = Cast(present, target);
+                return true;
+            }
+
+            if (!CanConvert(sourceUnderlying, targetUnderlying))
+            {
+                return false;
+            }
+
+            projected = OverValue(value, target, Expression.Default(target), present => Cast(present, targetUnderlying));
+            return true;
+        }
+
+        if (!CanConvert(elementType, target))
+        {
+            return false;
+        }
+
+        projected = Cast(value, target);
+        return true;
+    }
+
+    /// <summary>
+    /// The exception a scatter throws when a NULL row reaches a property that cannot hold one. Called from
+    /// compiled code, so the constant parts arrive as arguments rather than being formatted at build time.
+    /// </summary>
+    /// <param name="columnName">The column name.</param>
+    /// <param name="columnType">The column's ClickHouse type.</param>
+    /// <param name="pocoType">The POCO type's name.</param>
+    /// <param name="memberName">The property name.</param>
+    /// <param name="memberType">The property type.</param>
+    /// <param name="row">The zero-based row the NULL was found at.</param>
+    /// <returns>The exception to throw.</returns>
+    public static Exception NullNotAssignable(string columnName, string columnType, string pocoType, string memberName, string memberType, int row)
+        => new InvalidOperationException(
+            $"Column '{columnName}' ({columnType}) is NULL at row {row}, but it maps to property '{pocoType}.{memberName}' of type {memberType}, which cannot hold null. " +
+            $"Make that property nullable, or exclude the NULLs in the query.");
+
+    /// <summary>Whether the codec advertises a projection to <paramref name="target"/>.</summary>
+    /// <param name="codec">The codec.</param>
+    /// <param name="target">The type to look for.</param>
+    /// <returns>Whether the type is one of the codec's readable element types.</returns>
+    private static bool Offers(IColumnCodec codec, Type target)
+    {
+        IReadOnlyList<Type> readable = codec.ReadableElementTypes;
+        for (int i = 0; i < readable.Count; i++)
+        {
+            if (readable[i] == target)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// The conversions that need no codec: a CLR <c>enum</c> over its own ordinal type, and a target the source is
+    /// assignable to. Both are exactly what the equivalent C# cast does, which is why neither needs the codec's
+    /// per-column state (scale, timezone, labels).
+    /// </summary>
+    /// <param name="from">The source type.</param>
+    /// <param name="to">The target type.</param>
+    /// <returns>Whether a plain cast converts one to the other.</returns>
+    private static bool CanConvert(Type from, Type to)
+        // The ordinal cast is unchecked, matching (TEnum)raw in C#: the column's declared labels are not consulted
+        // (D6b), so an ordinal the CLR enum does not name arrives as that ordinal instead of being rejected.
+        => (to.IsEnum && Enum.GetUnderlyingType(to) == from) || to.IsAssignableFrom(from);
+
+    private static Expression Cast(Expression value, Type target)
+        => value.Type == target ? value : Expression.Convert(value, target);
+
+    /// <summary>
+    /// Runs <paramref name="fromValue"/> over a nullable expression's value, using <paramref name="onNull"/> for a
+    /// null row. The source is bound to a local first: it is referenced twice (<c>HasValue</c> and <c>Value</c>)
+    /// and may be a whole projection, which must not run twice.
+    /// </summary>
+    /// <param name="nullable">An expression of some <see cref="Nullable{T}"/> type.</param>
+    /// <param name="target">The type the result must have.</param>
+    /// <param name="onNull">The expression yielding the result for a null row (a default, or a throw).</param>
+    /// <param name="fromValue">Builds the result from the unwrapped value.</param>
+    /// <returns>An expression of type <paramref name="target"/>.</returns>
+    private static Expression OverValue(Expression nullable, Type target, Expression onNull, Func<Expression, Expression> fromValue)
+    {
+        ParameterExpression source = Expression.Variable(nullable.Type, "nullable");
+        return Expression.Block(
+            new[] { source },
+            Expression.Assign(source, nullable),
+            Expression.Condition(
+                Expression.Property(source, "HasValue"),
+                Cast(fromValue(Expression.Property(source, "Value")), target),
+                onNull));
+    }
+
+    private static Expression ThrowNull(PocoProjectionSite site, Type target) => Expression.Throw(
+        Expression.Call(
+            NullNotAssignableMethod,
+            Expression.Constant(site.ColumnName, typeof(string)),
+            Expression.Constant(site.ColumnType, typeof(string)),
+            Expression.Constant(site.PocoTypeName, typeof(string)),
+            Expression.Constant(site.MemberName, typeof(string)),
+            Expression.Constant(target.ToString(), typeof(string)),
+            site.Row),
+        target);
+}
+
+/// <summary>
+/// What a projection needs to name in a runtime failure: which column, which property, and which row. The row is
+/// an expression because it is the scatter's loop counter, not a constant.
+/// </summary>
+internal readonly struct PocoProjectionSite
+{
+    /// <summary>The column name from the block header.</summary>
+    public string ColumnName { get; init; }
+
+    /// <summary>The column's ClickHouse type from the block header.</summary>
+    public string ColumnType { get; init; }
+
+    /// <summary>The POCO type's name.</summary>
+    public string PocoTypeName { get; init; }
+
+    /// <summary>The property's name.</summary>
+    public string MemberName { get; init; }
+
+    /// <summary>An <see cref="int"/> expression yielding the row being scattered.</summary>
+    public Expression Row { get; init; }
+}

--- a/ClickHouse.Driver.Tcp/Poco/PocoValueProjection.cs
+++ b/ClickHouse.Driver.Tcp/Poco/PocoValueProjection.cs
@@ -140,11 +140,11 @@ internal static class PocoValueProjection
     /// <param name="pocoType">The POCO type's name.</param>
     /// <param name="memberName">The property name.</param>
     /// <param name="memberType">The property type.</param>
-    /// <param name="row">The zero-based row the NULL was found at.</param>
+    /// <param name="row">The zero-based row of the result the NULL was found at.</param>
     /// <returns>The exception to throw.</returns>
-    public static Exception NullNotAssignable(string columnName, string columnType, string pocoType, string memberName, string memberType, int row)
+    public static Exception NullNotAssignable(string columnName, string columnType, string pocoType, string memberName, string memberType, long row)
         => new InvalidOperationException(
-            $"Column '{columnName}' ({columnType}) is NULL at row {row}, but it maps to property '{pocoType}.{memberName}' of type {memberType}, which cannot hold null. " +
+            $"Column '{columnName}' ({columnType}) is NULL at row {row} of the result, but it maps to property '{pocoType}.{memberName}' of type {memberType}, which cannot hold null. " +
             $"Make that property nullable, or exclude the NULLs in the query.");
 
     /// <summary>Whether the codec advertises a projection to <paramref name="target"/>.</summary>
@@ -233,6 +233,9 @@ internal readonly struct PocoProjectionSite
     /// <summary>The property's name.</summary>
     public string MemberName { get; init; }
 
-    /// <summary>An <see cref="int"/> expression yielding the row being scattered.</summary>
+    /// <summary>
+    /// A <see cref="long"/> expression yielding the row being scattered, counted across the whole result rather than
+    /// within the block — a caller never sees the blocks, so a block-local index would name the wrong row.
+    /// </summary>
     public Expression Row { get; init; }
 }

--- a/ClickHouse.Driver.Tcp/Types/ArrayColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/ArrayColumn.cs
@@ -23,7 +23,7 @@ internal delegate void ColumnValueFill<T>(ReadOnlySpan<byte> source, Span<T> des
 /// borrowed view over the array.
 /// </summary>
 /// <typeparam name="T">The CLR element type.</typeparam>
-internal sealed class ArrayColumn<T> : IColumn<T>, ISpanColumn<T>
+internal sealed class ArrayColumn<T> : IColumn<T>, ISpanColumn<T>, IStoredValuesColumn
 {
     /// <summary>
     /// The backing array may be rented from <see cref="ArrayPool{T}"/> (via <see cref="ReadAsync"/>) and returned on

--- a/ClickHouse.Driver.Tcp/Types/DateTime64Column.cs
+++ b/ClickHouse.Driver.Tcp/Types/DateTime64Column.cs
@@ -20,7 +20,7 @@ namespace ClickHouse.Driver.Tcp.Types;
 /// out to retain.
 /// </para>
 /// </summary>
-internal sealed class DateTime64Column : IColumn<long>
+internal sealed class DateTime64Column : IColumn<long>, IStoredValuesColumn
 {
     private readonly int scale;
     private readonly TimeZoneInfo timeZone;

--- a/ClickHouse.Driver.Tcp/Types/DateTimeColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/DateTimeColumn.cs
@@ -25,7 +25,7 @@ namespace ClickHouse.Driver.Tcp.Types;
 /// out to retain.
 /// </para>
 /// </summary>
-internal sealed class DateTimeColumn : IColumn<uint>
+internal sealed class DateTimeColumn : IColumn<uint>, IStoredValuesColumn
 {
     private readonly TimeZoneInfo timeZone;
     private readonly int length;

--- a/ClickHouse.Driver.Tcp/Types/IStoredValuesColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/IStoredValuesColumn.cs
@@ -1,0 +1,24 @@
+namespace ClickHouse.Driver.Tcp.Types;
+
+/// <summary>
+/// A column whose <see cref="IColumn{T}.Values"/> is a view over storage it already holds, so reading that property
+/// materializes nothing and costs nothing. The fixed-width and calendar columns are these: their values <em>are</em>
+/// the decode buffer.
+///
+/// <para>
+/// The distinction matters to anything that reads a whole column. A column without this marker builds its values on
+/// first access and caches them for the block's lifetime, which pins one object per row: a <c>String</c> column
+/// decodes every row's UTF-8, a <c>LowCardinality</c> column allocates one reference per row. Hoisting
+/// <see cref="IColumn{T}.Values"/> out of a loop is free for a marked column and materializes the whole block for an
+/// unmarked one, so a reader that only wants a window of rows should hoist for the former and index the latter.
+/// </para>
+///
+/// <para>
+/// Not the same question as <see cref="ISpanColumn{T}"/>, which asks whether the values are one contiguous run so a
+/// codec can blit them. A materializing column's cache is contiguous too; what this marker says is that no cache has
+/// to exist.
+/// </para>
+/// </summary>
+internal interface IStoredValuesColumn
+{
+}

--- a/ClickHouse.Driver.Tcp/Types/IStoredValuesColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/IStoredValuesColumn.cs
@@ -1,23 +1,8 @@
 namespace ClickHouse.Driver.Tcp.Types;
 
 /// <summary>
-/// A column whose <see cref="IColumn{T}.Values"/> is a view over storage it already holds, so reading that property
-/// materializes nothing and costs nothing. The fixed-width and calendar columns are these: their values <em>are</em>
-/// the decode buffer.
-///
-/// <para>
-/// The distinction matters to anything that reads a whole column. A column without this marker builds its values on
-/// first access and caches them for the block's lifetime, which pins one object per row: a <c>String</c> column
-/// decodes every row's UTF-8, a <c>LowCardinality</c> column allocates one reference per row. Hoisting
-/// <see cref="IColumn{T}.Values"/> out of a loop is free for a marked column and materializes the whole block for an
-/// unmarked one, so a reader that only wants a window of rows should hoist for the former and index the latter.
-/// </para>
-///
-/// <para>
-/// Not the same question as <see cref="ISpanColumn{T}"/>, which asks whether the values are one contiguous run so a
-/// codec can blit them. A materializing column's cache is contiguous too; what this marker says is that no cache has
-/// to exist.
-/// </para>
+/// Marks a column whose <see cref="IColumn{T}.Values"/> already exists as stored data and can be read without
+/// materializing or caching the whole column.
 /// </summary>
 internal interface IStoredValuesColumn
 {

--- a/ClickHouse.Driver.Tcp/Types/LowCardinalityColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/LowCardinalityColumn.cs
@@ -105,10 +105,11 @@ internal sealed class LowCardinalityColumn<T> : IColumn<T>, ILowCardinalityColum
     }
 
     /// <inheritdoc/>
-    // Index through the RowCount-sliced keys, not the raw buffer: the buffer is usually a pooled array longer than
-    // the column, and a stale key left in its tail by a previous read is a perfectly valid dictionary index — so an
-    // out-of-range row would quietly return a real value from the dictionary instead of throwing.
-    public T this[int row] => cache is not null ? cache[row] : dictionary[Keys[row]];
+    // Keys, not the raw buffer: the buffer is usually pooled and longer than the column, and a stale key in its tail
+    // is a valid dictionary index, so an out-of-range row would return a real value instead of throwing.
+    // The dictionary's Values, not its indexer: a dictionary that builds values on access (a String one decodes
+    // UTF-8) would otherwise rebuild an entry per row rather than share it across the rows holding that key.
+    public T this[int row] => cache is not null ? cache[row] : dictionary.Values[Keys[row]];
 
     /// <inheritdoc/>
     public object GetValue(int row) => this[row];

--- a/ClickHouse.Driver.Tcp/Types/NullableLowCardinalityReferenceColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/NullableLowCardinalityReferenceColumn.cs
@@ -114,8 +114,10 @@ internal sealed class NullableLowCardinalityReferenceColumn<T> : IColumn<T>, IDe
                 return cache[row];
             }
 
+            // Through Values rather than the dictionary's indexer, so an entry built on access (a decoded string)
+            // is shared by every row holding it instead of rebuilt per row. See LowCardinalityColumn.
             int key = Keys[row];
-            return key == 0 ? null : dictionary[key];
+            return key == 0 ? null : dictionary.Values[key];
         }
     }
 

--- a/ClickHouse.Driver.Tcp/Types/PrimitiveColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/PrimitiveColumn.cs
@@ -18,7 +18,7 @@ namespace ClickHouse.Driver.Tcp.Types;
 /// </para>
 /// </summary>
 /// <typeparam name="T">The CLR type the ClickHouse integer maps to.</typeparam>
-internal sealed class PrimitiveColumn<T> : IColumn<T>, ISpanColumn<T>
+internal sealed class PrimitiveColumn<T> : IColumn<T>, ISpanColumn<T>, IStoredValuesColumn
     where T : unmanaged
 {
     private readonly int byteOffset;

--- a/ClickHouse.Driver.Tcp/Types/Time64Column.cs
+++ b/ClickHouse.Driver.Tcp/Types/Time64Column.cs
@@ -26,7 +26,7 @@ namespace ClickHouse.Driver.Tcp.Types;
 /// out to retain.
 /// </para>
 /// </summary>
-internal sealed class Time64Column : IColumn<long>
+internal sealed class Time64Column : IColumn<long>, IStoredValuesColumn
 {
     private readonly int scale;
     private readonly int length;

--- a/ClickHouse.Driver.Tcp/Types/TimeColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/TimeColumn.cs
@@ -23,7 +23,7 @@ namespace ClickHouse.Driver.Tcp.Types;
 /// out to retain.
 /// </para>
 /// </summary>
-internal sealed class TimeColumn : IColumn<int>
+internal sealed class TimeColumn : IColumn<int>, IStoredValuesColumn
 {
     private readonly int length;
     private readonly bool pooled;


### PR DESCRIPTION
Epic N5 of the native-TCP client: query results materialize into your own class.

```csharp
await foreach (Order order in client.QueryAsync<Order>("SELECT id, created_at FROM orders"))
```

## What this adds

`QueryAsync<T>` on `ClickHouseTcpClient` and `IClickHouseTcpClient`, plus the compiled plan behind it in `ClickHouse.Driver.Tcp/Poco/`.

Each property is matched to the column of the same name, ignoring case and then underscores, so `created_at` reaches `CreatedAt`. `[ClickHouseTcpColumn]` renames and `[ClickHouseTcpNotMapped]` excludes. A column no property maps to is not read. A property no column maps to keeps its default.

## The compiled unit is one whole column, not one row

The block arrives already decoded into typed columns, so each mapped column gets one delegate that loops that column into the property. Nothing is boxed on the way. The conversions a property asks for (`DateTime`, `DateTimeOffset`, `TimeSpan`, a CLR enum, nullable lifting) are inlined into the loop through the codec's own `ProjectRead` (#548), so no per-row delegate call is left either.

This matters because the canonical CLR type of a `DateTime` column is raw epoch seconds. `DateTime CreatedAt { get; set; }` is the common case, not an edge case.

### Two tiers source a value

The tiers differ only in the step that reads one cell. The conversion and the property assignment are identical, so the two must produce equal rows.

Take `class Order { public DateTime CreatedAt { get; set; } }` over a `created_at DateTime('UTC')` column. That column decodes to an `IColumn<uint>` of epoch seconds, so the compiled loop is one of these two.

**span**, the default wherever expression trees compile to IL:

```csharp
ReadOnlySpan<uint> values = ((IColumn<uint>)column).Values;    // hoisted, read once
for (int row = 0; row < rowCount; row++)
    rows[row].CreatedAt = DateTimeToDateTime(values[row], timeZone);
```

For a fixed-width column `Values` is the pooled decode buffer itself, so this reads straight out of the block's storage with no copy.

**indexer**, on a runtime with no dynamic code (`RuntimeFeature.IsDynamicCodeCompiled` is false: NativeAOT and friends):

```csharp
IColumn<uint> typed = (IColumn<uint>)column;                   // hoisted, cast once
for (int row = 0; row < rowCount; row++)
    rows[row].CreatedAt = DateTimeToDateTime(typed[row], timeZone);
```

Still box-free. It exists because such a runtime interprets the tree instead of compiling it, and an interpreted tree cannot hold a `ReadOnlySpan<T>`: the interpreter keeps locals in an `object[]` frame, which a ref struct cannot enter. So the span tier is not merely slower there, it cannot be built.

**Which tier a column gets is decided per column, not once per runtime.** The span tier is only chosen when both of these hold:

1. the runtime compiles expression trees to IL, and
2. the column's `Values` is a view over storage it already holds, rather than a cache it builds on first access.

The second condition is the interesting one. For a fixed-width or calendar column, `Values` *is* the decode buffer, so hoisting it is free. For a `String` column it is not: reading `Values` decodes every row of the block to text and caches the result for the block's lifetime. Hoisting it therefore materializes the whole block, which is exactly what the windowed materialization below is trying to avoid. So those columns take the indexer, which decodes one row on demand and caches nothing.

The distinction is carried by an internal marker, `IStoredValuesColumn`, on the six columns whose `Values` is a view. It is deliberately *not* `ISpanColumn<T>`, which asks whether the values are one contiguous run so a codec can blit them: a built cache is contiguous too, and the question here is whether a cache has to exist at all.

`QueryAsync<T>` never names a tier, so the client carries nothing for testing. The parity harness names one where the plan is built: `PocoReadPlan<T>.Build` takes a tier, which overrides the per-column choice, and `StreamAsync` already hands out a real server block, so a test materializes the same query at each tier and compares. Together with `Expression.Compile(preferInterpretation: true)`, that is how the interpreted fallback is proven rather than assumed on a JIT host.

A column that does not implement `IColumn<T>` over its own codec's element type is refused at plan build, naming the column and the codec. No shipped codec produces one, since a codec and the column it reads are written together, but both tiers cast to that interface, so without the check it would fail that cast inside compiled code on the first block.

## Rows are materialized a window at a time

A compiled scatter holds a `ReadOnlySpan<T>`, and a C# iterator cannot hold a ref struct across a `yield`. So the rows have to be built by a synchronous call that finishes before any of them is handed out. The obvious unit for that call is one whole block, and that is what the first version of this did.

The problem is that a block is sized by the server, not by the client: `max_block_size` defaults to 65,409 rows and a caller can raise it. Materializing a whole block means that many rows, plus everything they reference, are reachable at the same time. For an 11-column row of mixed types that is around 11 MB, and .NET's generational collector charges for exactly this. A gen0 collection costs in proportion to what *survives* it, not to what it frees; the whole bet of a generational heap is that short-lived objects die before the collection runs. Rows held for a whole block do not die in time, so each collection copies them into gen1 instead of dropping them, gen1 fills with the survivors, and the overflow lands in gen2 — whose collections trace the entire heap. On a 1M-row read that doubled the wall clock.

So the block is materialized in windows of at most **256 rows**:

```csharp
int window = Math.Min(MaterializationWindowRows, block.RowCount);
T[] rows = ArrayPool<T>.Shared.Rent(window);
for (int start = 0; start < block.RowCount; start += window)
{
    int count = Math.Min(window, block.RowCount - start);
    plan.Materialize(block, rows, start, count, produced + start);   // no span is live after this returns
    for (int i = 0; i < count; i++)
        yield return rows[i];
}
```

Each scatter now takes a `start`, so `rows[i]` is filled from column row `start + i` while the destination stays at 0.

**Both halves are needed, and neither works alone.** Bounding the window bounds the rows, but a scatter that hoists `Values` has already decoded every row of its column into a cache the column pins regardless — so the strings stay alive and nothing improves. Choosing the indexer for those columns stops the cache being built, but with a whole block of rows alive each row still holds its own strings, so they stay alive anyway. Measured, on a 65,536-row block: the window alone and the per-column tier alone each leave all 7 gen2 collections in place; together there are none.

### Why 256

The window was swept from 64 to 16,384 rows. Wall clock is flat from 64 to 4096 and worse outside it, so 256 is mid-plateau rather than a measured optimum. It errs small on purpose. The cost of a smaller window is a per-window cast and loop setup per column, which did not register even on a two-column row of fixed-width values, where the scatter loop is as tight as it gets. The cost of too large a window is the promotion this exists to prevent, measured against a gen0 budget that varies by host and GC mode.

## Everything that can fail does so at plan build

Before the first row: an unsettable property, a type the column cannot be read as, a type that cannot be constructed, two columns reaching one property, and no column reaching any property.

## Two things in the cache key that are easy to miss

The plan caches per (type, block shape, tier).

1. **The session timezone.** A `DateTime` column that names no timezone resolves against it, and the header says nothing about it, so two queries with identical headers and different `session_timezone` must not share a plan. `Block` now carries the registry and context the read used, so the plan resolves a codec the way the read did.

2. **A length prefix per field.** A column name is arbitrary text: the alias `` `a<tab>b<newline>c` `` is legal and the server sends it verbatim. A delimiter-joined key lets one header spell another, and the cache then serves the wrong plan, silently leaving columns unread. Found in review, with a regression test that fails on the old key.

## Decisions

Recorded with their reasoning in the design notes:

- a **NULL** into a property that cannot hold one **throws**, naming column and row, rather than assigning a default no caller could tell from a stored zero;
- a **CLR enum** property is a **blind ordinal cast**, exactly as the equivalent C# cast is. Declared labels are not consulted;
- **numeric widening is declined** (an `Int32` column does not fill a `long`), for predictability;
- an **unmappable pair fails fast**, naming what the column does read as. That also gives the right message for a composite whose element type would need projecting (`DateTime[]` over `Array(DateTime)` says `uint[]`), and for an untyped `NULL AS x` column, which is told to type itself in the query.

## Contract: rows are owned, but one element can be shared

Unlike a borrowed `Block`, no value in a row borrows the block's storage, so a row stays valid after the enumeration moves on.

One caveat, and it is about sharing rather than lifetime. A `LowCardinality` column holds a dictionary of distinct values plus one key per row, and its `Values` copies a **reference** out of that dictionary for each row:

```csharp
for (int i = 0; i < rowCount; i++)
    decoded[i] = dict[keys[i]];      // the same object for every row with the same key
```

For a value type, or for an immutable element type such as the `string` of `LowCardinality(String)`, this cannot be observed. Today it is observable for exactly one shape, `LowCardinality(FixedString(N))`, whose element type is `byte[]`:

```csharp
// hash is LowCardinality(FixedString(4)); the rows are 'aaaa', 'bbbb', 'aaaa'
class Hashed { public byte[] Hash { get; set; } }

var rows = await client.QueryAsync<Hashed>("SELECT hash FROM t").ToListAsync();

ReferenceEquals(rows[0].Hash, rows[2].Hash);   // true: both are dictionary entry 'aaaa'
rows[0].Hash[0] = 0;                           // this also changes rows[2].Hash
```

So an array-valued property must not be mutated in place. The aliasing is bounded to one block, because each Native block ships its own dictionary.

**This now also applies to the `object[]` and block APIs**, which reach the same value through `IColumn.GetValue`. That indexer used to hand each row a fresh copy for this shape; it now shares the dictionary entry, which is what makes reading a `LowCardinality` column row by row cheap (see Performance). The two paths agree where they used to differ, and the tier parity tests are correspondingly stronger: they can assert identical references rather than merely equal values. But it does remove a mutation that was previously safe for an `object[]` consumer of a `LowCardinality(FixedString(N))` column, which is the one behavioural change in this PR that is not a pure addition. That makes it harder to catch rather than easier: a small result is a single block and aliases, while a large one aliases only within each block, so the pattern depends on where the server drew block boundaries.

A result with no rows carries no block, so it yields nothing and validates nothing.

## Testing

- **All 203 round-trip corpus cases** materialize through `QueryAsync<Row<T>>`, so every supported type is covered without a corpus of its own, including `Nullable`, `Array`, `Map`, `Tuple`, `Nested`, `LowCardinality`, `Variant` and `Dynamic`.
- Integration: the calendar and enum projections a property asks for, the bare-`DateTime` session timezone, a 200k-row multi-block read proving rows outlive their blocks, early abandonment, the attributes, a tab-and-newline column name, and tier parity against a real server.
- Unit tests are confined to what a server cannot reach: the refusals, the tier choice and parity (including under the expression interpreter), the cache key, and column shapes a real result cannot produce.

For the windowing and the dictionary read, 9 tests, each of which was checked against a mutated build to confirm it fails without the fix:

- **A window that starts past row 0**, at both tiers. A window starting at 0 proves nothing here: a scatter that ignored its `start` would pass. Both tiers source a value differently, so each is asserted separately.
- **A whole block taken in windows equals the same block in one pass**, with a window size that does not divide the block evenly so the last one is short.
- **A NULL in a later window names the row of the result**, not of the window. Off-by-one in that arithmetic is invisible in the first window of the first block, where every candidate expression agrees.
- **The tier chosen per column shape**: a stored-values column gets the span tier, a column that builds its values gets the indexer, and a forced tier outranks both.
- **A block larger than the window, in one block** (integration). The existing multi-block test cannot reach this: there every block boundary is also a window boundary. The test asserts the query really does produce a single block, so it cannot silently stop testing what it is named for.
- **A NULL past the first window through `QueryAsync<T>`** (integration), which is the same arithmetic end to end.
- **`LowCardinality` rows sharing a dictionary entry get the same instance**, over a `String` dictionary — the case that matters, since its entries are built on access.
- **The aliasing that follows for `LowCardinality(FixedString(N))`**, pinned deliberately so the behavioural change above cannot be reverted by accident.

## Performance

Measured against a real server; the benchmarks are not committed. Absolute milliseconds include server and loopback cost, so the comparisons within a table are the measurement and the raw numbers are not a throughput claim. Setup is at the end.

### The three read tiers

1M rows, 11 columns (`UInt64`, `Int32`, `Float64`, `Float32`, `Bool`, `String`, `LowCardinality(String)`, `Nullable(String)`, `DateTime64(3, 'UTC')`, `Date`, `UUID`), MergeTree with server defaults, each row consumed and dropped. Every tier reads every value of every column, so the difference is materialization and nothing else. The floor reads the result off the socket and looks at no value, which is what all three pay before doing anything.

| Tier | Mean | over floor | Allocated | Bytes/row |
|---|---|---|---|---|
| floor: read and discard | 107.8 ms | | 0.7 MB | 0.8 |
| `StreamAsync` blocks, typed spans | 133.1 ms | +25 ns/row | 82.7 MB | 87 |
| `QueryAsync<T>`, `DateTime64` as `long` | 198.2 ms | +90 ns/row | 166.6 MB | 175 |
| `QueryAsync<T>`, `DateTime64` as `DateTimeOffset` | 203.4 ms | +96 ns/row | 181.9 MB | 191 |
| `QueryAsync` (`object[]`) | 263.7 ms | +156 ns/row | 372.6 MB | 391 |

POCO rows cost **0.75x the time and 0.45x the allocation** of `object[]` rows. The allocation figures decompose exactly, which is a useful check that nothing unexpected is on the path:

- 87 B/row is the two `String` columns being decoded to text. A `String` column keeps the wire bytes and materializes on demand, so every tier above the floor pays this and the floor pays none of it.
- POCO adds 96 B/row, which is one instance of the row class. Nothing else.
- `object[]` adds 304 B/row: 112 for the array, the rest boxing the eight value-typed columns.

### The windowed materialization

Same data, with the block size forced so the effect of a server-sized block is visible. `window` is the 256-row window; `tier` is the per-column tier choice. Both are on in what ships.

Consumer drops each row:

| Rows per block | before | window only | tier only | **both (shipped)** |
|---|---|---|---|---|
| 8,192 | 185.9 ms | 195.9 ms | 180.2 ms | **174.6 ms** |
| 65,536 | 367.3 ms | 313.0 ms | 334.5 ms | **174.5 ms** |
| gen2 collections at 65,536 | 7 | 7 | 7 | **0** |

Consumer keeps every row (`ToList()`):

| Rows per block | before | **both (shipped)** |
|---|---|---|
| 8,192 | 387.5 ms | 380.2 ms |
| 65,536 | 432.0 ms | **348.3 ms** |

Three things to read off this:

- **A server-sized block used to cost 2x.** Before: 185.9 ms at 8,192 rows per block against 367.3 ms at 65,536. After: 174.6 against 174.5, flat. Whether a query landed on the slow side was decided by the server, not the caller — MergeTree caps a block by `preferred_block_size_bytes` (1 MB) and so gives small blocks for a wide row, while the `Memory` engine hands back whatever blocks it was given and ignores the setting.
- **Neither half works alone**, which is why both are here. The gen2 row is the clearest statement of it.
- **No regression at the common block size**, and a 4% allocation saving everywhere.

A caller who keeps the whole result gains less (0.81x at a large block, ~1.00x at a small one), because retained rows are reachable to the end of the query and no window can bound that. The gains for that pattern come from the allocation saving rather than from avoiding promotion.

### The `DateTime64` conversion

A `DateTime64` column's canonical CLR value is the raw tick count, so a `DateTimeOffset` property runs a conversion per row. Over 2M rows of one such column:

| Property type | Mean | Δ vs `long` | Allocated |
|---|---|---|---|
| `long` (identity) | 63.4 ms | | 46.1 MB |
| `DateTimeOffset`, `UTC` column | 82.2 ms | +9.4 ns/row | 61.4 MB |
| `DateTime`, `UTC` column | 85.0 ms | +10.8 ns/row | 46.1 MB |
| `DateTimeOffset`, `America/New_York` column | 108.5 ms | +22.6 ns/row | 61.4 MB |

`DateTime` and `DateTimeOffset` are within each other's error bars on a UTC column, with `DateTime` cheaper on allocation (8 bytes against 16). The timezone is what costs: the offset is resolved per instant, so a zone with daylight-saving rules is 2.4x the conversion of one without. Declaring the property `long` avoids all of it.

### The LowCardinality dictionary read

A `LowCardinality(T)` column is a small dictionary of distinct values plus one key per row. Its indexer used to reach the dictionary through the dictionary's *own* indexer, which for a `String` dictionary decodes UTF-8 on every call — so reading such a column row by row rebuilt the same handful of entries once per row. Going through the dictionary's `Values` instead materializes it once (bounded by distinct values, not by rows) and shares each entry.

This was worth 8% of the `object[]` tier's allocation as well (404.6 MB to 372.6 MB), because `IColumn.GetValue` routes through the same indexer. See the contract note above for the aliasing this introduces.

### Setup

Server and client on one 2-physical-core machine (Intel Core Ultra 7 255U, WSL2), the server pinned to CPUs 0-1 and the benchmark to 2-3 so they do not compete; ClickHouse 26.7.1 in Docker; localhost TCP, no compression; .NET 10, BenchmarkDotNet 0.15.8, `RunStrategy.Monitoring`, 5 warmup and 30 measured iterations.

Run-to-run variance on this box is around 8% on identical code, and several rows above have error bars of 10-20 ms. The large effects (the 2x block-size penalty, the gen2 counts, the 0.75x and 0.45x tier ratios) are well clear of that. The small ones (the 0.94x at 8,192 rows, `DateTime` against `DateTimeOffset`) are not, and are reported as ties where that is what they are.

No changelog entry, matching the other TCP epic PRs: the client is unreleased and `[Experimental]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)






