### PR TITLE
TCP N9: POCO row insert — InsertRowsAsync<T> over a compiled per-column gather

### DIFF
--- a/ClickHouse.Driver.Tcp.Tests/Client/ClickHouseTcpClientOptionsTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Client/ClickHouseTcpClientOptionsTests.cs
@@ -21,7 +21,7 @@ public class ClickHouseTcpClientOptionsTests
             Assert.That(options.Database, Is.EqualTo("default"));
             Assert.That(options.DialTimeout, Is.EqualTo(TimeSpan.FromSeconds(30)));
             Assert.That(options.ReadTimeout, Is.EqualTo(TimeSpan.FromSeconds(300)));
-            Assert.That(options.MaxSendBufferBytes, Is.EqualTo(10 * 1024 * 1024));
+            Assert.That(options.MaxSendBufferBytes, Is.EqualTo(1024 * 1024));
         });
     }
 

--- a/ClickHouse.Driver.Tcp.Tests/Client/ClickHouseTcpInsertOptionsTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Client/ClickHouseTcpInsertOptionsTests.cs
@@ -8,7 +8,7 @@ public class ClickHouseTcpInsertOptionsTests
     [Test]
     public void MaxRowsPerBlock_NotSet_DefaultsToTheBlockRowCap()
     {
-        Assert.That(new ClickHouseTcpInsertOptions().MaxRowsPerBlock, Is.EqualTo(1_000_000));
+        Assert.That(new ClickHouseTcpInsertOptions().MaxRowsPerBlock, Is.EqualTo(50_000));
     }
 
     [Test]
@@ -23,13 +23,13 @@ public class ClickHouseTcpInsertOptionsTests
     [Test]
     public void ResolveMaxRowsPerBlock_NoOptions_UsesTheDefaultCap()
     {
-        Assert.That(ClickHouseTcpClient.ResolveMaxRowsPerBlock(null), Is.EqualTo(1_000_000));
+        Assert.That(ClickHouseTcpClient.ResolveMaxRowsPerBlock(null), Is.EqualTo(50_000));
     }
 
     [Test]
     public void ResolveMaxRowsPerBlock_OptionsWithoutTheCapSet_UsesTheDefaultCap()
     {
-        Assert.That(ClickHouseTcpClient.ResolveMaxRowsPerBlock(new ClickHouseTcpInsertOptions()), Is.EqualTo(1_000_000));
+        Assert.That(ClickHouseTcpClient.ResolveMaxRowsPerBlock(new ClickHouseTcpInsertOptions()), Is.EqualTo(50_000));
     }
 
     [Test]

--- a/ClickHouse.Driver.Tcp.Tests/Integration/PocoWriteIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/PocoWriteIntegrationTests.cs
@@ -10,7 +10,7 @@ using ClickHouse.Driver.Tcp.Types;
 namespace ClickHouse.Driver.Tcp.Tests.Integration;
 
 /// <summary>
-/// <c>InsertAsync&lt;T&gt;</c> and the untyped <c>object[]</c> insert against a real server. Per-type coverage rides
+/// <c>InsertRowsAsync&lt;T&gt;</c> and the untyped <c>object[]</c> insert against a real server. Per-type coverage rides
 /// the round-trip corpus, as the read side's does: each case's insert column names the CLR type a property would
 /// hold, so it becomes a <see cref="Row{TValue}"/> insert and a read-back with no corpus of its own. The rest are
 /// the shapes the corpus cannot state — a POCO over several columns, the calendar types a property declares instead
@@ -28,13 +28,18 @@ public class PocoWriteIntegrationTests
         ["allow_experimental_time_time64_type"] = "1",
     };
 
+    private static readonly IReadOnlyDictionary<string, string> AmsterdamSessionSettings = new Dictionary<string, string>(StringComparer.Ordinal)
+    {
+        ["session_timezone"] = "Europe/Amsterdam",
+    };
+
     [TestCaseSource(typeof(InsertRoundTripCase), nameof(InsertRoundTripCase.Cases))]
-    public async Task InsertAsync_EveryCorpusType_WritesThePropertyIntoTheColumn(InsertRoundTripCase testCase)
+    public async Task InsertRowsAsync_EveryCorpusType_WritesThePropertyIntoTheColumn(InsertRoundTripCase testCase)
     {
         await using var client = TcpServerFixture.CreateClient();
         var queryOptions = new ClickHouseTcpQueryOptions { Settings = testCase.Settings };
         var insertOptions = new ClickHouseTcpInsertOptions { Settings = testCase.Settings };
-        string table = UniqueTableName();
+        string table = CreateTableName();
         try
         {
             await client.ExecuteAsync($"CREATE TABLE {table} (value {testCase.ClickHouseType}) ENGINE = Memory", queryOptions, None);
@@ -76,12 +81,12 @@ public class PocoWriteIntegrationTests
     }
 
     [Test]
-    public async Task InsertAsync_PocoOverSeveralColumns_RoundTripsThroughQueryAsync()
+    public async Task InsertRowsAsync_PocoOverSeveralColumns_RoundTripsThroughQueryAsync()
     {
         // The POCO-to-POCO round trip: one type inserted and read back through both compiled paths. The property
         // order deliberately differs from the column order, since both directions match by name.
         await using var client = TcpServerFixture.CreateClient();
-        string table = UniqueTableName();
+        string table = CreateTableName();
         try
         {
             await client.ExecuteAsync($"CREATE TABLE {table} (id UInt64, user_name String, score Nullable(Float64)) ENGINE = Memory", cancellationToken: None);
@@ -92,7 +97,7 @@ public class PocoWriteIntegrationTests
                 new Account { UserName = "grace", Id = 2, Score = null },
             };
 
-            await client.InsertAsync($"INSERT INTO {table} (id, user_name, score) VALUES", written, cancellationToken: None);
+            await client.InsertRowsAsync($"INSERT INTO {table} (id, user_name, score) VALUES", written, cancellationToken: None);
 
             List<Account> read = await client.QueryAsync<Account>($"SELECT id, user_name, score FROM {table} ORDER BY id", cancellationToken: None).ToListAsync();
 
@@ -110,13 +115,13 @@ public class PocoWriteIntegrationTests
     }
 
     [Test]
-    public async Task InsertAsync_CalendarAndEnumProperties_WriteThroughTheCodecsConversions()
+    public async Task InsertRowsAsync_CalendarAndEnumProperties_WriteThroughTheCodecsConversions()
     {
         // The corpus inserts these columns as their raw wire values; a POCO declares the type a caller would, and
         // the conversion is the codec's own — the same one the columnar path uses for a DateTime column.
         await using var client = TcpServerFixture.CreateClient();
         var options = new ClickHouseTcpQueryOptions { Settings = TimeSettings };
-        string table = UniqueTableName();
+        string table = CreateTableName();
         try
         {
             const string columns = "stamp, precise, day, clock, level, maybe_stamp, maybe_precise";
@@ -155,7 +160,7 @@ public class PocoWriteIntegrationTests
                 },
             };
 
-            await client.InsertAsync(
+            await client.InsertRowsAsync(
                 $"INSERT INTO {table} ({columns}) VALUES",
                 written,
                 new ClickHouseTcpInsertOptions { Settings = TimeSettings },
@@ -184,19 +189,58 @@ public class PocoWriteIntegrationTests
         }
     }
 
+    [TestCase("DateTime")]
+    [TestCase("DateTime64(3)")]
+    public async Task InsertAsync_CustomGenericColumnArrayWithSessionTimezone_StoresUnspecifiedWallClockInSessionTimezone(string clickHouseType)
+    {
+        await AssertSessionTimezoneInsertAsync(
+            clickHouseType,
+            (client, sql, options, value) => client.InsertAsync(
+                sql,
+                new[] { new ExternalColumn<DateTime>("value", clickHouseType, value) },
+                options,
+                None).AsTask());
+    }
+
+    [TestCase("DateTime")]
+    [TestCase("DateTime64(3)")]
+    public async Task InsertRowsAsync_PocoWithSessionTimezone_StoresUnspecifiedWallClockInSessionTimezone(string clickHouseType)
+    {
+        await AssertSessionTimezoneInsertAsync(
+            clickHouseType,
+            (client, sql, options, value) => client.InsertRowsAsync(
+                sql,
+                new[] { new Row<DateTime> { Value = value } },
+                options,
+                None).AsTask());
+    }
+
+    [TestCase("DateTime")]
+    [TestCase("DateTime64(3)")]
+    public async Task InsertRowsAsync_UntypedRowsWithSessionTimezone_StoresUnspecifiedWallClockInSessionTimezone(string clickHouseType)
+    {
+        await AssertSessionTimezoneInsertAsync(
+            clickHouseType,
+            (client, sql, options, value) => client.InsertRowsAsync(
+                sql,
+                new[] { new object[] { value } },
+                options,
+                None).AsTask());
+    }
+
     [Test]
-    public async Task InsertAsync_NamedColumnSubset_LeavesTheRestToTheirDefaults()
+    public async Task InsertRowsAsync_NamedColumnSubset_LeavesTheRestToTheirDefaults()
     {
         // A property no target column maps to is simply not inserted, which is what lets one POCO fill part of a
         // table: the statement names the columns, and the server defaults the others.
         await using var client = TcpServerFixture.CreateClient();
-        string table = UniqueTableName();
+        string table = CreateTableName();
         try
         {
             await client.ExecuteAsync($"CREATE TABLE {table} (id UInt64, user_name String DEFAULT 'unset', score Nullable(Float64)) ENGINE = Memory", cancellationToken: None);
 
             var written = new[] { new Account { Id = 7, UserName = "ada", Score = 1.5 } };
-            await client.InsertAsync($"INSERT INTO {table} (id) VALUES", written, cancellationToken: None);
+            await client.InsertRowsAsync($"INSERT INTO {table} (id) VALUES", written, cancellationToken: None);
 
             List<Account> read = await client.QueryAsync<Account>($"SELECT id, user_name, score FROM {table}", cancellationToken: None).ToListAsync();
 
@@ -214,19 +258,19 @@ public class PocoWriteIntegrationTests
     }
 
     [Test]
-    public async Task InsertAsync_TargetColumnWithNoProperty_ThrowsAndLeavesTheClientUsable()
+    public async Task InsertRowsAsync_TargetColumnWithNoProperty_ThrowsAndLeavesTheClientUsable()
     {
         // The mapping is compiled from the sample block, so this failure lands with the INSERT already open. The
         // insert has to close its row stream with no rows and hand the connection back, or every mapping mistake
         // would cost a redial.
         await using var client = TcpServerFixture.CreateClient();
-        string table = UniqueTableName();
+        string table = CreateTableName();
         try
         {
             await client.ExecuteAsync($"CREATE TABLE {table} (id UInt64, user_name String, score Nullable(Float64), extra String) ENGINE = Memory", cancellationToken: None);
 
             InvalidOperationException error = Assert.ThrowsAsync<InvalidOperationException>(
-                async () => await client.InsertAsync($"INSERT INTO {table} VALUES", new[] { new Account { Id = 1 } }, cancellationToken: None));
+                async () => await client.InsertRowsAsync($"INSERT INTO {table} VALUES", new[] { new Account { Id = 1 } }, cancellationToken: None));
 
             Assert.That(error.Message, Does.Contain("extra").And.Contain("Account"));
 
@@ -240,10 +284,10 @@ public class PocoWriteIntegrationTests
     }
 
     [Test]
-    public async Task InsertAsync_NullPropertyIntoNonNullableColumn_ThrowsNamingTheRowAndInsertsNothing()
+    public async Task InsertRowsAsync_NullPropertyIntoNonNullableColumn_ThrowsNamingTheRowAndInsertsNothing()
     {
         await using var client = TcpServerFixture.CreateClient();
-        string table = UniqueTableName();
+        string table = CreateTableName();
         try
         {
             await client.ExecuteAsync($"CREATE TABLE {table} (value Int32) ENGINE = Memory", cancellationToken: None);
@@ -251,7 +295,7 @@ public class PocoWriteIntegrationTests
             var rows = new[] { new Row<int?> { Value = 1 }, new Row<int?> { Value = null } };
 
             InvalidOperationException error = Assert.ThrowsAsync<InvalidOperationException>(
-                async () => await client.InsertAsync($"INSERT INTO {table} (value) VALUES", rows, cancellationToken: None));
+                async () => await client.InsertRowsAsync($"INSERT INTO {table} (value) VALUES", rows, cancellationToken: None));
 
             Assert.That(error.Message, Does.Contain("row 1").And.Contain("value"));
 
@@ -265,13 +309,13 @@ public class PocoWriteIntegrationTests
     }
 
     [Test]
-    public async Task InsertAsync_NullStringPropertyIntoANonNullableColumn_ThrowsAndLeavesTheClientUsable()
+    public async Task InsertRowsAsync_NullStringPropertyIntoANonNullableColumn_ThrowsAndLeavesTheClientUsable()
     {
         // The commonest way a row arrives incomplete, and the one that used to be worst: a null reference reaching
         // the codec faults part-way through writing the block, which terminates the connection. It has to fail like
         // any other unwritable value — before anything is sent, naming the row, connection intact.
         await using var client = TcpServerFixture.CreateClient();
-        string table = UniqueTableName();
+        string table = CreateTableName();
         try
         {
             await client.ExecuteAsync($"CREATE TABLE {table} (id UInt64, user_name String, score Nullable(Float64)) ENGINE = Memory", cancellationToken: None);
@@ -279,7 +323,7 @@ public class PocoWriteIntegrationTests
             var rows = new[] { new Account { Id = 1, UserName = "ada" }, new Account { Id = 2, UserName = null } };
 
             InvalidOperationException error = Assert.ThrowsAsync<InvalidOperationException>(
-                async () => await client.InsertAsync($"INSERT INTO {table} (id, user_name, score) VALUES", rows, cancellationToken: None));
+                async () => await client.InsertRowsAsync($"INSERT INTO {table} (id, user_name, score) VALUES", rows, cancellationToken: None));
 
             Assert.That(error.Message, Does.Contain("row 1").And.Contain("user_name"));
             Assert.That(await CountAsync(client, table), Is.EqualTo(0));
@@ -291,10 +335,10 @@ public class PocoWriteIntegrationTests
     }
 
     [Test]
-    public async Task InsertAsync_UntypedNullIntoANonNullableStringColumn_ThrowsAndLeavesTheClientUsable()
+    public async Task InsertRowsAsync_UntypedNullIntoANonNullableStringColumn_ThrowsAndLeavesTheClientUsable()
     {
         await using var client = TcpServerFixture.CreateClient();
-        string table = UniqueTableName();
+        string table = CreateTableName();
         try
         {
             await client.ExecuteAsync($"CREATE TABLE {table} (name String) ENGINE = Memory", cancellationToken: None);
@@ -302,7 +346,7 @@ public class PocoWriteIntegrationTests
             var rows = new[] { new object[] { "ada" }, new object[] { null } };
 
             InvalidOperationException error = Assert.ThrowsAsync<InvalidOperationException>(
-                async () => await client.InsertAsync($"INSERT INTO {table} (name) VALUES", rows, cancellationToken: None));
+                async () => await client.InsertRowsAsync($"INSERT INTO {table} (name) VALUES", rows, cancellationToken: None));
 
             Assert.That(error.Message, Does.Contain("row 1").And.Contain("name"));
             Assert.That(await CountAsync(client, table), Is.EqualTo(0));
@@ -314,18 +358,18 @@ public class PocoWriteIntegrationTests
     }
 
     [Test]
-    public async Task InsertAsync_LazyRowSourceAcrossSeveralBlocks_WritesEveryRow()
+    public async Task InsertRowsAsync_LazyRowSourceAcrossSeveralBlocks_WritesEveryRow()
     {
         // Two things at once: a source with no count, which the row buffer has to grow into, and more rows than one
         // wire block holds, which is the slice path the columns are read through.
         const int rowCount = 5_000;
         await using var client = TcpServerFixture.CreateClient();
-        string table = UniqueTableName();
+        string table = CreateTableName();
         try
         {
             await client.ExecuteAsync($"CREATE TABLE {table} (value Int32) ENGINE = Memory", cancellationToken: None);
 
-            await client.InsertAsync(
+            await client.InsertRowsAsync(
                 $"INSERT INTO {table} (value) VALUES",
                 Counting(rowCount),
                 new ClickHouseTcpInsertOptions { MaxRowsPerBlock = 1_000 },
@@ -347,15 +391,15 @@ public class PocoWriteIntegrationTests
     }
 
     [Test]
-    public async Task InsertAsync_ZeroRows_IsNoOp()
+    public async Task InsertRowsAsync_ZeroRows_IsNoOp()
     {
         await using var client = TcpServerFixture.CreateClient();
-        string table = UniqueTableName();
+        string table = CreateTableName();
         try
         {
             await client.ExecuteAsync($"CREATE TABLE {table} (value Int32) ENGINE = Memory", cancellationToken: None);
 
-            await client.InsertAsync($"INSERT INTO {table} (value) VALUES", Array.Empty<Row<int>>(), cancellationToken: None);
+            await client.InsertRowsAsync($"INSERT INTO {table} (value) VALUES", Array.Empty<Row<int>>(), cancellationToken: None);
 
             Assert.That(await CountAsync(client, table), Is.EqualTo(0));
         }
@@ -366,10 +410,10 @@ public class PocoWriteIntegrationTests
     }
 
     [Test]
-    public async Task InsertAsync_AttributedProperties_RenameAndExclude()
+    public async Task InsertRowsAsync_AttributedProperties_RenameAndExclude()
     {
         await using var client = TcpServerFixture.CreateClient();
-        string table = UniqueTableName();
+        string table = CreateTableName();
         try
         {
             await client.ExecuteAsync($"CREATE TABLE {table} (event_time DateTime('UTC')) ENGINE = Memory", cancellationToken: None);
@@ -379,7 +423,7 @@ public class PocoWriteIntegrationTests
                 new AttributedRow { Timestamp = new DateTime(2024, 3, 1, 12, 0, 0, DateTimeKind.Utc), Ignored = "not a column" },
             };
 
-            await client.InsertAsync($"INSERT INTO {table} (event_time) VALUES", written, cancellationToken: None);
+            await client.InsertRowsAsync($"INSERT INTO {table} (event_time) VALUES", written, cancellationToken: None);
 
             List<AttributedRow> read = await client.QueryAsync<AttributedRow>($"SELECT event_time FROM {table}", cancellationToken: None).ToListAsync();
 
@@ -396,18 +440,18 @@ public class PocoWriteIntegrationTests
     }
 
     [Test]
-    public async Task InsertAsync_TypeThatCannotBeMaterialized_StillInserts()
+    public async Task InsertRowsAsync_TypeThatCannotBeMaterialized_StillInserts()
     {
         // An insert needs getters and no constructor of ours, so an immutable POCO — the shape a query refuses,
         // since there is nothing to construct — is a perfectly good insert source. The read plan asks the
         // descriptor for its activator first and this one has none; the write plan must never ask.
         await using var client = TcpServerFixture.CreateClient();
-        string table = UniqueTableName();
+        string table = CreateTableName();
         try
         {
             await client.ExecuteAsync($"CREATE TABLE {table} (id UInt64, user_name String) ENGINE = Memory", cancellationToken: None);
 
-            await client.InsertAsync(
+            await client.InsertRowsAsync(
                 $"INSERT INTO {table} (id, user_name) VALUES",
                 new[] { new ImmutableAccount(3, "ada") },
                 cancellationToken: None);
@@ -429,26 +473,26 @@ public class PocoWriteIntegrationTests
     }
 
     [Test]
-    public async Task InsertAsync_ColumnSequenceThatIsNotAList_SaysToUseTheColumnarOverload()
+    public async Task InsertRowsAsync_ColumnSequenceThatIsNotAList_SaysToUseTheColumnarOverload()
     {
-        // The plausible slip: a LINQ operator over the columns yields IEnumerable<IColumn>, which binds to the POCO
-        // overload and would otherwise map IColumn's own properties to columns.
+        // The plausible explicit misuse: a LINQ operator over columns passed to the row API would otherwise map
+        // IColumn's own properties to target columns.
         await using var client = TcpServerFixture.CreateClient();
         IEnumerable<IColumn> columns = new List<IColumn> { new ArrayColumn<int>("value", "Int32", new[] { 1 }) };
 
         ArgumentException error = Assert.ThrowsAsync<ArgumentException>(
-            async () => await client.InsertAsync("INSERT INTO nowhere (value) VALUES", columns, cancellationToken: None));
+            async () => await client.InsertRowsAsync("INSERT INTO nowhere (value) VALUES", columns, cancellationToken: None));
 
         Assert.That(error.Message, Does.Contain("IReadOnlyList<IColumn>"));
     }
 
     [Test]
-    public async Task InsertAsync_UntypedRows_RoundTripPositionally()
+    public async Task InsertRowsAsync_UntypedRows_RoundTripPositionally()
     {
         // The dynamic tier: no type, values matched to the target columns by position. The DateTime column is given
         // a DateTime rather than the raw epoch seconds, which is the spelling a caller writing rows by hand has.
         await using var client = TcpServerFixture.CreateClient();
-        string table = UniqueTableName();
+        string table = CreateTableName();
         try
         {
             await client.ExecuteAsync($"CREATE TABLE {table} (id UInt64, name String, stamp DateTime('UTC'), score Nullable(Float64)) ENGINE = Memory", cancellationToken: None);
@@ -460,7 +504,7 @@ public class PocoWriteIntegrationTests
                 new object[] { 2UL, "grace", stamp.AddHours(1), null },
             };
 
-            await client.InsertAsync($"INSERT INTO {table} (id, name, stamp, score) VALUES", rows, cancellationToken: None);
+            await client.InsertRowsAsync($"INSERT INTO {table} (id, name, stamp, score) VALUES", rows, cancellationToken: None);
 
             List<object[]> read = await client
                 .QueryAsync($"SELECT id, name, stamp, score FROM {table} ORDER BY id", cancellationToken: None)
@@ -482,13 +526,13 @@ public class PocoWriteIntegrationTests
     }
 
     [Test]
-    public async Task InsertAsync_UntypedRowsFromAnUntypedRead_ReinsertWithoutConversion()
+    public async Task InsertRowsAsync_UntypedRowsFromAnUntypedRead_ReinsertWithoutConversion()
     {
-        // The property that makes the untyped tier usable as a pipe: what QueryAsync hands out is what InsertAsync
+        // The property that makes the untyped tier usable as a pipe: what QueryAsync hands out is what InsertRowsAsync
         // takes, raw wire values (a DateTime column's epoch seconds) included.
         await using var client = TcpServerFixture.CreateClient();
-        string source = UniqueTableName();
-        string copy = UniqueTableName();
+        string source = CreateTableName();
+        string copy = CreateTableName();
         try
         {
             await client.ExecuteAsync($"CREATE TABLE {source} (id UInt64, stamp DateTime('UTC')) ENGINE = Memory", cancellationToken: None);
@@ -496,7 +540,7 @@ public class PocoWriteIntegrationTests
             await client.ExecuteAsync($"INSERT INTO {source} SELECT number, toDateTime('2024-01-01 00:00:00', 'UTC') + number FROM numbers(3)", cancellationToken: None);
 
             List<object[]> read = await client.QueryAsync($"SELECT id, stamp FROM {source} ORDER BY id", cancellationToken: None).ToListAsync();
-            await client.InsertAsync($"INSERT INTO {copy} (id, stamp) VALUES", read, cancellationToken: None);
+            await client.InsertRowsAsync($"INSERT INTO {copy} (id, stamp) VALUES", read, cancellationToken: None);
 
             List<object[]> reread = await client.QueryAsync($"SELECT id, stamp FROM {copy} ORDER BY id", cancellationToken: None).ToListAsync();
 
@@ -514,10 +558,10 @@ public class PocoWriteIntegrationTests
     }
 
     [Test]
-    public async Task InsertAsync_UntypedRowOfTheWrongLength_ThrowsAndLeavesTheClientUsable()
+    public async Task InsertRowsAsync_UntypedRowOfTheWrongLength_ThrowsAndLeavesTheClientUsable()
     {
         await using var client = TcpServerFixture.CreateClient();
-        string table = UniqueTableName();
+        string table = CreateTableName();
         try
         {
             await client.ExecuteAsync($"CREATE TABLE {table} (id UInt64, name String) ENGINE = Memory", cancellationToken: None);
@@ -525,7 +569,7 @@ public class PocoWriteIntegrationTests
             var rows = new[] { new object[] { 1UL, "ada" }, new object[] { 2UL } };
 
             ArgumentException error = Assert.ThrowsAsync<ArgumentException>(
-                async () => await client.InsertAsync($"INSERT INTO {table} (id, name) VALUES", rows, cancellationToken: None));
+                async () => await client.InsertRowsAsync($"INSERT INTO {table} (id, name) VALUES", rows, cancellationToken: None));
 
             Assert.That(error.Message, Does.Contain("Row 1"));
             Assert.That(await CountAsync(client, table), Is.EqualTo(0));
@@ -537,10 +581,10 @@ public class PocoWriteIntegrationTests
     }
 
     [Test]
-    public async Task InsertAsync_UntypedValueOfAWrongType_ThrowsNamingTheColumnAndLeavesTheClientUsable()
+    public async Task InsertRowsAsync_UntypedValueOfAWrongType_ThrowsNamingTheColumnAndLeavesTheClientUsable()
     {
         await using var client = TcpServerFixture.CreateClient();
-        string table = UniqueTableName();
+        string table = CreateTableName();
         try
         {
             await client.ExecuteAsync($"CREATE TABLE {table} (id UInt64) ENGINE = Memory", cancellationToken: None);
@@ -548,7 +592,7 @@ public class PocoWriteIntegrationTests
             var rows = new[] { new object[] { "not a number" } };
 
             InvalidOperationException error = Assert.ThrowsAsync<InvalidOperationException>(
-                async () => await client.InsertAsync($"INSERT INTO {table} (id) VALUES", rows, cancellationToken: None));
+                async () => await client.InsertRowsAsync($"INSERT INTO {table} (id) VALUES", rows, cancellationToken: None));
 
             Assert.That(error.Message, Does.Contain("id").And.Contain("System.String"));
             Assert.That(await CountAsync(client, table), Is.EqualTo(0));
@@ -560,16 +604,16 @@ public class PocoWriteIntegrationTests
     }
 
     [Test]
-    public async Task InsertAsync_BothRowShapes_UsableThroughTheInterface()
+    public async Task InsertRowsAsync_BothRowShapes_UsableThroughTheInterface()
     {
         IClickHouseTcpClient client = TcpServerFixture.CreateClient();
-        string table = UniqueTableName();
+        string table = CreateTableName();
         try
         {
             await client.ExecuteAsync($"CREATE TABLE {table} (value Int32) ENGINE = Memory", cancellationToken: None);
 
-            await client.InsertAsync($"INSERT INTO {table} (value) VALUES", new[] { new Row<int> { Value = 1 } }, cancellationToken: None);
-            await client.InsertAsync($"INSERT INTO {table} (value) VALUES", new[] { new object[] { 2 } }, cancellationToken: None);
+            await client.InsertRowsAsync($"INSERT INTO {table} (value) VALUES", new[] { new Row<int> { Value = 1 } }, cancellationToken: None);
+            await client.InsertRowsAsync($"INSERT INTO {table} (value) VALUES", new[] { new object[] { 2 } }, cancellationToken: None);
 
             Assert.That(await CountAsync(client, table), Is.EqualTo(2));
         }
@@ -608,7 +652,7 @@ public class PocoWriteIntegrationTests
             rows[row] = new Row<TValue> { Value = typed[row] };
         }
 
-        await client.InsertAsync(sql, rows, options, None);
+        await client.InsertRowsAsync(sql, rows, options, None);
     }
 
     private static Task<object[]> ReadColumnAsRowsAsync(IClickHouseTcpClient client, string sql, ClickHouseTcpQueryOptions options, Type valueType)
@@ -648,6 +692,34 @@ public class PocoWriteIntegrationTests
         return (int)(ulong)rows[0][0];
     }
 
+    private static async Task AssertSessionTimezoneInsertAsync(
+        string clickHouseType,
+        Func<IClickHouseTcpClient, string, ClickHouseTcpInsertOptions, DateTime, Task> insert)
+    {
+        await using IClickHouseTcpClient client = TcpServerFixture.CreateClient();
+        string table = CreateTableName();
+        try
+        {
+            await client.ExecuteAsync($"CREATE TABLE {table} (value {clickHouseType}) ENGINE = Memory", cancellationToken: None);
+
+            var wallClock = new DateTime(2024, 1, 15, 10, 30, 0, DateTimeKind.Unspecified);
+            var options = new ClickHouseTcpInsertOptions { Settings = AmsterdamSessionSettings };
+            await insert(client, $"INSERT INTO {table} (value) VALUES", options, wallClock);
+
+            List<object[]> read = await client.QueryAsync($"SELECT value FROM {table}", cancellationToken: None).ToListAsync();
+            var expectedInstant = new DateTimeOffset(2024, 1, 15, 10, 30, 0, TimeSpan.FromHours(1));
+            object expected = clickHouseType == "DateTime"
+                ? (uint)expectedInstant.ToUnixTimeSeconds()
+                : expectedInstant.ToUnixTimeMilliseconds();
+
+            Assert.That(read[0][0], Is.EqualTo(expected));
+        }
+        finally
+        {
+            await client.ExecuteAsync($"DROP TABLE IF EXISTS {table}", cancellationToken: None);
+        }
+    }
+
     /// <summary>The <c>T</c> of the <see cref="IColumn{T}"/> a column surfaces.</summary>
     /// <param name="column">The column.</param>
     /// <returns>Its CLR element type.</returns>
@@ -664,7 +736,7 @@ public class PocoWriteIntegrationTests
         throw new InvalidOperationException($"Column '{column.Name}' ({column.TypeName}) surfaces no IColumn<T>.");
     }
 
-    private static string UniqueTableName() => $"tcp_poco_write_test_{Guid.NewGuid():N}";
+    private static string CreateTableName() => $"tcp_poco_write_test_{Guid.NewGuid():N}";
 
     private enum Level : sbyte
     {
@@ -721,5 +793,37 @@ public class PocoWriteIntegrationTests
 
         [ClickHouseTcpNotMapped]
         public string Ignored { get; set; }
+    }
+
+    /// <summary>
+    /// A public-surface-only column implementation, matching what a caller outside the assembly can provide. Its
+    /// concrete array used to make the columnar and generic row overloads equally good candidates (CS0121).
+    /// </summary>
+    private sealed class ExternalColumn<T> : IColumn<T>
+    {
+        private readonly T[] values;
+
+        public ExternalColumn(string name, string typeName, params T[] values)
+        {
+            Name = name;
+            TypeName = typeName;
+            this.values = values;
+        }
+
+        public string Name { get; }
+
+        public string TypeName { get; }
+
+        public int RowCount => values.Length;
+
+        public ReadOnlySpan<T> Values => values;
+
+        public T this[int row] => values[row];
+
+        public object GetValue(int row) => values[row];
+
+        public void Dispose()
+        {
+        }
     }
 }

--- a/ClickHouse.Driver.Tcp.Tests/Integration/PocoWriteIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/PocoWriteIntegrationTests.cs
@@ -45,7 +45,11 @@ public class PocoWriteIntegrationTests
             // A Nested target is the one corpus shape rows cannot be gathered into: its codec writes from its own
             // column type (flat field columns behind shared offsets), which no property can hold. It has to say so
             // rather than fail once the values are on the wire.
-            if (testCase.ClickHouseType.StartsWith("Nested(", StringComparison.Ordinal))
+            //
+            // Contains, not StartsWith: a Nested inside a composite is just as ungatherable, because the composite
+            // can only hand its child the column shape a row yields. Array(Nested(...)), Tuple(Nested(...), String)
+            // and both Map positions are corpus cases, and each one refuses for exactly this reason.
+            if (testCase.ClickHouseType.Contains("Nested(", StringComparison.Ordinal))
             {
                 InvalidOperationException refusal = Assert.ThrowsAsync<InvalidOperationException>(
                     async () => await InsertColumnAsRowsAsync(client, sql, insertOptions, insert, ElementTypeOf(insert)));

--- a/ClickHouse.Driver.Tcp.Tests/Integration/PocoWriteIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/PocoWriteIntegrationTests.cs
@@ -70,6 +70,86 @@ public class PocoWriteIntegrationTests
         }
     }
 
+    [TestCase(1)]
+    [TestCase(7)]
+    [TestCase(1000)]
+    public async Task InsertRowsAsync_StatefulTypesSplitIntoBlocks_StoreWhatOneBlockStores(int maxRowsPerBlock)
+    {
+        // A row insert converts one block at a time, so every codec carrying per-block write state — the
+        // LowCardinality dictionary, Array and Map offsets, the Nullable null map, the Tuple fields — writes that
+        // state once per block, over gather buffers reused from the block before. Whatever the split, the stored
+        // rows must be the ones a single block stores, which sum(cityHash64(*)) compares independently of order.
+        await using var client = TcpServerFixture.CreateClient();
+        string table = CreateTableName();
+        try
+        {
+            await client.ExecuteAsync(
+                $@"CREATE TABLE {table} (
+                    id UInt32,
+                    lc LowCardinality(String),
+                    arr Array(String),
+                    pairs Map(String, String),
+                    tup Tuple(a Int32, b String),
+                    maybe Nullable(Int64))
+                   ENGINE = MergeTree ORDER BY id",
+                cancellationToken: None);
+
+            StatefulRow[] rows = StatefulRows(2_000);
+            string sql = $"INSERT INTO {table} (id, lc, arr, pairs, tup, maybe) VALUES";
+
+            await client.InsertRowsAsync(sql, rows, new ClickHouseTcpInsertOptions { MaxRowsPerBlock = null }, None);
+            ulong whole = await HashAsync(client, table);
+
+            await client.ExecuteAsync($"TRUNCATE TABLE {table}", cancellationToken: None);
+            await client.InsertRowsAsync(sql, rows, new ClickHouseTcpInsertOptions { MaxRowsPerBlock = maxRowsPerBlock }, None);
+
+            int count = await CountAsync(client, table);
+            ulong split = await HashAsync(client, table);
+            Assert.Multiple(() =>
+            {
+                Assert.That(count, Is.EqualTo(rows.Length));
+                Assert.That(split, Is.EqualTo(whole));
+            });
+        }
+        finally
+        {
+            await client.ExecuteAsync($"DROP TABLE IF EXISTS {table}", cancellationToken: None);
+        }
+    }
+
+    [Test]
+    public async Task InsertRowsAsync_NullPropertyInALaterBlock_ThrowsAndKeepsWhatWasAlreadySent()
+    {
+        // The block is the conversion unit, so a value the target cannot take is found only when its block is
+        // gathered — after the blocks before it have gone out. The connection is still at a block boundary, so it
+        // stays usable.
+        await using var client = TcpServerFixture.CreateClient();
+        string table = CreateTableName();
+        try
+        {
+            await client.ExecuteAsync($"CREATE TABLE {table} (value Int32) ENGINE = Memory", cancellationToken: None);
+
+            var rows = new[] { new Row<int?> { Value = 1 }, new Row<int?> { Value = 2 }, new Row<int?> { Value = null } };
+
+            InvalidOperationException error = Assert.ThrowsAsync<InvalidOperationException>(
+                async () => await client.InsertRowsAsync(
+                    $"INSERT INTO {table} (value) VALUES",
+                    rows,
+                    new ClickHouseTcpInsertOptions { MaxRowsPerBlock = 2 },
+                    None));
+
+            Assert.That(error.Message, Does.Contain("row 2").And.Contain("value"));
+            Assert.That(await CountAsync(client, table), Is.EqualTo(2), "the block written before the failing one");
+
+            await client.InsertRowsAsync($"INSERT INTO {table} (value) VALUES", new[] { new Row<int> { Value = 3 } }, cancellationToken: None);
+            Assert.That(await CountAsync(client, table), Is.EqualTo(3), "the client is still usable");
+        }
+        finally
+        {
+            await client.ExecuteAsync($"DROP TABLE IF EXISTS {table}", cancellationToken: None);
+        }
+    }
+
     [Test]
     public async Task InsertRowsAsync_PocoOverSeveralColumns_RoundTripsThroughQueryAsync()
     {
@@ -624,6 +704,60 @@ public class PocoWriteIntegrationTests
         await client.InsertRowsAsync(sql, rows, options, None);
     }
 
+    /// <summary>
+    /// Builds rows whose every column carries per-block write state, with values that vary from row to row so a
+    /// block's dictionary, offsets and null map differ from its neighbours'.
+    /// </summary>
+    /// <param name="count">How many rows to build.</param>
+    /// <returns>The rows.</returns>
+    private static StatefulRow[] StatefulRows(int count)
+    {
+        var rows = new StatefulRow[count];
+        for (int i = 0; i < count; i++)
+        {
+            rows[i] = new StatefulRow
+            {
+                Id = (uint)i,
+                Lc = $"label{i % 7}",
+                Arr = BuildStrings(i % 4, element => $"e{i}-{element}"),
+                Pairs = BuildPairs(i % 3, element => $"k{element}", element => $"v{i}-{element}"),
+                Tup = (i, $"t{i}"),
+                Maybe = i % 5 == 0 ? null : i,
+            };
+        }
+
+        return rows;
+    }
+
+    private static string[] BuildStrings(int length, Func<int, string> element)
+    {
+        var values = new string[length];
+        for (int i = 0; i < length; i++)
+        {
+            values[i] = element(i);
+        }
+
+        return values;
+    }
+
+    private static KeyValuePair<string, string>[] BuildPairs(int length, Func<int, string> key, Func<int, string> value)
+    {
+        var pairs = new KeyValuePair<string, string>[length];
+        for (int i = 0; i < length; i++)
+        {
+            pairs[i] = new KeyValuePair<string, string>(key(i), value(i));
+        }
+
+        return pairs;
+    }
+
+    /// <summary>Hashes the stored rows independently of their order, for comparing two inserts of the same data.</summary>
+    private static async Task<ulong> HashAsync(IClickHouseTcpClient client, string table)
+    {
+        List<object[]> rows = await client.QueryAsync($"SELECT sum(cityHash64(*)) FROM {table}", cancellationToken: None).ToListAsync();
+        return (ulong)rows[0][0];
+    }
+
     private static Task<object[]> ReadColumnAsRowsAsync(IClickHouseTcpClient client, string sql, ClickHouseTcpQueryOptions options, Type valueType)
     {
         MethodInfo reader = typeof(PocoWriteIntegrationTests)
@@ -720,6 +854,22 @@ public class PocoWriteIntegrationTests
         public ulong Id { get; set; }
 
         public double? Score { get; set; }
+    }
+
+    /// <summary>A row whose every column's codec carries write state of its own within a block.</summary>
+    private sealed class StatefulRow
+    {
+        public uint Id { get; set; }
+
+        public string Lc { get; set; }
+
+        public string[] Arr { get; set; }
+
+        public KeyValuePair<string, string>[] Pairs { get; set; }
+
+        public (int A, string B) Tup { get; set; }
+
+        public long? Maybe { get; set; }
     }
 
     private sealed class CalendarRow

--- a/ClickHouse.Driver.Tcp.Tests/Integration/PocoWriteIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/PocoWriteIntegrationTests.cs
@@ -10,11 +10,7 @@ using ClickHouse.Driver.Tcp.Types;
 namespace ClickHouse.Driver.Tcp.Tests.Integration;
 
 /// <summary>
-/// <c>InsertRowsAsync&lt;T&gt;</c> and the untyped <c>object[]</c> insert against a real server. Per-type coverage rides
-/// the round-trip corpus, as the read side's does: each case's insert column names the CLR type a property would
-/// hold, so it becomes a <see cref="Row{TValue}"/> insert and a read-back with no corpus of its own. The rest are
-/// the shapes the corpus cannot state — a POCO over several columns, the calendar types a property declares instead
-/// of the raw wire value, and what a mapping failure does to the connection it happens on.
+/// Exercises typed and untyped row inserts against a real server, including mapping failures and connection reuse.
 /// </summary>
 [TestFixture]
 [Category("Integration")]
@@ -47,13 +43,7 @@ public class PocoWriteIntegrationTests
             IColumn insert = testCase.BuildInsertColumn("value");
             string sql = $"INSERT INTO {table} (value) VALUES";
 
-            // A Nested target is the one corpus shape rows cannot be gathered into: its codec writes from its own
-            // column type (flat field columns behind shared offsets), which no property can hold. It has to say so
-            // rather than fail once the values are on the wire.
-            //
-            // Contains, not StartsWith: a Nested inside a composite is just as ungatherable, because the composite
-            // can only hand its child the column shape a row yields. Array(Nested(...)), Tuple(Nested(...), String)
-            // and both Map positions are corpus cases, and each one refuses for exactly this reason.
+            // Nested and composites containing it require a specialized column shape that row gathering cannot build.
             if (testCase.ClickHouseType.Contains("Nested(", StringComparison.Ordinal))
             {
                 InvalidOperationException refusal = Assert.ThrowsAsync<InvalidOperationException>(
@@ -83,15 +73,14 @@ public class PocoWriteIntegrationTests
     [Test]
     public async Task InsertRowsAsync_PocoOverSeveralColumns_RoundTripsThroughQueryAsync()
     {
-        // The POCO-to-POCO round trip: one type inserted and read back through both compiled paths. The property
-        // order deliberately differs from the column order, since both directions match by name.
+        // Property order differs from column order to verify name-based mapping in both directions.
         await using var client = TcpServerFixture.CreateClient();
         string table = CreateTableName();
         try
         {
             await client.ExecuteAsync($"CREATE TABLE {table} (id UInt64, user_name String, score Nullable(Float64)) ENGINE = Memory", cancellationToken: None);
 
-            var written = new[]
+            var written = new List<Account>
             {
                 new Account { UserName = "ada", Id = 1, Score = 99.5 },
                 new Account { UserName = "grace", Id = 2, Score = null },
@@ -117,8 +106,7 @@ public class PocoWriteIntegrationTests
     [Test]
     public async Task InsertRowsAsync_CalendarAndEnumProperties_WriteThroughTheCodecsConversions()
     {
-        // The corpus inserts these columns as their raw wire values; a POCO declares the type a caller would, and
-        // the conversion is the codec's own — the same one the columnar path uses for a DateTime column.
+        // Use caller-facing calendar types to exercise the codecs' conversions.
         await using var client = TcpServerFixture.CreateClient();
         var options = new ClickHouseTcpQueryOptions { Settings = TimeSettings };
         string table = CreateTableName();
@@ -143,8 +131,7 @@ public class PocoWriteIntegrationTests
                     Clock = new TimeSpan(10, 30, 0),
                     Level = Level.High,
 
-                    // The nullable calendar spellings: a Nullable(DateTime) column accepts DateTime? only because
-                    // the codec lifts its inner's write types, so a present row and a null row both have to survive.
+                    // Exercise both present and null calendar values.
                     MaybeStamp = stamp,
                     MaybePrecise = precise,
                 },
@@ -231,8 +218,7 @@ public class PocoWriteIntegrationTests
     [Test]
     public async Task InsertRowsAsync_NamedColumnSubset_LeavesTheRestToTheirDefaults()
     {
-        // A property no target column maps to is simply not inserted, which is what lets one POCO fill part of a
-        // table: the statement names the columns, and the server defaults the others.
+        // The INSERT column list controls which properties are used.
         await using var client = TcpServerFixture.CreateClient();
         string table = CreateTableName();
         try
@@ -260,9 +246,7 @@ public class PocoWriteIntegrationTests
     [Test]
     public async Task InsertRowsAsync_TargetColumnWithNoProperty_ThrowsAndLeavesTheClientUsable()
     {
-        // The mapping is compiled from the sample block, so this failure lands with the INSERT already open. The
-        // insert has to close its row stream with no rows and hand the connection back, or every mapping mistake
-        // would cost a redial.
+        // A mapping failure after the sample block must leave the connection reusable.
         await using var client = TcpServerFixture.CreateClient();
         string table = CreateTableName();
         try
@@ -311,9 +295,7 @@ public class PocoWriteIntegrationTests
     [Test]
     public async Task InsertRowsAsync_NullStringPropertyIntoANonNullableColumn_ThrowsAndLeavesTheClientUsable()
     {
-        // The commonest way a row arrives incomplete, and the one that used to be worst: a null reference reaching
-        // the codec faults part-way through writing the block, which terminates the connection. It has to fail like
-        // any other unwritable value — before anything is sent, naming the row, connection intact.
+        // Reject the null before writing so the insert remains atomic and the connection reusable.
         await using var client = TcpServerFixture.CreateClient();
         string table = CreateTableName();
         try
@@ -358,10 +340,9 @@ public class PocoWriteIntegrationTests
     }
 
     [Test]
-    public async Task InsertRowsAsync_LazyRowSourceAcrossSeveralBlocks_WritesEveryRow()
+    public async Task InsertRowsAsync_MaterializedListAcrossSeveralBlocks_WritesEveryRow()
     {
-        // Two things at once: a source with no count, which the row buffer has to grow into, and more rows than one
-        // wire block holds, which is the slice path the columns are read through.
+        // Exercise list normalization and multi-block slicing together.
         const int rowCount = 5_000;
         await using var client = TcpServerFixture.CreateClient();
         string table = CreateTableName();
@@ -371,7 +352,7 @@ public class PocoWriteIntegrationTests
 
             await client.InsertRowsAsync(
                 $"INSERT INTO {table} (value) VALUES",
-                Counting(rowCount),
+                new List<Row<int>>(Counting(rowCount)),
                 new ClickHouseTcpInsertOptions { MaxRowsPerBlock = 1_000 },
                 None);
 
@@ -442,9 +423,7 @@ public class PocoWriteIntegrationTests
     [Test]
     public async Task InsertRowsAsync_TypeThatCannotBeMaterialized_StillInserts()
     {
-        // An insert needs getters and no constructor of ours, so an immutable POCO — the shape a query refuses,
-        // since there is nothing to construct — is a perfectly good insert source. The read plan asks the
-        // descriptor for its activator first and this one has none; the write plan must never ask.
+        // Writes need getters but do not need a constructor.
         await using var client = TcpServerFixture.CreateClient();
         string table = CreateTableName();
         try
@@ -473,12 +452,11 @@ public class PocoWriteIntegrationTests
     }
 
     [Test]
-    public async Task InsertRowsAsync_ColumnSequenceThatIsNotAList_SaysToUseTheColumnarOverload()
+    public async Task InsertRowsAsync_ColumnList_SaysToUseInsertAsync()
     {
-        // The plausible explicit misuse: a LINQ operator over columns passed to the row API would otherwise map
-        // IColumn's own properties to target columns.
+        // A column list should direct the caller to InsertAsync.
         await using var client = TcpServerFixture.CreateClient();
-        IEnumerable<IColumn> columns = new List<IColumn> { new ArrayColumn<int>("value", "Int32", new[] { 1 }) };
+        IReadOnlyList<IColumn> columns = new List<IColumn> { new ArrayColumn<int>("value", "Int32", new[] { 1 }) };
 
         ArgumentException error = Assert.ThrowsAsync<ArgumentException>(
             async () => await client.InsertRowsAsync("INSERT INTO nowhere (value) VALUES", columns, cancellationToken: None));
@@ -489,8 +467,7 @@ public class PocoWriteIntegrationTests
     [Test]
     public async Task InsertRowsAsync_UntypedRows_RoundTripPositionally()
     {
-        // The dynamic tier: no type, values matched to the target columns by position. The DateTime column is given
-        // a DateTime rather than the raw epoch seconds, which is the spelling a caller writing rows by hand has.
+        // Use a caller-facing DateTime to verify positional conversion.
         await using var client = TcpServerFixture.CreateClient();
         string table = CreateTableName();
         try
@@ -528,8 +505,7 @@ public class PocoWriteIntegrationTests
     [Test]
     public async Task InsertRowsAsync_UntypedRowsFromAnUntypedRead_ReinsertWithoutConversion()
     {
-        // The property that makes the untyped tier usable as a pipe: what QueryAsync hands out is what InsertRowsAsync
-        // takes, raw wire values (a DateTime column's epoch seconds) included.
+        // Verify that untyped query rows can be inserted without reshaping their values.
         await using var client = TcpServerFixture.CreateClient();
         string source = CreateTableName();
         string copy = CreateTableName();
@@ -625,15 +601,8 @@ public class PocoWriteIntegrationTests
     }
 
     /// <summary>
-    /// Inserts a one-column corpus case as <c>Row&lt;TValue&gt;</c> rows for a CLR type only known at runtime — the
-    /// write mirror of the read fixture's reader, and what lets the corpus drive the POCO write path.
+    /// Invokes the generic row insert for a column type known only at runtime.
     /// </summary>
-    /// <param name="client">The client to insert with.</param>
-    /// <param name="sql">The INSERT statement.</param>
-    /// <param name="options">The per-insert options the case needs.</param>
-    /// <param name="column">The case's insert column, read row by row into the property.</param>
-    /// <param name="valueType">The CLR type of the column's values.</param>
-    /// <returns>A task that completes when the insert is acknowledged.</returns>
     private static Task InsertColumnAsRowsAsync(IClickHouseTcpClient client, string sql, ClickHouseTcpInsertOptions options, IColumn column, Type valueType)
     {
         MethodInfo writer = typeof(PocoWriteIntegrationTests)
@@ -770,9 +739,7 @@ public class PocoWriteIntegrationTests
         public DateTimeOffset? MaybePrecise { get; set; }
     }
 
-    /// <summary>
-    /// Getter-only, with no parameterless constructor: insertable, but nothing a query could materialize into.
-    /// </summary>
+    /// <summary>A getter-only type that can be inserted but not materialized.</summary>
     private sealed class ImmutableAccount
     {
         public ImmutableAccount(ulong id, string userName)
@@ -796,8 +763,7 @@ public class PocoWriteIntegrationTests
     }
 
     /// <summary>
-    /// A public-surface-only column implementation, matching what a caller outside the assembly can provide. Its
-    /// concrete array used to make the columnar and generic row overloads equally good candidates (CS0121).
+    /// A public-only column used to exercise overload resolution from a caller's perspective.
     /// </summary>
     private sealed class ExternalColumn<T> : IColumn<T>
     {

--- a/ClickHouse.Driver.Tcp.Tests/Integration/PocoWriteIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/PocoWriteIntegrationTests.cs
@@ -1,0 +1,721 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Poco;
+using ClickHouse.Driver.Tcp.Tests.Utilities;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Tests.Integration;
+
+/// <summary>
+/// <c>InsertAsync&lt;T&gt;</c> and the untyped <c>object[]</c> insert against a real server. Per-type coverage rides
+/// the round-trip corpus, as the read side's does: each case's insert column names the CLR type a property would
+/// hold, so it becomes a <see cref="Row{TValue}"/> insert and a read-back with no corpus of its own. The rest are
+/// the shapes the corpus cannot state — a POCO over several columns, the calendar types a property declares instead
+/// of the raw wire value, and what a mapping failure does to the connection it happens on.
+/// </summary>
+[TestFixture]
+[Category("Integration")]
+public class PocoWriteIntegrationTests
+{
+    private static readonly CancellationToken None = CancellationToken.None;
+
+    private static readonly IReadOnlyDictionary<string, string> TimeSettings = new Dictionary<string, string>(StringComparer.Ordinal)
+    {
+        ["enable_time_time64_type"] = "1",
+        ["allow_experimental_time_time64_type"] = "1",
+    };
+
+    [TestCaseSource(typeof(InsertRoundTripCase), nameof(InsertRoundTripCase.Cases))]
+    public async Task InsertAsync_EveryCorpusType_WritesThePropertyIntoTheColumn(InsertRoundTripCase testCase)
+    {
+        await using var client = TcpServerFixture.CreateClient();
+        var queryOptions = new ClickHouseTcpQueryOptions { Settings = testCase.Settings };
+        var insertOptions = new ClickHouseTcpInsertOptions { Settings = testCase.Settings };
+        string table = UniqueTableName();
+        try
+        {
+            await client.ExecuteAsync($"CREATE TABLE {table} (value {testCase.ClickHouseType}) ENGINE = Memory", queryOptions, None);
+
+            IColumn insert = testCase.BuildInsertColumn("value");
+            string sql = $"INSERT INTO {table} (value) VALUES";
+
+            // A Nested target is the one corpus shape rows cannot be gathered into: its codec writes from its own
+            // column type (flat field columns behind shared offsets), which no property can hold. It has to say so
+            // rather than fail once the values are on the wire.
+            if (testCase.ClickHouseType.StartsWith("Nested(", StringComparison.Ordinal))
+            {
+                InvalidOperationException refusal = Assert.ThrowsAsync<InvalidOperationException>(
+                    async () => await InsertColumnAsRowsAsync(client, sql, insertOptions, insert, ElementTypeOf(insert)));
+
+                Assert.That(refusal.Message, Does.Contain("columnar API"));
+                return;
+            }
+
+            await InsertColumnAsRowsAsync(client, sql, insertOptions, insert, ElementTypeOf(insert));
+
+            IColumn expected = testCase.BuildExpectedColumn("value");
+            object[] read = await ReadColumnAsRowsAsync(client, $"SELECT value FROM {table}", queryOptions, ElementTypeOf(expected));
+
+            Assert.That(read, Has.Length.EqualTo(expected.RowCount), "row count");
+            for (int row = 0; row < expected.RowCount; row++)
+            {
+                Assert.That(read[row], Is.EqualTo(expected.GetValue(row)), $"row {row}");
+            }
+        }
+        finally
+        {
+            await client.ExecuteAsync($"DROP TABLE IF EXISTS {table}", cancellationToken: None);
+        }
+    }
+
+    [Test]
+    public async Task InsertAsync_PocoOverSeveralColumns_RoundTripsThroughQueryAsync()
+    {
+        // The POCO-to-POCO round trip: one type inserted and read back through both compiled paths. The property
+        // order deliberately differs from the column order, since both directions match by name.
+        await using var client = TcpServerFixture.CreateClient();
+        string table = UniqueTableName();
+        try
+        {
+            await client.ExecuteAsync($"CREATE TABLE {table} (id UInt64, user_name String, score Nullable(Float64)) ENGINE = Memory", cancellationToken: None);
+
+            var written = new[]
+            {
+                new Account { UserName = "ada", Id = 1, Score = 99.5 },
+                new Account { UserName = "grace", Id = 2, Score = null },
+            };
+
+            await client.InsertAsync($"INSERT INTO {table} (id, user_name, score) VALUES", written, cancellationToken: None);
+
+            List<Account> read = await client.QueryAsync<Account>($"SELECT id, user_name, score FROM {table} ORDER BY id", cancellationToken: None).ToListAsync();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(Array.ConvertAll(read.ToArray(), row => row.Id), Is.EqualTo(new ulong[] { 1, 2 }));
+                Assert.That(Array.ConvertAll(read.ToArray(), row => row.UserName), Is.EqualTo(new[] { "ada", "grace" }));
+                Assert.That(Array.ConvertAll(read.ToArray(), row => row.Score), Is.EqualTo(new double?[] { 99.5, null }));
+            });
+        }
+        finally
+        {
+            await client.ExecuteAsync($"DROP TABLE IF EXISTS {table}", cancellationToken: None);
+        }
+    }
+
+    [Test]
+    public async Task InsertAsync_CalendarAndEnumProperties_WriteThroughTheCodecsConversions()
+    {
+        // The corpus inserts these columns as their raw wire values; a POCO declares the type a caller would, and
+        // the conversion is the codec's own — the same one the columnar path uses for a DateTime column.
+        await using var client = TcpServerFixture.CreateClient();
+        var options = new ClickHouseTcpQueryOptions { Settings = TimeSettings };
+        string table = UniqueTableName();
+        try
+        {
+            const string columns = "stamp, precise, day, clock, level, maybe_stamp, maybe_precise";
+            await client.ExecuteAsync(
+                $"CREATE TABLE {table} (stamp DateTime('UTC'), precise DateTime64(3, 'UTC'), day Date, clock Time, " +
+                $"level Enum8('low' = -1, 'high' = 127), maybe_stamp Nullable(DateTime('UTC')), maybe_precise Nullable(DateTime64(3, 'UTC'))) ENGINE = Memory",
+                options,
+                None);
+
+            var stamp = new DateTime(2024, 1, 15, 10, 30, 0, DateTimeKind.Utc);
+            var precise = new DateTimeOffset(2024, 1, 15, 10, 30, 0, 250, TimeSpan.Zero);
+            var written = new[]
+            {
+                new CalendarRow
+                {
+                    Stamp = stamp,
+                    Precise = precise,
+                    Day = new DateOnly(2024, 1, 15),
+                    Clock = new TimeSpan(10, 30, 0),
+                    Level = Level.High,
+
+                    // The nullable calendar spellings: a Nullable(DateTime) column accepts DateTime? only because
+                    // the codec lifts its inner's write types, so a present row and a null row both have to survive.
+                    MaybeStamp = stamp,
+                    MaybePrecise = precise,
+                },
+                new CalendarRow
+                {
+                    Stamp = stamp,
+                    Precise = precise,
+                    Day = new DateOnly(2024, 1, 15),
+                    Clock = new TimeSpan(10, 30, 0),
+                    Level = Level.Low,
+                    MaybeStamp = null,
+                    MaybePrecise = null,
+                },
+            };
+
+            await client.InsertAsync(
+                $"INSERT INTO {table} ({columns}) VALUES",
+                written,
+                new ClickHouseTcpInsertOptions { Settings = TimeSettings },
+                None);
+
+            List<CalendarRow> read = await client
+                .QueryAsync<CalendarRow>($"SELECT {columns} FROM {table} ORDER BY level", options, None)
+                .ToListAsync();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(read[1].Stamp, Is.EqualTo(stamp));
+                Assert.That(read[1].Precise, Is.EqualTo(precise));
+                Assert.That(read[1].Day, Is.EqualTo(written[0].Day));
+                Assert.That(read[1].Clock, Is.EqualTo(written[0].Clock));
+                Assert.That(read[1].Level, Is.EqualTo(Level.High));
+                Assert.That(read[1].MaybeStamp, Is.EqualTo(stamp));
+                Assert.That(read[1].MaybePrecise, Is.EqualTo(precise));
+                Assert.That(read[0].MaybeStamp, Is.Null);
+                Assert.That(read[0].MaybePrecise, Is.Null);
+            });
+        }
+        finally
+        {
+            await client.ExecuteAsync($"DROP TABLE IF EXISTS {table}", cancellationToken: None);
+        }
+    }
+
+    [Test]
+    public async Task InsertAsync_NamedColumnSubset_LeavesTheRestToTheirDefaults()
+    {
+        // A property no target column maps to is simply not inserted, which is what lets one POCO fill part of a
+        // table: the statement names the columns, and the server defaults the others.
+        await using var client = TcpServerFixture.CreateClient();
+        string table = UniqueTableName();
+        try
+        {
+            await client.ExecuteAsync($"CREATE TABLE {table} (id UInt64, user_name String DEFAULT 'unset', score Nullable(Float64)) ENGINE = Memory", cancellationToken: None);
+
+            var written = new[] { new Account { Id = 7, UserName = "ada", Score = 1.5 } };
+            await client.InsertAsync($"INSERT INTO {table} (id) VALUES", written, cancellationToken: None);
+
+            List<Account> read = await client.QueryAsync<Account>($"SELECT id, user_name, score FROM {table}", cancellationToken: None).ToListAsync();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(read[0].Id, Is.EqualTo(7UL));
+                Assert.That(read[0].UserName, Is.EqualTo("unset"));
+                Assert.That(read[0].Score, Is.Null);
+            });
+        }
+        finally
+        {
+            await client.ExecuteAsync($"DROP TABLE IF EXISTS {table}", cancellationToken: None);
+        }
+    }
+
+    [Test]
+    public async Task InsertAsync_TargetColumnWithNoProperty_ThrowsAndLeavesTheClientUsable()
+    {
+        // The mapping is compiled from the sample block, so this failure lands with the INSERT already open. The
+        // insert has to close its row stream with no rows and hand the connection back, or every mapping mistake
+        // would cost a redial.
+        await using var client = TcpServerFixture.CreateClient();
+        string table = UniqueTableName();
+        try
+        {
+            await client.ExecuteAsync($"CREATE TABLE {table} (id UInt64, user_name String, score Nullable(Float64), extra String) ENGINE = Memory", cancellationToken: None);
+
+            InvalidOperationException error = Assert.ThrowsAsync<InvalidOperationException>(
+                async () => await client.InsertAsync($"INSERT INTO {table} VALUES", new[] { new Account { Id = 1 } }, cancellationToken: None));
+
+            Assert.That(error.Message, Does.Contain("extra").And.Contain("Account"));
+
+            // The connection survived: the same client runs the next statement.
+            Assert.That(await CountAsync(client, table), Is.EqualTo(0));
+        }
+        finally
+        {
+            await client.ExecuteAsync($"DROP TABLE IF EXISTS {table}", cancellationToken: None);
+        }
+    }
+
+    [Test]
+    public async Task InsertAsync_NullPropertyIntoNonNullableColumn_ThrowsNamingTheRowAndInsertsNothing()
+    {
+        await using var client = TcpServerFixture.CreateClient();
+        string table = UniqueTableName();
+        try
+        {
+            await client.ExecuteAsync($"CREATE TABLE {table} (value Int32) ENGINE = Memory", cancellationToken: None);
+
+            var rows = new[] { new Row<int?> { Value = 1 }, new Row<int?> { Value = null } };
+
+            InvalidOperationException error = Assert.ThrowsAsync<InvalidOperationException>(
+                async () => await client.InsertAsync($"INSERT INTO {table} (value) VALUES", rows, cancellationToken: None));
+
+            Assert.That(error.Message, Does.Contain("row 1").And.Contain("value"));
+
+            // The gather runs before any row goes out, so the failing insert is all-or-nothing.
+            Assert.That(await CountAsync(client, table), Is.EqualTo(0));
+        }
+        finally
+        {
+            await client.ExecuteAsync($"DROP TABLE IF EXISTS {table}", cancellationToken: None);
+        }
+    }
+
+    [Test]
+    public async Task InsertAsync_NullStringPropertyIntoANonNullableColumn_ThrowsAndLeavesTheClientUsable()
+    {
+        // The commonest way a row arrives incomplete, and the one that used to be worst: a null reference reaching
+        // the codec faults part-way through writing the block, which terminates the connection. It has to fail like
+        // any other unwritable value — before anything is sent, naming the row, connection intact.
+        await using var client = TcpServerFixture.CreateClient();
+        string table = UniqueTableName();
+        try
+        {
+            await client.ExecuteAsync($"CREATE TABLE {table} (id UInt64, user_name String, score Nullable(Float64)) ENGINE = Memory", cancellationToken: None);
+
+            var rows = new[] { new Account { Id = 1, UserName = "ada" }, new Account { Id = 2, UserName = null } };
+
+            InvalidOperationException error = Assert.ThrowsAsync<InvalidOperationException>(
+                async () => await client.InsertAsync($"INSERT INTO {table} (id, user_name, score) VALUES", rows, cancellationToken: None));
+
+            Assert.That(error.Message, Does.Contain("row 1").And.Contain("user_name"));
+            Assert.That(await CountAsync(client, table), Is.EqualTo(0));
+        }
+        finally
+        {
+            await client.ExecuteAsync($"DROP TABLE IF EXISTS {table}", cancellationToken: None);
+        }
+    }
+
+    [Test]
+    public async Task InsertAsync_UntypedNullIntoANonNullableStringColumn_ThrowsAndLeavesTheClientUsable()
+    {
+        await using var client = TcpServerFixture.CreateClient();
+        string table = UniqueTableName();
+        try
+        {
+            await client.ExecuteAsync($"CREATE TABLE {table} (name String) ENGINE = Memory", cancellationToken: None);
+
+            var rows = new[] { new object[] { "ada" }, new object[] { null } };
+
+            InvalidOperationException error = Assert.ThrowsAsync<InvalidOperationException>(
+                async () => await client.InsertAsync($"INSERT INTO {table} (name) VALUES", rows, cancellationToken: None));
+
+            Assert.That(error.Message, Does.Contain("row 1").And.Contain("name"));
+            Assert.That(await CountAsync(client, table), Is.EqualTo(0));
+        }
+        finally
+        {
+            await client.ExecuteAsync($"DROP TABLE IF EXISTS {table}", cancellationToken: None);
+        }
+    }
+
+    [Test]
+    public async Task InsertAsync_LazyRowSourceAcrossSeveralBlocks_WritesEveryRow()
+    {
+        // Two things at once: a source with no count, which the row buffer has to grow into, and more rows than one
+        // wire block holds, which is the slice path the columns are read through.
+        const int rowCount = 5_000;
+        await using var client = TcpServerFixture.CreateClient();
+        string table = UniqueTableName();
+        try
+        {
+            await client.ExecuteAsync($"CREATE TABLE {table} (value Int32) ENGINE = Memory", cancellationToken: None);
+
+            await client.InsertAsync(
+                $"INSERT INTO {table} (value) VALUES",
+                Counting(rowCount),
+                new ClickHouseTcpInsertOptions { MaxRowsPerBlock = 1_000 },
+                None);
+
+                List<object[]> aggregates = await client.QueryAsync($"SELECT count(), sum(value) FROM {table}", cancellationToken: None).ToListAsync();
+            object[] countAndSum = aggregates[0];
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(countAndSum[0], Is.EqualTo((ulong)rowCount));
+                Assert.That(countAndSum[1], Is.EqualTo((long)rowCount * (rowCount - 1) / 2));
+            });
+        }
+        finally
+        {
+            await client.ExecuteAsync($"DROP TABLE IF EXISTS {table}", cancellationToken: None);
+        }
+    }
+
+    [Test]
+    public async Task InsertAsync_ZeroRows_IsNoOp()
+    {
+        await using var client = TcpServerFixture.CreateClient();
+        string table = UniqueTableName();
+        try
+        {
+            await client.ExecuteAsync($"CREATE TABLE {table} (value Int32) ENGINE = Memory", cancellationToken: None);
+
+            await client.InsertAsync($"INSERT INTO {table} (value) VALUES", Array.Empty<Row<int>>(), cancellationToken: None);
+
+            Assert.That(await CountAsync(client, table), Is.EqualTo(0));
+        }
+        finally
+        {
+            await client.ExecuteAsync($"DROP TABLE IF EXISTS {table}", cancellationToken: None);
+        }
+    }
+
+    [Test]
+    public async Task InsertAsync_AttributedProperties_RenameAndExclude()
+    {
+        await using var client = TcpServerFixture.CreateClient();
+        string table = UniqueTableName();
+        try
+        {
+            await client.ExecuteAsync($"CREATE TABLE {table} (event_time DateTime('UTC')) ENGINE = Memory", cancellationToken: None);
+
+            var written = new[]
+            {
+                new AttributedRow { Timestamp = new DateTime(2024, 3, 1, 12, 0, 0, DateTimeKind.Utc), Ignored = "not a column" },
+            };
+
+            await client.InsertAsync($"INSERT INTO {table} (event_time) VALUES", written, cancellationToken: None);
+
+            List<AttributedRow> read = await client.QueryAsync<AttributedRow>($"SELECT event_time FROM {table}", cancellationToken: None).ToListAsync();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(read[0].Timestamp, Is.EqualTo(written[0].Timestamp));
+                Assert.That(read[0].Ignored, Is.Null);
+            });
+        }
+        finally
+        {
+            await client.ExecuteAsync($"DROP TABLE IF EXISTS {table}", cancellationToken: None);
+        }
+    }
+
+    [Test]
+    public async Task InsertAsync_TypeThatCannotBeMaterialized_StillInserts()
+    {
+        // An insert needs getters and no constructor of ours, so an immutable POCO — the shape a query refuses,
+        // since there is nothing to construct — is a perfectly good insert source. The read plan asks the
+        // descriptor for its activator first and this one has none; the write plan must never ask.
+        await using var client = TcpServerFixture.CreateClient();
+        string table = UniqueTableName();
+        try
+        {
+            await client.ExecuteAsync($"CREATE TABLE {table} (id UInt64, user_name String) ENGINE = Memory", cancellationToken: None);
+
+            await client.InsertAsync(
+                $"INSERT INTO {table} (id, user_name) VALUES",
+                new[] { new ImmutableAccount(3, "ada") },
+                cancellationToken: None);
+
+            List<object[]> read = await client.QueryAsync($"SELECT id, user_name FROM {table}", cancellationToken: None).ToListAsync();
+
+            Assert.That(read[0], Is.EqualTo(new object[] { 3UL, "ada" }));
+
+            // The other half of the contract: the same type cannot be queried into, and says why.
+            InvalidOperationException error = Assert.ThrowsAsync<InvalidOperationException>(
+                async () => await client.QueryAsync<ImmutableAccount>($"SELECT id, user_name FROM {table}", cancellationToken: None).ToListAsync());
+
+            Assert.That(error.Message, Does.Contain("no public parameterless constructor"));
+        }
+        finally
+        {
+            await client.ExecuteAsync($"DROP TABLE IF EXISTS {table}", cancellationToken: None);
+        }
+    }
+
+    [Test]
+    public async Task InsertAsync_ColumnSequenceThatIsNotAList_SaysToUseTheColumnarOverload()
+    {
+        // The plausible slip: a LINQ operator over the columns yields IEnumerable<IColumn>, which binds to the POCO
+        // overload and would otherwise map IColumn's own properties to columns.
+        await using var client = TcpServerFixture.CreateClient();
+        IEnumerable<IColumn> columns = new List<IColumn> { new ArrayColumn<int>("value", "Int32", new[] { 1 }) };
+
+        ArgumentException error = Assert.ThrowsAsync<ArgumentException>(
+            async () => await client.InsertAsync("INSERT INTO nowhere (value) VALUES", columns, cancellationToken: None));
+
+        Assert.That(error.Message, Does.Contain("IReadOnlyList<IColumn>"));
+    }
+
+    [Test]
+    public async Task InsertAsync_UntypedRows_RoundTripPositionally()
+    {
+        // The dynamic tier: no type, values matched to the target columns by position. The DateTime column is given
+        // a DateTime rather than the raw epoch seconds, which is the spelling a caller writing rows by hand has.
+        await using var client = TcpServerFixture.CreateClient();
+        string table = UniqueTableName();
+        try
+        {
+            await client.ExecuteAsync($"CREATE TABLE {table} (id UInt64, name String, stamp DateTime('UTC'), score Nullable(Float64)) ENGINE = Memory", cancellationToken: None);
+
+            var stamp = new DateTime(2024, 5, 6, 7, 8, 9, DateTimeKind.Utc);
+            var rows = new[]
+            {
+                new object[] { 1UL, "ada", stamp, 99.5 },
+                new object[] { 2UL, "grace", stamp.AddHours(1), null },
+            };
+
+            await client.InsertAsync($"INSERT INTO {table} (id, name, stamp, score) VALUES", rows, cancellationToken: None);
+
+            List<object[]> read = await client
+                .QueryAsync($"SELECT id, name, stamp, score FROM {table} ORDER BY id", cancellationToken: None)
+                .ToListAsync();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(read[0][0], Is.EqualTo(1UL));
+                Assert.That(read[0][1], Is.EqualTo("ada"));
+                Assert.That(read[0][2], Is.EqualTo((uint)new DateTimeOffset(stamp).ToUnixTimeSeconds()));
+                Assert.That(read[0][3], Is.EqualTo(99.5));
+                Assert.That(read[1][3], Is.Null);
+            });
+        }
+        finally
+        {
+            await client.ExecuteAsync($"DROP TABLE IF EXISTS {table}", cancellationToken: None);
+        }
+    }
+
+    [Test]
+    public async Task InsertAsync_UntypedRowsFromAnUntypedRead_ReinsertWithoutConversion()
+    {
+        // The property that makes the untyped tier usable as a pipe: what QueryAsync hands out is what InsertAsync
+        // takes, raw wire values (a DateTime column's epoch seconds) included.
+        await using var client = TcpServerFixture.CreateClient();
+        string source = UniqueTableName();
+        string copy = UniqueTableName();
+        try
+        {
+            await client.ExecuteAsync($"CREATE TABLE {source} (id UInt64, stamp DateTime('UTC')) ENGINE = Memory", cancellationToken: None);
+            await client.ExecuteAsync($"CREATE TABLE {copy} (id UInt64, stamp DateTime('UTC')) ENGINE = Memory", cancellationToken: None);
+            await client.ExecuteAsync($"INSERT INTO {source} SELECT number, toDateTime('2024-01-01 00:00:00', 'UTC') + number FROM numbers(3)", cancellationToken: None);
+
+            List<object[]> read = await client.QueryAsync($"SELECT id, stamp FROM {source} ORDER BY id", cancellationToken: None).ToListAsync();
+            await client.InsertAsync($"INSERT INTO {copy} (id, stamp) VALUES", read, cancellationToken: None);
+
+            List<object[]> reread = await client.QueryAsync($"SELECT id, stamp FROM {copy} ORDER BY id", cancellationToken: None).ToListAsync();
+
+            Assert.That(reread, Has.Count.EqualTo(3));
+            for (int row = 0; row < reread.Count; row++)
+            {
+                Assert.That(reread[row], Is.EqualTo(read[row]), $"row {row}");
+            }
+        }
+        finally
+        {
+            await client.ExecuteAsync($"DROP TABLE IF EXISTS {source}", cancellationToken: None);
+            await client.ExecuteAsync($"DROP TABLE IF EXISTS {copy}", cancellationToken: None);
+        }
+    }
+
+    [Test]
+    public async Task InsertAsync_UntypedRowOfTheWrongLength_ThrowsAndLeavesTheClientUsable()
+    {
+        await using var client = TcpServerFixture.CreateClient();
+        string table = UniqueTableName();
+        try
+        {
+            await client.ExecuteAsync($"CREATE TABLE {table} (id UInt64, name String) ENGINE = Memory", cancellationToken: None);
+
+            var rows = new[] { new object[] { 1UL, "ada" }, new object[] { 2UL } };
+
+            ArgumentException error = Assert.ThrowsAsync<ArgumentException>(
+                async () => await client.InsertAsync($"INSERT INTO {table} (id, name) VALUES", rows, cancellationToken: None));
+
+            Assert.That(error.Message, Does.Contain("Row 1"));
+            Assert.That(await CountAsync(client, table), Is.EqualTo(0));
+        }
+        finally
+        {
+            await client.ExecuteAsync($"DROP TABLE IF EXISTS {table}", cancellationToken: None);
+        }
+    }
+
+    [Test]
+    public async Task InsertAsync_UntypedValueOfAWrongType_ThrowsNamingTheColumnAndLeavesTheClientUsable()
+    {
+        await using var client = TcpServerFixture.CreateClient();
+        string table = UniqueTableName();
+        try
+        {
+            await client.ExecuteAsync($"CREATE TABLE {table} (id UInt64) ENGINE = Memory", cancellationToken: None);
+
+            var rows = new[] { new object[] { "not a number" } };
+
+            InvalidOperationException error = Assert.ThrowsAsync<InvalidOperationException>(
+                async () => await client.InsertAsync($"INSERT INTO {table} (id) VALUES", rows, cancellationToken: None));
+
+            Assert.That(error.Message, Does.Contain("id").And.Contain("System.String"));
+            Assert.That(await CountAsync(client, table), Is.EqualTo(0));
+        }
+        finally
+        {
+            await client.ExecuteAsync($"DROP TABLE IF EXISTS {table}", cancellationToken: None);
+        }
+    }
+
+    [Test]
+    public async Task InsertAsync_BothRowShapes_UsableThroughTheInterface()
+    {
+        IClickHouseTcpClient client = TcpServerFixture.CreateClient();
+        string table = UniqueTableName();
+        try
+        {
+            await client.ExecuteAsync($"CREATE TABLE {table} (value Int32) ENGINE = Memory", cancellationToken: None);
+
+            await client.InsertAsync($"INSERT INTO {table} (value) VALUES", new[] { new Row<int> { Value = 1 } }, cancellationToken: None);
+            await client.InsertAsync($"INSERT INTO {table} (value) VALUES", new[] { new object[] { 2 } }, cancellationToken: None);
+
+            Assert.That(await CountAsync(client, table), Is.EqualTo(2));
+        }
+        finally
+        {
+            await client.ExecuteAsync($"DROP TABLE IF EXISTS {table}", cancellationToken: None);
+            await client.DisposeAsync();
+        }
+    }
+
+    /// <summary>
+    /// Inserts a one-column corpus case as <c>Row&lt;TValue&gt;</c> rows for a CLR type only known at runtime — the
+    /// write mirror of the read fixture's reader, and what lets the corpus drive the POCO write path.
+    /// </summary>
+    /// <param name="client">The client to insert with.</param>
+    /// <param name="sql">The INSERT statement.</param>
+    /// <param name="options">The per-insert options the case needs.</param>
+    /// <param name="column">The case's insert column, read row by row into the property.</param>
+    /// <param name="valueType">The CLR type of the column's values.</param>
+    /// <returns>A task that completes when the insert is acknowledged.</returns>
+    private static Task InsertColumnAsRowsAsync(IClickHouseTcpClient client, string sql, ClickHouseTcpInsertOptions options, IColumn column, Type valueType)
+    {
+        MethodInfo writer = typeof(PocoWriteIntegrationTests)
+            .GetMethod(nameof(InsertRowsAsync), BindingFlags.NonPublic | BindingFlags.Static)
+            .MakeGenericMethod(valueType);
+
+        return (Task)writer.Invoke(null, new object[] { client, sql, options, column });
+    }
+
+    private static async Task InsertRowsAsync<TValue>(IClickHouseTcpClient client, string sql, ClickHouseTcpInsertOptions options, IColumn column)
+    {
+        var typed = (IColumn<TValue>)column;
+        var rows = new Row<TValue>[column.RowCount];
+        for (int row = 0; row < rows.Length; row++)
+        {
+            rows[row] = new Row<TValue> { Value = typed[row] };
+        }
+
+        await client.InsertAsync(sql, rows, options, None);
+    }
+
+    private static Task<object[]> ReadColumnAsRowsAsync(IClickHouseTcpClient client, string sql, ClickHouseTcpQueryOptions options, Type valueType)
+    {
+        MethodInfo reader = typeof(PocoWriteIntegrationTests)
+            .GetMethod(nameof(ReadRowsAsync), BindingFlags.NonPublic | BindingFlags.Static)
+            .MakeGenericMethod(valueType);
+
+        return (Task<object[]>)reader.Invoke(null, new object[] { client, sql, options });
+    }
+
+    private static async Task<object[]> ReadRowsAsync<TValue>(IClickHouseTcpClient client, string sql, ClickHouseTcpQueryOptions options)
+    {
+        var values = new List<object>();
+        await foreach (Row<TValue> row in client.QueryAsync<Row<TValue>>(sql, options, None))
+        {
+            values.Add(row.Value);
+        }
+
+        return values.ToArray();
+    }
+
+    /// <summary>A source with no count, so the row buffer has to grow rather than rent once.</summary>
+    /// <param name="count">How many rows to yield.</param>
+    /// <returns>The rows, one at a time.</returns>
+    private static IEnumerable<Row<int>> Counting(int count)
+    {
+        for (int value = 0; value < count; value++)
+        {
+            yield return new Row<int> { Value = value };
+        }
+    }
+
+    private static async Task<int> CountAsync(IClickHouseTcpClient client, string table)
+    {
+        List<object[]> rows = await client.QueryAsync($"SELECT count() FROM {table}", cancellationToken: None).ToListAsync();
+        return (int)(ulong)rows[0][0];
+    }
+
+    /// <summary>The <c>T</c> of the <see cref="IColumn{T}"/> a column surfaces.</summary>
+    /// <param name="column">The column.</param>
+    /// <returns>Its CLR element type.</returns>
+    private static Type ElementTypeOf(IColumn column)
+    {
+        foreach (Type implemented in column.GetType().GetInterfaces())
+        {
+            if (implemented.IsGenericType && implemented.GetGenericTypeDefinition() == typeof(IColumn<>))
+            {
+                return implemented.GetGenericArguments()[0];
+            }
+        }
+
+        throw new InvalidOperationException($"Column '{column.Name}' ({column.TypeName}) surfaces no IColumn<T>.");
+    }
+
+    private static string UniqueTableName() => $"tcp_poco_write_test_{Guid.NewGuid():N}";
+
+    private enum Level : sbyte
+    {
+        Low = -1,
+        High = 127,
+    }
+
+    private sealed class Account
+    {
+        public string UserName { get; set; }
+
+        public ulong Id { get; set; }
+
+        public double? Score { get; set; }
+    }
+
+    private sealed class CalendarRow
+    {
+        public DateTime Stamp { get; set; }
+
+        public DateTimeOffset Precise { get; set; }
+
+        public DateOnly Day { get; set; }
+
+        public TimeSpan Clock { get; set; }
+
+        public Level Level { get; set; }
+
+        public DateTime? MaybeStamp { get; set; }
+
+        public DateTimeOffset? MaybePrecise { get; set; }
+    }
+
+    /// <summary>
+    /// Getter-only, with no parameterless constructor: insertable, but nothing a query could materialize into.
+    /// </summary>
+    private sealed class ImmutableAccount
+    {
+        public ImmutableAccount(ulong id, string userName)
+        {
+            Id = id;
+            UserName = userName;
+        }
+
+        public ulong Id { get; }
+
+        public string UserName { get; }
+    }
+
+    private sealed class AttributedRow
+    {
+        [ClickHouseTcpColumn(Name = "event_time")]
+        public DateTime Timestamp { get; set; }
+
+        [ClickHouseTcpNotMapped]
+        public string Ignored { get; set; }
+    }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Poco/PocoGatherColumnTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Poco/PocoGatherColumnTests.cs
@@ -1,0 +1,78 @@
+using System;
+using ClickHouse.Driver.Tcp.Poco;
+
+namespace ClickHouse.Driver.Tcp.Tests.Poco;
+
+/// <summary>
+/// Covers the gather buffer a row insert reuses for every block: what it exposes, and its pooled ownership.
+/// </summary>
+[TestFixture]
+public class PocoGatherColumnTests
+{
+    [Test]
+    public void Publish_FewerRowsThanTheBuffer_ExposesOnlyThePublishedRows()
+    {
+        using var column = new PocoGatherColumn<int>("c", "Int32", capacity: 8);
+        column.Buffer[0] = 1;
+        column.Buffer[1] = 2;
+        column.Buffer[2] = 3;
+
+        column.Publish(2);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(column.RowCount, Is.EqualTo(2));
+            Assert.That(column.Values.ToArray(), Is.EqualTo(new[] { 1, 2 }));
+            Assert.That(column.GetValue(1), Is.EqualTo(2));
+            Assert.That(() => column[2], Throws.TypeOf<IndexOutOfRangeException>(), "past the published rows, not past the buffer");
+        });
+    }
+
+    [Test]
+    public void Publish_ASecondBlock_ReplacesTheRowsOfTheFirst()
+    {
+        // The buffer is rented once and refilled, so the values are always the current block's.
+        using var column = new PocoGatherColumn<int>("c", "Int32", capacity: 4);
+        column.Buffer[0] = 1;
+        column.Buffer[1] = 2;
+        column.Publish(2);
+
+        column.Buffer[0] = 9;
+        column.Publish(1);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(column.RowCount, Is.EqualTo(1));
+            Assert.That(column.Values.ToArray(), Is.EqualTo(new[] { 9 }));
+        });
+    }
+
+    [Test]
+    public void Dispose_CalledTwice_ReturnsTheBufferOnce()
+    {
+        // An owning column must return its buffer exactly once.
+        var column = new PocoGatherColumn<int>("c", "Int32", capacity: 4);
+        column.Publish(2);
+
+        column.Dispose();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(() => column.Dispose(), Throws.Nothing);
+            Assert.That(column.RowCount, Is.Zero, "the values are gone with the buffer");
+        });
+    }
+
+    [Test]
+    public void Dispose_ZeroCapacity_IsStillDisposable()
+    {
+        // A zero-row insert rents the pool's shared empty array.
+        var column = new PocoGatherColumn<int>("c", "Int32", capacity: 0);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(column.RowCount, Is.Zero);
+            Assert.That(() => column.Dispose(), Throws.Nothing);
+        });
+    }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Poco/PocoRowBufferTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Poco/PocoRowBufferTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Threading;
 using ClickHouse.Driver.Tcp.Poco;
@@ -8,8 +9,9 @@ namespace ClickHouse.Driver.Tcp.Tests.Poco;
 
 /// <summary>
 /// The row buffer a row-oriented insert materializes its source into. Not reachable from a server round trip beyond
-/// "the rows arrived": what is here is the sizing (a counted source rents once, a lazy one grows) and the null-row
-/// refusal, which has to name the row rather than surface as a NullReferenceException from compiled code.
+/// "the rows arrived": what is here is the sizing (a counted source rents once, a lazy one grows), the null-row
+/// refusal — which has to name the row rather than surface as a NullReferenceException from compiled code — and
+/// cancellation, this being the one stretch of an insert that runs before any I/O.
 /// </summary>
 [TestFixture]
 public class PocoRowBufferTests
@@ -80,7 +82,7 @@ public class PocoRowBufferTests
     }
 
     [Test]
-    public void Materialize_CancelledToken_StopsWithoutDrainingTheSource()
+    public void Materialize_TokenCancelledBeforeTheCall_StopsWithoutDrainingTheSource()
     {
         // The source is enumerated before any I/O, and it can be the long part of an insert, so the token has to be
         // observed here rather than only once the connection is rented.
@@ -91,11 +93,77 @@ public class PocoRowBufferTests
             () => PocoRowBuffer<Row<int>>.Materialize(Counting(500), "rows", cancellation.Token));
     }
 
+    [Test]
+    public void Materialize_TokenCancelledPartWayThroughACountedSource_StopsThere()
+    {
+        // A counted source sizes the rent to fit, so it never reaches a growth point: testing the token only there
+        // would drain a long collection in full however early the caller cancelled.
+        using var cancellation = new CancellationTokenSource();
+        var source = new CancellingCollection(cancellation, count: 500, cancelAfter: 3);
+
+        Assert.Throws<OperationCanceledException>(
+            () => PocoRowBuffer<Row<int>>.Materialize(source, "rows", cancellation.Token));
+
+        Assert.That(source.Yielded, Is.LessThan(10), "the enumeration stopped where it was cancelled");
+    }
+
     private static IEnumerable<Row<int>> Counting(int count)
     {
         for (int value = 0; value < count; value++)
         {
             yield return new Row<int> { Value = value };
         }
+    }
+
+    /// <summary>
+    /// A source that reports its count — so the buffer rents once and never grows — and cancels the token part-way
+    /// through yielding. <see cref="ICollection{T}"/> rather than <see cref="IReadOnlyCollection{T}"/> because that
+    /// is the interface a count is read through; the mutators are never called.
+    /// </summary>
+    private sealed class CancellingCollection : ICollection<Row<int>>
+    {
+        private readonly CancellationTokenSource cancellation;
+        private readonly int count;
+        private readonly int cancelAfter;
+
+        public CancellingCollection(CancellationTokenSource cancellation, int count, int cancelAfter)
+        {
+            this.cancellation = cancellation;
+            this.count = count;
+            this.cancelAfter = cancelAfter;
+        }
+
+        public int Count => count;
+
+        public bool IsReadOnly => true;
+
+        /// <summary>How many rows the enumeration asked for before it stopped.</summary>
+        public int Yielded { get; private set; }
+
+        public IEnumerator<Row<int>> GetEnumerator()
+        {
+            for (int value = 0; value < count; value++)
+            {
+                if (value == cancelAfter)
+                {
+                    cancellation.Cancel();
+                }
+
+                Yielded++;
+                yield return new Row<int> { Value = value };
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public void Add(Row<int> item) => throw new NotSupportedException();
+
+        public void Clear() => throw new NotSupportedException();
+
+        public bool Contains(Row<int> item) => throw new NotSupportedException();
+
+        public void CopyTo(Row<int>[] array, int arrayIndex) => throw new NotSupportedException();
+
+        public bool Remove(Row<int> item) => throw new NotSupportedException();
     }
 }

--- a/ClickHouse.Driver.Tcp.Tests/Poco/PocoRowBufferTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Poco/PocoRowBufferTests.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using ClickHouse.Driver.Tcp.Poco;
+using ClickHouse.Driver.Tcp.Tests.Utilities;
+
+namespace ClickHouse.Driver.Tcp.Tests.Poco;
+
+/// <summary>
+/// The row buffer a row-oriented insert materializes its source into. Not reachable from a server round trip beyond
+/// "the rows arrived": what is here is the sizing (a counted source rents once, a lazy one grows) and the null-row
+/// refusal, which has to name the row rather than surface as a NullReferenceException from compiled code.
+/// </summary>
+[TestFixture]
+public class PocoRowBufferTests
+{
+    [Test]
+    public void Materialize_CountedSource_HoldsEveryRowInOrder()
+    {
+        var source = new List<Row<int>> { new() { Value = 1 }, new() { Value = 2 } };
+
+        using PocoRowBuffer<Row<int>> buffer = PocoRowBuffer<Row<int>>.Materialize(source, "rows", CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(buffer.Count, Is.EqualTo(2));
+            Assert.That(buffer.Rows[0], Is.SameAs(source[0]));
+            Assert.That(buffer.Rows[1], Is.SameAs(source[1]));
+        });
+    }
+
+    [Test]
+    public void Materialize_LazySource_GrowsPastTheInitialRent()
+    {
+        const int count = 500;
+
+        using PocoRowBuffer<Row<int>> buffer = PocoRowBuffer<Row<int>>.Materialize(Counting(count), "rows", CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(buffer.Count, Is.EqualTo(count));
+            Assert.That(buffer.Rows[0].Value, Is.EqualTo(0));
+            Assert.That(buffer.Rows[count - 1].Value, Is.EqualTo(count - 1));
+        });
+    }
+
+    [Test]
+    public void Materialize_EmptySource_HoldsNoRows()
+    {
+        using PocoRowBuffer<Row<int>> buffer = PocoRowBuffer<Row<int>>.Materialize(Array.Empty<Row<int>>(), "rows", CancellationToken.None);
+
+        Assert.That(buffer.Count, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void Materialize_NullRow_ThrowsNamingTheRowAndTheParameter()
+    {
+        var source = new List<Row<int>> { new() { Value = 1 }, null };
+
+        ArgumentException error = Assert.Throws<ArgumentException>(() => PocoRowBuffer<Row<int>>.Materialize(source, "rows", CancellationToken.None));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(error.Message, Does.Contain("Row 1"));
+            Assert.That(error.ParamName, Is.EqualTo("rows"));
+        });
+    }
+
+    [Test]
+    public void Dispose_Twice_ReturnsTheArrayOnce()
+    {
+        // Returning a pooled array twice puts one array in the pool twice, which hands the same storage to two
+        // callers — so the second Dispose has to be a no-op rather than a second Return.
+        PocoRowBuffer<Row<int>> buffer = PocoRowBuffer<Row<int>>.Materialize(new[] { new Row<int> { Value = 1 } }, "rows", CancellationToken.None);
+
+        buffer.Dispose();
+
+        Assert.DoesNotThrow(() => buffer.Dispose());
+        Assert.That(buffer.Rows, Is.Empty);
+    }
+
+    [Test]
+    public void Materialize_CancelledToken_StopsWithoutDrainingTheSource()
+    {
+        // The source is enumerated before any I/O, and it can be the long part of an insert, so the token has to be
+        // observed here rather than only once the connection is rented.
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        Assert.Throws<OperationCanceledException>(
+            () => PocoRowBuffer<Row<int>>.Materialize(Counting(500), "rows", cancellation.Token));
+    }
+
+    private static IEnumerable<Row<int>> Counting(int count)
+    {
+        for (int value = 0; value < count; value++)
+        {
+            yield return new Row<int> { Value = value };
+        }
+    }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Poco/PocoRowBufferTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Poco/PocoRowBufferTests.cs
@@ -8,58 +8,56 @@ using ClickHouse.Driver.Tcp.Tests.Utilities;
 namespace ClickHouse.Driver.Tcp.Tests.Poco;
 
 /// <summary>
-/// The row buffer a row-oriented insert materializes its source into. Not reachable from a server round trip beyond
-/// "the rows arrived": what is here is the sizing (a counted source rents once, a lazy one grows), the null-row
-/// refusal — which has to name the row rather than surface as a NullReferenceException from compiled code — and
-/// cancellation, this being the one stretch of an insert that runs before any I/O.
+/// Covers row buffering, pooled-array ownership, null validation, and cancellation.
 /// </summary>
 [TestFixture]
 public class PocoRowBufferTests
 {
     [Test]
-    public void Materialize_CountedSource_HoldsEveryRowInOrder()
+    public void Create_ArrayInput_BorrowsTheCallerArray()
     {
-        var source = new List<Row<int>> { new() { Value = 1 }, new() { Value = 2 } };
+        var source = new[] { new Row<int> { Value = 1 }, new Row<int> { Value = 2 } };
 
-        using PocoRowBuffer<Row<int>> buffer = PocoRowBuffer<Row<int>>.Materialize(source, "rows", CancellationToken.None);
+        using PocoRowBuffer<Row<int>> buffer = PocoRowBuffer<Row<int>>.Create(source, "rows", CancellationToken.None);
 
         Assert.Multiple(() =>
         {
             Assert.That(buffer.Count, Is.EqualTo(2));
-            Assert.That(buffer.Rows[0], Is.SameAs(source[0]));
+            Assert.That(buffer.Rows, Is.SameAs(source));
+        });
+    }
+
+    [Test]
+    public void Create_ListInput_CopiesEveryRowInOrder()
+    {
+        var first = new Row<int> { Value = 1 };
+        var source = new List<Row<int>> { first, new() { Value = 2 } };
+
+        using PocoRowBuffer<Row<int>> buffer = PocoRowBuffer<Row<int>>.Create(source, "rows", CancellationToken.None);
+        source[0] = new Row<int> { Value = 3 };
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(buffer.Count, Is.EqualTo(2));
+            Assert.That(buffer.Rows[0], Is.SameAs(first));
             Assert.That(buffer.Rows[1], Is.SameAs(source[1]));
         });
     }
 
     [Test]
-    public void Materialize_LazySource_GrowsPastTheInitialRent()
+    public void Create_EmptyList_HoldsNoRows()
     {
-        const int count = 500;
-
-        using PocoRowBuffer<Row<int>> buffer = PocoRowBuffer<Row<int>>.Materialize(Counting(count), "rows", CancellationToken.None);
-
-        Assert.Multiple(() =>
-        {
-            Assert.That(buffer.Count, Is.EqualTo(count));
-            Assert.That(buffer.Rows[0].Value, Is.EqualTo(0));
-            Assert.That(buffer.Rows[count - 1].Value, Is.EqualTo(count - 1));
-        });
-    }
-
-    [Test]
-    public void Materialize_EmptySource_HoldsNoRows()
-    {
-        using PocoRowBuffer<Row<int>> buffer = PocoRowBuffer<Row<int>>.Materialize(Array.Empty<Row<int>>(), "rows", CancellationToken.None);
+        using PocoRowBuffer<Row<int>> buffer = PocoRowBuffer<Row<int>>.Create(new List<Row<int>>(), "rows", CancellationToken.None);
 
         Assert.That(buffer.Count, Is.EqualTo(0));
     }
 
     [Test]
-    public void Materialize_NullRow_ThrowsNamingTheRowAndTheParameter()
+    public void Create_ListContainingNull_ThrowsNamingTheRowAndTheParameter()
     {
         var source = new List<Row<int>> { new() { Value = 1 }, null };
 
-        ArgumentException error = Assert.Throws<ArgumentException>(() => PocoRowBuffer<Row<int>>.Materialize(source, "rows", CancellationToken.None));
+        ArgumentException error = Assert.Throws<ArgumentException>(() => PocoRowBuffer<Row<int>>.Create(source, "rows", CancellationToken.None));
 
         Assert.Multiple(() =>
         {
@@ -69,11 +67,39 @@ public class PocoRowBufferTests
     }
 
     [Test]
-    public void Dispose_Twice_ReturnsTheArrayOnce()
+    public void Create_ArrayContainingNull_ThrowsNamingTheRowAndTheParameter()
     {
-        // Returning a pooled array twice puts one array in the pool twice, which hands the same storage to two
-        // callers — so the second Dispose has to be a no-op rather than a second Return.
-        PocoRowBuffer<Row<int>> buffer = PocoRowBuffer<Row<int>>.Materialize(new[] { new Row<int> { Value = 1 } }, "rows", CancellationToken.None);
+        Row<int>[] source = { new() { Value = 1 }, null };
+
+        ArgumentException error = Assert.Throws<ArgumentException>(() => PocoRowBuffer<Row<int>>.Create(source, "rows", CancellationToken.None));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(error.Message, Does.Contain("Row 1"));
+            Assert.That(error.ParamName, Is.EqualTo("rows"));
+        });
+    }
+
+    [Test]
+    public void Dispose_BorrowedArray_LeavesTheCallerArrayUntouched()
+    {
+        var row = new Row<int> { Value = 1 };
+        var source = new[] { row };
+        PocoRowBuffer<Row<int>> buffer = PocoRowBuffer<Row<int>>.Create(source, "rows", CancellationToken.None);
+
+        buffer.Dispose();
+
+        Assert.That(source[0], Is.SameAs(row));
+    }
+
+    [Test]
+    public void Dispose_OwnedCopyCalledTwice_ReleasesItOnce()
+    {
+        // A second disposal must not return the same array twice.
+        PocoRowBuffer<Row<int>> buffer = PocoRowBuffer<Row<int>>.Create(
+            new List<Row<int>> { new() { Value = 1 } },
+            "rows",
+            CancellationToken.None);
 
         buffer.Dispose();
 
@@ -82,51 +108,35 @@ public class PocoRowBufferTests
     }
 
     [Test]
-    public void Materialize_TokenCancelledBeforeTheCall_StopsWithoutDrainingTheSource()
+    public void Create_TokenCancelledBeforeTheCall_ThrowsForAnEmptyList()
     {
-        // The source is enumerated before any I/O, and it can be the long part of an insert, so the token has to be
-        // observed here rather than only once the connection is rented.
         using var cancellation = new CancellationTokenSource();
         cancellation.Cancel();
 
         Assert.Throws<OperationCanceledException>(
-            () => PocoRowBuffer<Row<int>>.Materialize(Counting(500), "rows", cancellation.Token));
+            () => PocoRowBuffer<Row<int>>.Create(Array.Empty<Row<int>>(), "rows", cancellation.Token));
     }
 
     [Test]
-    public void Materialize_TokenCancelledPartWayThroughACountedSource_StopsThere()
+    public void Create_TokenCancelledDuringCopy_StopsThere()
     {
-        // A counted source sizes the rent to fit, so it never reaches a growth point: testing the token only there
-        // would drain a long collection in full however early the caller cancelled.
         using var cancellation = new CancellationTokenSource();
-        var source = new CancellingCollection(cancellation, count: 500, cancelAfter: 3);
+        var source = new CancellingList(cancellation, count: 500, cancelAfter: 3);
 
         Assert.Throws<OperationCanceledException>(
-            () => PocoRowBuffer<Row<int>>.Materialize(source, "rows", cancellation.Token));
+            () => PocoRowBuffer<Row<int>>.Create(source, "rows", cancellation.Token));
 
-        Assert.That(source.Yielded, Is.LessThan(10), "the enumeration stopped where it was cancelled");
+        Assert.That(source.Read, Is.LessThan(10), "copying stopped where it was cancelled");
     }
 
-    private static IEnumerable<Row<int>> Counting(int count)
-    {
-        for (int value = 0; value < count; value++)
-        {
-            yield return new Row<int> { Value = value };
-        }
-    }
-
-    /// <summary>
-    /// A source that reports its count — so the buffer rents once and never grows — and cancels the token part-way
-    /// through yielding. <see cref="ICollection{T}"/> rather than <see cref="IReadOnlyCollection{T}"/> because that
-    /// is the interface a count is read through; the mutators are never called.
-    /// </summary>
-    private sealed class CancellingCollection : ICollection<Row<int>>
+    /// <summary>A list that cancels while its indexer is being read.</summary>
+    private sealed class CancellingList : IReadOnlyList<Row<int>>
     {
         private readonly CancellationTokenSource cancellation;
         private readonly int count;
         private readonly int cancelAfter;
 
-        public CancellingCollection(CancellationTokenSource cancellation, int count, int cancelAfter)
+        public CancellingList(CancellationTokenSource cancellation, int count, int cancelAfter)
         {
             this.cancellation = cancellation;
             this.count = count;
@@ -135,35 +145,25 @@ public class PocoRowBufferTests
 
         public int Count => count;
 
-        public bool IsReadOnly => true;
+        /// <summary>How many rows the indexer returned.</summary>
+        public int Read { get; private set; }
 
-        /// <summary>How many rows the enumeration asked for before it stopped.</summary>
-        public int Yielded { get; private set; }
-
-        public IEnumerator<Row<int>> GetEnumerator()
+        public Row<int> this[int index]
         {
-            for (int value = 0; value < count; value++)
+            get
             {
-                if (value == cancelAfter)
+                Read++;
+                if (Read == cancelAfter)
                 {
                     cancellation.Cancel();
                 }
 
-                Yielded++;
-                yield return new Row<int> { Value = value };
+                return new Row<int> { Value = index };
             }
         }
 
+        public IEnumerator<Row<int>> GetEnumerator() => throw new NotSupportedException();
+
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-
-        public void Add(Row<int> item) => throw new NotSupportedException();
-
-        public void Clear() => throw new NotSupportedException();
-
-        public bool Contains(Row<int> item) => throw new NotSupportedException();
-
-        public void CopyTo(Row<int>[] array, int arrayIndex) => throw new NotSupportedException();
-
-        public bool Remove(Row<int> item) => throw new NotSupportedException();
     }
 }

--- a/ClickHouse.Driver.Tcp.Tests/Poco/PocoRowBufferTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Poco/PocoRowBufferTests.cs
@@ -8,7 +8,7 @@ using ClickHouse.Driver.Tcp.Tests.Utilities;
 namespace ClickHouse.Driver.Tcp.Tests.Poco;
 
 /// <summary>
-/// Covers row buffering, pooled-array ownership, null validation, and cancellation.
+/// Covers row buffering, block staging, pooled-array ownership, null validation, and cancellation.
 /// </summary>
 [TestFixture]
 public class PocoRowBufferTests
@@ -18,7 +18,7 @@ public class PocoRowBufferTests
     {
         var source = new[] { new Row<int> { Value = 1 }, new Row<int> { Value = 2 } };
 
-        using PocoRowBuffer<Row<int>> buffer = PocoRowBuffer<Row<int>>.Create(source, "rows", CancellationToken.None);
+        using PocoRowBuffer<Row<int>> buffer = PocoRowBuffer<Row<int>>.Create(source, "rows", blockRows: 2, CancellationToken.None);
 
         Assert.Multiple(() =>
         {
@@ -28,36 +28,99 @@ public class PocoRowBufferTests
     }
 
     [Test]
-    public void Create_ListInput_CopiesEveryRowInOrder()
+    public void Prepare_ArrayInput_ReadsTheBlockWhereItIs()
+    {
+        var source = new[] { new Row<int> { Value = 1 }, new Row<int> { Value = 2 }, new Row<int> { Value = 3 } };
+
+        using PocoRowBuffer<Row<int>> buffer = PocoRowBuffer<Row<int>>.Create(source, "rows", blockRows: 2, CancellationToken.None);
+        int offset = buffer.Prepare(start: 1, length: 2);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(offset, Is.EqualTo(1), "the caller's array is indexed in place");
+            Assert.That(buffer.Rows, Is.SameAs(source));
+        });
+    }
+
+    [Test]
+    public void Prepare_ListInput_StagesTheBlockAtTheStartOfTheWindow()
+    {
+        var third = new Row<int> { Value = 3 };
+        var source = new List<Row<int>> { new() { Value = 1 }, new() { Value = 2 }, third };
+
+        using PocoRowBuffer<Row<int>> buffer = PocoRowBuffer<Row<int>>.Create(source, "rows", blockRows: 2, CancellationToken.None);
+        int offset = buffer.Prepare(start: 2, length: 1);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(offset, Is.Zero, "a staged block starts at the window's first slot");
+            Assert.That(buffer.Rows[0], Is.SameAs(third));
+        });
+    }
+
+    [Test]
+    public void Prepare_ListInput_CopiesEveryRowOfTheBlockInOrder()
     {
         var first = new Row<int> { Value = 1 };
-        var source = new List<Row<int>> { first, new() { Value = 2 } };
+        var second = new Row<int> { Value = 2 };
+        var source = new List<Row<int>> { first, second };
 
-        using PocoRowBuffer<Row<int>> buffer = PocoRowBuffer<Row<int>>.Create(source, "rows", CancellationToken.None);
-        source[0] = new Row<int> { Value = 3 };
+        using PocoRowBuffer<Row<int>> buffer = PocoRowBuffer<Row<int>>.Create(source, "rows", blockRows: 2, CancellationToken.None);
+        buffer.Prepare(start: 0, length: 2);
 
         Assert.Multiple(() =>
         {
             Assert.That(buffer.Count, Is.EqualTo(2));
             Assert.That(buffer.Rows[0], Is.SameAs(first));
-            Assert.That(buffer.Rows[1], Is.SameAs(source[1]));
+            Assert.That(buffer.Rows[1], Is.SameAs(second));
+        });
+    }
+
+    [Test]
+    public void Create_ListLongerThanABlock_StagesOnlyOneBlockAtATime()
+    {
+        // The window is the block, not the insert: a whole-insert copy of the row references is what this avoids.
+        var source = new List<Row<int>>();
+        for (int i = 0; i < 500; i++)
+        {
+            source.Add(new Row<int> { Value = i });
+        }
+
+        using PocoRowBuffer<Row<int>> buffer = PocoRowBuffer<Row<int>>.Create(source, "rows", blockRows: 8, CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(buffer.Count, Is.EqualTo(500));
+            Assert.That(buffer.Rows, Has.Length.LessThan(500));
         });
     }
 
     [Test]
     public void Create_EmptyList_HoldsNoRows()
     {
-        using PocoRowBuffer<Row<int>> buffer = PocoRowBuffer<Row<int>>.Create(new List<Row<int>>(), "rows", CancellationToken.None);
+        using PocoRowBuffer<Row<int>> buffer = PocoRowBuffer<Row<int>>.Create(new List<Row<int>>(), "rows", blockRows: 0, CancellationToken.None);
 
         Assert.That(buffer.Count, Is.EqualTo(0));
     }
 
     [Test]
-    public void Create_ListContainingNull_ThrowsNamingTheRowAndTheParameter()
+    public void RowAt_ListInput_ReadsAnyRowWithoutStagingIt()
+    {
+        var third = new Row<int> { Value = 3 };
+        var source = new List<Row<int>> { new() { Value = 1 }, new() { Value = 2 }, third };
+
+        using PocoRowBuffer<Row<int>> buffer = PocoRowBuffer<Row<int>>.Create(source, "rows", blockRows: 1, CancellationToken.None);
+
+        Assert.That(buffer.RowAt(2), Is.SameAs(third));
+    }
+
+    [Test]
+    public void Prepare_ListContainingNull_ThrowsNamingTheRowAndTheParameter()
     {
         var source = new List<Row<int>> { new() { Value = 1 }, null };
+        using PocoRowBuffer<Row<int>> buffer = PocoRowBuffer<Row<int>>.Create(source, "rows", blockRows: 2, CancellationToken.None);
 
-        ArgumentException error = Assert.Throws<ArgumentException>(() => PocoRowBuffer<Row<int>>.Create(source, "rows", CancellationToken.None));
+        ArgumentException error = Assert.Throws<ArgumentException>(() => buffer.Prepare(start: 0, length: 2));
 
         Assert.Multiple(() =>
         {
@@ -67,17 +130,29 @@ public class PocoRowBufferTests
     }
 
     [Test]
-    public void Create_ArrayContainingNull_ThrowsNamingTheRowAndTheParameter()
+    public void Prepare_ArrayContainingNull_ThrowsNamingTheRowAndTheParameter()
     {
         Row<int>[] source = { new() { Value = 1 }, null };
+        using PocoRowBuffer<Row<int>> buffer = PocoRowBuffer<Row<int>>.Create(source, "rows", blockRows: 2, CancellationToken.None);
 
-        ArgumentException error = Assert.Throws<ArgumentException>(() => PocoRowBuffer<Row<int>>.Create(source, "rows", CancellationToken.None));
+        ArgumentException error = Assert.Throws<ArgumentException>(() => buffer.Prepare(start: 0, length: 2));
 
         Assert.Multiple(() =>
         {
             Assert.That(error.Message, Does.Contain("Row 1"));
             Assert.That(error.ParamName, Is.EqualTo("rows"));
         });
+    }
+
+    [Test]
+    public void Prepare_NullInALaterBlock_IsNotReportedByAnEarlierOne()
+    {
+        // Each block validates only its own rows, so a bad row surfaces when its block is gathered.
+        var source = new List<Row<int>> { new() { Value = 1 }, null };
+        using PocoRowBuffer<Row<int>> buffer = PocoRowBuffer<Row<int>>.Create(source, "rows", blockRows: 1, CancellationToken.None);
+
+        Assert.DoesNotThrow(() => buffer.Prepare(start: 0, length: 1));
+        Assert.Throws<ArgumentException>(() => buffer.Prepare(start: 1, length: 1));
     }
 
     [Test]
@@ -85,7 +160,7 @@ public class PocoRowBufferTests
     {
         var row = new Row<int> { Value = 1 };
         var source = new[] { row };
-        PocoRowBuffer<Row<int>> buffer = PocoRowBuffer<Row<int>>.Create(source, "rows", CancellationToken.None);
+        PocoRowBuffer<Row<int>> buffer = PocoRowBuffer<Row<int>>.Create(source, "rows", blockRows: 1, CancellationToken.None);
 
         buffer.Dispose();
 
@@ -93,12 +168,13 @@ public class PocoRowBufferTests
     }
 
     [Test]
-    public void Dispose_OwnedCopyCalledTwice_ReleasesItOnce()
+    public void Dispose_OwnedWindowCalledTwice_ReleasesItOnce()
     {
         // A second disposal must not return the same array twice.
         PocoRowBuffer<Row<int>> buffer = PocoRowBuffer<Row<int>>.Create(
             new List<Row<int>> { new() { Value = 1 } },
             "rows",
+            blockRows: 1,
             CancellationToken.None);
 
         buffer.Dispose();
@@ -114,19 +190,19 @@ public class PocoRowBufferTests
         cancellation.Cancel();
 
         Assert.Throws<OperationCanceledException>(
-            () => PocoRowBuffer<Row<int>>.Create(Array.Empty<Row<int>>(), "rows", cancellation.Token));
+            () => PocoRowBuffer<Row<int>>.Create(Array.Empty<Row<int>>(), "rows", blockRows: 0, cancellation.Token));
     }
 
     [Test]
-    public void Create_TokenCancelledDuringCopy_StopsThere()
+    public void Prepare_TokenCancelledDuringStaging_StopsThere()
     {
         using var cancellation = new CancellationTokenSource();
         var source = new CancellingList(cancellation, count: 500, cancelAfter: 3);
+        using PocoRowBuffer<Row<int>> buffer = PocoRowBuffer<Row<int>>.Create(source, "rows", blockRows: 500, cancellation.Token);
 
-        Assert.Throws<OperationCanceledException>(
-            () => PocoRowBuffer<Row<int>>.Create(source, "rows", cancellation.Token));
+        Assert.Throws<OperationCanceledException>(() => buffer.Prepare(start: 0, length: 500));
 
-        Assert.That(source.Read, Is.LessThan(10), "copying stopped where it was cancelled");
+        Assert.That(source.Read, Is.LessThan(10), "staging stopped where it was cancelled");
     }
 
     /// <summary>A list that cancels while its indexer is being read.</summary>

--- a/ClickHouse.Driver.Tcp.Tests/Poco/PocoUntypedColumnsTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Poco/PocoUntypedColumnsTests.cs
@@ -1,0 +1,208 @@
+using System;
+using System.Collections.Generic;
+using ClickHouse.Driver.Tcp.Format;
+using ClickHouse.Driver.Tcp.Poco;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Tests.Poco;
+
+/// <summary>
+/// The untyped <c>object[]</c> insert's transposition. Round-trip coverage is in the integration suite; what is here
+/// is the choice a round trip cannot see — which CLR type each column was written in, which the values themselves
+/// decide — and the failures, which name a row and a column the caller counted.
+///
+/// <para>
+/// The sample blocks are empty columns stamped with the type under test, which is what the server's own sample block
+/// is: only the name and the type string are read, the codec coming from the latter.
+/// </para>
+/// </summary>
+[TestFixture]
+public class PocoUntypedColumnsTests
+{
+    [Test]
+    public void Build_ValuesInTheColumnsCanonicalType_WritesThemUnchanged()
+    {
+        Block schema = SchemaOf(Target("id", "Int32"), Target("name", "String"));
+        object[][] rows = { new object[] { 1, "a" }, new object[] { 2, "b" } };
+
+        IReadOnlyList<IColumn> columns = PocoUntypedColumns.Build(schema, rows, rows.Length);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(columns[0], Is.InstanceOf<IColumn<int>>());
+            Assert.That(columns[1], Is.InstanceOf<IColumn<string>>());
+            Assert.That(columns[0].GetValue(1), Is.EqualTo(2));
+            Assert.That(columns[1].GetValue(1), Is.EqualTo("b"));
+        });
+    }
+
+    [Test]
+    public void Build_ValuesInAConvenienceType_WritesThemInThatTypeRatherThanTheWireCount()
+    {
+        // What lets rows written by hand and rows from an untyped read both work: a DateTime column takes either
+        // spelling, and the one the values are in is the one the codec is handed.
+        Block schema = SchemaOf(Target("raw", "DateTime('UTC')"), Target("calendar", "DateTime('UTC')"));
+        object[][] rows = { new object[] { 1_700_000_000u, DateTime.UnixEpoch } };
+
+        IReadOnlyList<IColumn> columns = PocoUntypedColumns.Build(schema, rows, rows.Length);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(columns[0], Is.InstanceOf<IColumn<uint>>());
+            Assert.That(columns[1], Is.InstanceOf<IColumn<DateTime>>());
+        });
+    }
+
+    [Test]
+    public void Build_LeadingNulls_TakeTheTypeFromTheFirstRowWithAValue()
+    {
+        Block schema = SchemaOf(Target("value", "Nullable(DateTime('UTC'))"));
+        object[][] rows = { new object[] { null }, new object[] { DateTime.UnixEpoch } };
+
+        IReadOnlyList<IColumn> columns = PocoUntypedColumns.Build(schema, rows, rows.Length);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(columns[0], Is.InstanceOf<IColumn<DateTime?>>());
+            Assert.That(columns[0].GetValue(0), Is.Null);
+            Assert.That(columns[0].GetValue(1), Is.EqualTo(DateTime.UnixEpoch));
+        });
+    }
+
+    [Test]
+    public void Build_ColumnOfOnlyNulls_FallsBackToTheTargetsCanonicalType()
+    {
+        // Nothing names a type, so the target's own leading write type is the only answer available — and the right
+        // one, since a Nullable target takes the nulls whichever spelling carries them.
+        Block schema = SchemaOf(Target("value", "Nullable(Int32)"));
+        object[][] rows = { new object[] { null }, new object[] { null } };
+
+        IReadOnlyList<IColumn> columns = PocoUntypedColumns.Build(schema, rows, rows.Length);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(columns[0], Is.InstanceOf<IColumn<int?>>());
+            Assert.That(columns[0].GetValue(0), Is.Null);
+        });
+    }
+
+    [Test]
+    public void Build_NullInANonNullableColumn_ThrowsNamingTheRowAndTheColumn()
+    {
+        Block schema = SchemaOf(Target("value", "Int32"));
+        object[][] rows = { new object[] { 1 }, new object[] { null } };
+
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => PocoUntypedColumns.Build(schema, rows, rows.Length));
+
+        Assert.That(error.Message, Does.Contain("row 1").And.Contain("value"));
+    }
+
+    [Test]
+    public void Build_ALaterColumnFailing_ThrowsNamingIt()
+    {
+        // Also the path that releases what the earlier columns rented — each is filled into its own buffer, and only
+        // the column that wraps one returns it. The release itself is not observable; this pins the failure.
+        Block schema = SchemaOf(Target("ok", "Int32"), Target("bad", "Int32"));
+        object[][] rows = { new object[] { 1, null } };
+
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => PocoUntypedColumns.Build(schema, rows, rows.Length));
+
+        Assert.That(error.Message, Does.Contain("bad"));
+    }
+
+    [Test]
+    public void Build_MixedTypesInOneColumn_ThrowsNamingTheRow()
+    {
+        // The type is settled by the first row that has a value, so a later row in another type would otherwise fail
+        // as a bare unboxing error with no row to point at.
+        Block schema = SchemaOf(Target("value", "Int32"));
+        object[][] rows = { new object[] { 1 }, new object[] { "two" } };
+
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => PocoUntypedColumns.Build(schema, rows, rows.Length));
+
+        Assert.That(error.Message, Does.Contain("row 1").And.Contain("System.String"));
+    }
+
+    [Test]
+    public void Build_ADynamicTarget_TakesEveryValueThroughItsObjectSurface()
+    {
+        // Dynamic and Variant are written from a column of object, so the type sniffing has nothing to reject and a
+        // column may legitimately hold values of several types.
+        Block schema = SchemaOf(Target("value", "Dynamic"));
+        object[][] rows = { new object[] { 1 }, new object[] { "two" } };
+
+        IReadOnlyList<IColumn> columns = PocoUntypedColumns.Build(schema, rows, rows.Length);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(columns[0], Is.InstanceOf<IColumn<object>>());
+            Assert.That(columns[0].GetValue(1), Is.EqualTo("two"));
+        });
+    }
+
+    [Test]
+    public void Build_ValueOfATypeTheColumnDoesNotAccept_ThrowsNamingWhatItAccepts()
+    {
+        Block schema = SchemaOf(Target("value", "Int32"));
+        object[][] rows = { new object[] { "not a number" } };
+
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => PocoUntypedColumns.Build(schema, rows, rows.Length));
+
+        Assert.That(error.Message, Does.Contain("System.String").And.Contain("System.Int32"));
+    }
+
+    [Test]
+    public void Build_RowOfTheWrongLength_ThrowsNamingTheRowAndTheTargets()
+    {
+        Block schema = SchemaOf(Target("id", "Int32"), Target("name", "String"));
+        object[][] rows = { new object[] { 1, "a" }, new object[] { 2 } };
+
+        ArgumentException error = Assert.Throws<ArgumentException>(() => PocoUntypedColumns.Build(schema, rows, rows.Length));
+
+        Assert.That(error.Message, Does.Contain("Row 1").And.Contain("id, name"));
+    }
+
+    [Test]
+    public void Build_TargetWhoseWriterNeedsItsOwnColumnShape_SaysToUseTheColumnarApi()
+    {
+        Block schema = SchemaOf(Target("value", "Nested(a UInt8, b String)"));
+        object[][] rows = { new object[] { Array.Empty<object[]>() } };
+
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => PocoUntypedColumns.Build(schema, rows, rows.Length));
+
+        Assert.That(error.Message, Does.Contain("columnar API"));
+    }
+
+    [Test]
+    public void Build_ZeroRows_BuildsAnEmptyColumnPerTarget()
+    {
+        Block schema = SchemaOf(Target("id", "Int32"), Target("name", "String"));
+
+        IReadOnlyList<IColumn> columns = PocoUntypedColumns.Build(schema, Array.Empty<object[]>(), rowCount: 0);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(columns, Has.Count.EqualTo(2));
+            Assert.That(columns[0].RowCount, Is.EqualTo(0));
+            Assert.That(columns[1].RowCount, Is.EqualTo(0));
+        });
+    }
+
+    [Test]
+    public void Build_FewerRowsThanTheBuffer_ReadsOnlyTheRowsAsked()
+    {
+        // The rows arrive in a pooled array that is usually longer than the insert, and the entries past the count
+        // are whatever the pool last held.
+        Block schema = SchemaOf(Target("value", "Int32"));
+        object[][] rows = { new object[] { 1 }, new object[] { 2 }, null };
+
+        IReadOnlyList<IColumn> columns = PocoUntypedColumns.Build(schema, rows, rowCount: 2);
+
+        Assert.That(columns[0].RowCount, Is.EqualTo(2));
+    }
+
+    private static IColumn Target(string name, string typeName) => new ArrayColumn<object>(name, typeName, Array.Empty<object>());
+
+    private static Block SchemaOf(params IColumn[] columns)
+        => new(string.Empty, BlockInfo.Default, rowCount: 0, columns, ColumnCodecRegistry.Default, new ResolveContext { ServerTimezone = "UTC" });
+}

--- a/ClickHouse.Driver.Tcp.Tests/Poco/PocoWritePlanTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Poco/PocoWritePlanTests.cs
@@ -376,11 +376,10 @@ public class PocoWritePlanTests
     }
 
     [Test]
-    public void WritePlanFor_SameSchemaDifferentSessionTimezone_ReturnsTheCachedPlan()
+    public void WritePlanFor_SameSchemaDifferentSessionTimezone_CompilesItsOwnPlan()
     {
-        // The read plan keys on the session timezone, because a bare DateTime column is *presented* in it. The write
-        // path resolves its codecs in ResolveContext.ForWrite, which carries no session timezone at all, so one
-        // target shape is one plan whatever the session's is.
+        // A bare DateTime target interprets an Unspecified property in the session timezone. The type string does
+        // not carry that context, so the cache key must: a plan compiled for UTC cannot serve Kolkata's wall clock.
         var registry = new PocoTypeRegistry();
         var utc = new ResolveContext { ServerTimezone = "UTC" };
         var kolkata = new ResolveContext { ServerTimezone = "Asia/Kolkata" };
@@ -388,7 +387,7 @@ public class PocoWritePlanTests
         PocoWritePlan<Row<DateTime>> first = registry.WritePlanFor<Row<DateTime>>(SchemaOf(utc, Target("value", "DateTime")));
         PocoWritePlan<Row<DateTime>> second = registry.WritePlanFor<Row<DateTime>>(SchemaOf(kolkata, Target("value", "DateTime")));
 
-        Assert.That(second, Is.SameAs(first));
+        Assert.That(second, Is.Not.SameAs(first));
     }
 
     [Test]

--- a/ClickHouse.Driver.Tcp.Tests/Poco/PocoWritePlanTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Poco/PocoWritePlanTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using ClickHouse.Driver.Tcp.Format;
 using ClickHouse.Driver.Tcp.Poco;
 using ClickHouse.Driver.Tcp.Tests.Utilities;
@@ -76,46 +77,46 @@ public class PocoWritePlanTests
     }
 
     [Test]
-    public void BuildColumns_CalendarProperty_WritesThroughTheCalendarTypeNotTheWireCount()
+    public void Gather_CalendarProperty_WritesThroughTheCalendarTypeNotTheWireCount()
     {
         // Leave DateTime conversion to the codec.
         Block schema = SchemaOf(Target("value", "DateTime('UTC')"));
         var rows = new[] { new Row<DateTime> { Value = DateTime.UnixEpoch } };
 
-        IReadOnlyList<IColumn> columns = Plan<Row<DateTime>>(schema).BuildColumns(rows, rows.Length);
+        using PocoInsertSource<Row<DateTime>> source = GatherAll(Plan<Row<DateTime>>(schema), rows, rows.Length);
 
-        Assert.That(columns[0], Is.InstanceOf<IColumn<DateTime>>());
+        Assert.That(source.Columns[0], Is.InstanceOf<IColumn<DateTime>>());
     }
 
     [Test]
-    public void BuildColumns_NonNullablePropertyIntoANullableColumn_LiftsToTheNullableWriteType()
+    public void Gather_NonNullablePropertyIntoANullableColumn_LiftsToTheNullableWriteType()
     {
         Block schema = SchemaOf(Target("value", "Nullable(Int32)"));
         var rows = new[] { new Row<int> { Value = 42 } };
 
-        IReadOnlyList<IColumn> columns = Plan<Row<int>>(schema).BuildColumns(rows, rows.Length);
+        using PocoInsertSource<Row<int>> source = GatherAll(Plan<Row<int>>(schema), rows, rows.Length);
 
         Assert.Multiple(() =>
         {
-            Assert.That(columns[0], Is.InstanceOf<IColumn<int?>>());
-            Assert.That(columns[0].GetValue(0), Is.EqualTo(42));
+            Assert.That(source.Columns[0], Is.InstanceOf<IColumn<int?>>());
+            Assert.That(source.Columns[0].GetValue(0), Is.EqualTo(42));
         });
     }
 
     [Test]
-    public void BuildColumns_NullableCalendarProperty_WritesThroughTheLiftedCalendarType()
+    public void Gather_NullableCalendarProperty_WritesThroughTheLiftedCalendarType()
     {
         // Verify that nullable codecs expose their lifted calendar spelling.
         Block schema = SchemaOf(Target("value", "Nullable(DateTime('UTC'))"));
         var rows = new[] { new Row<DateTime?> { Value = DateTime.UnixEpoch }, new Row<DateTime?> { Value = null } };
 
-        IReadOnlyList<IColumn> columns = Plan<Row<DateTime?>>(schema).BuildColumns(rows, rows.Length);
+        using PocoInsertSource<Row<DateTime?>> source = GatherAll(Plan<Row<DateTime?>>(schema), rows, rows.Length);
 
         Assert.Multiple(() =>
         {
-            Assert.That(columns[0], Is.InstanceOf<IColumn<DateTime?>>());
-            Assert.That(columns[0].GetValue(0), Is.EqualTo(DateTime.UnixEpoch));
-            Assert.That(columns[0].GetValue(1), Is.Null);
+            Assert.That(source.Columns[0], Is.InstanceOf<IColumn<DateTime?>>());
+            Assert.That(source.Columns[0].GetValue(0), Is.EqualTo(DateTime.UnixEpoch));
+            Assert.That(source.Columns[0].GetValue(1), Is.Null);
         });
     }
 
@@ -129,173 +130,242 @@ public class PocoWritePlanTests
 
         Assert.That(descriptor.CanActivate, Is.False, "the type a query could not materialize");
 
-        IReadOnlyList<IColumn> columns = PocoWritePlan<ConstructorOnlyPoco>.Build(descriptor, schema).BuildColumns(rows, rows.Length);
+        using PocoInsertSource<ConstructorOnlyPoco> source =
+            GatherAll(PocoWritePlan<ConstructorOnlyPoco>.Build(descriptor, schema), rows, rows.Length);
 
-        Assert.That(columns[0].GetValue(0), Is.EqualTo(7));
+        Assert.That(source.Columns[0].GetValue(0), Is.EqualTo(7));
     }
 
     [Test]
-    public void BuildColumns_NullablePropertyIntoANullableColumn_CarriesTheNullThrough()
+    public void Gather_NullablePropertyIntoANullableColumn_CarriesTheNullThrough()
     {
         Block schema = SchemaOf(Target("value", "Nullable(Int32)"));
         var rows = new[] { new Row<int?> { Value = null }, new Row<int?> { Value = 7 } };
 
-        IReadOnlyList<IColumn> columns = Plan<Row<int?>>(schema).BuildColumns(rows, rows.Length);
+        using PocoInsertSource<Row<int?>> source = GatherAll(Plan<Row<int?>>(schema), rows, rows.Length);
 
         Assert.Multiple(() =>
         {
-            Assert.That(columns[0].GetValue(0), Is.Null);
-            Assert.That(columns[0].GetValue(1), Is.EqualTo(7));
+            Assert.That(source.Columns[0].GetValue(0), Is.Null);
+            Assert.That(source.Columns[0].GetValue(1), Is.EqualTo(7));
         });
     }
 
     [Test]
-    public void BuildColumns_NullPropertyIntoANonNullableColumn_ThrowsNamingTheRow()
+    public void Gather_NullPropertyIntoANonNullableColumn_ThrowsNamingTheRow()
     {
         // Nullability is checked per row because non-null values remain valid.
         Block schema = SchemaOf(Target("value", "Int32"));
         var rows = new[] { new Row<int?> { Value = 1 }, new Row<int?> { Value = null } };
         PocoWritePlan<Row<int?>> plan = Plan<Row<int?>>(schema);
 
-        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => plan.BuildColumns(rows, rows.Length));
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => GatherAll(plan, rows, rows.Length));
 
         Assert.That(error.Message, Does.Contain("row 1").And.Contain("value").And.Contain("Value"));
     }
 
     [Test]
-    public void BuildColumns_ALaterColumnFailing_ThrowsNamingIt()
+    public void Gather_ASecondBlock_NamesTheRowByItsNumberInTheInsertNotInTheBlock()
+    {
+        // The row a value failed at must be the caller's row number, whichever block held it.
+        Block schema = SchemaOf(Target("value", "Int32"));
+        var rows = new[] { new Row<int?> { Value = 1 }, new Row<int?> { Value = 2 }, new Row<int?> { Value = null } };
+        using var buffer = PocoRowBuffer<Row<int?>>.Create(rows, "rows", blockRows: 2, CancellationToken.None);
+        using PocoInsertSource<Row<int?>> source = Plan<Row<int?>>(schema).CreateSource(buffer, blockRows: 2);
+
+        source.Gather(0, 2);
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => source.Gather(2, 1));
+
+        Assert.That(error.Message, Does.Contain("row 2"));
+    }
+
+    [Test]
+    public void Gather_ALaterColumnFailing_ThrowsNamingIt()
     {
         // A later failure also exercises cleanup of earlier columns.
         Block schema = SchemaOf(Target("Ok", "Int32"), Target("Bad", "Int32"));
         var rows = new[] { new TwoValues { Ok = 1, Bad = null } };
         PocoWritePlan<TwoValues> plan = Plan<TwoValues>(schema);
 
-        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => plan.BuildColumns(rows, rows.Length));
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => GatherAll(plan, rows, rows.Length));
 
         Assert.That(error.Message, Does.Contain("Bad"));
     }
 
     [Test]
-    public void BuildColumns_NullablePropertyIntoAColumnWrittenFromObject_CarriesTheNullThrough()
+    public void Gather_NullablePropertyIntoAColumnWrittenFromObject_CarriesTheNullThrough()
     {
         // Dynamic's object surface can carry null.
         Block schema = SchemaOf(Target("value", "Dynamic"));
         var rows = new[] { new Row<int?> { Value = null }, new Row<int?> { Value = 7 } };
 
-        IReadOnlyList<IColumn> columns = Plan<Row<int?>>(schema).BuildColumns(rows, rows.Length);
+        using PocoInsertSource<Row<int?>> source = GatherAll(Plan<Row<int?>>(schema), rows, rows.Length);
 
         Assert.Multiple(() =>
         {
-            Assert.That(columns[0], Is.InstanceOf<IColumn<object>>());
-            Assert.That(columns[0].GetValue(0), Is.Null);
-            Assert.That(columns[0].GetValue(1), Is.EqualTo(7));
+            Assert.That(source.Columns[0], Is.InstanceOf<IColumn<object>>());
+            Assert.That(source.Columns[0].GetValue(0), Is.Null);
+            Assert.That(source.Columns[0].GetValue(1), Is.EqualTo(7));
         });
     }
 
     [Test]
-    public void BuildColumns_NullStringPropertyIntoANonNullableColumn_ThrowsNamingTheRow()
+    public void Gather_NullStringPropertyIntoANonNullableColumn_ThrowsNamingTheRow()
     {
-        // Reject null references before any block is written.
+        // Reject null references before the block is written.
         Block schema = SchemaOf(Target("value", "String"));
         var rows = new[] { new Row<string> { Value = "a" }, new Row<string> { Value = null } };
         PocoWritePlan<Row<string>> plan = Plan<Row<string>>(schema);
 
-        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => plan.BuildColumns(rows, rows.Length));
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => GatherAll(plan, rows, rows.Length));
 
         Assert.That(error.Message, Does.Contain("row 1").And.Contain("value").And.Contain("Value"));
     }
 
     [Test]
-    public void BuildColumns_NullArrayPropertyIntoANonNullableColumn_ThrowsNamingTheRow()
+    public void Gather_NullArrayPropertyIntoANonNullableColumn_ThrowsNamingTheRow()
     {
         // The same rule reaches every reference-typed write type, not just string.
         Block schema = SchemaOf(Target("value", "Array(Int32)"));
         var rows = new[] { new Row<int[]> { Value = new[] { 1 } }, new Row<int[]> { Value = null } };
         PocoWritePlan<Row<int[]>> plan = Plan<Row<int[]>>(schema);
 
-        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => plan.BuildColumns(rows, rows.Length));
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => GatherAll(plan, rows, rows.Length));
 
         Assert.That(error.Message, Does.Contain("row 1"));
     }
 
     [Test]
-    public void BuildColumns_NullReferencePropertyIntoANullableColumn_CarriesTheNullThrough()
+    public void Gather_NullReferencePropertyIntoANullableColumn_CarriesTheNullThrough()
     {
         // A nullable target accepts the reference null directly.
         Block schema = SchemaOf(Target("value", "Nullable(String)"));
         var rows = new[] { new Row<string> { Value = "a" }, new Row<string> { Value = null } };
 
-        IReadOnlyList<IColumn> columns = Plan<Row<string>>(schema).BuildColumns(rows, rows.Length);
+        using PocoInsertSource<Row<string>> source = GatherAll(Plan<Row<string>>(schema), rows, rows.Length);
 
         Assert.Multiple(() =>
         {
-            Assert.That(columns[0].GetValue(0), Is.EqualTo("a"));
-            Assert.That(columns[0].GetValue(1), Is.Null);
+            Assert.That(source.Columns[0].GetValue(0), Is.EqualTo("a"));
+            Assert.That(source.Columns[0].GetValue(1), Is.Null);
         });
     }
 
     [Test]
-    public void BuildColumns_EnumProperty_WritesTheOrdinal()
+    public void Gather_EnumProperty_WritesTheOrdinal()
     {
         Block schema = SchemaOf(Target("value", "Enum8('low' = -1, 'high' = 127)"));
         var rows = new[] { new Row<Level> { Value = Level.High } };
 
-        IReadOnlyList<IColumn> columns = Plan<Row<Level>>(schema).BuildColumns(rows, rows.Length);
+        using PocoInsertSource<Row<Level>> source = GatherAll(Plan<Row<Level>>(schema), rows, rows.Length);
 
         Assert.Multiple(() =>
         {
-            Assert.That(columns[0], Is.InstanceOf<IColumn<sbyte>>());
-            Assert.That(columns[0].GetValue(0), Is.EqualTo((sbyte)127));
+            Assert.That(source.Columns[0], Is.InstanceOf<IColumn<sbyte>>());
+            Assert.That(source.Columns[0].GetValue(0), Is.EqualTo((sbyte)127));
         });
     }
 
     [Test]
-    public void BuildColumns_PropertyMatchingNoTargetColumn_IsNotInserted()
+    public void Gather_PropertyMatchingNoTargetColumn_IsNotInserted()
     {
         // Properties not named by the INSERT are ignored.
         Block schema = SchemaOf(Target("Id", "Int32"));
         var rows = new[] { new IdName { Id = 3, Name = "not inserted" } };
 
-        IReadOnlyList<IColumn> columns = Plan<IdName>(schema).BuildColumns(rows, rows.Length);
+        using PocoInsertSource<IdName> source = GatherAll(Plan<IdName>(schema), rows, rows.Length);
 
         Assert.Multiple(() =>
         {
-            Assert.That(columns, Has.Count.EqualTo(1));
-            Assert.That(columns[0].Name, Is.EqualTo("Id"));
-            Assert.That(columns[0].GetValue(0), Is.EqualTo(3));
+            Assert.That(source.Columns, Has.Count.EqualTo(1));
+            Assert.That(source.Columns[0].Name, Is.EqualTo("Id"));
+            Assert.That(source.Columns[0].GetValue(0), Is.EqualTo(3));
         });
     }
 
     [Test]
-    public void BuildColumns_SeveralTargets_AreBuiltInSchemaOrderWithTheTargetsNamesAndTypes()
+    public void Gather_SeveralTargets_AreFilledInSchemaOrderWithTheTargetsNamesAndTypes()
     {
         // Output columns follow the sample block's order, names, and types.
         Block schema = SchemaOf(Target("Name", "String"), Target("Id", "Int32"));
         var rows = new[] { new IdName { Id = 1, Name = "a" }, new IdName { Id = 2, Name = "b" } };
 
-        IReadOnlyList<IColumn> columns = Plan<IdName>(schema).BuildColumns(rows, rows.Length);
+        using PocoInsertSource<IdName> source = GatherAll(Plan<IdName>(schema), rows, rows.Length);
 
         Assert.Multiple(() =>
         {
-            Assert.That(columns[0].Name, Is.EqualTo("Name"));
-            Assert.That(columns[0].TypeName, Is.EqualTo("String"));
-            Assert.That(columns[0].RowCount, Is.EqualTo(2));
-            Assert.That(columns[1].Name, Is.EqualTo("Id"));
-            Assert.That(columns[1].TypeName, Is.EqualTo("Int32"));
-            Assert.That(columns[1].GetValue(1), Is.EqualTo(2));
+            Assert.That(source.Columns[0].Name, Is.EqualTo("Name"));
+            Assert.That(source.Columns[0].TypeName, Is.EqualTo("String"));
+            Assert.That(source.Columns[0].RowCount, Is.EqualTo(2));
+            Assert.That(source.Columns[1].Name, Is.EqualTo("Id"));
+            Assert.That(source.Columns[1].TypeName, Is.EqualTo("Int32"));
+            Assert.That(source.Columns[1].GetValue(1), Is.EqualTo(2));
         });
     }
 
     [Test]
-    public void BuildColumns_FewerRowsThanTheBuffer_ExposesOnlyTheRowsAsked()
+    public void Gather_FewerRowsThanTheBuffer_ExposesOnlyTheRowsAsked()
     {
-        // Use the logical row count, not the pooled buffer length.
+        // Use the block's row count, not the pooled buffer length.
         Block schema = SchemaOf(Target("value", "Int32"));
         var rows = new[] { new Row<int> { Value = 1 }, new Row<int> { Value = 2 }, new Row<int> { Value = 3 } };
 
-        IReadOnlyList<IColumn> columns = Plan<Row<int>>(schema).BuildColumns(rows, rowCount: 2);
+        using PocoInsertSource<Row<int>> source = GatherAll(Plan<Row<int>>(schema), rows, rowCount: 2);
 
-        Assert.That(columns[0].RowCount, Is.EqualTo(2));
+        Assert.That(source.Columns[0].RowCount, Is.EqualTo(2));
+    }
+
+    [Test]
+    public void CreateSource_BeforeTheFirstGather_HoldsColumnsWithNoRows()
+    {
+        // The insert plan is built from these columns before any row is converted.
+        Block schema = SchemaOf(Target("value", "Int32"));
+        var rows = new[] { new Row<int> { Value = 1 } };
+        using var buffer = PocoRowBuffer<Row<int>>.Create(rows, "rows", blockRows: 1, CancellationToken.None);
+
+        using PocoInsertSource<Row<int>> source = Plan<Row<int>>(schema).CreateSource(buffer, blockRows: 1);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(source.Columns, Has.Count.EqualTo(1));
+            Assert.That(source.Columns[0].RowCount, Is.Zero);
+            Assert.That(source.Columns[0], Is.InstanceOf<IColumn<int>>());
+        });
+    }
+
+    [Test]
+    public void Gather_EachBlockInTurn_ReusesTheSameColumnObjects()
+    {
+        // The write plan holds these columns, so their identity has to survive every block.
+        Block schema = SchemaOf(Target("value", "Int32"));
+        var rows = new[] { new Row<int> { Value = 1 }, new Row<int> { Value = 2 }, new Row<int> { Value = 3 } };
+        using var buffer = PocoRowBuffer<Row<int>>.Create(rows, "rows", blockRows: 2, CancellationToken.None);
+        using PocoInsertSource<Row<int>> source = Plan<Row<int>>(schema).CreateSource(buffer, blockRows: 2);
+
+        source.Gather(0, 2);
+        IColumn first = source.Columns[0];
+        object firstBlock = first.GetValue(1);
+
+        source.Gather(2, 1);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(firstBlock, Is.EqualTo(2));
+            Assert.That(source.Columns[0], Is.SameAs(first));
+            Assert.That(source.Columns[0].RowCount, Is.EqualTo(1), "the column holds the current block only");
+            Assert.That(source.Columns[0].GetValue(0), Is.EqualTo(3));
+        });
+    }
+
+    [Test]
+    public void Gather_ABlockLongerThanTheBuffer_ThrowsRatherThanWriteAWrongSizedBlock()
+    {
+        Block schema = SchemaOf(Target("value", "Int32"));
+        var rows = new[] { new Row<int> { Value = 1 }, new Row<int> { Value = 2 } };
+        using var buffer = PocoRowBuffer<Row<int>>.Create(rows, "rows", blockRows: 1, CancellationToken.None);
+        using PocoInsertSource<Row<int>> source = Plan<Row<int>>(schema).CreateSource(buffer, blockRows: 1);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => source.Gather(0, 2));
     }
 
     [Test]
@@ -319,11 +389,13 @@ public class PocoWritePlanTests
         PocoWritePlan<Row<int>> nullables = registry.WritePlanFor<Row<int>>(SchemaOf(Target("value", "Nullable(Int32)")));
 
         var rows = new[] { new Row<int> { Value = 1 } };
+        using PocoInsertSource<Row<int>> intSource = GatherAll(ints, rows, rows.Length);
+        using PocoInsertSource<Row<int>> nullableSource = GatherAll(nullables, rows, rows.Length);
         Assert.Multiple(() =>
         {
             Assert.That(nullables, Is.Not.SameAs(ints));
-            Assert.That(ints.BuildColumns(rows, 1)[0], Is.InstanceOf<IColumn<int>>());
-            Assert.That(nullables.BuildColumns(rows, 1)[0], Is.InstanceOf<IColumn<int?>>());
+            Assert.That(intSource.Columns[0], Is.InstanceOf<IColumn<int>>());
+            Assert.That(nullableSource.Columns[0], Is.InstanceOf<IColumn<int?>>());
         });
     }
 
@@ -339,11 +411,13 @@ public class PocoWritePlanTests
         PocoWritePlan<SeparatorColumns> threePlan = registry.WritePlanFor<SeparatorColumns>(three);
 
         var rows = new[] { new SeparatorColumns { Id = 1, Spelled = 9, Name = 2, Score = 3 } };
+        using PocoInsertSource<SeparatorColumns> spelledSource = GatherAll(spelledPlan, rows, rows.Length);
+        using PocoInsertSource<SeparatorColumns> threeSource = GatherAll(threePlan, rows, rows.Length);
         Assert.Multiple(() =>
         {
             Assert.That(threePlan, Is.Not.SameAs(spelledPlan));
-            Assert.That(Names(spelledPlan.BuildColumns(rows, 1)), Is.EqualTo(new[] { "Id", "Name\tInt32\nScore" }));
-            Assert.That(Names(threePlan.BuildColumns(rows, 1)), Is.EqualTo(new[] { "Id", "Name", "Score" }));
+            Assert.That(Names(spelledSource.Columns), Is.EqualTo(new[] { "Id", "Name\tInt32\nScore" }));
+            Assert.That(Names(threeSource.Columns), Is.EqualTo(new[] { "Id", "Name", "Score" }));
         });
     }
 
@@ -374,6 +448,28 @@ public class PocoWritePlanTests
     private static PocoWritePlan<T> Plan<T>(Block schema)
         where T : class
         => PocoWritePlan<T>.Build(PocoTypeDescriptor<T>.Build(), schema);
+
+    /// <summary>
+    /// Gathers the rows as a single block. The source is returned rather than its columns, because it owns the
+    /// buffers the columns read from.
+    /// </summary>
+    private static PocoInsertSource<T> GatherAll<T>(PocoWritePlan<T> plan, T[] rows, int rowCount)
+        where T : class
+    {
+        // The rows are an array, so the buffer borrows them and holds nothing past the gather.
+        using var buffer = PocoRowBuffer<T>.Create(rows, "rows", rowCount, CancellationToken.None);
+        PocoInsertSource<T> source = plan.CreateSource(buffer, rowCount);
+        try
+        {
+            source.Gather(0, rowCount);
+            return source;
+        }
+        catch
+        {
+            source.Dispose();
+            throw;
+        }
+    }
 
     private static string[] Names(IReadOnlyList<IColumn> columns)
     {

--- a/ClickHouse.Driver.Tcp.Tests/Poco/PocoWritePlanTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Poco/PocoWritePlanTests.cs
@@ -1,0 +1,493 @@
+using System;
+using System.Collections.Generic;
+using ClickHouse.Driver.Tcp.Format;
+using ClickHouse.Driver.Tcp.Poco;
+using ClickHouse.Driver.Tcp.Tests.Utilities;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Tests.Poco;
+
+/// <summary>
+/// The compiled write plan: which CLR type a target column is written in, which (property type, column type) pairs
+/// are accepted, and which are refused. Per-type value coverage lives in the integration suite, driven off the
+/// round-trip corpus; what is here is what a server round trip cannot reach — the refusals, the write type the plan
+/// picked (a round trip sees only the values, not the spelling they went out in), and the plan cache key.
+///
+/// <para>
+/// A plan reads only a target column's name and <see cref="IColumn.TypeName"/> — the codec comes from the type
+/// string — so the sample blocks here are empty columns stamped with the type under test, which is what the
+/// server's own sample block is.
+/// </para>
+/// </summary>
+[TestFixture]
+public class PocoWritePlanTests
+{
+    [Test]
+    public void Build_TargetColumnMatchingNoProperty_Throws()
+    {
+        // Unlike a read, where an unmapped column is simply not read, every target column has to be filled: the
+        // server expects a value for each column of the statement's list.
+        Block schema = SchemaOf(Target("value", "Int32"), Target("extra", "String"));
+
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => Plan<Row<int>>(schema));
+
+        Assert.That(error.Message, Does.Contain("extra").And.Contain("INSERT INTO t (a, b) VALUES"));
+    }
+
+    [Test]
+    public void Build_PropertyWithNoPublicGetter_Throws()
+    {
+        Block schema = SchemaOf(Target("Value", "Int32"));
+
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => Plan<SetterOnlyPoco>(schema));
+
+        Assert.That(error.Message, Does.Contain("no public getter"));
+    }
+
+    [Test]
+    public void Build_TwoTargetColumnsReachingOneProperty_Throws()
+    {
+        // Both names reach UserId through the matcher's looser tiers, and one property cannot decide which column it
+        // means — the mirror of the read side's refusal.
+        Block schema = SchemaOf(Target("user_id", "Int32"), Target("userId", "Int32"));
+
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => Plan<UserRow>(schema));
+
+        Assert.That(error.Message, Does.Contain("user_id").And.Contain("userId").And.Contain("UserId"));
+    }
+
+    [Test]
+    public void Build_PropertyTypeTheColumnCannotBeWrittenFrom_ThrowsNamingWhatItAccepts()
+    {
+        Block schema = SchemaOf(Target("value", "Int32"));
+
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => Plan<Row<Guid>>(schema));
+
+        Assert.That(error.Message, Does.Contain("System.Guid").And.Contain("System.Int32"));
+    }
+
+    [Test]
+    public void Build_WideningPropertyType_IsDeclined()
+    {
+        // D6c, in the write direction: an Int32 property does not fill an Int64 column, because a POCO that inserts
+        // has to be a POCO that reads back, and the read side declines the same pair.
+        Block schema = SchemaOf(Target("value", "Int64"));
+
+        Assert.Throws<InvalidOperationException>(() => Plan<Row<int>>(schema));
+    }
+
+    [Test]
+    public void Build_TargetWhoseWriterNeedsItsOwnColumnShape_SaysToUseTheColumnarApi()
+    {
+        // Nested writes from flat field columns behind shared offsets, a shape no property can hold. Naming the CLR
+        // types it "accepts" would send the caller round a loop they cannot win, so the message names the way out.
+        Block schema = SchemaOf(Target("value", "Nested(a UInt8, b String)"));
+
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => Plan<Row<object[][]>>(schema));
+
+        Assert.That(error.Message, Does.Contain("columnar API"));
+    }
+
+    [Test]
+    public void BuildColumns_CalendarProperty_WritesThroughTheCalendarTypeNotTheWireCount()
+    {
+        // The choice a round trip cannot observe: the plan hands the codec a DateTime column and lets it do the
+        // epoch arithmetic, rather than converting to the canonical uint itself.
+        Block schema = SchemaOf(Target("value", "DateTime('UTC')"));
+        var rows = new[] { new Row<DateTime> { Value = DateTime.UnixEpoch } };
+
+        IReadOnlyList<IColumn> columns = Plan<Row<DateTime>>(schema).BuildColumns(rows, rows.Length);
+
+        Assert.That(columns[0], Is.InstanceOf<IColumn<DateTime>>());
+    }
+
+    [Test]
+    public void BuildColumns_NonNullablePropertyIntoANullableColumn_LiftsToTheNullableWriteType()
+    {
+        Block schema = SchemaOf(Target("value", "Nullable(Int32)"));
+        var rows = new[] { new Row<int> { Value = 42 } };
+
+        IReadOnlyList<IColumn> columns = Plan<Row<int>>(schema).BuildColumns(rows, rows.Length);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(columns[0], Is.InstanceOf<IColumn<int?>>());
+            Assert.That(columns[0].GetValue(0), Is.EqualTo(42));
+        });
+    }
+
+    [Test]
+    public void BuildColumns_NullableCalendarProperty_WritesThroughTheLiftedCalendarType()
+    {
+        // A Nullable(DateTime) column accepts DateTime? only because the codec lifts its inner's write types to its
+        // own nullable surface. Which of the three lifted spellings was chosen is invisible to a round trip.
+        Block schema = SchemaOf(Target("value", "Nullable(DateTime('UTC'))"));
+        var rows = new[] { new Row<DateTime?> { Value = DateTime.UnixEpoch }, new Row<DateTime?> { Value = null } };
+
+        IReadOnlyList<IColumn> columns = Plan<Row<DateTime?>>(schema).BuildColumns(rows, rows.Length);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(columns[0], Is.InstanceOf<IColumn<DateTime?>>());
+            Assert.That(columns[0].GetValue(0), Is.EqualTo(DateTime.UnixEpoch));
+            Assert.That(columns[0].GetValue(1), Is.Null);
+        });
+    }
+
+    [Test]
+    public void Build_TypeThatCannotBeMaterialized_StillBuildsAWritePlan()
+    {
+        // The read plan asks the descriptor for its activator before anything else, so an immutable POCO fails
+        // there. An insert never constructs a T, so the write plan must not ask — that is what makes such a type
+        // insert-only rather than unusable.
+        Block schema = SchemaOf(Target("Value", "Int32"));
+        PocoTypeDescriptor<ConstructorOnlyPoco> descriptor = PocoTypeDescriptor<ConstructorOnlyPoco>.Build();
+        var rows = new[] { new ConstructorOnlyPoco(7) };
+
+        Assert.That(descriptor.CanActivate, Is.False, "the type a query could not materialize");
+
+        IReadOnlyList<IColumn> columns = PocoWritePlan<ConstructorOnlyPoco>.Build(descriptor, schema).BuildColumns(rows, rows.Length);
+
+        Assert.That(columns[0].GetValue(0), Is.EqualTo(7));
+    }
+
+    [Test]
+    public void BuildColumns_NullablePropertyIntoANullableColumn_CarriesTheNullThrough()
+    {
+        Block schema = SchemaOf(Target("value", "Nullable(Int32)"));
+        var rows = new[] { new Row<int?> { Value = null }, new Row<int?> { Value = 7 } };
+
+        IReadOnlyList<IColumn> columns = Plan<Row<int?>>(schema).BuildColumns(rows, rows.Length);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(columns[0].GetValue(0), Is.Null);
+            Assert.That(columns[0].GetValue(1), Is.EqualTo(7));
+        });
+    }
+
+    [Test]
+    public void BuildColumns_NullPropertyIntoANonNullableColumn_ThrowsNamingTheRow()
+    {
+        // D6a in the write direction: the shape is legal — a nullable property holding no nulls writes fine — so the
+        // check is per row rather than a build-time refusal.
+        Block schema = SchemaOf(Target("value", "Int32"));
+        var rows = new[] { new Row<int?> { Value = 1 }, new Row<int?> { Value = null } };
+        PocoWritePlan<Row<int?>> plan = Plan<Row<int?>>(schema);
+
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => plan.BuildColumns(rows, rows.Length));
+
+        Assert.That(error.Message, Does.Contain("row 1").And.Contain("value").And.Contain("Value"));
+    }
+
+    [Test]
+    public void BuildColumns_ALaterColumnFailing_ThrowsNamingIt()
+    {
+        // Also the path that releases what the earlier columns rented — each is gathered into its own buffer, and
+        // only the column that wraps one returns it. The release itself is not observable; this pins the failure.
+        Block schema = SchemaOf(Target("Ok", "Int32"), Target("Bad", "Int32"));
+        var rows = new[] { new TwoValues { Ok = 1, Bad = null } };
+        PocoWritePlan<TwoValues> plan = Plan<TwoValues>(schema);
+
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => plan.BuildColumns(rows, rows.Length));
+
+        Assert.That(error.Message, Does.Contain("Bad"));
+    }
+
+    [Test]
+    public void BuildColumns_NullablePropertyIntoAColumnWrittenFromObject_CarriesTheNullThrough()
+    {
+        // Dynamic and Variant are written from a column of object, which holds a null perfectly well — so the
+        // "nowhere to put a null" refusal is about a bare value type, not about the write type being unwrapped.
+        Block schema = SchemaOf(Target("value", "Dynamic"));
+        var rows = new[] { new Row<int?> { Value = null }, new Row<int?> { Value = 7 } };
+
+        IReadOnlyList<IColumn> columns = Plan<Row<int?>>(schema).BuildColumns(rows, rows.Length);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(columns[0], Is.InstanceOf<IColumn<object>>());
+            Assert.That(columns[0].GetValue(0), Is.Null);
+            Assert.That(columns[0].GetValue(1), Is.EqualTo(7));
+        });
+    }
+
+    [Test]
+    public void BuildColumns_NullStringPropertyIntoANonNullableColumn_ThrowsNamingTheRow()
+    {
+        // A reference-typed property is null whenever it was not set, which is the commonest way a row arrives
+        // incomplete. Unguarded, that null reaches the codec, which faults part-way through writing the block and
+        // takes the connection with it — where a value-typed null fails cleanly before anything is sent.
+        Block schema = SchemaOf(Target("value", "String"));
+        var rows = new[] { new Row<string> { Value = "a" }, new Row<string> { Value = null } };
+        PocoWritePlan<Row<string>> plan = Plan<Row<string>>(schema);
+
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => plan.BuildColumns(rows, rows.Length));
+
+        Assert.That(error.Message, Does.Contain("row 1").And.Contain("value").And.Contain("Value"));
+    }
+
+    [Test]
+    public void BuildColumns_NullArrayPropertyIntoANonNullableColumn_ThrowsNamingTheRow()
+    {
+        // The same rule reaches every reference-typed write type, not just string.
+        Block schema = SchemaOf(Target("value", "Array(Int32)"));
+        var rows = new[] { new Row<int[]> { Value = new[] { 1 } }, new Row<int[]> { Value = null } };
+        PocoWritePlan<Row<int[]>> plan = Plan<Row<int[]>>(schema);
+
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => plan.BuildColumns(rows, rows.Length));
+
+        Assert.That(error.Message, Does.Contain("row 1"));
+    }
+
+    [Test]
+    public void BuildColumns_NullReferencePropertyIntoANullableColumn_CarriesTheNullThrough()
+    {
+        // The other side of the same rule: a target with a NULL of its own takes the null, and no test is compiled
+        // into the loop at all.
+        Block schema = SchemaOf(Target("value", "Nullable(String)"));
+        var rows = new[] { new Row<string> { Value = "a" }, new Row<string> { Value = null } };
+
+        IReadOnlyList<IColumn> columns = Plan<Row<string>>(schema).BuildColumns(rows, rows.Length);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(columns[0].GetValue(0), Is.EqualTo("a"));
+            Assert.That(columns[0].GetValue(1), Is.Null);
+        });
+    }
+
+    [Test]
+    public void BuildColumns_EnumProperty_WritesTheOrdinal()
+    {
+        Block schema = SchemaOf(Target("value", "Enum8('low' = -1, 'high' = 127)"));
+        var rows = new[] { new Row<Level> { Value = Level.High } };
+
+        IReadOnlyList<IColumn> columns = Plan<Row<Level>>(schema).BuildColumns(rows, rows.Length);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(columns[0], Is.InstanceOf<IColumn<sbyte>>());
+            Assert.That(columns[0].GetValue(0), Is.EqualTo((sbyte)127));
+        });
+    }
+
+    [Test]
+    public void BuildColumns_PropertyMatchingNoTargetColumn_IsNotInserted()
+    {
+        // What lets one POCO fill part of a table: the statement's column list decides, and the properties it does
+        // not name are left out rather than being an error.
+        Block schema = SchemaOf(Target("Id", "Int32"));
+        var rows = new[] { new IdName { Id = 3, Name = "not inserted" } };
+
+        IReadOnlyList<IColumn> columns = Plan<IdName>(schema).BuildColumns(rows, rows.Length);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(columns, Has.Count.EqualTo(1));
+            Assert.That(columns[0].Name, Is.EqualTo("Id"));
+            Assert.That(columns[0].GetValue(0), Is.EqualTo(3));
+        });
+    }
+
+    [Test]
+    public void BuildColumns_SeveralTargets_AreBuiltInSchemaOrderWithTheTargetsNamesAndTypes()
+    {
+        // The insert aligns by name against the sample block, and the target's own type string is what the values
+        // are serialized as — so both have to come from the schema rather than from the property.
+        Block schema = SchemaOf(Target("Name", "String"), Target("Id", "Int32"));
+        var rows = new[] { new IdName { Id = 1, Name = "a" }, new IdName { Id = 2, Name = "b" } };
+
+        IReadOnlyList<IColumn> columns = Plan<IdName>(schema).BuildColumns(rows, rows.Length);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(columns[0].Name, Is.EqualTo("Name"));
+            Assert.That(columns[0].TypeName, Is.EqualTo("String"));
+            Assert.That(columns[0].RowCount, Is.EqualTo(2));
+            Assert.That(columns[1].Name, Is.EqualTo("Id"));
+            Assert.That(columns[1].TypeName, Is.EqualTo("Int32"));
+            Assert.That(columns[1].GetValue(1), Is.EqualTo(2));
+        });
+    }
+
+    [Test]
+    public void BuildColumns_FewerRowsThanTheBuffer_ExposesOnlyTheRowsAsked()
+    {
+        // The rows arrive in a pooled array that is usually longer than the insert, so the count decides the column's
+        // length, not the array's.
+        Block schema = SchemaOf(Target("value", "Int32"));
+        var rows = new[] { new Row<int> { Value = 1 }, new Row<int> { Value = 2 }, new Row<int> { Value = 3 } };
+
+        IReadOnlyList<IColumn> columns = Plan<Row<int>>(schema).BuildColumns(rows, rowCount: 2);
+
+        Assert.That(columns[0].RowCount, Is.EqualTo(2));
+    }
+
+    [Test]
+    public void WritePlanFor_SameSchema_ReturnsTheCachedPlan()
+    {
+        var registry = new PocoTypeRegistry();
+
+        PocoWritePlan<Row<int>> first = registry.WritePlanFor<Row<int>>(SchemaOf(Target("value", "Int32")));
+        PocoWritePlan<Row<int>> second = registry.WritePlanFor<Row<int>>(SchemaOf(Target("value", "Int32")));
+
+        Assert.That(second, Is.SameAs(first));
+    }
+
+    [Test]
+    public void WritePlanFor_SameColumnNameDifferentType_CompilesItsOwnPlan()
+    {
+        // Keying on anything less exact than the server's own type string would hand one target's plan to another,
+        // which then writes the wrong CLR type into it.
+        var registry = new PocoTypeRegistry();
+
+        PocoWritePlan<Row<int>> ints = registry.WritePlanFor<Row<int>>(SchemaOf(Target("value", "Int32")));
+        PocoWritePlan<Row<int>> nullables = registry.WritePlanFor<Row<int>>(SchemaOf(Target("value", "Nullable(Int32)")));
+
+        var rows = new[] { new Row<int> { Value = 1 } };
+        Assert.Multiple(() =>
+        {
+            Assert.That(nullables, Is.Not.SameAs(ints));
+            Assert.That(ints.BuildColumns(rows, 1)[0], Is.InstanceOf<IColumn<int>>());
+            Assert.That(nullables.BuildColumns(rows, 1)[0], Is.InstanceOf<IColumn<int?>>());
+        });
+    }
+
+    [Test]
+    public void WritePlanFor_ColumnNameHoldingTheKeySeparators_DoesNotCollideWithAnotherSchema()
+    {
+        // A column name is arbitrary text, so a key joined on separators alone lets one target shape spell another.
+        // The collision would be silent: one plan's columns handed to a differently shaped target.
+        var registry = new PocoTypeRegistry();
+        Block spelled = SchemaOf(Target("Id", "Int32"), Target("Name\tInt32\nScore", "Int32"));
+        Block three = SchemaOf(Target("Id", "Int32"), Target("Name", "Int32"), Target("Score", "Int32"));
+
+        PocoWritePlan<SeparatorColumns> spelledPlan = registry.WritePlanFor<SeparatorColumns>(spelled);
+        PocoWritePlan<SeparatorColumns> threePlan = registry.WritePlanFor<SeparatorColumns>(three);
+
+        var rows = new[] { new SeparatorColumns { Id = 1, Spelled = 9, Name = 2, Score = 3 } };
+        Assert.Multiple(() =>
+        {
+            Assert.That(threePlan, Is.Not.SameAs(spelledPlan));
+            Assert.That(Names(spelledPlan.BuildColumns(rows, 1)), Is.EqualTo(new[] { "Id", "Name\tInt32\nScore" }));
+            Assert.That(Names(threePlan.BuildColumns(rows, 1)), Is.EqualTo(new[] { "Id", "Name", "Score" }));
+        });
+    }
+
+    [Test]
+    public void WritePlanFor_SameSchemaDifferentSessionTimezone_ReturnsTheCachedPlan()
+    {
+        // The read plan keys on the session timezone, because a bare DateTime column is *presented* in it. The write
+        // path resolves its codecs in ResolveContext.ForWrite, which carries no session timezone at all, so one
+        // target shape is one plan whatever the session's is.
+        var registry = new PocoTypeRegistry();
+        var utc = new ResolveContext { ServerTimezone = "UTC" };
+        var kolkata = new ResolveContext { ServerTimezone = "Asia/Kolkata" };
+
+        PocoWritePlan<Row<DateTime>> first = registry.WritePlanFor<Row<DateTime>>(SchemaOf(utc, Target("value", "DateTime")));
+        PocoWritePlan<Row<DateTime>> second = registry.WritePlanFor<Row<DateTime>>(SchemaOf(kolkata, Target("value", "DateTime")));
+
+        Assert.That(second, Is.SameAs(first));
+    }
+
+    [Test]
+    public void WritePlanFor_BuildFailure_IsNotCached()
+    {
+        var registry = new PocoTypeRegistry();
+        Block schema = SchemaOf(Target("value", "Int32"));
+
+        Assert.Throws<InvalidOperationException>(() => registry.WritePlanFor<Row<Guid>>(schema));
+        Assert.Throws<InvalidOperationException>(() => registry.WritePlanFor<Row<Guid>>(schema), "the failure must be reported to every caller, not only the first");
+    }
+
+    private static PocoWritePlan<T> Plan<T>(Block schema)
+        where T : class
+        => PocoWritePlan<T>.Build(PocoTypeDescriptor<T>.Build(), schema);
+
+    private static string[] Names(IReadOnlyList<IColumn> columns)
+    {
+        var names = new string[columns.Count];
+        for (int i = 0; i < names.Length; i++)
+        {
+            names[i] = columns[i].Name;
+        }
+
+        return names;
+    }
+
+    /// <summary>
+    /// One target column of a sample block. Empty and untyped on purpose: the server's sample block carries no rows,
+    /// and a write plan reads only the name and the type string, resolving the codec from the latter.
+    /// </summary>
+    /// <param name="name">The target column's name.</param>
+    /// <param name="typeName">The target column's ClickHouse type.</param>
+    /// <returns>The column.</returns>
+    private static IColumn Target(string name, string typeName) => new ArrayColumn<object>(name, typeName, Array.Empty<object>());
+
+    private static Block SchemaOf(params IColumn[] columns) => SchemaOf(new ResolveContext { ServerTimezone = "UTC" }, columns);
+
+    private static Block SchemaOf(ResolveContext context, params IColumn[] columns)
+        => new(string.Empty, BlockInfo.Default, rowCount: 0, columns, ColumnCodecRegistry.Default, context);
+
+    private enum Level : sbyte
+    {
+        Low = -1,
+        High = 127,
+    }
+
+    private sealed class IdName
+    {
+        public int Id { get; set; }
+
+        public string Name { get; set; }
+    }
+
+    /// <summary>
+    /// Carries a property for the separator-spelling column as well as for the three plain ones, so both target
+    /// shapes build — a target column with no property is a refusal, which would hide the key collision the test is
+    /// about.
+    /// </summary>
+    private sealed class SeparatorColumns
+    {
+        public int Id { get; set; }
+
+        [ClickHouseTcpColumn(Name = "Name\tInt32\nScore")]
+        public int Spelled { get; set; }
+
+        public int Name { get; set; }
+
+        public int Score { get; set; }
+    }
+
+    private sealed class UserRow
+    {
+        public int UserId { get; set; }
+    }
+
+    private sealed class TwoValues
+    {
+        public int Ok { get; set; }
+
+        public int? Bad { get; set; }
+    }
+
+    private sealed class ConstructorOnlyPoco
+    {
+        public ConstructorOnlyPoco(int value) => Value = value;
+
+        public int Value { get; }
+    }
+
+    private sealed class SetterOnlyPoco
+    {
+        private int written;
+
+        public int Value
+        {
+            set => written = value;
+        }
+
+        public int Read() => written;
+    }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Poco/PocoWritePlanTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Poco/PocoWritePlanTests.cs
@@ -8,16 +8,7 @@ using ClickHouse.Driver.Tcp.Types;
 namespace ClickHouse.Driver.Tcp.Tests.Poco;
 
 /// <summary>
-/// The compiled write plan: which CLR type a target column is written in, which (property type, column type) pairs
-/// are accepted, and which are refused. Per-type value coverage lives in the integration suite, driven off the
-/// round-trip corpus; what is here is what a server round trip cannot reach — the refusals, the write type the plan
-/// picked (a round trip sees only the values, not the spelling they went out in), and the plan cache key.
-///
-/// <para>
-/// A plan reads only a target column's name and <see cref="IColumn.TypeName"/> — the codec comes from the type
-/// string — so the sample blocks here are empty columns stamped with the type under test, which is what the
-/// server's own sample block is.
-/// </para>
+/// Covers POCO write-plan mapping, CLR write-type selection, and cache keys.
 /// </summary>
 [TestFixture]
 public class PocoWritePlanTests
@@ -25,8 +16,7 @@ public class PocoWritePlanTests
     [Test]
     public void Build_TargetColumnMatchingNoProperty_Throws()
     {
-        // Unlike a read, where an unmapped column is simply not read, every target column has to be filled: the
-        // server expects a value for each column of the statement's list.
+        // Every target named by the INSERT must be filled.
         Block schema = SchemaOf(Target("value", "Int32"), Target("extra", "String"));
 
         InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => Plan<Row<int>>(schema));
@@ -47,8 +37,7 @@ public class PocoWritePlanTests
     [Test]
     public void Build_TwoTargetColumnsReachingOneProperty_Throws()
     {
-        // Both names reach UserId through the matcher's looser tiers, and one property cannot decide which column it
-        // means — the mirror of the read side's refusal.
+        // Both target names resolve to the same property.
         Block schema = SchemaOf(Target("user_id", "Int32"), Target("userId", "Int32"));
 
         InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => Plan<UserRow>(schema));
@@ -69,8 +58,7 @@ public class PocoWritePlanTests
     [Test]
     public void Build_WideningPropertyType_IsDeclined()
     {
-        // D6c, in the write direction: an Int32 property does not fill an Int64 column, because a POCO that inserts
-        // has to be a POCO that reads back, and the read side declines the same pair.
+        // Preserve read/write symmetry by declining numeric widening.
         Block schema = SchemaOf(Target("value", "Int64"));
 
         Assert.Throws<InvalidOperationException>(() => Plan<Row<int>>(schema));
@@ -79,8 +67,7 @@ public class PocoWritePlanTests
     [Test]
     public void Build_TargetWhoseWriterNeedsItsOwnColumnShape_SaysToUseTheColumnarApi()
     {
-        // Nested writes from flat field columns behind shared offsets, a shape no property can hold. Naming the CLR
-        // types it "accepts" would send the caller round a loop they cannot win, so the message names the way out.
+        // Nested requires a specialized column shape that a property cannot provide.
         Block schema = SchemaOf(Target("value", "Nested(a UInt8, b String)"));
 
         InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => Plan<Row<object[][]>>(schema));
@@ -91,8 +78,7 @@ public class PocoWritePlanTests
     [Test]
     public void BuildColumns_CalendarProperty_WritesThroughTheCalendarTypeNotTheWireCount()
     {
-        // The choice a round trip cannot observe: the plan hands the codec a DateTime column and lets it do the
-        // epoch arithmetic, rather than converting to the canonical uint itself.
+        // Leave DateTime conversion to the codec.
         Block schema = SchemaOf(Target("value", "DateTime('UTC')"));
         var rows = new[] { new Row<DateTime> { Value = DateTime.UnixEpoch } };
 
@@ -119,8 +105,7 @@ public class PocoWritePlanTests
     [Test]
     public void BuildColumns_NullableCalendarProperty_WritesThroughTheLiftedCalendarType()
     {
-        // A Nullable(DateTime) column accepts DateTime? only because the codec lifts its inner's write types to its
-        // own nullable surface. Which of the three lifted spellings was chosen is invisible to a round trip.
+        // Verify that nullable codecs expose their lifted calendar spelling.
         Block schema = SchemaOf(Target("value", "Nullable(DateTime('UTC'))"));
         var rows = new[] { new Row<DateTime?> { Value = DateTime.UnixEpoch }, new Row<DateTime?> { Value = null } };
 
@@ -137,9 +122,7 @@ public class PocoWritePlanTests
     [Test]
     public void Build_TypeThatCannotBeMaterialized_StillBuildsAWritePlan()
     {
-        // The read plan asks the descriptor for its activator before anything else, so an immutable POCO fails
-        // there. An insert never constructs a T, so the write plan must not ask — that is what makes such a type
-        // insert-only rather than unusable.
+        // A write plan does not need to construct the row type.
         Block schema = SchemaOf(Target("Value", "Int32"));
         PocoTypeDescriptor<ConstructorOnlyPoco> descriptor = PocoTypeDescriptor<ConstructorOnlyPoco>.Build();
         var rows = new[] { new ConstructorOnlyPoco(7) };
@@ -169,8 +152,7 @@ public class PocoWritePlanTests
     [Test]
     public void BuildColumns_NullPropertyIntoANonNullableColumn_ThrowsNamingTheRow()
     {
-        // D6a in the write direction: the shape is legal — a nullable property holding no nulls writes fine — so the
-        // check is per row rather than a build-time refusal.
+        // Nullability is checked per row because non-null values remain valid.
         Block schema = SchemaOf(Target("value", "Int32"));
         var rows = new[] { new Row<int?> { Value = 1 }, new Row<int?> { Value = null } };
         PocoWritePlan<Row<int?>> plan = Plan<Row<int?>>(schema);
@@ -183,8 +165,7 @@ public class PocoWritePlanTests
     [Test]
     public void BuildColumns_ALaterColumnFailing_ThrowsNamingIt()
     {
-        // Also the path that releases what the earlier columns rented — each is gathered into its own buffer, and
-        // only the column that wraps one returns it. The release itself is not observable; this pins the failure.
+        // A later failure also exercises cleanup of earlier columns.
         Block schema = SchemaOf(Target("Ok", "Int32"), Target("Bad", "Int32"));
         var rows = new[] { new TwoValues { Ok = 1, Bad = null } };
         PocoWritePlan<TwoValues> plan = Plan<TwoValues>(schema);
@@ -197,8 +178,7 @@ public class PocoWritePlanTests
     [Test]
     public void BuildColumns_NullablePropertyIntoAColumnWrittenFromObject_CarriesTheNullThrough()
     {
-        // Dynamic and Variant are written from a column of object, which holds a null perfectly well — so the
-        // "nowhere to put a null" refusal is about a bare value type, not about the write type being unwrapped.
+        // Dynamic's object surface can carry null.
         Block schema = SchemaOf(Target("value", "Dynamic"));
         var rows = new[] { new Row<int?> { Value = null }, new Row<int?> { Value = 7 } };
 
@@ -215,9 +195,7 @@ public class PocoWritePlanTests
     [Test]
     public void BuildColumns_NullStringPropertyIntoANonNullableColumn_ThrowsNamingTheRow()
     {
-        // A reference-typed property is null whenever it was not set, which is the commonest way a row arrives
-        // incomplete. Unguarded, that null reaches the codec, which faults part-way through writing the block and
-        // takes the connection with it — where a value-typed null fails cleanly before anything is sent.
+        // Reject null references before any block is written.
         Block schema = SchemaOf(Target("value", "String"));
         var rows = new[] { new Row<string> { Value = "a" }, new Row<string> { Value = null } };
         PocoWritePlan<Row<string>> plan = Plan<Row<string>>(schema);
@@ -243,8 +221,7 @@ public class PocoWritePlanTests
     [Test]
     public void BuildColumns_NullReferencePropertyIntoANullableColumn_CarriesTheNullThrough()
     {
-        // The other side of the same rule: a target with a NULL of its own takes the null, and no test is compiled
-        // into the loop at all.
+        // A nullable target accepts the reference null directly.
         Block schema = SchemaOf(Target("value", "Nullable(String)"));
         var rows = new[] { new Row<string> { Value = "a" }, new Row<string> { Value = null } };
 
@@ -275,8 +252,7 @@ public class PocoWritePlanTests
     [Test]
     public void BuildColumns_PropertyMatchingNoTargetColumn_IsNotInserted()
     {
-        // What lets one POCO fill part of a table: the statement's column list decides, and the properties it does
-        // not name are left out rather than being an error.
+        // Properties not named by the INSERT are ignored.
         Block schema = SchemaOf(Target("Id", "Int32"));
         var rows = new[] { new IdName { Id = 3, Name = "not inserted" } };
 
@@ -293,8 +269,7 @@ public class PocoWritePlanTests
     [Test]
     public void BuildColumns_SeveralTargets_AreBuiltInSchemaOrderWithTheTargetsNamesAndTypes()
     {
-        // The insert aligns by name against the sample block, and the target's own type string is what the values
-        // are serialized as — so both have to come from the schema rather than from the property.
+        // Output columns follow the sample block's order, names, and types.
         Block schema = SchemaOf(Target("Name", "String"), Target("Id", "Int32"));
         var rows = new[] { new IdName { Id = 1, Name = "a" }, new IdName { Id = 2, Name = "b" } };
 
@@ -314,8 +289,7 @@ public class PocoWritePlanTests
     [Test]
     public void BuildColumns_FewerRowsThanTheBuffer_ExposesOnlyTheRowsAsked()
     {
-        // The rows arrive in a pooled array that is usually longer than the insert, so the count decides the column's
-        // length, not the array's.
+        // Use the logical row count, not the pooled buffer length.
         Block schema = SchemaOf(Target("value", "Int32"));
         var rows = new[] { new Row<int> { Value = 1 }, new Row<int> { Value = 2 }, new Row<int> { Value = 3 } };
 
@@ -338,8 +312,7 @@ public class PocoWritePlanTests
     [Test]
     public void WritePlanFor_SameColumnNameDifferentType_CompilesItsOwnPlan()
     {
-        // Keying on anything less exact than the server's own type string would hand one target's plan to another,
-        // which then writes the wrong CLR type into it.
+        // The exact target type is part of the plan key.
         var registry = new PocoTypeRegistry();
 
         PocoWritePlan<Row<int>> ints = registry.WritePlanFor<Row<int>>(SchemaOf(Target("value", "Int32")));
@@ -357,8 +330,7 @@ public class PocoWritePlanTests
     [Test]
     public void WritePlanFor_ColumnNameHoldingTheKeySeparators_DoesNotCollideWithAnotherSchema()
     {
-        // A column name is arbitrary text, so a key joined on separators alone lets one target shape spell another.
-        // The collision would be silent: one plan's columns handed to a differently shaped target.
+        // Arbitrary column names must not collide with cache-key separators.
         var registry = new PocoTypeRegistry();
         Block spelled = SchemaOf(Target("Id", "Int32"), Target("Name\tInt32\nScore", "Int32"));
         Block three = SchemaOf(Target("Id", "Int32"), Target("Name", "Int32"), Target("Score", "Int32"));
@@ -378,8 +350,7 @@ public class PocoWritePlanTests
     [Test]
     public void WritePlanFor_SameSchemaDifferentSessionTimezone_CompilesItsOwnPlan()
     {
-        // A bare DateTime target interprets an Unspecified property in the session timezone. The type string does
-        // not carry that context, so the cache key must: a plan compiled for UTC cannot serve Kolkata's wall clock.
+        // Timezone-less DateTime plans depend on the session timezone.
         var registry = new PocoTypeRegistry();
         var utc = new ResolveContext { ServerTimezone = "UTC" };
         var kolkata = new ResolveContext { ServerTimezone = "Asia/Kolkata" };
@@ -415,13 +386,7 @@ public class PocoWritePlanTests
         return names;
     }
 
-    /// <summary>
-    /// One target column of a sample block. Empty and untyped on purpose: the server's sample block carries no rows,
-    /// and a write plan reads only the name and the type string, resolving the codec from the latter.
-    /// </summary>
-    /// <param name="name">The target column's name.</param>
-    /// <param name="typeName">The target column's ClickHouse type.</param>
-    /// <returns>The column.</returns>
+    /// <summary>Creates an empty sample-block column.</summary>
     private static IColumn Target(string name, string typeName) => new ArrayColumn<object>(name, typeName, Array.Empty<object>());
 
     private static Block SchemaOf(params IColumn[] columns) => SchemaOf(new ResolveContext { ServerTimezone = "UTC" }, columns);
@@ -442,11 +407,7 @@ public class PocoWritePlanTests
         public string Name { get; set; }
     }
 
-    /// <summary>
-    /// Carries a property for the separator-spelling column as well as for the three plain ones, so both target
-    /// shapes build — a target column with no property is a refusal, which would hide the key collision the test is
-    /// about.
-    /// </summary>
+    /// <summary>Maps both cache-key collision shapes used by the test.</summary>
     private sealed class SeparatorColumns
     {
         public int Id { get; set; }

--- a/ClickHouse.Driver.Tcp.Tests/Poco/UntypedRowColumnsTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Poco/UntypedRowColumnsTests.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Collections.Generic;
+using System.Threading;
 using ClickHouse.Driver.Tcp.Format;
 using ClickHouse.Driver.Tcp.Poco;
 using ClickHouse.Driver.Tcp.Types;
@@ -13,179 +13,235 @@ namespace ClickHouse.Driver.Tcp.Tests.Poco;
 public class UntypedRowColumnsTests
 {
     [Test]
-    public void Build_ValuesInTheColumnsCanonicalType_WritesThemUnchanged()
+    public void Gather_ValuesInTheColumnsCanonicalType_WritesThemUnchanged()
     {
         Block schema = SchemaOf(Target("id", "Int32"), Target("name", "String"));
         object[][] rows = { new object[] { 1, "a" }, new object[] { 2, "b" } };
 
-        IReadOnlyList<IColumn> columns = UntypedRowColumns.Build(schema, rows, rows.Length);
+        using PocoInsertSource<object[]> source = GatherAll(schema, rows, rows.Length);
 
         Assert.Multiple(() =>
         {
-            Assert.That(columns[0], Is.InstanceOf<IColumn<int>>());
-            Assert.That(columns[1], Is.InstanceOf<IColumn<string>>());
-            Assert.That(columns[0].GetValue(1), Is.EqualTo(2));
-            Assert.That(columns[1].GetValue(1), Is.EqualTo("b"));
+            Assert.That(source.Columns[0], Is.InstanceOf<IColumn<int>>());
+            Assert.That(source.Columns[1], Is.InstanceOf<IColumn<string>>());
+            Assert.That(source.Columns[0].GetValue(1), Is.EqualTo(2));
+            Assert.That(source.Columns[1].GetValue(1), Is.EqualTo("b"));
         });
     }
 
     [Test]
-    public void Build_ValuesInAConvenienceType_WritesThemInThatTypeRatherThanTheWireCount()
+    public void Gather_ValuesInAConvenienceType_WritesThemInThatTypeRatherThanTheWireCount()
     {
         // Preserve the CLR spelling chosen by the values.
         Block schema = SchemaOf(Target("raw", "DateTime('UTC')"), Target("calendar", "DateTime('UTC')"));
         object[][] rows = { new object[] { 1_700_000_000u, DateTime.UnixEpoch } };
 
-        IReadOnlyList<IColumn> columns = UntypedRowColumns.Build(schema, rows, rows.Length);
+        using PocoInsertSource<object[]> source = GatherAll(schema, rows, rows.Length);
 
         Assert.Multiple(() =>
         {
-            Assert.That(columns[0], Is.InstanceOf<IColumn<uint>>());
-            Assert.That(columns[1], Is.InstanceOf<IColumn<DateTime>>());
+            Assert.That(source.Columns[0], Is.InstanceOf<IColumn<uint>>());
+            Assert.That(source.Columns[1], Is.InstanceOf<IColumn<DateTime>>());
         });
     }
 
     [Test]
-    public void Build_LeadingNulls_TakeTheTypeFromTheFirstRowWithAValue()
+    public void CreateSource_LeadingNulls_TakeTheTypeFromTheFirstRowWithAValue()
     {
         Block schema = SchemaOf(Target("value", "Nullable(DateTime('UTC'))"));
         object[][] rows = { new object[] { null }, new object[] { DateTime.UnixEpoch } };
 
-        IReadOnlyList<IColumn> columns = UntypedRowColumns.Build(schema, rows, rows.Length);
+        using PocoInsertSource<object[]> source = GatherAll(schema, rows, rows.Length);
 
         Assert.Multiple(() =>
         {
-            Assert.That(columns[0], Is.InstanceOf<IColumn<DateTime?>>());
-            Assert.That(columns[0].GetValue(0), Is.Null);
-            Assert.That(columns[0].GetValue(1), Is.EqualTo(DateTime.UnixEpoch));
+            Assert.That(source.Columns[0], Is.InstanceOf<IColumn<DateTime?>>());
+            Assert.That(source.Columns[0].GetValue(0), Is.Null);
+            Assert.That(source.Columns[0].GetValue(1), Is.EqualTo(DateTime.UnixEpoch));
         });
     }
 
     [Test]
-    public void Build_ColumnOfOnlyNulls_FallsBackToTheTargetsCanonicalType()
+    public void CreateSource_ValueInALaterBlock_StillChoosesTheWriteTypeFromIt()
+    {
+        // The write type is chosen once for the whole insert, so it has to look past the first block.
+        Block schema = SchemaOf(Target("value", "Nullable(DateTime('UTC'))"));
+        object[][] rows = { new object[] { null }, new object[] { null }, new object[] { DateTime.UnixEpoch } };
+        using var buffer = PocoRowBuffer<object[]>.Create(rows, "rows", blockRows: 2, CancellationToken.None);
+
+        using PocoInsertSource<object[]> source = UntypedRowColumns.CreateSource(schema, buffer, blockRows: 2);
+
+        Assert.That(source.Columns[0], Is.InstanceOf<IColumn<DateTime?>>());
+    }
+
+    [Test]
+    public void CreateSource_ColumnOfOnlyNulls_FallsBackToTheTargetsCanonicalType()
     {
         // With no non-null value, use the target's preferred write type.
         Block schema = SchemaOf(Target("value", "Nullable(Int32)"));
         object[][] rows = { new object[] { null }, new object[] { null } };
 
-        IReadOnlyList<IColumn> columns = UntypedRowColumns.Build(schema, rows, rows.Length);
+        using PocoInsertSource<object[]> source = GatherAll(schema, rows, rows.Length);
 
         Assert.Multiple(() =>
         {
-            Assert.That(columns[0], Is.InstanceOf<IColumn<int?>>());
-            Assert.That(columns[0].GetValue(0), Is.Null);
+            Assert.That(source.Columns[0], Is.InstanceOf<IColumn<int?>>());
+            Assert.That(source.Columns[0].GetValue(0), Is.Null);
         });
     }
 
     [Test]
-    public void Build_NullInANonNullableColumn_ThrowsNamingTheRowAndTheColumn()
+    public void Gather_NullInANonNullableColumn_ThrowsNamingTheRowAndTheColumn()
     {
         Block schema = SchemaOf(Target("value", "Int32"));
         object[][] rows = { new object[] { 1 }, new object[] { null } };
 
-        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => UntypedRowColumns.Build(schema, rows, rows.Length));
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => GatherAll(schema, rows, rows.Length));
 
         Assert.That(error.Message, Does.Contain("row 1").And.Contain("value"));
     }
 
     [Test]
-    public void Build_ALaterColumnFailing_ThrowsNamingIt()
+    public void Gather_ASecondBlock_NamesTheRowByItsNumberInTheInsertNotInTheBlock()
+    {
+        Block schema = SchemaOf(Target("value", "Int32"));
+        object[][] rows = { new object[] { 1 }, new object[] { 2 }, new object[] { null } };
+        using var buffer = PocoRowBuffer<object[]>.Create(rows, "rows", blockRows: 2, CancellationToken.None);
+        using PocoInsertSource<object[]> source = UntypedRowColumns.CreateSource(schema, buffer, blockRows: 2);
+
+        source.Gather(0, 2);
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => source.Gather(2, 1));
+
+        Assert.That(error.Message, Does.Contain("row 2"));
+    }
+
+    [Test]
+    public void Gather_ALaterColumnFailing_ThrowsNamingIt()
     {
         // A later failure also exercises cleanup of earlier columns.
         Block schema = SchemaOf(Target("ok", "Int32"), Target("bad", "Int32"));
         object[][] rows = { new object[] { 1, null } };
 
-        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => UntypedRowColumns.Build(schema, rows, rows.Length));
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => GatherAll(schema, rows, rows.Length));
 
         Assert.That(error.Message, Does.Contain("bad"));
     }
 
     [Test]
-    public void Build_MixedTypesInOneColumn_ThrowsNamingTheRow()
+    public void Gather_MixedTypesInOneColumn_ThrowsNamingTheRow()
     {
         // Report the row that conflicts with the selected CLR type.
         Block schema = SchemaOf(Target("value", "Int32"));
         object[][] rows = { new object[] { 1 }, new object[] { "two" } };
 
-        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => UntypedRowColumns.Build(schema, rows, rows.Length));
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => GatherAll(schema, rows, rows.Length));
 
         Assert.That(error.Message, Does.Contain("row 1").And.Contain("System.String"));
     }
 
     [Test]
-    public void Build_ADynamicTarget_TakesEveryValueThroughItsObjectSurface()
+    public void Gather_ADynamicTarget_TakesEveryValueThroughItsObjectSurface()
     {
         // Dynamic's object surface permits mixed CLR types.
         Block schema = SchemaOf(Target("value", "Dynamic"));
         object[][] rows = { new object[] { 1 }, new object[] { "two" } };
 
-        IReadOnlyList<IColumn> columns = UntypedRowColumns.Build(schema, rows, rows.Length);
+        using PocoInsertSource<object[]> source = GatherAll(schema, rows, rows.Length);
 
         Assert.Multiple(() =>
         {
-            Assert.That(columns[0], Is.InstanceOf<IColumn<object>>());
-            Assert.That(columns[0].GetValue(1), Is.EqualTo("two"));
+            Assert.That(source.Columns[0], Is.InstanceOf<IColumn<object>>());
+            Assert.That(source.Columns[0].GetValue(1), Is.EqualTo("two"));
         });
     }
 
     [Test]
-    public void Build_ValueOfATypeTheColumnDoesNotAccept_ThrowsNamingWhatItAccepts()
+    public void CreateSource_ValueOfATypeTheColumnDoesNotAccept_ThrowsNamingWhatItAccepts()
     {
         Block schema = SchemaOf(Target("value", "Int32"));
         object[][] rows = { new object[] { "not a number" } };
 
-        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => UntypedRowColumns.Build(schema, rows, rows.Length));
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => GatherAll(schema, rows, rows.Length));
 
         Assert.That(error.Message, Does.Contain("System.String").And.Contain("System.Int32"));
     }
 
     [Test]
-    public void Build_RowOfTheWrongLength_ThrowsNamingTheRowAndTheTargets()
+    public void Gather_RowOfTheWrongLength_ThrowsNamingTheRowAndTheTargets()
     {
         Block schema = SchemaOf(Target("id", "Int32"), Target("name", "String"));
         object[][] rows = { new object[] { 1, "a" }, new object[] { 2 } };
 
-        ArgumentException error = Assert.Throws<ArgumentException>(() => UntypedRowColumns.Build(schema, rows, rows.Length));
+        ArgumentException error = Assert.Throws<ArgumentException>(() => GatherAll(schema, rows, rows.Length));
 
-        Assert.That(error.Message, Does.Contain("Row 1").And.Contain("id, name"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(error.Message, Does.Contain("Row 1").And.Contain("id, name"));
+            Assert.That(error.ParamName, Is.EqualTo("rows"));
+        });
     }
 
     [Test]
-    public void Build_TargetWhoseWriterNeedsItsOwnColumnShape_SaysToUseTheColumnarApi()
+    public void CreateSource_TargetWhoseWriterNeedsItsOwnColumnShape_SaysToUseTheColumnarApi()
     {
         Block schema = SchemaOf(Target("value", "Nested(a UInt8, b String)"));
         object[][] rows = { new object[] { Array.Empty<object[]>() } };
 
-        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => UntypedRowColumns.Build(schema, rows, rows.Length));
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => GatherAll(schema, rows, rows.Length));
 
         Assert.That(error.Message, Does.Contain("columnar API"));
     }
 
     [Test]
-    public void Build_ZeroRows_BuildsAnEmptyColumnPerTarget()
+    public void CreateSource_ZeroRows_HoldsAnEmptyColumnPerTarget()
     {
         Block schema = SchemaOf(Target("id", "Int32"), Target("name", "String"));
 
-        IReadOnlyList<IColumn> columns = UntypedRowColumns.Build(schema, Array.Empty<object[]>(), rowCount: 0);
+        using PocoInsertSource<object[]> source = GatherAll(schema, Array.Empty<object[]>(), rowCount: 0);
 
         Assert.Multiple(() =>
         {
-            Assert.That(columns, Has.Count.EqualTo(2));
-            Assert.That(columns[0].RowCount, Is.EqualTo(0));
-            Assert.That(columns[1].RowCount, Is.EqualTo(0));
+            Assert.That(source.Columns, Has.Count.EqualTo(2));
+            Assert.That(source.Columns[0].RowCount, Is.EqualTo(0));
+            Assert.That(source.Columns[1].RowCount, Is.EqualTo(0));
         });
     }
 
     [Test]
-    public void Build_FewerRowsThanTheBuffer_ReadsOnlyTheRowsAsked()
+    public void Gather_FewerRowsThanTheBuffer_ReadsOnlyTheRowsAsked()
     {
         // Ignore unused entries in the pooled row buffer.
         Block schema = SchemaOf(Target("value", "Int32"));
         object[][] rows = { new object[] { 1 }, new object[] { 2 }, null };
 
-        IReadOnlyList<IColumn> columns = UntypedRowColumns.Build(schema, rows, rowCount: 2);
+        using PocoInsertSource<object[]> source = GatherAll(schema, rows, rowCount: 2);
 
-        Assert.That(columns[0].RowCount, Is.EqualTo(2));
+        Assert.That(source.Columns[0].RowCount, Is.EqualTo(2));
+    }
+
+    /// <summary>
+    /// Gathers the rows as a single block. The source is returned rather than its columns, because it owns the
+    /// buffers the columns read from.
+    /// </summary>
+    private static PocoInsertSource<object[]> GatherAll(Block schema, object[][] rows, int rowCount)
+    {
+        // The rows are an array, so the buffer borrows them and holds nothing past the gather.
+        using var buffer = PocoRowBuffer<object[]>.Create(rows, "rows", rowCount, CancellationToken.None);
+        PocoInsertSource<object[]> source = UntypedRowColumns.CreateSource(schema, buffer, rowCount);
+        try
+        {
+            if (rowCount > 0)
+            {
+                source.Gather(0, rowCount);
+            }
+
+            return source;
+        }
+        catch
+        {
+            source.Dispose();
+            throw;
+        }
     }
 
     private static IColumn Target(string name, string typeName) => new ArrayColumn<object>(name, typeName, Array.Empty<object>());

--- a/ClickHouse.Driver.Tcp.Tests/Poco/UntypedRowColumnsTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Poco/UntypedRowColumnsTests.cs
@@ -7,17 +7,10 @@ using ClickHouse.Driver.Tcp.Types;
 namespace ClickHouse.Driver.Tcp.Tests.Poco;
 
 /// <summary>
-/// The untyped <c>object[]</c> insert's transposition. Round-trip coverage is in the integration suite; what is here
-/// is the choice a round trip cannot see — which CLR type each column was written in, which the values themselves
-/// decide — and the failures, which name a row and a column the caller counted.
-///
-/// <para>
-/// The sample blocks are empty columns stamped with the type under test, which is what the server's own sample block
-/// is: only the name and the type string are read, the codec coming from the latter.
-/// </para>
+/// Covers untyped-row transposition, write-type selection, and diagnostics.
 /// </summary>
 [TestFixture]
-public class PocoUntypedColumnsTests
+public class UntypedRowColumnsTests
 {
     [Test]
     public void Build_ValuesInTheColumnsCanonicalType_WritesThemUnchanged()
@@ -25,7 +18,7 @@ public class PocoUntypedColumnsTests
         Block schema = SchemaOf(Target("id", "Int32"), Target("name", "String"));
         object[][] rows = { new object[] { 1, "a" }, new object[] { 2, "b" } };
 
-        IReadOnlyList<IColumn> columns = PocoUntypedColumns.Build(schema, rows, rows.Length);
+        IReadOnlyList<IColumn> columns = UntypedRowColumns.Build(schema, rows, rows.Length);
 
         Assert.Multiple(() =>
         {
@@ -39,12 +32,11 @@ public class PocoUntypedColumnsTests
     [Test]
     public void Build_ValuesInAConvenienceType_WritesThemInThatTypeRatherThanTheWireCount()
     {
-        // What lets rows written by hand and rows from an untyped read both work: a DateTime column takes either
-        // spelling, and the one the values are in is the one the codec is handed.
+        // Preserve the CLR spelling chosen by the values.
         Block schema = SchemaOf(Target("raw", "DateTime('UTC')"), Target("calendar", "DateTime('UTC')"));
         object[][] rows = { new object[] { 1_700_000_000u, DateTime.UnixEpoch } };
 
-        IReadOnlyList<IColumn> columns = PocoUntypedColumns.Build(schema, rows, rows.Length);
+        IReadOnlyList<IColumn> columns = UntypedRowColumns.Build(schema, rows, rows.Length);
 
         Assert.Multiple(() =>
         {
@@ -59,7 +51,7 @@ public class PocoUntypedColumnsTests
         Block schema = SchemaOf(Target("value", "Nullable(DateTime('UTC'))"));
         object[][] rows = { new object[] { null }, new object[] { DateTime.UnixEpoch } };
 
-        IReadOnlyList<IColumn> columns = PocoUntypedColumns.Build(schema, rows, rows.Length);
+        IReadOnlyList<IColumn> columns = UntypedRowColumns.Build(schema, rows, rows.Length);
 
         Assert.Multiple(() =>
         {
@@ -72,12 +64,11 @@ public class PocoUntypedColumnsTests
     [Test]
     public void Build_ColumnOfOnlyNulls_FallsBackToTheTargetsCanonicalType()
     {
-        // Nothing names a type, so the target's own leading write type is the only answer available — and the right
-        // one, since a Nullable target takes the nulls whichever spelling carries them.
+        // With no non-null value, use the target's preferred write type.
         Block schema = SchemaOf(Target("value", "Nullable(Int32)"));
         object[][] rows = { new object[] { null }, new object[] { null } };
 
-        IReadOnlyList<IColumn> columns = PocoUntypedColumns.Build(schema, rows, rows.Length);
+        IReadOnlyList<IColumn> columns = UntypedRowColumns.Build(schema, rows, rows.Length);
 
         Assert.Multiple(() =>
         {
@@ -92,7 +83,7 @@ public class PocoUntypedColumnsTests
         Block schema = SchemaOf(Target("value", "Int32"));
         object[][] rows = { new object[] { 1 }, new object[] { null } };
 
-        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => PocoUntypedColumns.Build(schema, rows, rows.Length));
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => UntypedRowColumns.Build(schema, rows, rows.Length));
 
         Assert.That(error.Message, Does.Contain("row 1").And.Contain("value"));
     }
@@ -100,12 +91,11 @@ public class PocoUntypedColumnsTests
     [Test]
     public void Build_ALaterColumnFailing_ThrowsNamingIt()
     {
-        // Also the path that releases what the earlier columns rented — each is filled into its own buffer, and only
-        // the column that wraps one returns it. The release itself is not observable; this pins the failure.
+        // A later failure also exercises cleanup of earlier columns.
         Block schema = SchemaOf(Target("ok", "Int32"), Target("bad", "Int32"));
         object[][] rows = { new object[] { 1, null } };
 
-        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => PocoUntypedColumns.Build(schema, rows, rows.Length));
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => UntypedRowColumns.Build(schema, rows, rows.Length));
 
         Assert.That(error.Message, Does.Contain("bad"));
     }
@@ -113,12 +103,11 @@ public class PocoUntypedColumnsTests
     [Test]
     public void Build_MixedTypesInOneColumn_ThrowsNamingTheRow()
     {
-        // The type is settled by the first row that has a value, so a later row in another type would otherwise fail
-        // as a bare unboxing error with no row to point at.
+        // Report the row that conflicts with the selected CLR type.
         Block schema = SchemaOf(Target("value", "Int32"));
         object[][] rows = { new object[] { 1 }, new object[] { "two" } };
 
-        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => PocoUntypedColumns.Build(schema, rows, rows.Length));
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => UntypedRowColumns.Build(schema, rows, rows.Length));
 
         Assert.That(error.Message, Does.Contain("row 1").And.Contain("System.String"));
     }
@@ -126,12 +115,11 @@ public class PocoUntypedColumnsTests
     [Test]
     public void Build_ADynamicTarget_TakesEveryValueThroughItsObjectSurface()
     {
-        // Dynamic and Variant are written from a column of object, so the type sniffing has nothing to reject and a
-        // column may legitimately hold values of several types.
+        // Dynamic's object surface permits mixed CLR types.
         Block schema = SchemaOf(Target("value", "Dynamic"));
         object[][] rows = { new object[] { 1 }, new object[] { "two" } };
 
-        IReadOnlyList<IColumn> columns = PocoUntypedColumns.Build(schema, rows, rows.Length);
+        IReadOnlyList<IColumn> columns = UntypedRowColumns.Build(schema, rows, rows.Length);
 
         Assert.Multiple(() =>
         {
@@ -146,7 +134,7 @@ public class PocoUntypedColumnsTests
         Block schema = SchemaOf(Target("value", "Int32"));
         object[][] rows = { new object[] { "not a number" } };
 
-        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => PocoUntypedColumns.Build(schema, rows, rows.Length));
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => UntypedRowColumns.Build(schema, rows, rows.Length));
 
         Assert.That(error.Message, Does.Contain("System.String").And.Contain("System.Int32"));
     }
@@ -157,7 +145,7 @@ public class PocoUntypedColumnsTests
         Block schema = SchemaOf(Target("id", "Int32"), Target("name", "String"));
         object[][] rows = { new object[] { 1, "a" }, new object[] { 2 } };
 
-        ArgumentException error = Assert.Throws<ArgumentException>(() => PocoUntypedColumns.Build(schema, rows, rows.Length));
+        ArgumentException error = Assert.Throws<ArgumentException>(() => UntypedRowColumns.Build(schema, rows, rows.Length));
 
         Assert.That(error.Message, Does.Contain("Row 1").And.Contain("id, name"));
     }
@@ -168,7 +156,7 @@ public class PocoUntypedColumnsTests
         Block schema = SchemaOf(Target("value", "Nested(a UInt8, b String)"));
         object[][] rows = { new object[] { Array.Empty<object[]>() } };
 
-        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => PocoUntypedColumns.Build(schema, rows, rows.Length));
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() => UntypedRowColumns.Build(schema, rows, rows.Length));
 
         Assert.That(error.Message, Does.Contain("columnar API"));
     }
@@ -178,7 +166,7 @@ public class PocoUntypedColumnsTests
     {
         Block schema = SchemaOf(Target("id", "Int32"), Target("name", "String"));
 
-        IReadOnlyList<IColumn> columns = PocoUntypedColumns.Build(schema, Array.Empty<object[]>(), rowCount: 0);
+        IReadOnlyList<IColumn> columns = UntypedRowColumns.Build(schema, Array.Empty<object[]>(), rowCount: 0);
 
         Assert.Multiple(() =>
         {
@@ -191,12 +179,11 @@ public class PocoUntypedColumnsTests
     [Test]
     public void Build_FewerRowsThanTheBuffer_ReadsOnlyTheRowsAsked()
     {
-        // The rows arrive in a pooled array that is usually longer than the insert, and the entries past the count
-        // are whatever the pool last held.
+        // Ignore unused entries in the pooled row buffer.
         Block schema = SchemaOf(Target("value", "Int32"));
         object[][] rows = { new object[] { 1 }, new object[] { 2 }, null };
 
-        IReadOnlyList<IColumn> columns = PocoUntypedColumns.Build(schema, rows, rowCount: 2);
+        IReadOnlyList<IColumn> columns = UntypedRowColumns.Build(schema, rows, rowCount: 2);
 
         Assert.That(columns[0].RowCount, Is.EqualTo(2));
     }

--- a/ClickHouse.Driver.Tcp.Tests/Protocol/ClickHouseTcpConnectionInsertTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Protocol/ClickHouseTcpConnectionInsertTests.cs
@@ -234,6 +234,99 @@ public class ClickHouseTcpConnectionInsertTests
     }
 
     [Test]
+    public async Task InsertAsync_SuppliedColumns_AreLeftForTheCallerToDispose()
+    {
+        // The ownership half the factory overload contrasts with: a caller's columns outlive the insert, and may be
+        // inserted again.
+        byte[] script = Concat(
+            await ServerHelloBytesAsync(54476),
+            await SchemaBlockAsync(("x", "UInt64")),
+            EndOfStreamPacket());
+        using var connection = await ConnectedAsync(script);
+        var spy = new DisposeSpyColumn<ulong>("x", "UInt64", new ulong[] { 1, 2 });
+
+        await connection.InsertAsync("INSERT INTO t VALUES", Columns(spy), cancellationToken: None);
+
+        Assert.That(spy.DisposeCount, Is.EqualTo(0));
+    }
+
+    [Test]
+    public async Task InsertAsync_ColumnFactory_SeesTheTargetSchemaAndOwnsWhatItBuilt()
+    {
+        // The row-oriented seam: the factory runs once the target types are known, and the columns it hands over are
+        // the insert's to release — a POCO gather builds them over pooled buffers.
+        byte[] script = Concat(
+            await ServerHelloBytesAsync(54476),
+            await SchemaBlockAsync(("x", "UInt64")),
+            EndOfStreamPacket());
+        using var connection = await ConnectedAsync(script);
+        var spy = new DisposeSpyColumn<ulong>("x", "UInt64", new ulong[] { 1, 2 });
+        var targets = new List<string>();
+
+        await connection.InsertAsync(
+            "INSERT INTO t VALUES",
+            rowCount: 2,
+            schema =>
+            {
+                for (int i = 0; i < schema.ColumnCount; i++)
+                {
+                    targets.Add($"{schema[i].Name} {schema[i].TypeName}");
+                }
+
+                return new IColumn[] { spy };
+            },
+            cancellationToken: None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(targets, Is.EqualTo(new[] { "x UInt64" }));
+            Assert.That(spy.DisposeCount, Is.EqualTo(1));
+            Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+        });
+    }
+
+    [Test]
+    public async Task InsertAsync_ThrowingColumnFactory_RethrowsItAndStaysReady()
+    {
+        // A mapping failure lands mid-INSERT, with the server waiting for row data. Terminating the connection for
+        // what is a caller's shape error would cost a redial on every one, so the insert closes its row stream with
+        // no rows and reports afterwards — the same course the schema-mismatch path takes.
+        byte[] script = Concat(
+            await ServerHelloBytesAsync(54476),
+            await SchemaBlockAsync(("x", "UInt64")),
+            EndOfStreamPacket());
+        using var connection = await ConnectedAsync(script);
+        var failure = new InvalidOperationException("no property maps to 'x'");
+
+        InvalidOperationException thrown = Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await connection.InsertAsync("INSERT INTO t VALUES", rowCount: 2, _ => throw failure, cancellationToken: None));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(thrown, Is.SameAs(failure), "the factory's own exception, not a wrapper");
+            Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+        });
+    }
+
+    [Test]
+    public void InsertAsync_NegativeRowCount_ThrowsArgumentOutOfRange()
+    {
+        using var connection = new ClickHouseTcpConnection(new ScriptedDuplexStream(Array.Empty<byte>()), socket: null);
+
+        Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
+            await connection.InsertAsync("INSERT INTO t VALUES", rowCount: -1, _ => Array.Empty<IColumn>(), cancellationToken: None));
+    }
+
+    [Test]
+    public void InsertAsync_NullColumnFactory_ThrowsArgumentNull()
+    {
+        using var connection = new ClickHouseTcpConnection(new ScriptedDuplexStream(Array.Empty<byte>()), socket: null);
+
+        Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            await connection.InsertAsync("INSERT INTO t VALUES", rowCount: 0, buildColumns: null, cancellationToken: None));
+    }
+
+    [Test]
     public void PlanInsertBlocks_NoRowCap_ProducesOneBlock()
     {
         // With no row cap the whole insert is one block; peak memory is bounded by the flush backstop, not a split.

--- a/ClickHouse.Driver.Tcp.Tests/Protocol/ClickHouseTcpConnectionInsertTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Protocol/ClickHouseTcpConnectionInsertTests.cs
@@ -252,13 +252,14 @@ public class ClickHouseTcpConnectionInsertTests
     [Test]
     public async Task InsertAsync_ColumnFactory_SeesTheTargetSchemaAndOwnsWhatItBuilt()
     {
-        // Factory-built columns become insert-owned once the schema is known.
+        // A factory-built source becomes insert-owned once the schema is known.
         byte[] script = Concat(
             await ServerHelloBytesAsync(54476),
             await SchemaBlockAsync(("x", "UInt64")),
             EndOfStreamPacket());
         using var connection = await ConnectedAsync(script);
         var spy = new DisposeSpyColumn<ulong>("x", "UInt64", new ulong[] { 1, 2 });
+        var source = new StubInsertColumnSource(spy);
         var targets = new List<string>();
 
         await connection.InsertAsync(
@@ -271,14 +272,69 @@ public class ClickHouseTcpConnectionInsertTests
                     targets.Add($"{schema[i].Name} {schema[i].TypeName}");
                 }
 
-                return new IColumn[] { spy };
+                return source;
             },
             cancellationToken: None);
 
         Assert.Multiple(() =>
         {
             Assert.That(targets, Is.EqualTo(new[] { "x UInt64" }));
-            Assert.That(spy.DisposeCount, Is.EqualTo(1));
+            Assert.That(source.DisposeCount, Is.EqualTo(1));
+            Assert.That(spy.DisposeCount, Is.EqualTo(1), "the source disposes its own columns");
+            Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+        });
+    }
+
+    [Test]
+    public async Task InsertAsync_ColumnFactoryWithMaxRowsPerBlock_GathersEachBlockBeforeWritingIt()
+    {
+        // The block is the conversion unit: one gather of each row range, in order, none of them the whole insert.
+        byte[] script = Concat(
+            await ServerHelloBytesAsync(54476),
+            await SchemaBlockAsync(("x", "UInt64")),
+            EndOfStreamPacket());
+        using var connection = await ConnectedAsync(script);
+        var source = new StubInsertColumnSource(UInt64Column(1, 2));
+
+        await connection.InsertAsync(
+            "INSERT INTO t VALUES",
+            rowCount: 5,
+            _ => source,
+            maxRowsPerBlock: 2,
+            cancellationToken: None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(source.Gathered, Is.EqualTo(new[] { (0, 2), (2, 2), (4, 1) }));
+            Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+        });
+    }
+
+    [Test]
+    public async Task InsertAsync_ColumnSourceFailingOnALaterBlock_ThrowsItAndStaysReady()
+    {
+        // The failing block is not written, the row stream still closes, and the connection survives.
+        byte[] script = Concat(
+            await ServerHelloBytesAsync(54476),
+            await SchemaBlockAsync(("x", "UInt64")),
+            EndOfStreamPacket());
+        using var connection = await ConnectedAsync(script);
+        var failure = new InvalidOperationException("row 3 is null");
+        var source = new StubInsertColumnSource(UInt64Column(1, 2)) { FailAtStart = 2, Failure = failure };
+
+        InvalidOperationException thrown = Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await connection.InsertAsync(
+                "INSERT INTO t VALUES",
+                rowCount: 4,
+                _ => source,
+                maxRowsPerBlock: 2,
+                cancellationToken: None));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(thrown, Is.SameAs(failure), "the source's own exception, not a wrapper");
+            Assert.That(source.Gathered, Is.EqualTo(new[] { (0, 2), (2, 2) }), "gathering stopped at the failure");
+            Assert.That(source.DisposeCount, Is.EqualTo(1));
             Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
         });
     }
@@ -310,7 +366,7 @@ public class ClickHouseTcpConnectionInsertTests
         using var connection = new ClickHouseTcpConnection(new ScriptedDuplexStream(Array.Empty<byte>()), socket: null);
 
         Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
-            await connection.InsertAsync("INSERT INTO t VALUES", rowCount: -1, _ => Array.Empty<IColumn>(), cancellationToken: None));
+            await connection.InsertAsync("INSERT INTO t VALUES", rowCount: -1, _ => new StubInsertColumnSource(), cancellationToken: None));
     }
 
     [Test]
@@ -458,5 +514,42 @@ public class ClickHouseTcpConnectionInsertTests
         }
 
         return result;
+    }
+
+    /// <summary>A row source that records the ranges it was asked for, and can fail on one of them.</summary>
+    private sealed class StubInsertColumnSource : IInsertColumnSource
+    {
+        private readonly IColumn[] columns;
+
+        public StubInsertColumnSource(params IColumn[] columns) => this.columns = columns;
+
+        public IReadOnlyList<IColumn> Columns => columns;
+
+        public List<(int Start, int Length)> Gathered { get; } = new();
+
+        /// <summary>The block start to fail at, or null to gather every block.</summary>
+        public int? FailAtStart { get; init; }
+
+        public Exception Failure { get; init; }
+
+        public int DisposeCount { get; private set; }
+
+        public void Gather(int start, int length)
+        {
+            Gathered.Add((start, length));
+            if (FailAtStart == start)
+            {
+                throw Failure;
+            }
+        }
+
+        public void Dispose()
+        {
+            DisposeCount++;
+            foreach (IColumn column in columns)
+            {
+                column.Dispose();
+            }
+        }
     }
 }

--- a/ClickHouse.Driver.Tcp.Tests/Protocol/ClickHouseTcpConnectionInsertTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Protocol/ClickHouseTcpConnectionInsertTests.cs
@@ -236,8 +236,7 @@ public class ClickHouseTcpConnectionInsertTests
     [Test]
     public async Task InsertAsync_SuppliedColumns_AreLeftForTheCallerToDispose()
     {
-        // The ownership half the factory overload contrasts with: a caller's columns outlive the insert, and may be
-        // inserted again.
+        // Caller-supplied columns remain caller-owned.
         byte[] script = Concat(
             await ServerHelloBytesAsync(54476),
             await SchemaBlockAsync(("x", "UInt64")),
@@ -253,8 +252,7 @@ public class ClickHouseTcpConnectionInsertTests
     [Test]
     public async Task InsertAsync_ColumnFactory_SeesTheTargetSchemaAndOwnsWhatItBuilt()
     {
-        // The row-oriented seam: the factory runs once the target types are known, and the columns it hands over are
-        // the insert's to release — a POCO gather builds them over pooled buffers.
+        // Factory-built columns become insert-owned once the schema is known.
         byte[] script = Concat(
             await ServerHelloBytesAsync(54476),
             await SchemaBlockAsync(("x", "UInt64")),
@@ -288,9 +286,7 @@ public class ClickHouseTcpConnectionInsertTests
     [Test]
     public async Task InsertAsync_ThrowingColumnFactory_RethrowsItAndStaysReady()
     {
-        // A mapping failure lands mid-INSERT, with the server waiting for row data. Terminating the connection for
-        // what is a caller's shape error would cost a redial on every one, so the insert closes its row stream with
-        // no rows and reports afterwards — the same course the schema-mismatch path takes.
+        // A factory failure closes the row stream without terminating the connection.
         byte[] script = Concat(
             await ServerHelloBytesAsync(54476),
             await SchemaBlockAsync(("x", "UInt64")),

--- a/ClickHouse.Driver.Tcp.Tests/Types/ArrayColumnTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/ArrayColumnTests.cs
@@ -5,8 +5,7 @@ using ClickHouse.Driver.Tcp.Types;
 namespace ClickHouse.Driver.Tcp.Tests.Types;
 
 /// <summary>
-/// The array-backed column's ownership modes, which decide who returns a rented buffer. Only the modes matter here;
-/// the values themselves ride every codec test and the round-trip corpus.
+/// Covers owning and non-owning array-backed columns.
 /// </summary>
 [TestFixture]
 public class ArrayColumnTests
@@ -14,8 +13,7 @@ public class ArrayColumnTests
     [Test]
     public void OverBuffer_ABufferLongerThanTheData_ExposesOnlyTheRows()
     {
-        // A rented buffer is usually longer than what was asked for, so the row count is the length the column has
-        // to present — reading the array's own length would surface whatever the pool last held there.
+        // Expose only the logical rows, not the full rented buffer.
         int[] buffer = { 1, 2, 3, 4, 5 };
 
         using ArrayColumn<int> column = ArrayColumn<int>.OverBuffer("c", "Int32", buffer, length: 3);
@@ -31,8 +29,7 @@ public class ArrayColumnTests
     [Test]
     public void OverBuffer_Disposed_DoesNotReturnACallersBuffer()
     {
-        // The non-owning mode: the caller keeps the buffer, so disposing the column must not hand it to the pool —
-        // an array in the pool twice is handed to two owners at once.
+        // The caller retains ownership of a non-owning buffer.
         int[] buffer = ArrayPool<int>.Shared.Rent(4);
         buffer[0] = 42;
 
@@ -45,8 +42,7 @@ public class ArrayColumnTests
     [Test]
     public void OverPooledBuffer_DisposedTwice_ReturnsTheBufferOnce()
     {
-        // The owning mode a gathered insert column uses. A second Dispose must be a no-op: returning one array twice
-        // puts it in the pool twice, and the pool then hands the same storage to two callers.
+        // An owning column must return its buffer exactly once.
         ArrayColumn<int> column = ArrayColumn<int>.OverPooledBuffer("c", "Int32", ArrayPool<int>.Shared.Rent(4), length: 2);
 
         column.Dispose();
@@ -62,8 +58,7 @@ public class ArrayColumnTests
     [Test]
     public void OverPooledBuffer_ZeroRows_IsDisposable()
     {
-        // ArrayPool hands out the empty array for a zero-length rent, and returning that is not something the pool
-        // accepts — the zero-row insert reaches here.
+        // Zero-row inserts may produce the pool's shared empty array.
         ArrayColumn<int> column = ArrayColumn<int>.OverPooledBuffer("c", "Int32", ArrayPool<int>.Shared.Rent(0), length: 0);
 
         Assert.Multiple(() =>

--- a/ClickHouse.Driver.Tcp.Tests/Types/ArrayColumnTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/ArrayColumnTests.cs
@@ -39,32 +39,4 @@ public class ArrayColumnTests
         ArrayPool<int>.Shared.Return(buffer);
     }
 
-    [Test]
-    public void OverPooledBuffer_DisposedTwice_ReturnsTheBufferOnce()
-    {
-        // An owning column must return its buffer exactly once.
-        ArrayColumn<int> column = ArrayColumn<int>.OverPooledBuffer("c", "Int32", ArrayPool<int>.Shared.Rent(4), length: 2);
-
-        column.Dispose();
-
-        Assert.Multiple(() =>
-        {
-            Assert.That(() => column.Dispose(), Throws.Nothing);
-            Assert.That(column.RowCount, Is.EqualTo(2), "the row count is the column's own, not the released buffer's");
-            Assert.That(() => column[0], Throws.InstanceOf<ArgumentOutOfRangeException>(), "the values are gone with the buffer");
-        });
-    }
-
-    [Test]
-    public void OverPooledBuffer_ZeroRows_IsDisposable()
-    {
-        // Zero-row inserts may produce the pool's shared empty array.
-        ArrayColumn<int> column = ArrayColumn<int>.OverPooledBuffer("c", "Int32", ArrayPool<int>.Shared.Rent(0), length: 0);
-
-        Assert.Multiple(() =>
-        {
-            Assert.That(column.RowCount, Is.EqualTo(0));
-            Assert.That(() => column.Dispose(), Throws.Nothing);
-        });
-    }
 }

--- a/ClickHouse.Driver.Tcp.Tests/Types/ArrayColumnTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/ArrayColumnTests.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Buffers;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Tests.Types;
+
+/// <summary>
+/// The array-backed column's ownership modes, which decide who returns a rented buffer. Only the modes matter here;
+/// the values themselves ride every codec test and the round-trip corpus.
+/// </summary>
+[TestFixture]
+public class ArrayColumnTests
+{
+    [Test]
+    public void OverBuffer_ABufferLongerThanTheData_ExposesOnlyTheRows()
+    {
+        // A rented buffer is usually longer than what was asked for, so the row count is the length the column has
+        // to present — reading the array's own length would surface whatever the pool last held there.
+        int[] buffer = { 1, 2, 3, 4, 5 };
+
+        using ArrayColumn<int> column = ArrayColumn<int>.OverBuffer("c", "Int32", buffer, length: 3);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(column.RowCount, Is.EqualTo(3));
+            Assert.That(column.Values.ToArray(), Is.EqualTo(new[] { 1, 2, 3 }));
+            Assert.That(() => column[3], Throws.TypeOf<IndexOutOfRangeException>(), "past the row count, not past the buffer");
+        });
+    }
+
+    [Test]
+    public void OverBuffer_Disposed_DoesNotReturnACallersBuffer()
+    {
+        // The non-owning mode: the caller keeps the buffer, so disposing the column must not hand it to the pool —
+        // an array in the pool twice is handed to two owners at once.
+        int[] buffer = ArrayPool<int>.Shared.Rent(4);
+        buffer[0] = 42;
+
+        ArrayColumn<int>.OverBuffer("c", "Int32", buffer, length: 1).Dispose();
+
+        Assert.That(ArrayPool<int>.Shared.Rent(4), Is.Not.SameAs(buffer), "the column returned a buffer it does not own");
+        ArrayPool<int>.Shared.Return(buffer);
+    }
+
+    [Test]
+    public void OverPooledBuffer_DisposedTwice_ReturnsTheBufferOnce()
+    {
+        // The owning mode a gathered insert column uses. A second Dispose must be a no-op: returning one array twice
+        // puts it in the pool twice, and the pool then hands the same storage to two callers.
+        ArrayColumn<int> column = ArrayColumn<int>.OverPooledBuffer("c", "Int32", ArrayPool<int>.Shared.Rent(4), length: 2);
+
+        column.Dispose();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(() => column.Dispose(), Throws.Nothing);
+            Assert.That(column.RowCount, Is.EqualTo(2), "the row count is the column's own, not the released buffer's");
+            Assert.That(() => column[0], Throws.InstanceOf<ArgumentOutOfRangeException>(), "the values are gone with the buffer");
+        });
+    }
+
+    [Test]
+    public void OverPooledBuffer_ZeroRows_IsDisposable()
+    {
+        // ArrayPool hands out the empty array for a zero-length rent, and returning that is not something the pool
+        // accepts — the zero-row insert reaches here.
+        ArrayColumn<int> column = ArrayColumn<int>.OverPooledBuffer("c", "Int32", ArrayPool<int>.Shared.Rent(0), length: 0);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(column.RowCount, Is.EqualTo(0));
+            Assert.That(() => column.Dispose(), Throws.Nothing);
+        });
+    }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Types/NullableColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/NullableColumnCodecTests.cs
@@ -129,6 +129,34 @@ public class NullableColumnCodecTests
     }
 
     [Test]
+    public void WritableElementTypes_ListWhatCanWriteAccepts_CanonicalFirst()
+    {
+        // The list has to agree with CanWrite: a caller choosing a write type from it — a POCO insert picking the
+        // spelling to gather a property into — never gets to probe with a column first.
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                Resolve("Nullable(DateTime('UTC'))").WritableElementTypes,
+                Is.EqualTo(new[] { typeof(uint?), typeof(DateTimeOffset?), typeof(DateTime?) }));
+            Assert.That(Resolve("Nullable(Int32)").WritableElementTypes, Is.EqualTo(new[] { typeof(int?) }));
+            Assert.That(Resolve("Nullable(String)").WritableElementTypes, Is.EqualTo(new[] { typeof(string) }));
+        });
+    }
+
+    [Test]
+    public void NullPlaceholderAs_EveryWritableSpelling_IsNullAndAnythingElseThrows()
+    {
+        IColumnCodec codec = Resolve("Nullable(DateTime('UTC'))");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(codec.NullPlaceholderAs(typeof(uint?)), Is.Null);
+            Assert.That(codec.NullPlaceholderAs(typeof(DateTime?)), Is.Null);
+            Assert.Throws<NotSupportedException>(() => codec.NullPlaceholderAs(typeof(DateTime)));
+        });
+    }
+
+    [Test]
     public void CanWrite_NullableDateTime_AcceptsBothOffsetAndDateTimeSpellings()
     {
         IColumnCodec codec = Resolve("Nullable(DateTime('UTC'))");

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClient.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClient.cs
@@ -320,7 +320,7 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
     /// query can read into: an <see cref="object"/> property reads any column but fills only a <c>Variant</c> or
     /// <c>Dynamic</c> target, and a <c>LowCardinality(DateTime)</c> column reads as <see cref="DateTime"/> but is
     /// written only from the raw epoch seconds. Declare the property as the type the column is written from, or
-    /// insert that column through the columnar overload.
+    /// insert that column through the columnar <see cref="InsertAsync"/> method.
     /// </para>
     /// </remarks>
     /// <typeparam name="T">The row type.</typeparam>
@@ -331,11 +331,11 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
     /// <returns>A task that completes when the server acknowledges the insert.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="sql"/> or <paramref name="rows"/> is null.</exception>
     /// <exception cref="ArgumentException">A row is null, or <typeparamref name="T"/> is a column type — pass columns
-    /// to the columnar overload instead.</exception>
+    /// to <see cref="InsertAsync"/> instead.</exception>
     /// <exception cref="InvalidOperationException"><typeparamref name="T"/> cannot fill the target: it has nothing to
     /// map, a target column maps to no property or to one that cannot be read, or a property's type cannot be written
     /// as its target's type. Also when a property is null for a column that cannot hold null.</exception>
-    public async ValueTask InsertAsync<T>(
+    public async ValueTask InsertRowsAsync<T>(
         string sql,
         IEnumerable<T> rows,
         ClickHouseTcpInsertOptions options = null,
@@ -351,7 +351,7 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
         if (typeof(IColumn).IsAssignableFrom(typeof(T)))
         {
             throw new ArgumentException(
-                $"An insert of {typeof(T).Name} rows would map that type's properties to columns. To insert columnar data, call the overload taking IReadOnlyList<IColumn> — materialize the sequence (for example with ToList()) if it is not already a list.",
+                $"An insert of {typeof(T).Name} rows would map that type's properties to columns. To insert columnar data, call InsertAsync with an IReadOnlyList<IColumn> — materialize the sequence (for example with ToList()) if it is not already a list.",
                 nameof(rows));
         }
 
@@ -390,8 +390,8 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
     /// <c>Nullable</c> reports, naming the row.
     ///
     /// <para>
-    /// This tier boxes every value by construction. For bulk data prefer the columnar overload or
-    /// <see cref="InsertAsync{T}(string, IEnumerable{T}, ClickHouseTcpInsertOptions, CancellationToken)"/>, both of
+    /// This tier boxes every value by construction. For bulk data prefer the columnar <see cref="InsertAsync"/> method or
+    /// <see cref="InsertRowsAsync{T}(string, IEnumerable{T}, ClickHouseTcpInsertOptions, CancellationToken)"/>, both of
     /// which are box-free.
     /// </para>
     /// </remarks>
@@ -404,8 +404,8 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
     /// <exception cref="ArgumentException">A row is null or has the wrong number of values.</exception>
     /// <exception cref="InvalidOperationException">A value's CLR type is not one its target column accepts, a column
     /// holds values of more than one type, a value is null for a column that cannot hold null, or a target column's
-    /// type cannot be built from rows at all (<c>Nested</c>) and needs the columnar overload.</exception>
-    public async ValueTask InsertAsync(
+    /// type cannot be built from rows at all (<c>Nested</c>) and needs <see cref="InsertAsync"/>.</exception>
+    public async ValueTask InsertRowsAsync(
         string sql,
         IEnumerable<object[]> rows,
         ClickHouseTcpInsertOptions options = null,

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClient.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClient.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using ClickHouse.Driver.Tcp.Client;
 using ClickHouse.Driver.Tcp.Format;
 using ClickHouse.Driver.Tcp.Poco;
+using ClickHouse.Driver.Tcp.Protocol;
 using ClickHouse.Driver.Tcp.Types;
 
 namespace ClickHouse.Driver.Tcp;
@@ -313,17 +314,19 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
 
         IReadOnlyDictionary<string, string> settings = BuildSettings(options);
 
-        using var buffer = PocoRowBuffer<T>.Create(rows, nameof(rows), cancellationToken);
+        int? maxRowsPerBlock = ResolveMaxRowsPerBlock(options);
+        int blockRows = ClickHouseTcpConnection.RowsPerBlock(rows.Count, maxRowsPerBlock);
+        using var buffer = PocoRowBuffer<T>.Create(rows, nameof(rows), blockRows, cancellationToken);
 
         await using IConnectionLease lease = await source.RentAsync(cancellationToken).ConfigureAwait(false);
         await lease.Connection.InsertAsync(
             sql,
             buffer.Count,
-            schema => pocoTypes.WritePlanFor<T>(schema).BuildColumns(buffer.Rows, buffer.Count),
+            schema => pocoTypes.WritePlanFor<T>(schema).CreateSource(buffer, blockRows),
             settings,
             parameters: null,
             options?.QueryId,
-            ResolveMaxRowsPerBlock(options),
+            maxRowsPerBlock,
             Options.MaxSendBufferBytes,
             handlers: null,
             cancellationToken).ConfigureAwait(false);
@@ -340,17 +343,19 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
         ArgumentNullException.ThrowIfNull(rows);
 
         IReadOnlyDictionary<string, string> settings = BuildSettings(options);
-        using var buffer = PocoRowBuffer<object[]>.Create(rows, nameof(rows), cancellationToken);
+        int? maxRowsPerBlock = ResolveMaxRowsPerBlock(options);
+        int blockRows = ClickHouseTcpConnection.RowsPerBlock(rows.Count, maxRowsPerBlock);
+        using var buffer = PocoRowBuffer<object[]>.Create(rows, nameof(rows), blockRows, cancellationToken);
 
         await using IConnectionLease lease = await source.RentAsync(cancellationToken).ConfigureAwait(false);
         await lease.Connection.InsertAsync(
             sql,
             buffer.Count,
-            schema => UntypedRowColumns.Build(schema, buffer.Rows, buffer.Count),
+            schema => UntypedRowColumns.CreateSource(schema, buffer, blockRows),
             settings,
             parameters: null,
             options?.QueryId,
-            ResolveMaxRowsPerBlock(options),
+            maxRowsPerBlock,
             Options.MaxSendBufferBytes,
             handlers: null,
             cancellationToken).ConfigureAwait(false);

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClient.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClient.cs
@@ -14,7 +14,7 @@ namespace ClickHouse.Driver.Tcp;
 
 /// <summary>
 /// A high-level client for a ClickHouse server over the native TCP protocol: run queries and stream results,
-/// execute statements, and insert columnar data. Build one from a <see cref="ClickHouseTcpClientOptions"/> or a
+/// execute statements, and insert data columnwise or row by row. Build one from a <see cref="ClickHouseTcpClientOptions"/> or a
 /// connection string and reuse it — it is safe to share across threads. Operations are serialized onto the
 /// underlying connection today (one in flight at a time); a future connection pool lifts that transparently.
 ///
@@ -283,6 +283,145 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
         await lease.Connection.InsertAsync(
             sql,
             columns,
+            settings,
+            parameters: null,
+            options?.QueryId,
+            ResolveMaxRowsPerBlock(options),
+            Options.MaxSendBufferBytes,
+            handlers: null,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Inserts rows of <typeparamref name="T"/>, reading each target column from the property of the same name.
+    /// Matching is the mirror of <see cref="QueryAsync{T}(string, ClickHouseTcpQueryOptions, CancellationToken)"/>'s:
+    /// case- and then underscore-insensitive, with <c>[ClickHouseTcpColumn]</c> renaming a property and
+    /// <c>[ClickHouseTcpNotMapped]</c> excluding one. With no rows nothing is written, though the statement is still
+    /// sent and the mapping still checked.
+    /// </summary>
+    /// <remarks>
+    /// Every target column must map to a property, so name the columns to insert in the statement
+    /// (<c>INSERT INTO t (a, b) VALUES</c>) when the POCO covers only some of the table — the server then fills the
+    /// rest from their defaults. A property no target column maps to is not inserted. <typeparamref name="T"/> needs
+    /// public getters but no constructor of ours, so a read-only POCO inserts even though it cannot be queried into.
+    ///
+    /// <para>
+    /// The gathering is box-free — each property goes into the buffer its column is written from through a compiled
+    /// per-column loop — except for a <c>Variant</c> or <c>Dynamic</c> target, which is written from a column of
+    /// <see cref="object"/> and so boxes a value-typed property per row. The mapping is compiled against the target's
+    /// own types, which the server sends after the statement, so a mismatch is reported once the INSERT is under way,
+    /// having written no rows, and leaves the client usable. <paramref name="rows"/> is fully enumerated before any
+    /// row data goes out, so <see cref="ClickHouseTcpInsertOptions.MaxRowsPerBlock"/> bounds the wire blocks, not
+    /// client memory.
+    /// </para>
+    ///
+    /// <para>
+    /// A property's type must be one its target column can be written from, which is a shorter list than the one a
+    /// query can read into: an <see cref="object"/> property reads any column but fills only a <c>Variant</c> or
+    /// <c>Dynamic</c> target, and a <c>LowCardinality(DateTime)</c> column reads as <see cref="DateTime"/> but is
+    /// written only from the raw epoch seconds. Declare the property as the type the column is written from, or
+    /// insert that column through the columnar overload.
+    /// </para>
+    /// </remarks>
+    /// <typeparam name="T">The row type.</typeparam>
+    /// <param name="sql">The <c>INSERT INTO … VALUES</c> statement, with no inline <c>VALUES (...)</c> literal.</param>
+    /// <param name="rows">The rows to insert, each non-null.</param>
+    /// <param name="options">Per-insert options (query id, settings, block sizing), or null for the client defaults.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>A task that completes when the server acknowledges the insert.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="sql"/> or <paramref name="rows"/> is null.</exception>
+    /// <exception cref="ArgumentException">A row is null, or <typeparamref name="T"/> is a column type — pass columns
+    /// to the columnar overload instead.</exception>
+    /// <exception cref="InvalidOperationException"><typeparamref name="T"/> cannot fill the target: it has nothing to
+    /// map, a target column maps to no property or to one that cannot be read, or a property's type cannot be written
+    /// as its target's type. Also when a property is null for a column that cannot hold null.</exception>
+    public async ValueTask InsertAsync<T>(
+        string sql,
+        IEnumerable<T> rows,
+        ClickHouseTcpInsertOptions options = null,
+        CancellationToken cancellationToken = default)
+        where T : class
+    {
+        ArgumentNullException.ThrowIfNull(sql);
+        ArgumentNullException.ThrowIfNull(rows);
+
+        // Reached by handing over a sequence of columns that is not a list — the result of a LINQ operator over
+        // one, typically. Mapping IColumn as a POCO would "work" as far as reflecting over Name and RowCount, so
+        // say what was meant instead.
+        if (typeof(IColumn).IsAssignableFrom(typeof(T)))
+        {
+            throw new ArgumentException(
+                $"An insert of {typeof(T).Name} rows would map that type's properties to columns. To insert columnar data, call the overload taking IReadOnlyList<IColumn> — materialize the sequence (for example with ToList()) if it is not already a list.",
+                nameof(rows));
+        }
+
+        IReadOnlyDictionary<string, string> settings = BuildSettings(options);
+
+        // Materialized before the connection is rented: the target types arrive mid-INSERT, so the rows have to be
+        // in hand by then, and enumerating a slow source should not hold a connection open.
+        using var buffer = PocoRowBuffer<T>.Materialize(rows, nameof(rows), cancellationToken);
+
+        await using IConnectionLease lease = await source.RentAsync(cancellationToken).ConfigureAwait(false);
+        await lease.Connection.InsertAsync(
+            sql,
+            buffer.Count,
+            schema => pocoTypes.WritePlanFor<T>(schema).BuildColumns(buffer.Rows, buffer.Count),
+            settings,
+            parameters: null,
+            options?.QueryId,
+            ResolveMaxRowsPerBlock(options),
+            Options.MaxSendBufferBytes,
+            handlers: null,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Inserts untyped rows: each <c>object[]</c> holds one value per target column, <b>by position</b> — the order
+    /// of the statement's column list, or the table's own order when the statement names none. The dynamic
+    /// counterpart of <see cref="QueryAsync(string, ClickHouseTcpQueryOptions, CancellationToken)"/>, for a schema
+    /// known only at run time. With no rows nothing is written, though the statement is still sent.
+    /// </summary>
+    /// <remarks>
+    /// The CLR type each column is written in is taken from the first row that has a value there, so a column takes
+    /// either the calendar type (<see cref="DateTime"/> for a <c>DateTime</c> column) or the raw wire value the
+    /// untyped read produces — a read-then-reinsert needs no conversion — but every value of one column must then be
+    /// of that one type. The exception is a <c>Variant</c> or <c>Dynamic</c> target, which is written from
+    /// <see cref="object"/> and so takes a mixture. A null is inserted as NULL, which a column that is not
+    /// <c>Nullable</c> reports, naming the row.
+    ///
+    /// <para>
+    /// This tier boxes every value by construction. For bulk data prefer the columnar overload or
+    /// <see cref="InsertAsync{T}(string, IEnumerable{T}, ClickHouseTcpInsertOptions, CancellationToken)"/>, both of
+    /// which are box-free.
+    /// </para>
+    /// </remarks>
+    /// <param name="sql">The <c>INSERT INTO … VALUES</c> statement, with no inline <c>VALUES (...)</c> literal.</param>
+    /// <param name="rows">The rows to insert, each non-null and one value long per target column.</param>
+    /// <param name="options">Per-insert options (query id, settings, block sizing), or null for the client defaults.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>A task that completes when the server acknowledges the insert.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="sql"/> or <paramref name="rows"/> is null.</exception>
+    /// <exception cref="ArgumentException">A row is null or has the wrong number of values.</exception>
+    /// <exception cref="InvalidOperationException">A value's CLR type is not one its target column accepts, a column
+    /// holds values of more than one type, a value is null for a column that cannot hold null, or a target column's
+    /// type cannot be built from rows at all (<c>Nested</c>) and needs the columnar overload.</exception>
+    public async ValueTask InsertAsync(
+        string sql,
+        IEnumerable<object[]> rows,
+        ClickHouseTcpInsertOptions options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(sql);
+        ArgumentNullException.ThrowIfNull(rows);
+
+        IReadOnlyDictionary<string, string> settings = BuildSettings(options);
+        using var buffer = PocoRowBuffer<object[]>.Materialize(rows, nameof(rows), cancellationToken);
+
+        await using IConnectionLease lease = await source.RentAsync(cancellationToken).ConfigureAwait(false);
+        await lease.Connection.InsertAsync(
+            sql,
+            buffer.Count,
+            schema => PocoUntypedColumns.Build(schema, buffer.Rows, buffer.Count),
             settings,
             parameters: null,
             options?.QueryId,

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClient.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClient.cs
@@ -292,52 +292,10 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
             cancellationToken).ConfigureAwait(false);
     }
 
-    /// <summary>
-    /// Inserts rows of <typeparamref name="T"/>, reading each target column from the property of the same name.
-    /// Matching is the mirror of <see cref="QueryAsync{T}(string, ClickHouseTcpQueryOptions, CancellationToken)"/>'s:
-    /// case- and then underscore-insensitive, with <c>[ClickHouseTcpColumn]</c> renaming a property and
-    /// <c>[ClickHouseTcpNotMapped]</c> excluding one. With no rows nothing is written, though the statement is still
-    /// sent and the mapping still checked.
-    /// </summary>
-    /// <remarks>
-    /// Every target column must map to a property, so name the columns to insert in the statement
-    /// (<c>INSERT INTO t (a, b) VALUES</c>) when the POCO covers only some of the table — the server then fills the
-    /// rest from their defaults. A property no target column maps to is not inserted. <typeparamref name="T"/> needs
-    /// public getters but no constructor of ours, so a read-only POCO inserts even though it cannot be queried into.
-    ///
-    /// <para>
-    /// The gathering is box-free — each property goes into the buffer its column is written from through a compiled
-    /// per-column loop — except for a <c>Variant</c> or <c>Dynamic</c> target, which is written from a column of
-    /// <see cref="object"/> and so boxes a value-typed property per row. The mapping is compiled against the target's
-    /// own types, which the server sends after the statement, so a mismatch is reported once the INSERT is under way,
-    /// having written no rows, and leaves the client usable. <paramref name="rows"/> is fully enumerated before any
-    /// row data goes out, so <see cref="ClickHouseTcpInsertOptions.MaxRowsPerBlock"/> bounds the wire blocks, not
-    /// client memory.
-    /// </para>
-    ///
-    /// <para>
-    /// A property's type must be one its target column can be written from, which is a shorter list than the one a
-    /// query can read into: an <see cref="object"/> property reads any column but fills only a <c>Variant</c> or
-    /// <c>Dynamic</c> target, and a <c>LowCardinality(DateTime)</c> column reads as <see cref="DateTime"/> but is
-    /// written only from the raw epoch seconds. Declare the property as the type the column is written from, or
-    /// insert that column through the columnar <see cref="InsertAsync"/> method.
-    /// </para>
-    /// </remarks>
-    /// <typeparam name="T">The row type.</typeparam>
-    /// <param name="sql">The <c>INSERT INTO … VALUES</c> statement, with no inline <c>VALUES (...)</c> literal.</param>
-    /// <param name="rows">The rows to insert, each non-null.</param>
-    /// <param name="options">Per-insert options (query id, settings, block sizing), or null for the client defaults.</param>
-    /// <param name="cancellationToken">A token to observe for cancellation.</param>
-    /// <returns>A task that completes when the server acknowledges the insert.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="sql"/> or <paramref name="rows"/> is null.</exception>
-    /// <exception cref="ArgumentException">A row is null, or <typeparamref name="T"/> is a column type — pass columns
-    /// to <see cref="InsertAsync"/> instead.</exception>
-    /// <exception cref="InvalidOperationException"><typeparamref name="T"/> cannot fill the target: it has nothing to
-    /// map, a target column maps to no property or to one that cannot be read, or a property's type cannot be written
-    /// as its target's type. Also when a property is null for a column that cannot hold null.</exception>
+    /// <inheritdoc/>
     public async ValueTask InsertRowsAsync<T>(
         string sql,
-        IEnumerable<T> rows,
+        IReadOnlyList<T> rows,
         ClickHouseTcpInsertOptions options = null,
         CancellationToken cancellationToken = default)
         where T : class
@@ -345,9 +303,7 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
         ArgumentNullException.ThrowIfNull(sql);
         ArgumentNullException.ThrowIfNull(rows);
 
-        // Reached by handing over a sequence of columns that is not a list — the result of a LINQ operator over
-        // one, typically. Mapping IColumn as a POCO would "work" as far as reflecting over Name and RowCount, so
-        // say what was meant instead.
+        // Prevent column lists from being mistaken for POCO rows.
         if (typeof(IColumn).IsAssignableFrom(typeof(T)))
         {
             throw new ArgumentException(
@@ -357,9 +313,7 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
 
         IReadOnlyDictionary<string, string> settings = BuildSettings(options);
 
-        // Materialized before the connection is rented: the target types arrive mid-INSERT, so the rows have to be
-        // in hand by then, and enumerating a slow source should not hold a connection open.
-        using var buffer = PocoRowBuffer<T>.Materialize(rows, nameof(rows), cancellationToken);
+        using var buffer = PocoRowBuffer<T>.Create(rows, nameof(rows), cancellationToken);
 
         await using IConnectionLease lease = await source.RentAsync(cancellationToken).ConfigureAwait(false);
         await lease.Connection.InsertAsync(
@@ -375,39 +329,10 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
             cancellationToken).ConfigureAwait(false);
     }
 
-    /// <summary>
-    /// Inserts untyped rows: each <c>object[]</c> holds one value per target column, <b>by position</b> — the order
-    /// of the statement's column list, or the table's own order when the statement names none. The dynamic
-    /// counterpart of <see cref="QueryAsync(string, ClickHouseTcpQueryOptions, CancellationToken)"/>, for a schema
-    /// known only at run time. With no rows nothing is written, though the statement is still sent.
-    /// </summary>
-    /// <remarks>
-    /// The CLR type each column is written in is taken from the first row that has a value there, so a column takes
-    /// either the calendar type (<see cref="DateTime"/> for a <c>DateTime</c> column) or the raw wire value the
-    /// untyped read produces — a read-then-reinsert needs no conversion — but every value of one column must then be
-    /// of that one type. The exception is a <c>Variant</c> or <c>Dynamic</c> target, which is written from
-    /// <see cref="object"/> and so takes a mixture. A null is inserted as NULL, which a column that is not
-    /// <c>Nullable</c> reports, naming the row.
-    ///
-    /// <para>
-    /// This tier boxes every value by construction. For bulk data prefer the columnar <see cref="InsertAsync"/> method or
-    /// <see cref="InsertRowsAsync{T}(string, IEnumerable{T}, ClickHouseTcpInsertOptions, CancellationToken)"/>, both of
-    /// which are box-free.
-    /// </para>
-    /// </remarks>
-    /// <param name="sql">The <c>INSERT INTO … VALUES</c> statement, with no inline <c>VALUES (...)</c> literal.</param>
-    /// <param name="rows">The rows to insert, each non-null and one value long per target column.</param>
-    /// <param name="options">Per-insert options (query id, settings, block sizing), or null for the client defaults.</param>
-    /// <param name="cancellationToken">A token to observe for cancellation.</param>
-    /// <returns>A task that completes when the server acknowledges the insert.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="sql"/> or <paramref name="rows"/> is null.</exception>
-    /// <exception cref="ArgumentException">A row is null or has the wrong number of values.</exception>
-    /// <exception cref="InvalidOperationException">A value's CLR type is not one its target column accepts, a column
-    /// holds values of more than one type, a value is null for a column that cannot hold null, or a target column's
-    /// type cannot be built from rows at all (<c>Nested</c>) and needs <see cref="InsertAsync"/>.</exception>
+    /// <inheritdoc/>
     public async ValueTask InsertRowsAsync(
         string sql,
-        IEnumerable<object[]> rows,
+        IReadOnlyList<object[]> rows,
         ClickHouseTcpInsertOptions options = null,
         CancellationToken cancellationToken = default)
     {
@@ -415,13 +340,13 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
         ArgumentNullException.ThrowIfNull(rows);
 
         IReadOnlyDictionary<string, string> settings = BuildSettings(options);
-        using var buffer = PocoRowBuffer<object[]>.Materialize(rows, nameof(rows), cancellationToken);
+        using var buffer = PocoRowBuffer<object[]>.Create(rows, nameof(rows), cancellationToken);
 
         await using IConnectionLease lease = await source.RentAsync(cancellationToken).ConfigureAwait(false);
         await lease.Connection.InsertAsync(
             sql,
             buffer.Count,
-            schema => PocoUntypedColumns.Build(schema, buffer.Rows, buffer.Count),
+            schema => UntypedRowColumns.Build(schema, buffer.Rows, buffer.Count),
             settings,
             parameters: null,
             options?.QueryId,

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClientOptions.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClientOptions.cs
@@ -21,7 +21,7 @@ public sealed record ClickHouseTcpClientOptions
     internal const int DefaultPort = 9000;
     internal const string DefaultUsername = "default";
     internal const string DefaultDatabase = "default";
-    internal const int DefaultMaxSendBufferBytes = 10 * 1024 * 1024;
+    internal const int DefaultMaxSendBufferBytes = Format.BlockWriter.DefaultFlushThresholdBytes;
     internal static readonly TimeSpan DefaultDialTimeout = TimeSpan.FromSeconds(30);
     internal static readonly TimeSpan DefaultReadTimeout = TimeSpan.FromSeconds(300);
 
@@ -56,9 +56,15 @@ public sealed record ClickHouseTcpClientOptions
 
     /// <summary>
     /// The soft cap, in bytes, on the client's send buffer during an insert: while a wire block is written, the
-    /// buffered bytes are flushed to the socket whenever they exceed this, bounding peak memory for a large
-    /// insert (a single column larger than the cap still buffers in full). Independent of the block-split target,
-    /// so blocks stay their natural size and simply stream out within this cap. Defaults to 10 MiB.
+    /// buffered bytes are flushed to the socket once they pass this, bounding peak memory for a large insert.
+    /// Independent of the block-split target, so blocks stay their natural size and simply stream out within this
+    /// cap. Defaults to 1 MiB.
+    ///
+    /// <para>
+    /// The cap is checked after each column, so peak buffered bytes are the cap plus the column that crossed it,
+    /// and a single column larger than the cap buffers in full. Raising it also raises what the send buffer keeps:
+    /// it grows by doubling, and every size it passes through stays in the array pool.
+    /// </para>
     /// </summary>
     public int MaxSendBufferBytes { get; init; } = DefaultMaxSendBufferBytes;
 

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpConnectionStringBuilder.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpConnectionStringBuilder.cs
@@ -85,7 +85,7 @@ public sealed class ClickHouseTcpConnectionStringBuilder : DbConnectionStringBui
         set => this["ReadTimeout"] = value.TotalSeconds;
     }
 
-    /// <summary>The soft send-buffer cap, in bytes. Defaults to 10 MiB.</summary>
+    /// <summary>The soft send-buffer cap, in bytes. Defaults to 1 MiB.</summary>
     public int MaxSendBufferBytes
     {
         get => GetIntOrDefault("MaxSendBufferBytes", ClickHouseTcpClientOptions.DefaultMaxSendBufferBytes);

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpInsertOptions.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpInsertOptions.cs
@@ -3,8 +3,9 @@ using ClickHouse.Driver.Tcp.Protocol;
 namespace ClickHouse.Driver.Tcp;
 
 /// <summary>
-/// Per-insert overrides passed to <see cref="ClickHouseTcpClient.InsertAsync"/>: the query options (query id,
-/// settings) plus the knobs that only apply when the client writes a data stream.
+/// Per-insert overrides passed to <see cref="ClickHouseTcpClient.InsertAsync"/> or
+/// <see cref="ClickHouseTcpClient.InsertRowsAsync{T}"/>: the query options (query id, settings) plus the knobs that
+/// only apply when the client writes a data stream.
 /// </summary>
 public sealed record ClickHouseTcpInsertOptions : ClickHouseTcpQueryOptions
 {

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpInsertOptions.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpInsertOptions.cs
@@ -9,8 +9,14 @@ public sealed record ClickHouseTcpInsertOptions : ClickHouseTcpQueryOptions
 {
     /// <summary>
     /// A cap on the rows per wire block, applied alongside the client's internal byte target, so a wide or large
-    /// insert is split into several blocks instead of one huge one. Defaults to 1,000,000 rows. Set null to write
+    /// insert is split into several blocks instead of one huge one. Defaults to 50,000 rows. Set null to write
     /// the whole insert as a single block, whatever its row count.
+    ///
+    /// <para>
+    /// A row insert (<c>InsertRowsAsync</c>) converts one block at a time, so this cap also bounds the memory it
+    /// converts through: one buffer per target column, of this many values. A larger cap — or null, for a single
+    /// block — raises that in proportion to the rows.
+    /// </para>
     /// </summary>
     public int? MaxRowsPerBlock { get; init; } = ClickHouseTcpConnection.DefaultMaxRowsPerBlock;
 }

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpInsertOptions.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpInsertOptions.cs
@@ -3,9 +3,7 @@ using ClickHouse.Driver.Tcp.Protocol;
 namespace ClickHouse.Driver.Tcp;
 
 /// <summary>
-/// Per-insert overrides passed to <see cref="ClickHouseTcpClient.InsertAsync"/> or
-/// <see cref="ClickHouseTcpClient.InsertRowsAsync{T}"/>: the query options (query id, settings) plus the knobs that
-/// only apply when the client writes a data stream.
+/// Per-insert query and data-stream options.
 /// </summary>
 public sealed record ClickHouseTcpInsertOptions : ClickHouseTcpQueryOptions
 {

--- a/ClickHouse.Driver.Tcp/Client/IClickHouseTcpClient.cs
+++ b/ClickHouse.Driver.Tcp/Client/IClickHouseTcpClient.cs
@@ -10,8 +10,8 @@ namespace ClickHouse.Driver.Tcp;
 
 /// <summary>
 /// The contract of a ClickHouse client that speaks the native TCP protocol: run queries and stream results,
-/// execute statements, and insert columnar data. <see cref="ClickHouseTcpClient"/> is the implementation; code
-/// against this interface to substitute a test double.
+/// execute statements, and insert data columnwise or row by row. <see cref="ClickHouseTcpClient"/> is the
+/// implementation; code against this interface to substitute a test double.
 ///
 /// <para>
 /// This type is experimental: its surface may change in a future release. Suppress diagnostic
@@ -116,6 +116,58 @@ public interface IClickHouseTcpClient : IAsyncDisposable
     ValueTask InsertAsync(
         string sql,
         IReadOnlyList<IColumn> columns,
+        ClickHouseTcpInsertOptions options = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Inserts rows of <typeparamref name="T"/>, reading each target column from the property of the same name —
+    /// the write mirror of <see cref="QueryAsync{T}"/>. Every target column must map to a property, so name the
+    /// columns to insert in the statement when the type covers only some of the table. With no rows nothing is
+    /// written, though the statement is still sent and the mapping still checked.
+    /// </summary>
+    /// <remarks>
+    /// <paramref name="rows"/> is fully enumerated before any row data goes out: the target types arrive only after
+    /// the statement has been sent, so the rows must be in hand to be transposed into columns. A mapping failure is
+    /// therefore reported with the INSERT already under way, having written no rows, and leaves the client usable.
+    /// A property's type must be one its target column can be written from, which is a shorter list than the one a
+    /// query can read into — see the implementation's remarks.
+    /// </remarks>
+    /// <typeparam name="T">The row type.</typeparam>
+    /// <param name="sql">The <c>INSERT INTO … VALUES</c> statement, with no inline <c>VALUES (...)</c> literal.</param>
+    /// <param name="rows">The rows to insert, each non-null.</param>
+    /// <param name="options">Per-insert options (query id, settings, block sizing), or null for the client defaults.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>A task that completes when the server acknowledges the insert.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="sql"/> or <paramref name="rows"/> is null.</exception>
+    /// <exception cref="ArgumentException">A row is null, or <typeparamref name="T"/> is a column type.</exception>
+    /// <exception cref="InvalidOperationException"><typeparamref name="T"/> cannot fill the target, or a property is
+    /// null for a column that cannot hold null.</exception>
+    ValueTask InsertAsync<T>(
+        string sql,
+        IEnumerable<T> rows,
+        ClickHouseTcpInsertOptions options = null,
+        CancellationToken cancellationToken = default)
+        where T : class;
+
+    /// <summary>
+    /// Inserts untyped rows: each <c>object[]</c> holds one value per target column, <b>by position</b>. The
+    /// dynamic counterpart of <see cref="QueryAsync(string, ClickHouseTcpQueryOptions, CancellationToken)"/>, and
+    /// the one insert tier that boxes every value. With no rows nothing is written, though the statement is still
+    /// sent.
+    /// </summary>
+    /// <param name="sql">The <c>INSERT INTO … VALUES</c> statement, with no inline <c>VALUES (...)</c> literal.</param>
+    /// <param name="rows">The rows to insert, each non-null and one value long per target column.</param>
+    /// <param name="options">Per-insert options (query id, settings, block sizing), or null for the client defaults.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>A task that completes when the server acknowledges the insert.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="sql"/> or <paramref name="rows"/> is null.</exception>
+    /// <exception cref="ArgumentException">A row is null or has the wrong number of values.</exception>
+    /// <exception cref="InvalidOperationException">A value's CLR type is not one its target column accepts, a column
+    /// holds values of more than one type, a value is null for a column that cannot hold null, or a target column's
+    /// type cannot be built from rows at all (<c>Nested</c>) and needs the columnar overload.</exception>
+    ValueTask InsertAsync(
+        string sql,
+        IEnumerable<object[]> rows,
         ClickHouseTcpInsertOptions options = null,
         CancellationToken cancellationToken = default);
 

--- a/ClickHouse.Driver.Tcp/Client/IClickHouseTcpClient.cs
+++ b/ClickHouse.Driver.Tcp/Client/IClickHouseTcpClient.cs
@@ -139,10 +139,11 @@ public interface IClickHouseTcpClient : IAsyncDisposable
     /// <param name="cancellationToken">A token to observe for cancellation.</param>
     /// <returns>A task that completes when the server acknowledges the insert.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="sql"/> or <paramref name="rows"/> is null.</exception>
-    /// <exception cref="ArgumentException">A row is null, or <typeparamref name="T"/> is a column type.</exception>
+    /// <exception cref="ArgumentException">A row is null, or <typeparamref name="T"/> is a column type — pass columns
+    /// to <see cref="InsertAsync"/> instead.</exception>
     /// <exception cref="InvalidOperationException"><typeparamref name="T"/> cannot fill the target, or a property is
     /// null for a column that cannot hold null.</exception>
-    ValueTask InsertAsync<T>(
+    ValueTask InsertRowsAsync<T>(
         string sql,
         IEnumerable<T> rows,
         ClickHouseTcpInsertOptions options = null,
@@ -164,8 +165,8 @@ public interface IClickHouseTcpClient : IAsyncDisposable
     /// <exception cref="ArgumentException">A row is null or has the wrong number of values.</exception>
     /// <exception cref="InvalidOperationException">A value's CLR type is not one its target column accepts, a column
     /// holds values of more than one type, a value is null for a column that cannot hold null, or a target column's
-    /// type cannot be built from rows at all (<c>Nested</c>) and needs the columnar overload.</exception>
-    ValueTask InsertAsync(
+    /// type cannot be built from rows at all (<c>Nested</c>) and needs <see cref="InsertAsync"/>.</exception>
+    ValueTask InsertRowsAsync(
         string sql,
         IEnumerable<object[]> rows,
         ClickHouseTcpInsertOptions options = null,

--- a/ClickHouse.Driver.Tcp/Client/IClickHouseTcpClient.cs
+++ b/ClickHouse.Driver.Tcp/Client/IClickHouseTcpClient.cs
@@ -120,55 +120,53 @@ public interface IClickHouseTcpClient : IAsyncDisposable
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Inserts rows of <typeparamref name="T"/>, reading each target column from the property of the same name —
-    /// the write mirror of <see cref="QueryAsync{T}"/>. Every target column must map to a property, so name the
-    /// columns to insert in the statement when the type covers only some of the table. With no rows nothing is
-    /// written, though the statement is still sent and the mapping still checked.
+    /// Inserts rows by mapping the target columns to properties of <typeparamref name="T"/>. Names match case- and
+    /// underscore-insensitively; <see cref="ClickHouseTcpColumnAttribute"/> can rename a property and
+    /// <see cref="ClickHouseTcpNotMappedAttribute"/> can exclude one.
     /// </summary>
     /// <remarks>
-    /// <paramref name="rows"/> is fully enumerated before any row data goes out: the target types arrive only after
-    /// the statement has been sent, so the rows must be in hand to be transposed into columns. A mapping failure is
-    /// therefore reported with the INSERT already under way, having written no rows, and leaves the client usable.
-    /// A property's type must be one its target column can be written from, which is a shorter list than the one a
-    /// query can read into — see the implementation's remarks.
+    /// Every column targeted by the INSERT must have a compatible public getter. Other properties
+    /// are ignored. Rows must be materialized and must not be modified until the operation completes. An empty list
+    /// still validates the mapping.
     /// </remarks>
     /// <typeparam name="T">The row type.</typeparam>
     /// <param name="sql">The <c>INSERT INTO … VALUES</c> statement, with no inline <c>VALUES (...)</c> literal.</param>
-    /// <param name="rows">The rows to insert, each non-null.</param>
+    /// <param name="rows">The materialized rows to insert, each non-null.</param>
     /// <param name="options">Per-insert options (query id, settings, block sizing), or null for the client defaults.</param>
     /// <param name="cancellationToken">A token to observe for cancellation.</param>
     /// <returns>A task that completes when the server acknowledges the insert.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="sql"/> or <paramref name="rows"/> is null.</exception>
     /// <exception cref="ArgumentException">A row is null, or <typeparamref name="T"/> is a column type — pass columns
     /// to <see cref="InsertAsync"/> instead.</exception>
-    /// <exception cref="InvalidOperationException"><typeparamref name="T"/> cannot fill the target, or a property is
-    /// null for a column that cannot hold null.</exception>
+    /// <exception cref="InvalidOperationException"><typeparamref name="T"/> cannot fill the target, or a value is
+    /// null where the target does not allow it.</exception>
     ValueTask InsertRowsAsync<T>(
         string sql,
-        IEnumerable<T> rows,
+        IReadOnlyList<T> rows,
         ClickHouseTcpInsertOptions options = null,
         CancellationToken cancellationToken = default)
         where T : class;
 
     /// <summary>
-    /// Inserts untyped rows: each <c>object[]</c> holds one value per target column, <b>by position</b>. The
-    /// dynamic counterpart of <see cref="QueryAsync(string, ClickHouseTcpQueryOptions, CancellationToken)"/>, and
-    /// the one insert tier that boxes every value. With no rows nothing is written, though the statement is still
-    /// sent.
+    /// Inserts untyped rows, matching each <c>object[]</c> to the target columns by position.
     /// </summary>
+    /// <remarks>
+    /// A column uses the CLR type of its first non-null value; later values must use the same type unless the target
+    /// is <c>Variant</c> or <c>Dynamic</c>. Rows must not be modified until the operation completes. Value types are
+    /// boxed because each row stores its values as <see cref="object"/>.
+    /// </remarks>
     /// <param name="sql">The <c>INSERT INTO … VALUES</c> statement, with no inline <c>VALUES (...)</c> literal.</param>
-    /// <param name="rows">The rows to insert, each non-null and one value long per target column.</param>
+    /// <param name="rows">The materialized rows to insert, each non-null and one value long per target column.</param>
     /// <param name="options">Per-insert options (query id, settings, block sizing), or null for the client defaults.</param>
     /// <param name="cancellationToken">A token to observe for cancellation.</param>
     /// <returns>A task that completes when the server acknowledges the insert.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="sql"/> or <paramref name="rows"/> is null.</exception>
     /// <exception cref="ArgumentException">A row is null or has the wrong number of values.</exception>
-    /// <exception cref="InvalidOperationException">A value's CLR type is not one its target column accepts, a column
-    /// holds values of more than one type, a value is null for a column that cannot hold null, or a target column's
-    /// type cannot be built from rows at all (<c>Nested</c>) and needs <see cref="InsertAsync"/>.</exception>
+    /// <exception cref="InvalidOperationException">A value has an unsupported or inconsistent CLR type, is null
+    /// where the target does not allow it, or the target cannot be built from rows.</exception>
     ValueTask InsertRowsAsync(
         string sql,
-        IEnumerable<object[]> rows,
+        IReadOnlyList<object[]> rows,
         ClickHouseTcpInsertOptions options = null,
         CancellationToken cancellationToken = default);
 

--- a/ClickHouse.Driver.Tcp/Client/IClickHouseTcpClient.cs
+++ b/ClickHouse.Driver.Tcp/Client/IClickHouseTcpClient.cs
@@ -128,6 +128,13 @@ public interface IClickHouseTcpClient : IAsyncDisposable
     /// Every column targeted by the INSERT must have a compatible public getter. Other properties
     /// are ignored. Rows must be materialized and must not be modified until the operation completes. An empty list
     /// still validates the mapping.
+    ///
+    /// <para>
+    /// Rows are converted to columns one wire block at a time (see
+    /// <see cref="ClickHouseTcpInsertOptions.MaxRowsPerBlock"/>), so the list is read as the insert runs rather
+    /// than copied up front. A value the target cannot take — a null for a non-nullable column, say — is
+    /// therefore found when its own block is converted, and the blocks before it have already been sent.
+    /// </para>
     /// </remarks>
     /// <typeparam name="T">The row type.</typeparam>
     /// <param name="sql">The <c>INSERT INTO … VALUES</c> statement, with no inline <c>VALUES (...)</c> literal.</param>
@@ -151,9 +158,10 @@ public interface IClickHouseTcpClient : IAsyncDisposable
     /// Inserts untyped rows, matching each <c>object[]</c> to the target columns by position.
     /// </summary>
     /// <remarks>
-    /// A column uses the CLR type of its first non-null value; later values must use the same type unless the target
-    /// is <c>Variant</c> or <c>Dynamic</c>. Rows must not be modified until the operation completes. Value types are
-    /// boxed because each row stores its values as <see cref="object"/>.
+    /// A column uses the CLR type of its first non-null value, wherever in the insert that row is; later values
+    /// must use the same type unless the target is <c>Variant</c> or <c>Dynamic</c>. Rows must not be modified
+    /// until the operation completes, since they are converted one wire block at a time as the insert runs. Value
+    /// types are boxed because each row stores its values as <see cref="object"/>.
     /// </remarks>
     /// <param name="sql">The <c>INSERT INTO … VALUES</c> statement, with no inline <c>VALUES (...)</c> literal.</param>
     /// <param name="rows">The materialized rows to insert, each non-null and one value long per target column.</param>

--- a/ClickHouse.Driver.Tcp/Format/Block.cs
+++ b/ClickHouse.Driver.Tcp/Format/Block.cs
@@ -45,7 +45,7 @@ public sealed class Block : IDisposable
     internal BlockInfo Info { get; }
 
     /// <summary>
-    /// The registry used to resolve this block's codecs, retained for POCO read projections.
+    /// The registry used to resolve this block's codecs, retained for projections and INSERT sample-block planning.
     /// </summary>
     internal ColumnCodecRegistry Codecs { get; }
 

--- a/ClickHouse.Driver.Tcp/Format/BlockWriter.cs
+++ b/ClickHouse.Driver.Tcp/Format/BlockWriter.cs
@@ -63,7 +63,8 @@ internal static class BlockWriter
             }
         }
 
-        // Writing uses each value's own instant, so the codec needs no server timezone.
+        // A self-described block has no server sample/context to borrow. Explicit type timezones still apply;
+        // timezone-less DateTime types fall back to UTC for an Unspecified wall clock.
         ResolveContext context = ResolveContext.ForWrite;
         var planned = new InsertColumn[columns.Count];
         for (int i = 0; i < columns.Count; i++)

--- a/ClickHouse.Driver.Tcp/Format/BlockWriter.cs
+++ b/ClickHouse.Driver.Tcp/Format/BlockWriter.cs
@@ -14,10 +14,11 @@ namespace ClickHouse.Driver.Tcp.Format;
 internal static class BlockWriter
 {
     /// <summary>
-    /// The default per-block encoded-size target (50 MiB): the insert path sizes blocks to stay within it, and
-    /// the encoder flushes between columns once the buffer passes it as a backstop.
+    /// The default buffered-byte threshold (1 MiB) for the flush between two columns of a block. Peak buffered
+    /// bytes are this plus the column that crossed it, since the check follows a whole column; the writer never
+    /// flushes on its own, it grows.
     /// </summary>
-    public const int DefaultFlushThresholdBytes = 50 * 1024 * 1024;
+    public const int DefaultFlushThresholdBytes = 1024 * 1024;
 
     /// <summary>
     /// Writes the empty end-of-input block: an empty name, the standard block info, and zero column/row counts.

--- a/ClickHouse.Driver.Tcp/Poco/PocoBlockSignature.cs
+++ b/ClickHouse.Driver.Tcp/Poco/PocoBlockSignature.cs
@@ -5,28 +5,13 @@ using ClickHouse.Driver.Tcp.Types;
 namespace ClickHouse.Driver.Tcp.Poco;
 
 /// <summary>
-/// The cache key for the block shape a POCO plan is compiled against — a result's header for a read plan, an
-/// INSERT's sample block for a write plan. Only the wire shape lives here, so it is shared by every POCO type
-/// rather than computed once per type.
+/// Builds cache keys for the block shapes used by POCO plans.
 /// </summary>
 internal static class PocoBlockSignature
 {
     /// <summary>
-    /// The key for a block's shape: the resolution context, then each column's name and ClickHouse type. The type
-    /// string is the server's own header text, so two types that print alike cannot collide.
-    ///
-    /// <para>
-    /// Every part is length-prefixed rather than merely separated, because a column name is arbitrary text — a
-    /// backtick- or double-quoted alias may itself contain any separator character. Joined on a delimiter alone, the
-    /// header <c>[a Int32, b Int32]</c> and a single column named with that delimiter sequence produce the same key,
-    /// and the cache then hands one shape's plan to the other: columns silently unread, or an index past the block's
-    /// columns. Length prefixes make the key injective, so the shape a plan was compiled for is the only shape that
-    /// can find it.
-    /// </para>
+    /// Returns a collision-safe key for the context, column names, and types.
     /// </summary>
-    /// <param name="block">The block whose header to key on.</param>
-    /// <param name="context">The context the plan resolves its codecs with.</param>
-    /// <returns>The key.</returns>
     public static string Of(Block block, in ResolveContext context)
     {
         var key = new StringBuilder();
@@ -41,13 +26,7 @@ internal static class PocoBlockSignature
         return key.ToString();
     }
 
-    /// <summary>
-    /// The part of the key that is not in the header. A <c>DateTime</c> column whose type string names no timezone
-    /// resolves against the session timezone, so a plan built for one session timezone must not be reused for
-    /// another — the header alone cannot tell the two apart.
-    /// </summary>
-    /// <param name="context">The context the plan's codecs were resolved with.</param>
-    /// <returns>The key part.</returns>
+    /// <summary>Returns the context that affects codec resolution but is absent from the block header.</summary>
     public static string ContextKey(in ResolveContext context) => context.ServerTimezone ?? string.Empty;
 
     private static void Append(StringBuilder key, string part) => key.Append(part.Length).Append(':').Append(part);

--- a/ClickHouse.Driver.Tcp/Poco/PocoBlockSignature.cs
+++ b/ClickHouse.Driver.Tcp/Poco/PocoBlockSignature.cs
@@ -1,0 +1,54 @@
+using System.Text;
+using ClickHouse.Driver.Tcp.Format;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Poco;
+
+/// <summary>
+/// The cache key for the block shape a POCO plan is compiled against — a result's header for a read plan, an
+/// INSERT's sample block for a write plan. Only the wire shape lives here, so it is shared by every POCO type
+/// rather than computed once per type.
+/// </summary>
+internal static class PocoBlockSignature
+{
+    /// <summary>
+    /// The key for a block's shape: the resolution context, then each column's name and ClickHouse type. The type
+    /// string is the server's own header text, so two types that print alike cannot collide.
+    ///
+    /// <para>
+    /// Every part is length-prefixed rather than merely separated, because a column name is arbitrary text — a
+    /// backtick- or double-quoted alias may itself contain any separator character. Joined on a delimiter alone, the
+    /// header <c>[a Int32, b Int32]</c> and a single column named with that delimiter sequence produce the same key,
+    /// and the cache then hands one shape's plan to the other: columns silently unread, or an index past the block's
+    /// columns. Length prefixes make the key injective, so the shape a plan was compiled for is the only shape that
+    /// can find it.
+    /// </para>
+    /// </summary>
+    /// <param name="block">The block whose header to key on.</param>
+    /// <param name="context">The context the plan resolves its codecs with.</param>
+    /// <returns>The key.</returns>
+    public static string Of(Block block, in ResolveContext context)
+    {
+        var key = new StringBuilder();
+        Append(key, ContextKey(in context));
+        for (int i = 0; i < block.ColumnCount; i++)
+        {
+            IColumn column = block[i];
+            Append(key, column.Name);
+            Append(key, column.TypeName);
+        }
+
+        return key.ToString();
+    }
+
+    /// <summary>
+    /// The part of the key that is not in the header. A <c>DateTime</c> column whose type string names no timezone
+    /// resolves against the session timezone, so a plan built for one session timezone must not be reused for
+    /// another — the header alone cannot tell the two apart.
+    /// </summary>
+    /// <param name="context">The context the plan's codecs were resolved with.</param>
+    /// <returns>The key part.</returns>
+    public static string ContextKey(in ResolveContext context) => context.ServerTimezone ?? string.Empty;
+
+    private static void Append(StringBuilder key, string part) => key.Append(part.Length).Append(':').Append(part);
+}

--- a/ClickHouse.Driver.Tcp/Poco/PocoColumnBuilder.cs
+++ b/ClickHouse.Driver.Tcp/Poco/PocoColumnBuilder.cs
@@ -1,0 +1,205 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Poco;
+
+/// <summary>
+/// Copies one property of every row into the buffer one column is written from — the compiled unit of a POCO
+/// insert, and the mirror of the read path's scatter. Column-major for the same reason: the loop is taken over one
+/// property, which keeps the conversion and the property access out of any per-row dispatch.
+/// </summary>
+/// <typeparam name="T">The row type.</typeparam>
+/// <typeparam name="TWrite">The CLR type the target column is written in.</typeparam>
+/// <param name="rows">The rows to gather from; at least <paramref name="rowCount"/> long, each non-null.</param>
+/// <param name="rowCount">The number of rows to gather.</param>
+/// <param name="destination">The buffer to fill; at least <paramref name="rowCount"/> long.</param>
+internal delegate void PocoColumnGather<in T, in TWrite>(T[] rows, int rowCount, TWrite[] destination);
+
+/// <summary>
+/// Builds one target column of an insert out of the caller's rows. One builder per column of the server's sample
+/// block, held by the plan and reused across inserts, so it keeps no per-insert state: the buffer is rented inside
+/// <see cref="Build"/> and owned by the column it returns.
+/// </summary>
+/// <typeparam name="T">The row type.</typeparam>
+internal abstract class PocoColumnBuilder<T>
+    where T : class
+{
+    /// <summary>Initializes the target column's identity.</summary>
+    /// <param name="name">The target column's name.</param>
+    /// <param name="typeName">The target column's ClickHouse type.</param>
+    protected PocoColumnBuilder(string name, string typeName)
+    {
+        Name = name;
+        TypeName = typeName;
+    }
+
+    /// <summary>The target column's name.</summary>
+    protected string Name { get; }
+
+    /// <summary>The target column's ClickHouse type.</summary>
+    protected string TypeName { get; }
+
+    /// <summary>
+    /// Gathers <paramref name="rowCount"/> values into a fresh column.
+    /// </summary>
+    /// <param name="rows">The rows, each non-null.</param>
+    /// <param name="rowCount">The number of rows to gather.</param>
+    /// <returns>The column, owning a pooled buffer it returns when disposed.</returns>
+    /// <exception cref="InvalidOperationException">A row has no value for a column that cannot hold null.</exception>
+    public abstract IColumn Build(T[] rows, int rowCount);
+}
+
+/// <summary>
+/// The typed builder: a rented <typeparamref name="TWrite"/> buffer, filled by the gather and handed to a column
+/// that owns it. <see cref="ArrayColumn{T}"/> is what the column is, because it surfaces both
+/// <see cref="IColumn{T}"/> — which every codec's <c>CanWrite</c> tests for — and a contiguous span, so a
+/// fixed-width column reaches the wire as one blit.
+/// </summary>
+/// <typeparam name="T">The row type.</typeparam>
+/// <typeparam name="TWrite">The CLR type the target column is written in.</typeparam>
+internal sealed class PocoColumnBuilder<T, TWrite> : PocoColumnBuilder<T>
+    where T : class
+{
+    private readonly PocoColumnGather<T, TWrite> gather;
+
+    /// <summary>Initializes the builder over a compiled gather.</summary>
+    /// <param name="name">The target column's name.</param>
+    /// <param name="typeName">The target column's ClickHouse type.</param>
+    /// <param name="gather">The gather filling the write buffer from the rows.</param>
+    public PocoColumnBuilder(string name, string typeName, PocoColumnGather<T, TWrite> gather)
+        : base(name, typeName) => this.gather = gather;
+
+    /// <inheritdoc/>
+    public override IColumn Build(T[] rows, int rowCount)
+    {
+        TWrite[] buffer = ArrayPool<TWrite>.Shared.Rent(rowCount);
+        try
+        {
+            gather(rows, rowCount, buffer);
+        }
+        catch
+        {
+            // The column never took ownership of the rent, so return it rather than leak it on a failed gather.
+            // Cleared unconditionally, unlike ArrayColumn's reference-type test: the gather stopped part-way, so
+            // this is the one path where what the buffer holds is unknown, and it costs nothing on a failure.
+            ArrayPool<TWrite>.Shared.Return(buffer, clearArray: true);
+            throw;
+        }
+
+        return ArrayColumn<TWrite>.OverPooledBuffer(Name, TypeName, buffer, rowCount);
+    }
+}
+
+/// <summary>
+/// Compiles the per-column builders a <see cref="PocoWritePlan{T}"/> is made of. One builder handles one (property,
+/// target column) pair for a whole insert, with the value conversion (<see cref="PocoWriteConversion"/>) inlined
+/// into the loop rather than called through a delegate per row.
+/// </summary>
+internal static class PocoColumnBuilderFactory
+{
+    private static readonly MethodInfo CreateTypedMethod =
+        typeof(PocoColumnBuilderFactory).GetMethod(nameof(CreateTyped), BindingFlags.NonPublic | BindingFlags.Static);
+
+    /// <summary>
+    /// Compiles the builder for one property into one target column.
+    /// </summary>
+    /// <typeparam name="T">The row type.</typeparam>
+    /// <param name="column">The target column from the server's sample block, for its name and type.</param>
+    /// <param name="codec">The target type's codec, resolved as the write path resolves it.</param>
+    /// <param name="member">The property the column is filled from; must be gettable.</param>
+    /// <returns>The compiled builder.</returns>
+    /// <exception cref="InvalidOperationException">The property's type cannot be written as the column's type.</exception>
+    public static PocoColumnBuilder<T> Create<T>(IColumn column, IColumnCodec codec, PocoMember member)
+        where T : class
+    {
+        if (!PocoWriteConversion.TryChooseWriteType(codec, member.MemberType, out Type writeType))
+        {
+            throw NotWritableAs(column, codec, member, typeof(T));
+        }
+
+        return (PocoColumnBuilder<T>)CreateTypedMethod
+            .MakeGenericMethod(typeof(T), writeType)
+            .Invoke(null, new object[] { column.Name, column.TypeName, member, PocoWriteConversion.TakesNull(codec) });
+    }
+
+    /// <summary>
+    /// Compiles the gather now that the write type is a type argument: <c>for (row) destination[row] =
+    /// convert(rows[row].P);</c>.
+    /// </summary>
+    /// <typeparam name="T">The row type.</typeparam>
+    /// <typeparam name="TWrite">The CLR type the target column is written in.</typeparam>
+    /// <param name="name">The target column's name.</param>
+    /// <param name="typeName">The target column's ClickHouse type.</param>
+    /// <param name="member">The property to gather.</param>
+    /// <param name="targetTakesNull">Whether the target column can carry a row with no value.</param>
+    /// <returns>The builder.</returns>
+    private static PocoColumnBuilder<T> CreateTyped<T, TWrite>(string name, string typeName, PocoMember member, bool targetTakesNull)
+        where T : class
+    {
+        ParameterExpression rows = Expression.Parameter(typeof(T[]), "rows");
+        ParameterExpression rowCount = Expression.Parameter(typeof(int), "rowCount");
+        ParameterExpression destination = Expression.Parameter(typeof(TWrite[]), "destination");
+        ParameterExpression row = Expression.Variable(typeof(int), "row");
+
+        var site = new PocoGatherSite
+        {
+            ColumnName = name,
+            ColumnType = typeName,
+            PocoTypeName = typeof(T).Name,
+            MemberName = member.MemberName,
+            Row = Expression.Convert(row, typeof(long)),
+        };
+
+        Expression value = Expression.Property(Expression.ArrayIndex(rows, row), member.Property);
+        Expression converted = PocoWriteConversion.Convert(value, typeof(TWrite), targetTakesNull, site);
+
+        // row = 0; while (row < rowCount) { destination[row] = <converted>; row++; }
+        LabelTarget done = Expression.Label("done");
+        Expression body = Expression.Block(
+            new[] { row },
+            Expression.Assign(row, Expression.Constant(0)),
+            Expression.Loop(
+                Expression.IfThenElse(
+                    Expression.LessThan(row, rowCount),
+                    Expression.Block(
+                        Expression.Assign(Expression.ArrayAccess(destination, row), converted),
+                        Expression.PostIncrementAssign(row)),
+                    Expression.Break(done)),
+                done));
+
+        var gather = Expression.Lambda<PocoColumnGather<T, TWrite>>(body, rows, rowCount, destination).Compile();
+        return new PocoColumnBuilder<T, TWrite>(name, typeName, gather);
+    }
+
+    /// <summary>
+    /// The failure for a property the column cannot be written from: raised at plan build, so it names the shape
+    /// rather than surfacing as a rejected column once the INSERT is already open.
+    /// </summary>
+    /// <param name="column">The target column.</param>
+    /// <param name="codec">The target type's codec, for the types it accepts.</param>
+    /// <param name="member">The property that cannot fill it.</param>
+    /// <param name="pocoType">The row type.</param>
+    /// <returns>The exception to throw.</returns>
+    private static Exception NotWritableAs(IColumn column, IColumnCodec codec, PocoMember member, Type pocoType)
+    {
+        IReadOnlyList<Type> accepted = PocoWriteConversion.AcceptedWriteTypes(codec);
+        var offered = new string[accepted.Count];
+        for (int i = 0; i < accepted.Count; i++)
+        {
+            offered[i] = accepted[i].ToString();
+        }
+
+        // No accepted type at all means the target's writer needs a column shape rows cannot be gathered into
+        // (Nested), so naming property types would send the caller round a loop they cannot win.
+        string remedy = accepted.Count == 0
+            ? $"No property type can fill a '{column.TypeName}' column: insert it through the columnar API, which can build the column shape it needs."
+            : $"It accepts {string.Join(" or ", offered)}. Give the property one of those types, or insert that column through the columnar API.";
+
+        return new InvalidOperationException(
+            $"Column '{column.Name}' ({column.TypeName}) is filled from property '{pocoType.Name}.{member.MemberName}' of type {member.MemberType}, which it cannot be written from. " + remedy);
+    }
+}

--- a/ClickHouse.Driver.Tcp/Poco/PocoColumnBuilder.cs
+++ b/ClickHouse.Driver.Tcp/Poco/PocoColumnBuilder.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Buffers;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -8,17 +7,19 @@ using ClickHouse.Driver.Tcp.Types;
 namespace ClickHouse.Driver.Tcp.Poco;
 
 /// <summary>
-/// Fills one target-column buffer from a property of each row.
+/// Fills one target-column buffer from a property of each row in a range.
 /// </summary>
 /// <typeparam name="T">The row type.</typeparam>
 /// <typeparam name="TWrite">The CLR type the target column is written in.</typeparam>
-/// <param name="rows">The rows to gather from; at least <paramref name="rowCount"/> long, each non-null.</param>
-/// <param name="rowCount">The number of rows to gather.</param>
-/// <param name="destination">The buffer to fill; at least <paramref name="rowCount"/> long.</param>
-internal delegate void PocoColumnGather<in T, in TWrite>(T[] rows, int rowCount, TWrite[] destination);
+/// <param name="rows">The rows to gather from; holds the range at <paramref name="start"/>, each non-null.</param>
+/// <param name="start">The index in <paramref name="rows"/> the range begins at.</param>
+/// <param name="rowNumber">The insert row number of that first row, for error messages.</param>
+/// <param name="count">The number of rows to gather.</param>
+/// <param name="destination">The buffer to fill from index zero; at least <paramref name="count"/> long.</param>
+internal delegate void PocoColumnGather<in T, in TWrite>(T[] rows, int start, int rowNumber, int count, TWrite[] destination);
 
 /// <summary>
-/// Builds one target column from buffered rows. The returned column owns its buffer.
+/// Gathers one target column, one block at a time, into a buffer it rents for the whole insert.
 /// </summary>
 /// <typeparam name="T">The row type.</typeparam>
 internal abstract class PocoColumnBuilder<T>
@@ -39,17 +40,23 @@ internal abstract class PocoColumnBuilder<T>
     /// <summary>The target column's ClickHouse type.</summary>
     protected string TypeName { get; }
 
-    /// <summary>Gathers <paramref name="rowCount"/> values into a new column.</summary>
-    /// <param name="rows">The rows, each non-null.</param>
-    /// <param name="rowCount">The number of rows to gather.</param>
+    /// <summary>Rents this column's gather destination, sized for one block.</summary>
+    /// <param name="blockRows">The most rows one block will hold.</param>
     /// <returns>The column, owning a pooled buffer it returns when disposed.</returns>
+    public abstract IColumn CreateColumn(int blockRows);
+
+    /// <summary>Gathers one block's values into a column from <see cref="CreateColumn"/>.</summary>
+    /// <param name="column">The column to fill, from this builder's <see cref="CreateColumn"/>.</param>
+    /// <param name="rows">The rows, each non-null.</param>
+    /// <param name="start">The index in <paramref name="rows"/> the block begins at.</param>
+    /// <param name="rowNumber">The insert row number of that first row, for error messages.</param>
+    /// <param name="count">The number of rows to gather.</param>
     /// <exception cref="InvalidOperationException">A row has no value for a column that cannot hold null.</exception>
-    public abstract IColumn Build(T[] rows, int rowCount);
+    public abstract void Gather(IColumn column, T[] rows, int start, int rowNumber, int count);
 }
 
 /// <summary>
-/// Gathers rows into a rented <typeparamref name="TWrite"/> buffer and transfers ownership to an
-/// <see cref="ArrayColumn{T}"/>.
+/// Gathers rows into a <see cref="PocoGatherColumn{T}"/>'s reused <typeparamref name="TWrite"/> buffer.
 /// </summary>
 /// <typeparam name="T">The row type.</typeparam>
 /// <typeparam name="TWrite">The CLR type the target column is written in.</typeparam>
@@ -66,21 +73,18 @@ internal sealed class PocoColumnBuilder<T, TWrite> : PocoColumnBuilder<T>
         : base(name, typeName) => this.gather = gather;
 
     /// <inheritdoc/>
-    public override IColumn Build(T[] rows, int rowCount)
-    {
-        TWrite[] buffer = ArrayPool<TWrite>.Shared.Rent(rowCount);
-        try
-        {
-            gather(rows, rowCount, buffer);
-        }
-        catch
-        {
-            // No column owns the rent yet; clear any partially gathered references before returning it.
-            ArrayPool<TWrite>.Shared.Return(buffer, clearArray: true);
-            throw;
-        }
+    public override IColumn CreateColumn(int blockRows) => new PocoGatherColumn<TWrite>(Name, TypeName, blockRows);
 
-        return ArrayColumn<TWrite>.OverPooledBuffer(Name, TypeName, buffer, rowCount);
+    /// <inheritdoc/>
+    public override void Gather(IColumn column, T[] rows, int start, int rowNumber, int count)
+    {
+        var destination = (PocoGatherColumn<TWrite>)column;
+
+        // Publish the rows only once they are all written, so a failed gather leaves no half-filled range
+        // readable through the column.
+        destination.Publish(0);
+        gather(rows, start, rowNumber, count, destination.Buffer);
+        destination.Publish(count);
     }
 }
 
@@ -124,9 +128,11 @@ internal static class PocoColumnBuilderFactory
         where T : class
     {
         ParameterExpression rows = Expression.Parameter(typeof(T[]), "rows");
-        ParameterExpression rowCount = Expression.Parameter(typeof(int), "rowCount");
+        ParameterExpression start = Expression.Parameter(typeof(int), "start");
+        ParameterExpression rowNumber = Expression.Parameter(typeof(int), "rowNumber");
+        ParameterExpression count = Expression.Parameter(typeof(int), "count");
         ParameterExpression destination = Expression.Parameter(typeof(TWrite[]), "destination");
-        ParameterExpression row = Expression.Variable(typeof(int), "row");
+        ParameterExpression slot = Expression.Variable(typeof(int), "slot");
 
         var site = new PocoGatherSite
         {
@@ -134,27 +140,30 @@ internal static class PocoColumnBuilderFactory
             ColumnType = typeName,
             PocoTypeName = typeof(T).Name,
             MemberName = member.MemberName,
-            Row = Expression.Convert(row, typeof(long)),
+
+            // Name the row by its number in the insert, not by its position in the block. Evaluated only where
+            // a conversion throws, so the addition costs nothing per row.
+            Row = Expression.Convert(Expression.Add(rowNumber, slot), typeof(long)),
         };
 
-        Expression value = Expression.Property(Expression.ArrayIndex(rows, row), member.Property);
+        Expression value = Expression.Property(Expression.ArrayIndex(rows, Expression.Add(start, slot)), member.Property);
         Expression converted = PocoWriteConversion.Convert(value, typeof(TWrite), targetTakesNull, site);
 
-        // row = 0; while (row < rowCount) { destination[row] = <converted>; row++; }
+        // slot = 0; while (slot < count) { destination[slot] = <converted from rows[start + slot]>; slot++; }
         LabelTarget done = Expression.Label("done");
         Expression body = Expression.Block(
-            new[] { row },
-            Expression.Assign(row, Expression.Constant(0)),
+            new[] { slot },
+            Expression.Assign(slot, Expression.Constant(0)),
             Expression.Loop(
                 Expression.IfThenElse(
-                    Expression.LessThan(row, rowCount),
+                    Expression.LessThan(slot, count),
                     Expression.Block(
-                        Expression.Assign(Expression.ArrayAccess(destination, row), converted),
-                        Expression.PostIncrementAssign(row)),
+                        Expression.Assign(Expression.ArrayAccess(destination, slot), converted),
+                        Expression.PostIncrementAssign(slot)),
                     Expression.Break(done)),
                 done));
 
-        var gather = Expression.Lambda<PocoColumnGather<T, TWrite>>(body, rows, rowCount, destination).Compile();
+        var gather = Expression.Lambda<PocoColumnGather<T, TWrite>>(body, rows, start, rowNumber, count, destination).Compile();
         return new PocoColumnBuilder<T, TWrite>(name, typeName, gather);
     }
 

--- a/ClickHouse.Driver.Tcp/Poco/PocoColumnBuilder.cs
+++ b/ClickHouse.Driver.Tcp/Poco/PocoColumnBuilder.cs
@@ -8,9 +8,7 @@ using ClickHouse.Driver.Tcp.Types;
 namespace ClickHouse.Driver.Tcp.Poco;
 
 /// <summary>
-/// Copies one property of every row into the buffer one column is written from — the compiled unit of a POCO
-/// insert, and the mirror of the read path's scatter. Column-major for the same reason: the loop is taken over one
-/// property, which keeps the conversion and the property access out of any per-row dispatch.
+/// Fills one target-column buffer from a property of each row.
 /// </summary>
 /// <typeparam name="T">The row type.</typeparam>
 /// <typeparam name="TWrite">The CLR type the target column is written in.</typeparam>
@@ -20,9 +18,7 @@ namespace ClickHouse.Driver.Tcp.Poco;
 internal delegate void PocoColumnGather<in T, in TWrite>(T[] rows, int rowCount, TWrite[] destination);
 
 /// <summary>
-/// Builds one target column of an insert out of the caller's rows. One builder per column of the server's sample
-/// block, held by the plan and reused across inserts, so it keeps no per-insert state: the buffer is rented inside
-/// <see cref="Build"/> and owned by the column it returns.
+/// Builds one target column from buffered rows. The returned column owns its buffer.
 /// </summary>
 /// <typeparam name="T">The row type.</typeparam>
 internal abstract class PocoColumnBuilder<T>
@@ -43,9 +39,7 @@ internal abstract class PocoColumnBuilder<T>
     /// <summary>The target column's ClickHouse type.</summary>
     protected string TypeName { get; }
 
-    /// <summary>
-    /// Gathers <paramref name="rowCount"/> values into a fresh column.
-    /// </summary>
+    /// <summary>Gathers <paramref name="rowCount"/> values into a new column.</summary>
     /// <param name="rows">The rows, each non-null.</param>
     /// <param name="rowCount">The number of rows to gather.</param>
     /// <returns>The column, owning a pooled buffer it returns when disposed.</returns>
@@ -54,10 +48,8 @@ internal abstract class PocoColumnBuilder<T>
 }
 
 /// <summary>
-/// The typed builder: a rented <typeparamref name="TWrite"/> buffer, filled by the gather and handed to a column
-/// that owns it. <see cref="ArrayColumn{T}"/> is what the column is, because it surfaces both
-/// <see cref="IColumn{T}"/> — which every codec's <c>CanWrite</c> tests for — and a contiguous span, so a
-/// fixed-width column reaches the wire as one blit.
+/// Gathers rows into a rented <typeparamref name="TWrite"/> buffer and transfers ownership to an
+/// <see cref="ArrayColumn{T}"/>.
 /// </summary>
 /// <typeparam name="T">The row type.</typeparam>
 /// <typeparam name="TWrite">The CLR type the target column is written in.</typeparam>
@@ -83,9 +75,7 @@ internal sealed class PocoColumnBuilder<T, TWrite> : PocoColumnBuilder<T>
         }
         catch
         {
-            // The column never took ownership of the rent, so return it rather than leak it on a failed gather.
-            // Cleared unconditionally, unlike ArrayColumn's reference-type test: the gather stopped part-way, so
-            // this is the one path where what the buffer holds is unknown, and it costs nothing on a failure.
+            // No column owns the rent yet; clear any partially gathered references before returning it.
             ArrayPool<TWrite>.Shared.Return(buffer, clearArray: true);
             throw;
         }
@@ -95,18 +85,14 @@ internal sealed class PocoColumnBuilder<T, TWrite> : PocoColumnBuilder<T>
 }
 
 /// <summary>
-/// Compiles the per-column builders a <see cref="PocoWritePlan{T}"/> is made of. One builder handles one (property,
-/// target column) pair for a whole insert, with the value conversion (<see cref="PocoWriteConversion"/>) inlined
-/// into the loop rather than called through a delegate per row.
+/// Compiles a builder for each property-to-column mapping in a <see cref="PocoWritePlan{T}"/>.
 /// </summary>
 internal static class PocoColumnBuilderFactory
 {
     private static readonly MethodInfo CreateTypedMethod =
         typeof(PocoColumnBuilderFactory).GetMethod(nameof(CreateTyped), BindingFlags.NonPublic | BindingFlags.Static);
 
-    /// <summary>
-    /// Compiles the builder for one property into one target column.
-    /// </summary>
+    /// <summary>Compiles the builder for one property and target column.</summary>
     /// <typeparam name="T">The row type.</typeparam>
     /// <param name="column">The target column from the server's sample block, for its name and type.</param>
     /// <param name="codec">The target type's codec, resolved as the write path resolves it.</param>
@@ -126,10 +112,7 @@ internal static class PocoColumnBuilderFactory
             .Invoke(null, new object[] { column.Name, column.TypeName, member, PocoWriteConversion.TakesNull(codec) });
     }
 
-    /// <summary>
-    /// Compiles the gather now that the write type is a type argument: <c>for (row) destination[row] =
-    /// convert(rows[row].P);</c>.
-    /// </summary>
+    /// <summary>Compiles the typed property gather.</summary>
     /// <typeparam name="T">The row type.</typeparam>
     /// <typeparam name="TWrite">The CLR type the target column is written in.</typeparam>
     /// <param name="name">The target column's name.</param>
@@ -175,10 +158,7 @@ internal static class PocoColumnBuilderFactory
         return new PocoColumnBuilder<T, TWrite>(name, typeName, gather);
     }
 
-    /// <summary>
-    /// The failure for a property the column cannot be written from: raised at plan build, so it names the shape
-    /// rather than surfacing as a rejected column once the INSERT is already open.
-    /// </summary>
+    /// <summary>Builds the plan-time error for an incompatible property and target column.</summary>
     /// <param name="column">The target column.</param>
     /// <param name="codec">The target type's codec, for the types it accepts.</param>
     /// <param name="member">The property that cannot fill it.</param>
@@ -193,8 +173,7 @@ internal static class PocoColumnBuilderFactory
             offered[i] = accepted[i].ToString();
         }
 
-        // No accepted type at all means the target's writer needs a column shape rows cannot be gathered into
-        // (Nested), so naming property types would send the caller round a loop they cannot win.
+        // An empty list means the codec requires a column shape that rows cannot provide.
         string remedy = accepted.Count == 0
             ? $"No property type can fill a '{column.TypeName}' column: insert it through the columnar API, which can build the column shape it needs."
             : $"It accepts {string.Join(" or ", offered)}. Give the property one of those types, or insert that column through the columnar API.";

--- a/ClickHouse.Driver.Tcp/Poco/PocoGatherColumn.cs
+++ b/ClickHouse.Driver.Tcp/Poco/PocoGatherColumn.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Buffers;
+using System.Runtime.CompilerServices;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Poco;
+
+/// <summary>
+/// One target column's gather destination: a buffer rented once for an insert and re-presented as the values of
+/// each wire block in turn. A compiled gather fills <see cref="Buffer"/>, then <see cref="Publish"/> takes the
+/// rows it wrote as this column's own, so the buffer is reused for every block instead of one being rented per
+/// block.
+/// </summary>
+/// <typeparam name="T">The CLR type the target column is written in.</typeparam>
+internal sealed class PocoGatherColumn<T> : IColumn<T>, ISpanColumn<T>
+{
+    private T[] buffer;
+    private int rowCount;
+
+    /// <summary>Rents a buffer for one block's values.</summary>
+    /// <param name="name">The target column's name.</param>
+    /// <param name="typeName">The target column's ClickHouse type.</param>
+    /// <param name="capacity">The most rows one block will hold.</param>
+    public PocoGatherColumn(string name, string typeName, int capacity)
+    {
+        Name = name;
+        TypeName = typeName;
+        buffer = ArrayPool<T>.Shared.Rent(capacity);
+    }
+
+    /// <inheritdoc/>
+    public string Name { get; }
+
+    /// <inheritdoc/>
+    public string TypeName { get; }
+
+    /// <inheritdoc/>
+    public int RowCount => rowCount;
+
+    /// <summary>The buffer to gather into. It is longer than a block, so only the published rows are values.</summary>
+    public T[] Buffer => buffer;
+
+    /// <inheritdoc/>
+    public ReadOnlySpan<T> Values => new(buffer, 0, rowCount);
+
+    /// <inheritdoc/>
+    ReadOnlySpan<T> ISpanColumn<T>.Span => Values;
+
+    /// <inheritdoc/>
+    // Index through the logical span: the buffer holds a whole block, so a direct buffer[row] would return the
+    // previous block's value for an out-of-range row instead of throwing.
+    public T this[int row] => Values[row];
+
+    /// <inheritdoc/>
+    public object GetValue(int row) => Values[row];
+
+    /// <summary>Takes the first <paramref name="count"/> buffered values as this column's rows.</summary>
+    /// <param name="count">The number of rows the gather filled.</param>
+    public void Publish(int count) => rowCount = count;
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        rowCount = 0;
+        if (buffer.Length != 0)
+        {
+            // Clear reference-bearing element types so a returned array does not pin what it last held.
+            ArrayPool<T>.Shared.Return(buffer, clearArray: RuntimeHelpers.IsReferenceOrContainsReferences<T>());
+        }
+
+        buffer = Array.Empty<T>();
+    }
+}

--- a/ClickHouse.Driver.Tcp/Poco/PocoInsertSource.cs
+++ b/ClickHouse.Driver.Tcp/Poco/PocoInsertSource.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using ClickHouse.Driver.Tcp.Protocol;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Poco;
+
+/// <summary>
+/// The columns of one row-oriented insert: a gather buffer per target column, rented for the insert and refilled
+/// for each wire block. Peak memory is therefore one block of values wide, not the whole insert.
+/// </summary>
+/// <typeparam name="T">The row type.</typeparam>
+internal class PocoInsertSource<T> : IInsertColumnSource
+    where T : class
+{
+    private readonly PocoColumnBuilder<T>[] builders;
+    private readonly PocoRowBuffer<T> rows;
+    private readonly IColumn[] columns;
+    private readonly int blockRows;
+
+    /// <summary>Rents one gather buffer per target column.</summary>
+    /// <param name="builders">The compiled gathers, one per target column in schema order.</param>
+    /// <param name="rows">The insert's rows; not owned, and outlives this source.</param>
+    /// <param name="blockRows">The most rows one block will hold.</param>
+    public PocoInsertSource(PocoColumnBuilder<T>[] builders, PocoRowBuffer<T> rows, int blockRows)
+    {
+        this.builders = builders;
+        this.rows = rows;
+        this.blockRows = blockRows;
+
+        columns = new IColumn[builders.Length];
+        int rented = 0;
+        try
+        {
+            for (; rented < builders.Length; rented++)
+            {
+                columns[rented] = builders[rented].CreateColumn(blockRows);
+            }
+        }
+        catch
+        {
+            // Release the buffers rented before a later column failed.
+            for (int i = 0; i < rented; i++)
+            {
+                columns[i].Dispose();
+            }
+
+            throw;
+        }
+    }
+
+    /// <inheritdoc/>
+    public IReadOnlyList<IColumn> Columns => columns;
+
+    /// <inheritdoc/>
+    public void Gather(int start, int length)
+    {
+        if (length > blockRows)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(length), length, $"The gather buffers hold {blockRows} row(s), so a longer block cannot be gathered.");
+        }
+
+        int offset = rows.Prepare(start, length);
+        CheckBlock(rows.Rows, offset, start, length);
+
+        for (int i = 0; i < builders.Length; i++)
+        {
+            builders[i].Gather(columns[i], rows.Rows, offset, start, length);
+        }
+    }
+
+    /// <summary>Checks a block's rows before any column reads them. Does nothing unless a row shape needs it.</summary>
+    /// <param name="window">The array the block's rows are in.</param>
+    /// <param name="offset">The index in <paramref name="window"/> the block begins at.</param>
+    /// <param name="rowNumber">The insert row number of that first row, for error messages.</param>
+    /// <param name="count">The number of rows in the block.</param>
+    protected virtual void CheckBlock(T[] window, int offset, int rowNumber, int count)
+    {
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        for (int i = 0; i < columns.Length; i++)
+        {
+            columns[i]?.Dispose();
+        }
+    }
+}

--- a/ClickHouse.Driver.Tcp/Poco/PocoReadPlan.cs
+++ b/ClickHouse.Driver.Tcp/Poco/PocoReadPlan.cs
@@ -1,44 +1,18 @@
 using System;
 using System.Collections.Generic;
-using System.Text;
 using ClickHouse.Driver.Tcp.Format;
 using ClickHouse.Driver.Tcp.Types;
 
 namespace ClickHouse.Driver.Tcp.Poco;
 
-/// <summary>
 /// Builds cache keys for result shapes used by <see cref="PocoReadPlan{T}"/>.
 /// </summary>
 internal static class PocoReadPlan
 {
-    /// <summary>
-    /// Builds a length-prefixed key from the resolution context and each column's name and type. Length prefixes
-    /// prevent aliases containing separator characters from colliding with another header.
-    /// </summary>
+    /// <summary>The cache key for the shape of a result block. See <see cref="PocoBlockSignature.Of"/>.</summary>
     /// <param name="block">The block whose header to key on.</param>
     /// <returns>The key.</returns>
-    public static string SignatureOf(Block block)
-    {
-        var key = new StringBuilder();
-        Append(key, ContextKey(block.Context));
-        for (int i = 0; i < block.ColumnCount; i++)
-        {
-            IColumn column = block[i];
-            Append(key, column.Name);
-            Append(key, column.TypeName);
-        }
-
-        return key.ToString();
-    }
-
-    /// <summary>
-    /// Builds the context part of the key, including the session timezone used by timezone-less types.
-    /// </summary>
-    /// <param name="context">The context the block's codecs were resolved with.</param>
-    /// <returns>The key part.</returns>
-    public static string ContextKey(in ResolveContext context) => context.ServerTimezone ?? string.Empty;
-
-    private static void Append(StringBuilder key, string part) => key.Append(part.Length).Append(':').Append(part);
+    public static string SignatureOf(Block block) => PocoBlockSignature.Of(block, block.Context);
 }
 
 /// <summary>
@@ -120,11 +94,11 @@ internal sealed class PocoReadPlan<T>
         if (claimedBy.Count == 0)
         {
             throw new InvalidOperationException(
-                $"No column of the result maps to a property of '{typeof(T).Name}': the result has {Describe(names)}, and the type has {Describe(descriptor)}. " +
+                $"No column of the result maps to a property of '{typeof(T).Name}': the result has {Describe(names)}, and the type has {descriptor.DescribeMappedColumns()}. " +
                 $"Every row would be left at its defaults, so this is reported rather than returned.");
         }
 
-        return new PocoReadPlan<T>(activator, names, types, PocoReadPlan.ContextKey(block.Context), scatters);
+        return new PocoReadPlan<T>(activator, names, types, PocoBlockSignature.ContextKey(block.Context), scatters);
     }
 
     /// <summary>
@@ -135,7 +109,7 @@ internal sealed class PocoReadPlan<T>
     public bool MatchesHeader(Block block)
     {
         if (block.ColumnCount != columnNames.Length
-            || !string.Equals(contextKey, PocoReadPlan.ContextKey(block.Context), StringComparison.Ordinal))
+            || !string.Equals(contextKey, PocoBlockSignature.ContextKey(block.Context), StringComparison.Ordinal))
         {
             return false;
         }
@@ -189,14 +163,4 @@ internal sealed class PocoReadPlan<T>
     private static string Describe(string[] columnNames)
         => columnNames.Length == 0 ? "no columns" : $"columns {string.Join(", ", columnNames)}";
 
-    private static string Describe(PocoTypeDescriptor descriptor)
-    {
-        var names = new string[descriptor.Members.Count];
-        for (int i = 0; i < names.Length; i++)
-        {
-            names[i] = descriptor.Members[i].ColumnName;
-        }
-
-        return $"properties mapping to {string.Join(", ", names)}";
-    }
 }

--- a/ClickHouse.Driver.Tcp/Poco/PocoRowBuffer.cs
+++ b/ClickHouse.Driver.Tcp/Poco/PocoRowBuffer.cs
@@ -1,35 +1,25 @@
 using System;
 using System.Buffers;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 
 namespace ClickHouse.Driver.Tcp.Poco;
 
 /// <summary>
-/// The caller's rows, materialized into one array so a row-oriented insert can transpose them into columns.
-///
-/// <para>
-/// Materializing up front is what the native protocol's ordering forces: the target column types arrive in the
-/// server's sample block, which only comes back <em>after</em> the INSERT has been sent, and building typed columns
-/// needs the row count as well as the types. So the whole source is resident before the first byte of row data goes
-/// out — a lazy <see cref="IEnumerable{T}"/> is fully enumerated first, and <c>MaxRowsPerBlock</c> bounds wire
-/// geometry, not client memory. Streaming a chunk at a time can be added later without changing the public
-/// signature.
-/// </para>
+/// Exposes materialized rows as an array for compiled gathers, borrowing arrays and pooling copies of other lists.
 /// </summary>
 /// <typeparam name="T">The row type.</typeparam>
 internal sealed class PocoRowBuffer<T> : IDisposable
     where T : class
 {
-    private const int InitialCapacity = 16;
-
     private T[] rows;
+    private readonly bool pooled;
 
-    private PocoRowBuffer(T[] rows, int count)
+    private PocoRowBuffer(T[] rows, int count, bool pooled)
     {
         this.rows = rows;
         Count = count;
+        this.pooled = pooled;
     }
 
     /// <summary>The rows; the first <see cref="Count"/> entries are the caller's, in order.</summary>
@@ -38,53 +28,45 @@ internal sealed class PocoRowBuffer<T> : IDisposable
     /// <summary>The number of rows.</summary>
     public int Count { get; }
 
-    /// <summary>
-    /// Drains <paramref name="source"/> into a pooled array.
-    /// </summary>
-    /// <param name="source">The caller's rows.</param>
+    /// <summary>Validates the rows and exposes them as an array.</summary>
+    /// <param name="source">The caller's materialized rows.</param>
     /// <param name="parameterName">The public parameter name to blame for a null row.</param>
     /// <param name="cancellationToken">A token to observe for cancellation.</param>
-    /// <returns>The buffer; dispose it to return the array to the pool.</returns>
+    /// <returns>The prepared buffer.</returns>
     /// <exception cref="ArgumentException">A row is null.</exception>
     /// <exception cref="OperationCanceledException"><paramref name="cancellationToken"/> was cancelled.</exception>
-    public static PocoRowBuffer<T> Materialize(IEnumerable<T> source, string parameterName, CancellationToken cancellationToken)
+    public static PocoRowBuffer<T> Create(IReadOnlyList<T> source, string parameterName, CancellationToken cancellationToken)
     {
-        // Draining the source is the one part of an insert that runs before any I/O, and it can be the long part —
-        // a source of millions of rows is enumerated in full here — so the token is observed as it goes rather than
-        // only once the connection is rented. Checked before the rent as well as per row, so an already-cancelled
-        // call is refused even for an empty source.
+        ArgumentNullException.ThrowIfNull(source);
         cancellationToken.ThrowIfCancellationRequested();
 
-        // A counted source sizes the rent exactly; anything else grows by doubling.
-        int capacity = source.TryGetNonEnumeratedCount(out int counted) ? counted : 0;
-        T[] buffer = ArrayPool<T>.Shared.Rent(Math.Max(capacity, InitialCapacity));
-        int count = 0;
+        if (source is T[] array)
+        {
+            Validate(array, parameterName, cancellationToken);
+            return new PocoRowBuffer<T>(array, array.Length, pooled: false);
+        }
+
+        int count = source.Count;
+        if (count == 0)
+        {
+            return new PocoRowBuffer<T>(Array.Empty<T>(), 0, pooled: false);
+        }
+
+        T[] buffer = ArrayPool<T>.Shared.Rent(count);
 
         try
         {
-            foreach (T row in source)
+            for (int i = 0; i < count; i++)
             {
-                // Tested every row, not at the growth points: a counted source rents once and never grows, so a long
-                // one would otherwise be drained in full whatever the token said. The read is a field test against a
-                // token that is usually None, next to a source's own MoveNext — so it costs nothing measurable.
                 cancellationToken.ThrowIfCancellationRequested();
+                T row = source[i];
 
-                // Checked here rather than in the compiled gather, which would report a bare NullReferenceException
-                // from a delegate with no name of its own.
                 if (row is null)
                 {
-                    throw new ArgumentException($"Row {count} is null; every row of an insert must be non-null.", parameterName);
+                    throw new ArgumentException($"Row {i} is null; every row of an insert must be non-null.", parameterName);
                 }
 
-                if (count == buffer.Length)
-                {
-                    T[] grown = ArrayPool<T>.Shared.Rent(buffer.Length * 2);
-                    Array.Copy(buffer, grown, count);
-                    ArrayPool<T>.Shared.Return(buffer, clearArray: true);
-                    buffer = grown;
-                }
-
-                buffer[count++] = row;
+                buffer[i] = row;
             }
         }
         catch
@@ -93,18 +75,29 @@ internal sealed class PocoRowBuffer<T> : IDisposable
             throw;
         }
 
-        return new PocoRowBuffer<T>(buffer, count);
+        return new PocoRowBuffer<T>(buffer, count, pooled: true);
     }
 
-    /// <summary>Returns the array to the pool. The rows themselves are the caller's and are not touched.</summary>
+    /// <summary>Releases an internally rented array. Caller-owned arrays are not touched.</summary>
     public void Dispose()
     {
-        if (rows.Length != 0)
+        if (pooled && rows.Length != 0)
         {
-            // Cleared, so a pooled array does not keep the caller's rows alive after the insert.
             ArrayPool<T>.Shared.Return(rows, clearArray: true);
         }
 
         rows = Array.Empty<T>();
+    }
+
+    private static void Validate(T[] source, string parameterName, CancellationToken cancellationToken)
+    {
+        for (int i = 0; i < source.Length; i++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (source[i] is null)
+            {
+                throw new ArgumentException($"Row {i} is null; every row of an insert must be non-null.", parameterName);
+            }
+        }
     }
 }

--- a/ClickHouse.Driver.Tcp/Poco/PocoRowBuffer.cs
+++ b/ClickHouse.Driver.Tcp/Poco/PocoRowBuffer.cs
@@ -50,8 +50,9 @@ internal sealed class PocoRowBuffer<T> : IDisposable
     public static PocoRowBuffer<T> Materialize(IEnumerable<T> source, string parameterName, CancellationToken cancellationToken)
     {
         // Draining the source is the one part of an insert that runs before any I/O, and it can be the long part —
-        // a lazy source of millions of rows is enumerated in full here — so the token is observed as it goes rather
-        // than only once the connection is rented.
+        // a source of millions of rows is enumerated in full here — so the token is observed as it goes rather than
+        // only once the connection is rented. Checked before the rent as well as per row, so an already-cancelled
+        // call is refused even for an empty source.
         cancellationToken.ThrowIfCancellationRequested();
 
         // A counted source sizes the rent exactly; anything else grows by doubling.
@@ -63,6 +64,11 @@ internal sealed class PocoRowBuffer<T> : IDisposable
         {
             foreach (T row in source)
             {
+                // Tested every row, not at the growth points: a counted source rents once and never grows, so a long
+                // one would otherwise be drained in full whatever the token said. The read is a field test against a
+                // token that is usually None, next to a source's own MoveNext — so it costs nothing measurable.
+                cancellationToken.ThrowIfCancellationRequested();
+
                 // Checked here rather than in the compiled gather, which would report a bare NullReferenceException
                 // from a delegate with no name of its own.
                 if (row is null)
@@ -72,9 +78,6 @@ internal sealed class PocoRowBuffer<T> : IDisposable
 
                 if (count == buffer.Length)
                 {
-                    // Every doubling, which is often enough for a long enumeration and rare enough to cost nothing.
-                    cancellationToken.ThrowIfCancellationRequested();
-
                     T[] grown = ArrayPool<T>.Shared.Rent(buffer.Length * 2);
                     Array.Copy(buffer, grown, count);
                     ArrayPool<T>.Shared.Return(buffer, clearArray: true);

--- a/ClickHouse.Driver.Tcp/Poco/PocoRowBuffer.cs
+++ b/ClickHouse.Driver.Tcp/Poco/PocoRowBuffer.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+namespace ClickHouse.Driver.Tcp.Poco;
+
+/// <summary>
+/// The caller's rows, materialized into one array so a row-oriented insert can transpose them into columns.
+///
+/// <para>
+/// Materializing up front is what the native protocol's ordering forces: the target column types arrive in the
+/// server's sample block, which only comes back <em>after</em> the INSERT has been sent, and building typed columns
+/// needs the row count as well as the types. So the whole source is resident before the first byte of row data goes
+/// out — a lazy <see cref="IEnumerable{T}"/> is fully enumerated first, and <c>MaxRowsPerBlock</c> bounds wire
+/// geometry, not client memory. Streaming a chunk at a time can be added later without changing the public
+/// signature.
+/// </para>
+/// </summary>
+/// <typeparam name="T">The row type.</typeparam>
+internal sealed class PocoRowBuffer<T> : IDisposable
+    where T : class
+{
+    private const int InitialCapacity = 16;
+
+    private T[] rows;
+
+    private PocoRowBuffer(T[] rows, int count)
+    {
+        this.rows = rows;
+        Count = count;
+    }
+
+    /// <summary>The rows; the first <see cref="Count"/> entries are the caller's, in order.</summary>
+    public T[] Rows => rows;
+
+    /// <summary>The number of rows.</summary>
+    public int Count { get; }
+
+    /// <summary>
+    /// Drains <paramref name="source"/> into a pooled array.
+    /// </summary>
+    /// <param name="source">The caller's rows.</param>
+    /// <param name="parameterName">The public parameter name to blame for a null row.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>The buffer; dispose it to return the array to the pool.</returns>
+    /// <exception cref="ArgumentException">A row is null.</exception>
+    /// <exception cref="OperationCanceledException"><paramref name="cancellationToken"/> was cancelled.</exception>
+    public static PocoRowBuffer<T> Materialize(IEnumerable<T> source, string parameterName, CancellationToken cancellationToken)
+    {
+        // Draining the source is the one part of an insert that runs before any I/O, and it can be the long part —
+        // a lazy source of millions of rows is enumerated in full here — so the token is observed as it goes rather
+        // than only once the connection is rented.
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // A counted source sizes the rent exactly; anything else grows by doubling.
+        int capacity = source.TryGetNonEnumeratedCount(out int counted) ? counted : 0;
+        T[] buffer = ArrayPool<T>.Shared.Rent(Math.Max(capacity, InitialCapacity));
+        int count = 0;
+
+        try
+        {
+            foreach (T row in source)
+            {
+                // Checked here rather than in the compiled gather, which would report a bare NullReferenceException
+                // from a delegate with no name of its own.
+                if (row is null)
+                {
+                    throw new ArgumentException($"Row {count} is null; every row of an insert must be non-null.", parameterName);
+                }
+
+                if (count == buffer.Length)
+                {
+                    // Every doubling, which is often enough for a long enumeration and rare enough to cost nothing.
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    T[] grown = ArrayPool<T>.Shared.Rent(buffer.Length * 2);
+                    Array.Copy(buffer, grown, count);
+                    ArrayPool<T>.Shared.Return(buffer, clearArray: true);
+                    buffer = grown;
+                }
+
+                buffer[count++] = row;
+            }
+        }
+        catch
+        {
+            ArrayPool<T>.Shared.Return(buffer, clearArray: true);
+            throw;
+        }
+
+        return new PocoRowBuffer<T>(buffer, count);
+    }
+
+    /// <summary>Returns the array to the pool. The rows themselves are the caller's and are not touched.</summary>
+    public void Dispose()
+    {
+        if (rows.Length != 0)
+        {
+            // Cleared, so a pooled array does not keep the caller's rows alive after the insert.
+            ArrayPool<T>.Shared.Return(rows, clearArray: true);
+        }
+
+        rows = Array.Empty<T>();
+    }
+}

--- a/ClickHouse.Driver.Tcp/Poco/PocoRowBuffer.cs
+++ b/ClickHouse.Driver.Tcp/Poco/PocoRowBuffer.cs
@@ -6,79 +6,125 @@ using System.Threading;
 namespace ClickHouse.Driver.Tcp.Poco;
 
 /// <summary>
-/// Exposes materialized rows as an array for compiled gathers, borrowing arrays and pooling copies of other lists.
+/// Exposes the caller's rows as an array for compiled gathers: an array is used where it is, and any other list
+/// is staged one block at a time through a pooled window.
 /// </summary>
+/// <remarks>
+/// The window is sized for a single wire block rather than the whole insert, because a copy of every row
+/// reference costs eight bytes a row — a large-object-heap array of its own on a large insert. The caller must
+/// not modify the list while the insert runs, since each block is read as it is written.
+/// </remarks>
 /// <typeparam name="T">The row type.</typeparam>
 internal sealed class PocoRowBuffer<T> : IDisposable
     where T : class
 {
-    private T[] rows;
+    private readonly IReadOnlyList<T> source;
+    private readonly string parameterName;
+    private readonly CancellationToken cancellationToken;
     private readonly bool pooled;
+    private T[] rows;
 
-    private PocoRowBuffer(T[] rows, int count, bool pooled)
+    private PocoRowBuffer(
+        IReadOnlyList<T> source,
+        T[] rows,
+        int count,
+        bool pooled,
+        string parameterName,
+        CancellationToken cancellationToken)
     {
+        this.source = source;
         this.rows = rows;
-        Count = count;
         this.pooled = pooled;
+        this.parameterName = parameterName;
+        this.cancellationToken = cancellationToken;
+        Count = count;
     }
 
-    /// <summary>The rows; the first <see cref="Count"/> entries are the caller's, in order.</summary>
+    /// <summary>The array a gather reads through: the caller's own, or the staging window.</summary>
     public T[] Rows => rows;
 
-    /// <summary>The number of rows.</summary>
+    /// <summary>The number of rows to insert.</summary>
     public int Count { get; }
 
-    /// <summary>Validates the rows and exposes them as an array.</summary>
+    /// <summary>The public parameter name a bad row is blamed on.</summary>
+    public string ParameterName => parameterName;
+
+    /// <summary>Prepares to read the caller's rows a block at a time.</summary>
     /// <param name="source">The caller's materialized rows.</param>
     /// <param name="parameterName">The public parameter name to blame for a null row.</param>
+    /// <param name="blockRows">The most rows one block will hold, sizing the staging window.</param>
     /// <param name="cancellationToken">A token to observe for cancellation.</param>
     /// <returns>The prepared buffer.</returns>
-    /// <exception cref="ArgumentException">A row is null.</exception>
     /// <exception cref="OperationCanceledException"><paramref name="cancellationToken"/> was cancelled.</exception>
-    public static PocoRowBuffer<T> Create(IReadOnlyList<T> source, string parameterName, CancellationToken cancellationToken)
+    public static PocoRowBuffer<T> Create(IReadOnlyList<T> source, string parameterName, int blockRows, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(source);
         cancellationToken.ThrowIfCancellationRequested();
 
+        // An array is already what the gather indexes, so read the caller's rows where they are.
         if (source is T[] array)
         {
-            Validate(array, parameterName, cancellationToken);
-            return new PocoRowBuffer<T>(array, array.Length, pooled: false);
+            return new PocoRowBuffer<T>(source: null, array, array.Length, pooled: false, parameterName, cancellationToken);
         }
 
         int count = source.Count;
         if (count == 0)
         {
-            return new PocoRowBuffer<T>(Array.Empty<T>(), 0, pooled: false);
+            return new PocoRowBuffer<T>(source: null, Array.Empty<T>(), 0, pooled: false, parameterName, cancellationToken);
         }
 
-        T[] buffer = ArrayPool<T>.Shared.Rent(count);
-
-        try
-        {
-            for (int i = 0; i < count; i++)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                T row = source[i];
-
-                if (row is null)
-                {
-                    throw new ArgumentException($"Row {i} is null; every row of an insert must be non-null.", parameterName);
-                }
-
-                buffer[i] = row;
-            }
-        }
-        catch
-        {
-            ArrayPool<T>.Shared.Return(buffer, clearArray: true);
-            throw;
-        }
-
-        return new PocoRowBuffer<T>(buffer, count, pooled: true);
+        int window = Math.Min(blockRows > 0 ? blockRows : count, count);
+        return new PocoRowBuffer<T>(source, ArrayPool<T>.Shared.Rent(window), count, pooled: true, parameterName, cancellationToken);
     }
 
-    /// <summary>Releases an internally rented array. Caller-owned arrays are not touched.</summary>
+    /// <summary>
+    /// Makes rows <c>[start, start + length)</c> readable through <see cref="Rows"/>, staging them into the
+    /// window when the caller's rows are not an array, and validates that none of them is null.
+    /// </summary>
+    /// <param name="start">The zero-based first row of the block.</param>
+    /// <param name="length">The number of rows in the block; at most the window's size.</param>
+    /// <returns>The index in <see cref="Rows"/> the block begins at.</returns>
+    /// <exception cref="ArgumentException">A row of the block is null.</exception>
+    /// <exception cref="OperationCanceledException">The insert's token was cancelled.</exception>
+    public int Prepare(int start, int length)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (source is null)
+        {
+            for (int i = 0; i < length; i++)
+            {
+                if (rows[start + i] is null)
+                {
+                    throw NullRow(start + i);
+                }
+            }
+
+            return start;
+        }
+
+        for (int i = 0; i < length; i++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            T row = source[start + i];
+
+            if (row is null)
+            {
+                throw NullRow(start + i);
+            }
+
+            rows[i] = row;
+        }
+
+        return 0;
+    }
+
+    /// <summary>Reads one row without staging it, for a pass over the whole insert.</summary>
+    /// <param name="index">The zero-based row number.</param>
+    /// <returns>The row, or null if the caller supplied one.</returns>
+    public T RowAt(int index) => source is null ? rows[index] : source[index];
+
+    /// <summary>Releases the staging window. A caller's own array is not touched.</summary>
     public void Dispose()
     {
         if (pooled && rows.Length != 0)
@@ -89,15 +135,6 @@ internal sealed class PocoRowBuffer<T> : IDisposable
         rows = Array.Empty<T>();
     }
 
-    private static void Validate(T[] source, string parameterName, CancellationToken cancellationToken)
-    {
-        for (int i = 0; i < source.Length; i++)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            if (source[i] is null)
-            {
-                throw new ArgumentException($"Row {i} is null; every row of an insert must be non-null.", parameterName);
-            }
-        }
-    }
+    private ArgumentException NullRow(int index)
+        => new($"Row {index} is null; every row of an insert must be non-null.", parameterName);
 }

--- a/ClickHouse.Driver.Tcp/Poco/PocoTypeDescriptor.cs
+++ b/ClickHouse.Driver.Tcp/Poco/PocoTypeDescriptor.cs
@@ -62,6 +62,21 @@ internal abstract class PocoTypeDescriptor
     public IReadOnlyList<PocoMember> Members { get; }
 
     /// <summary>
+    /// Names the columns this type maps to, for a plan reporting that a shape and a type do not meet.
+    /// </summary>
+    /// <returns>The column names, as a phrase.</returns>
+    public string DescribeMappedColumns()
+    {
+        var names = new string[Members.Count];
+        for (int i = 0; i < names.Length; i++)
+        {
+            names[i] = Members[i].ColumnName;
+        }
+
+        return $"properties mapping to {string.Join(", ", names)}";
+    }
+
+    /// <summary>
     /// Finds the member a column maps to, through the tiers described on this class.
     /// </summary>
     /// <param name="columnName">The column name as the server sent it.</param>

--- a/ClickHouse.Driver.Tcp/Poco/PocoTypeRegistry.cs
+++ b/ClickHouse.Driver.Tcp/Poco/PocoTypeRegistry.cs
@@ -44,16 +44,12 @@ internal sealed class PocoTypeRegistry
     }
 
     /// <summary>
-    /// Gets the write plan for <typeparamref name="T"/> over <paramref name="schema"/>'s target columns, compiling it
-    /// on first use. Keyed by the sample block's signature, so one type inserted into several tables — or into one
-    /// table through several column lists — keeps a plan per target shape.
+    /// Gets or builds the write plan for <typeparamref name="T"/> and the target schema.
     /// </summary>
     /// <typeparam name="T">The row type.</typeparam>
     /// <param name="schema">The server's sample block for the INSERT.</param>
     /// <returns>The cached plan.</returns>
-    /// <exception cref="InvalidOperationException"><typeparamref name="T"/> cannot fill the target — see
-    /// <see cref="PocoWritePlan{T}.Build"/>. Nothing is cached in that case, so every caller is told, not just the
-    /// first.</exception>
+    /// <exception cref="InvalidOperationException"><typeparamref name="T"/> cannot fill the target schema.</exception>
     public PocoWritePlan<T> WritePlanFor<T>(Block schema)
         where T : class
     {

--- a/ClickHouse.Driver.Tcp/Poco/PocoTypeRegistry.cs
+++ b/ClickHouse.Driver.Tcp/Poco/PocoTypeRegistry.cs
@@ -5,7 +5,7 @@ using ClickHouse.Driver.Tcp.Format;
 namespace ClickHouse.Driver.Tcp.Poco;
 
 /// <summary>
-/// Caches descriptors per POCO type and read plans per type and result shape. The per-client caches do not evict;
+/// Caches descriptors per POCO type and plans per type and wire shape. The per-client caches do not evict;
 /// disposing the client releases their type keys and compiled delegates.
 /// </summary>
 internal sealed class PocoTypeRegistry
@@ -13,6 +13,8 @@ internal sealed class PocoTypeRegistry
     private readonly ConcurrentDictionary<Type, PocoTypeDescriptor> descriptors = new();
 
     private readonly ConcurrentDictionary<(Type PocoType, string Signature, PocoScatterTier? ForcedTier), object> readPlans = new();
+
+    private readonly ConcurrentDictionary<(Type PocoType, string Signature), object> writePlans = new();
 
     /// <summary>Gets or builds the descriptor for <typeparamref name="T"/>.</summary>
     /// <typeparam name="T">The POCO type.</typeparam>
@@ -39,5 +41,25 @@ internal sealed class PocoTypeRegistry
         return (PocoReadPlan<T>)readPlans.GetOrAdd(
             (typeof(T), PocoReadPlan.SignatureOf(block), forcedTier),
             _ => PocoReadPlan<T>.Build(descriptor, block, forcedTier));
+    }
+
+    /// <summary>
+    /// Gets the write plan for <typeparamref name="T"/> over <paramref name="schema"/>'s target columns, compiling it
+    /// on first use. Keyed by the sample block's signature, so one type inserted into several tables — or into one
+    /// table through several column lists — keeps a plan per target shape.
+    /// </summary>
+    /// <typeparam name="T">The row type.</typeparam>
+    /// <param name="schema">The server's sample block for the INSERT.</param>
+    /// <returns>The cached plan.</returns>
+    /// <exception cref="InvalidOperationException"><typeparamref name="T"/> cannot fill the target — see
+    /// <see cref="PocoWritePlan{T}.Build"/>. Nothing is cached in that case, so every caller is told, not just the
+    /// first.</exception>
+    public PocoWritePlan<T> WritePlanFor<T>(Block schema)
+        where T : class
+    {
+        PocoTypeDescriptor<T> descriptor = DescriptorFor<T>();
+        return (PocoWritePlan<T>)writePlans.GetOrAdd(
+            (typeof(T), PocoWritePlan.SignatureOf(schema)),
+            _ => PocoWritePlan<T>.Build(descriptor, schema));
     }
 }

--- a/ClickHouse.Driver.Tcp/Poco/PocoUntypedColumns.cs
+++ b/ClickHouse.Driver.Tcp/Poco/PocoUntypedColumns.cs
@@ -54,7 +54,7 @@ internal static class PocoUntypedColumns
             for (; built < columnCount; built++)
             {
                 IColumn target = schema[built];
-                IColumnCodec codec = schema.Codecs.Resolve(target.TypeName, ResolveContext.ForWrite);
+                IColumnCodec codec = schema.Codecs.Resolve(target.TypeName, schema.Context);
                 Type writeType = ChooseWriteType(codec, target, rows, rowCount, built);
 
                 // Reflection constructs the builder and no more: the fill runs outside the Invoke, so a bad value

--- a/ClickHouse.Driver.Tcp/Poco/PocoUntypedColumns.cs
+++ b/ClickHouse.Driver.Tcp/Poco/PocoUntypedColumns.cs
@@ -1,0 +1,201 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using ClickHouse.Driver.Tcp.Format;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Poco;
+
+/// <summary>
+/// Transposes boxed <c>object[]</c> rows into the insert's target columns — the dynamic tier, positional by the
+/// sample block's order, which is the order of the statement's column list (D6e).
+///
+/// <para>
+/// Unlike the POCO path there is no plan to cache: nothing here is compiled, and the CLR type each column is
+/// written in is decided by the values rather than by a type's properties. That choice is what lets one
+/// <c>object[]</c> row source serve two callers whose rows mean the same thing in different spellings — a
+/// <c>DateTime</c> column takes hand-written <see cref="DateTime"/> values as readily as the raw epoch seconds the
+/// untyped <em>read</em> produces, so a read-then-reinsert round trip needs no conversion by the caller.
+/// </para>
+/// </summary>
+internal static class PocoUntypedColumns
+{
+    private static readonly MethodInfo CreateBuilderMethod =
+        typeof(PocoUntypedColumns).GetMethod(nameof(CreateBuilder), BindingFlags.NonPublic | BindingFlags.Static);
+
+    /// <summary>
+    /// Builds one column per target, each filled from its own position in every row.
+    /// </summary>
+    /// <param name="schema">The server's sample block, naming and typing the target columns.</param>
+    /// <param name="rows">The rows, each non-null; at least <paramref name="rowCount"/> long.</param>
+    /// <param name="rowCount">The number of rows to insert.</param>
+    /// <returns>The columns, each owning a pooled buffer it returns when disposed.</returns>
+    /// <exception cref="ArgumentException">A row has the wrong number of values.</exception>
+    /// <exception cref="InvalidOperationException">A value's CLR type is not one the target column accepts, or a
+    /// value is null for a column that cannot hold null.</exception>
+    public static IReadOnlyList<IColumn> Build(Block schema, object[][] rows, int rowCount)
+    {
+        int columnCount = schema.ColumnCount;
+        for (int row = 0; row < rowCount; row++)
+        {
+            if (rows[row].Length != columnCount)
+            {
+                throw new ArgumentException(
+                    $"Row {row} has {rows[row].Length} values, but the insert targets {columnCount} column(s) ({DescribeTargets(schema)}). " +
+                    $"Untyped rows are matched to the target columns by position, so every row must have one value per column.",
+                    nameof(rows));
+            }
+        }
+
+        var columns = new IColumn[columnCount];
+        int built = 0;
+        try
+        {
+            for (; built < columnCount; built++)
+            {
+                IColumn target = schema[built];
+                IColumnCodec codec = schema.Codecs.Resolve(target.TypeName, ResolveContext.ForWrite);
+                Type writeType = ChooseWriteType(codec, target, rows, rowCount, built);
+
+                // Reflection constructs the builder and no more: the fill runs outside the Invoke, so a bad value
+                // surfaces as its own exception rather than wrapped in a TargetInvocationException.
+                var builder = (PocoColumnBuilder<object[]>)CreateBuilderMethod
+                    .MakeGenericMethod(writeType)
+                    .Invoke(null, new object[] { target.Name, target.TypeName, built, PocoWriteConversion.TakesNull(codec) });
+
+                columns[built] = builder.Build(rows, rowCount);
+            }
+        }
+        catch
+        {
+            for (int i = 0; i < built; i++)
+            {
+                columns[i].Dispose();
+            }
+
+            throw;
+        }
+
+        return columns;
+    }
+
+    /// <summary>
+    /// Picks the CLR type a column is written in: the one the values themselves are in, matched against the types
+    /// the target accepts.
+    ///
+    /// <para>
+    /// Decided by the first row that has a value, because a boxed value knows its own type and nothing else here
+    /// does. A column of nothing but nulls falls back to the target's canonical type, which is right either way — a
+    /// <c>Nullable</c> target takes the nulls, and a non-nullable one has to report them, which the fill does
+    /// naming the row.
+    /// </para>
+    /// </summary>
+    /// <param name="codec">The target column's codec.</param>
+    /// <param name="target">The target column, for diagnostics.</param>
+    /// <param name="rows">The rows.</param>
+    /// <param name="rowCount">The number of rows.</param>
+    /// <param name="index">The column's position in every row.</param>
+    /// <returns>The write type.</returns>
+    /// <exception cref="InvalidOperationException">The values' type is not one the target accepts.</exception>
+    private static Type ChooseWriteType(IColumnCodec codec, IColumn target, object[][] rows, int rowCount, int index)
+    {
+        IReadOnlyList<Type> accepted = PocoWriteConversion.AcceptedWriteTypes(codec);
+        if (accepted.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"The target column '{target.Name}' has type '{target.TypeName}', which cannot be built from rows: insert it through the columnar API, which can build the column shape it needs.");
+        }
+
+        Type present = null;
+        for (int row = 0; row < rowCount && present is null; row++)
+        {
+            present = rows[row][index]?.GetType();
+        }
+
+        if (present is null)
+        {
+            return accepted[0];
+        }
+
+        for (int i = 0; i < accepted.Count; i++)
+        {
+            // A boxed value is never a boxed Nullable<T> — the CLR boxes the underlying value — so a nullable write
+            // type is matched by the type it wraps.
+            if ((Nullable.GetUnderlyingType(accepted[i]) ?? accepted[i]).IsAssignableFrom(present))
+            {
+                return accepted[i];
+            }
+        }
+
+        var offered = new string[accepted.Count];
+        for (int i = 0; i < accepted.Count; i++)
+        {
+            offered[i] = accepted[i].ToString();
+        }
+
+        throw new InvalidOperationException(
+            $"Column {index} ('{target.Name}', {target.TypeName}) was given values of type {present}, which it cannot be written from. " +
+            $"It accepts {string.Join(" or ", offered)}.");
+    }
+
+    /// <summary>
+    /// Builds the column builder for one position of every row, now that the write type is a type argument. The
+    /// same builder the POCO path uses, over an unboxing fill rather than a compiled gather.
+    /// </summary>
+    /// <typeparam name="TWrite">The CLR type the target column is written in.</typeparam>
+    /// <param name="name">The target column's name.</param>
+    /// <param name="typeName">The target column's ClickHouse type.</param>
+    /// <param name="index">The column's position in every row.</param>
+    /// <param name="targetTakesNull">Whether the target column can carry a row with no value.</param>
+    /// <returns>The builder.</returns>
+    private static PocoColumnBuilder<object[]> CreateBuilder<TWrite>(string name, string typeName, int index, bool targetTakesNull)
+    {
+        // Both halves are needed. A target with no NULL of its own cannot take one however the write type spells it
+        // — a String column rejects a null string, which would otherwise reach the codec and fault mid-block — and a
+        // bare value type has nowhere to put one even where the target would accept it.
+        bool acceptsNull = targetTakesNull && default(TWrite) is null;
+
+        // A boxed value is never a boxed Nullable<T>, so a value is tested against the type the write type wraps —
+        // the same rule that chose the write type. The cast itself is fine either way: unboxing to Nullable<T> from
+        // a boxed T is exactly what unbox.any does.
+        Type expected = Nullable.GetUnderlyingType(typeof(TWrite)) ?? typeof(TWrite);
+        return new PocoColumnBuilder<object[], TWrite>(name, typeName, (source, count, destination) =>
+        {
+            for (int row = 0; row < count; row++)
+            {
+                object value = source[row][index];
+                if (value is null)
+                {
+                    destination[row] = acceptsNull
+                        ? default
+                        : throw new InvalidOperationException(
+                            $"Column {index} ('{name}', {typeName}) is null at row {row} of the insert, but it cannot hold null. " +
+                            $"Make the column Nullable(...), or leave out the rows with no value.");
+                    continue;
+                }
+
+                // The write type was chosen from the first row that had a value, so a later row in another type is
+                // the caller mixing types in one column. Reported by row rather than left to an unbox failure.
+                if (!expected.IsInstanceOfType(value))
+                {
+                    throw new InvalidOperationException(
+                        $"Column {index} ('{name}', {typeName}) is written as {typeof(TWrite)}, but row {row} holds a {value.GetType()}. " +
+                        $"Every value of one column must have the same CLR type.");
+                }
+
+                destination[row] = (TWrite)value;
+            }
+        });
+    }
+
+    private static string DescribeTargets(Block schema)
+    {
+        var names = new string[schema.ColumnCount];
+        for (int i = 0; i < names.Length; i++)
+        {
+            names[i] = schema[i].Name;
+        }
+
+        return string.Join(", ", names);
+    }
+}

--- a/ClickHouse.Driver.Tcp/Poco/PocoWriteConversion.cs
+++ b/ClickHouse.Driver.Tcp/Poco/PocoWriteConversion.cs
@@ -1,0 +1,290 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Poco;
+
+/// <summary>
+/// Resolves how one POCO property value becomes one value of the CLR type a target column is written in, as an
+/// <see cref="Expression"/> the gather builder inlines into its per-row loop. Resolution happens once per
+/// (property, target column) pair at plan build, so a shape that cannot work fails before any row is gathered.
+///
+/// <para>
+/// The read side has to ask the codec for its conversions, because a column decodes into the raw wire value (a
+/// <c>DateTime</c> column reads as epoch seconds). The write side does not: a codec already accepts the
+/// calendar types directly — <see cref="IColumnCodec.WritableElementTypes"/> lists them and
+/// <see cref="IColumnCodec.WriteColumn"/> does the arithmetic — so the only conversions left here are the CLR-level
+/// ones a C# cast would do anyway.
+/// </para>
+///
+/// <para>
+/// One wrapper is asymmetric today, which a caller sees as a property that reads but does not insert:
+/// <c>LowCardinality</c> re-offers its inner codec's readable types but not its writable ones, so a
+/// <c>LowCardinality(DateTime)</c> column reads into a <see cref="DateTime"/> property and is written only from the
+/// raw epoch seconds. That is the wrapper's gap, not this class's — <c>Nullable</c> lifts both lists — and closing
+/// it means giving the <c>LowCardinality</c> write path a shape per write type, as <c>Nullable</c> has.
+/// </para>
+///
+/// <para>
+/// The rules, first match winning, applied to each of the codec's writable types in its own preference order:
+/// <list type="number">
+/// <item>the property type is that write type — the identity;</item>
+/// <item>a nullable property into a write type that cannot hold null — every row is required to have a value, and a
+/// null throws naming the row, mirroring the read side's D6a;</item>
+/// <item>a property into a nullable write type — null stays null, and a non-nullable property simply lifts;</item>
+/// <item>a CLR <c>enum</c> property over the column's own ordinal type — a blind unchecked cast (D6b);</item>
+/// <item>a property type assignable to the write type — a reference upcast, or the boxing a <c>Variant</c>/
+/// <c>Dynamic</c> column's <see cref="object"/> surface asks for.</item>
+/// </list>
+/// </para>
+///
+/// <para>
+/// Numeric conversion is deliberately absent, as it is on the read side (D6c): an <see cref="int"/> property does
+/// not fill a <c>UInt64</c> column. Declining keeps a POCO that round-trips: every shape this accepts is a shape
+/// <see cref="PocoValueProjection"/> can read back into the same property.
+/// </para>
+/// </summary>
+internal static class PocoWriteConversion
+{
+    private static readonly MethodInfo NullNotWritableMethod =
+        typeof(PocoWriteConversion).GetMethod(nameof(NullNotWritable), BindingFlags.Public | BindingFlags.Static);
+
+    /// <summary>
+    /// The CLR types a row-oriented insert can actually build a column of for this codec, in the codec's own
+    /// preference order: its <see cref="IColumnCodec.WritableElementTypes"/>, minus those it turns down when offered
+    /// as an array-backed column.
+    ///
+    /// <para>
+    /// The list names the CLR element types the write path understands, but a codec whose writer needs a particular
+    /// column implementation — <c>Nested</c> wants its own column — refuses a plain array-backed one whatever its
+    /// element type. Probing with the empty column the plan would build runs the same test the insert itself runs,
+    /// so such a column is reported at plan build rather than after the INSERT has gone out. An empty result means
+    /// the type is reachable only through the columnar API.
+    /// </para>
+    /// </summary>
+    /// <param name="codec">The target column's codec.</param>
+    /// <returns>The write types, possibly none.</returns>
+    public static IReadOnlyList<Type> AcceptedWriteTypes(IColumnCodec codec)
+    {
+        IReadOnlyList<Type> writable = codec.WritableElementTypes;
+        var accepted = new List<Type>(writable.Count);
+        for (int i = 0; i < writable.Count; i++)
+        {
+            if (Accepts(codec, writable[i]))
+            {
+                accepted.Add(writable[i]);
+            }
+        }
+
+        return accepted;
+    }
+
+    /// <summary>
+    /// Picks the CLR type a column is written in to carry <paramref name="memberType"/>: the codec's most preferred
+    /// accepted write type the property converts to.
+    /// </summary>
+    /// <param name="codec">The target column's codec.</param>
+    /// <param name="memberType">The property type the values come from.</param>
+    /// <param name="writeType">The chosen write type, or null when none applies.</param>
+    /// <returns>Whether a write type applies.</returns>
+    public static bool TryChooseWriteType(IColumnCodec codec, Type memberType, out Type writeType)
+    {
+        IReadOnlyList<Type> accepted = AcceptedWriteTypes(codec);
+        for (int i = 0; i < accepted.Count; i++)
+        {
+            if (CanConvert(memberType, accepted[i]))
+            {
+                writeType = accepted[i];
+                return true;
+            }
+        }
+
+        writeType = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Builds the conversion from one property value to one value of <paramref name="writeType"/>. Only ever called
+    /// for a pair <see cref="TryChooseWriteType"/> accepted.
+    /// </summary>
+    /// <param name="value">An expression yielding the property's value for one row.</param>
+    /// <param name="writeType">The CLR type the column is written in.</param>
+    /// <param name="targetTakesNull">Whether the target column has a NULL of its own — see
+    /// <see cref="TakesNull"/>.</param>
+    /// <param name="site">The column/property names a failed conversion reports at runtime.</param>
+    /// <returns>An expression of type <paramref name="writeType"/>.</returns>
+    public static Expression Convert(Expression value, Type writeType, bool targetTakesNull, PocoGatherSite site)
+    {
+        Type memberType = value.Type;
+
+        // A reference-typed property holds null whatever its type, and a target with no NULL of its own has nowhere
+        // to put one: the value would reach the codec, which faults part-way through a block and takes the
+        // connection with it. Tested here instead, before any byte goes out, naming the row — the same contract a
+        // nullable value-typed property gets below (D6a).
+        if (!targetTakesNull && !memberType.IsValueType)
+        {
+            value = RequireNotNull(value, site);
+        }
+
+        if (memberType == writeType)
+        {
+            return value;
+        }
+
+        Type memberUnderlying = Nullable.GetUnderlyingType(memberType);
+        Type writeUnderlying = Nullable.GetUnderlyingType(writeType);
+
+        if (memberUnderlying is not null)
+        {
+            // Bound to a local first: HasValue and Value both read it, and it is a property access, which must not
+            // run twice. A null row passes through as the write type's own null when the target has one to write
+            // and the write type can carry it — a Nullable spelling, or the object a Variant or Dynamic column is
+            // written from.
+            bool nullSurvives = targetTakesNull && (writeUnderlying is not null || !writeType.IsValueType);
+            ParameterExpression source = Expression.Variable(memberType, "nullable");
+            Expression present = Convert(Expression.Property(source, "Value"), writeUnderlying ?? writeType, targetTakesNull, site);
+            return Expression.Block(
+                new[] { source },
+                Expression.Assign(source, value),
+                Expression.Condition(
+                    Expression.Property(source, "HasValue"),
+                    Lift(present, writeType),
+                    nullSurvives ? Expression.Default(writeType) : ThrowNull(site, writeType)));
+        }
+
+        return writeUnderlying is not null
+            ? Lift(Convert(value, writeUnderlying, targetTakesNull, site), writeType)
+            : Expression.Convert(value, writeType);
+    }
+
+    /// <summary>
+    /// Whether a column of this type can carry a row with no value. True exactly for the types that have a NULL of
+    /// their own — <c>Nullable</c>, a nullable <c>LowCardinality</c>, <c>Variant</c> and <c>Dynamic</c> — which is
+    /// what a null placeholder of <see langword="null"/> means: every other codec answers with the zero value it
+    /// would encode instead, so a real null reaching it is an error rather than an absence.
+    /// </summary>
+    /// <param name="codec">The target column's codec.</param>
+    /// <returns>Whether a null can be written to it.</returns>
+    public static bool TakesNull(IColumnCodec codec) => codec.NullPlaceholder is null;
+
+    /// <summary>
+    /// The exception a gather throws when a null property value reaches a column that cannot hold one. Called from
+    /// compiled code, so the constant parts arrive as arguments rather than being formatted at build time.
+    /// </summary>
+    /// <param name="columnName">The target column's name.</param>
+    /// <param name="columnType">The target column's ClickHouse type.</param>
+    /// <param name="pocoType">The POCO type's name.</param>
+    /// <param name="memberName">The property name.</param>
+    /// <param name="row">The zero-based row of the insert the null was found at.</param>
+    /// <returns>The exception to throw.</returns>
+    public static Exception NullNotWritable(string columnName, string columnType, string pocoType, string memberName, long row)
+        => new InvalidOperationException(
+            $"Property '{pocoType}.{memberName}' is null at row {row} of the insert, but it maps to column '{columnName}' ({columnType}), which cannot hold null. " +
+            $"Make the column Nullable(...), or leave out the rows with no value.");
+
+    /// <summary>
+    /// Whether a plain cast converts one type to the other. The same rule the read side applies in reverse: a CLR
+    /// <c>enum</c> over its own ordinal type, or a target the source is assignable to. Nullability is transparent —
+    /// each side is unwrapped and the underlying types decide — because a null is carried, not converted.
+    /// </summary>
+    /// <param name="from">The property type.</param>
+    /// <param name="to">The candidate write type.</param>
+    /// <returns>Whether the conversion applies.</returns>
+    private static bool CanConvert(Type from, Type to)
+    {
+        if (from == to)
+        {
+            return true;
+        }
+
+        Type fromUnderlying = Nullable.GetUnderlyingType(from);
+        Type toUnderlying = Nullable.GetUnderlyingType(to);
+        if (fromUnderlying is not null)
+        {
+            return CanConvert(fromUnderlying, toUnderlying ?? to);
+        }
+
+        if (toUnderlying is not null)
+        {
+            return CanConvert(from, toUnderlying);
+        }
+
+        // The ordinal cast is unchecked, matching (sbyte)value in C#: the column's declared labels are not consulted
+        // (D6b), so an enum member the column does not name is written as its ordinal rather than being rejected.
+        return (from.IsEnum && Enum.GetUnderlyingType(from) == to) || to.IsAssignableFrom(from);
+    }
+
+    /// <summary>Whether the codec accepts a column of <paramref name="writeType"/> built the way the plan builds one.</summary>
+    /// <param name="codec">The target column's codec.</param>
+    /// <param name="writeType">The candidate write type.</param>
+    /// <returns>Whether the codec accepts such a column.</returns>
+    private static bool Accepts(IColumnCodec codec, Type writeType)
+    {
+        var probe = (IColumn)Activator.CreateInstance(
+            typeof(ArrayColumn<>).MakeGenericType(writeType),
+            string.Empty,
+            codec.TypeName,
+            Array.CreateInstance(writeType, 0));
+
+        return codec.CanWrite(probe);
+    }
+
+    private static Expression Lift(Expression value, Type target)
+        => value.Type == target ? value : Expression.Convert(value, target);
+
+    /// <summary>
+    /// Wraps a reference-typed expression in a null test that throws. Bound to a local, because the test and the
+    /// result both read it and it is a property access, which must not run twice.
+    /// </summary>
+    /// <param name="value">An expression of a reference type.</param>
+    /// <param name="site">The column/property names the failure reports.</param>
+    /// <returns>An expression of the same type, throwing where that would be null.</returns>
+    private static Expression RequireNotNull(Expression value, PocoGatherSite site)
+    {
+        ParameterExpression source = Expression.Variable(value.Type, "reference");
+        return Expression.Block(
+            new[] { source },
+            Expression.Assign(source, value),
+            Expression.Condition(
+                Expression.ReferenceEqual(source, Expression.Constant(null, value.Type)),
+                ThrowNull(site, value.Type),
+                source));
+    }
+
+    private static Expression ThrowNull(PocoGatherSite site, Type writeType) => Expression.Throw(
+        Expression.Call(
+            NullNotWritableMethod,
+            Expression.Constant(site.ColumnName, typeof(string)),
+            Expression.Constant(site.ColumnType, typeof(string)),
+            Expression.Constant(site.PocoTypeName, typeof(string)),
+            Expression.Constant(site.MemberName, typeof(string)),
+            site.Row),
+        writeType);
+}
+
+/// <summary>
+/// What a gather needs to name in a runtime failure: which column, which property, and which row. The row is an
+/// expression because it is the gather's loop counter, not a constant.
+/// </summary>
+internal readonly struct PocoGatherSite
+{
+    /// <summary>The target column's name.</summary>
+    public string ColumnName { get; init; }
+
+    /// <summary>The target column's ClickHouse type.</summary>
+    public string ColumnType { get; init; }
+
+    /// <summary>The POCO type's name.</summary>
+    public string PocoTypeName { get; init; }
+
+    /// <summary>The property's name.</summary>
+    public string MemberName { get; init; }
+
+    /// <summary>
+    /// A <see cref="long"/> expression yielding the row being gathered, counted over the whole insert — the caller
+    /// hands over all their rows at once, so this is the index into what they passed.
+    /// </summary>
+    public Expression Row { get; init; }
+}

--- a/ClickHouse.Driver.Tcp/Poco/PocoWriteConversion.cs
+++ b/ClickHouse.Driver.Tcp/Poco/PocoWriteConversion.cs
@@ -7,44 +7,8 @@ using ClickHouse.Driver.Tcp.Types;
 namespace ClickHouse.Driver.Tcp.Poco;
 
 /// <summary>
-/// Resolves how one POCO property value becomes one value of the CLR type a target column is written in, as an
-/// <see cref="Expression"/> the gather builder inlines into its per-row loop. Resolution happens once per
-/// (property, target column) pair at plan build, so a shape that cannot work fails before any row is gathered.
-///
-/// <para>
-/// The read side has to ask the codec for its conversions, because a column decodes into the raw wire value (a
-/// <c>DateTime</c> column reads as epoch seconds). The write side does not: a codec already accepts the
-/// calendar types directly — <see cref="IColumnCodec.WritableElementTypes"/> lists them and
-/// <see cref="IColumnCodec.WriteColumn"/> does the arithmetic — so the only conversions left here are the CLR-level
-/// ones a C# cast would do anyway.
-/// </para>
-///
-/// <para>
-/// One wrapper is asymmetric today, which a caller sees as a property that reads but does not insert:
-/// <c>LowCardinality</c> re-offers its inner codec's readable types but not its writable ones, so a
-/// <c>LowCardinality(DateTime)</c> column reads into a <see cref="DateTime"/> property and is written only from the
-/// raw epoch seconds. That is the wrapper's gap, not this class's — <c>Nullable</c> lifts both lists — and closing
-/// it means giving the <c>LowCardinality</c> write path a shape per write type, as <c>Nullable</c> has.
-/// </para>
-///
-/// <para>
-/// The rules, first match winning, applied to each of the codec's writable types in its own preference order:
-/// <list type="number">
-/// <item>the property type is that write type — the identity;</item>
-/// <item>a nullable property into a write type that cannot hold null — every row is required to have a value, and a
-/// null throws naming the row, mirroring the read side's D6a;</item>
-/// <item>a property into a nullable write type — null stays null, and a non-nullable property simply lifts;</item>
-/// <item>a CLR <c>enum</c> property over the column's own ordinal type — a blind unchecked cast (D6b);</item>
-/// <item>a property type assignable to the write type — a reference upcast, or the boxing a <c>Variant</c>/
-/// <c>Dynamic</c> column's <see cref="object"/> surface asks for.</item>
-/// </list>
-/// </para>
-///
-/// <para>
-/// Numeric conversion is deliberately absent, as it is on the read side (D6c): an <see cref="int"/> property does
-/// not fill a <c>UInt64</c> column. Declining keeps a POCO that round-trips: every shape this accepts is a shape
-/// <see cref="PocoValueProjection"/> can read back into the same property.
-/// </para>
+/// Selects a codec-compatible write type and builds the POCO property conversion. Numeric conversions are excluded
+/// to preserve read/write symmetry.
 /// </summary>
 internal static class PocoWriteConversion
 {
@@ -52,17 +16,7 @@ internal static class PocoWriteConversion
         typeof(PocoWriteConversion).GetMethod(nameof(NullNotWritable), BindingFlags.Public | BindingFlags.Static);
 
     /// <summary>
-    /// The CLR types a row-oriented insert can actually build a column of for this codec, in the codec's own
-    /// preference order: its <see cref="IColumnCodec.WritableElementTypes"/>, minus those it turns down when offered
-    /// as an array-backed column.
-    ///
-    /// <para>
-    /// The list names the CLR element types the write path understands, but a codec whose writer needs a particular
-    /// column implementation — <c>Nested</c> wants its own column — refuses a plain array-backed one whatever its
-    /// element type. Probing with the empty column the plan would build runs the same test the insert itself runs,
-    /// so such a column is reported at plan build rather than after the INSERT has gone out. An empty result means
-    /// the type is reachable only through the columnar API.
-    /// </para>
+    /// Returns the codec's writable CLR types that work in an array-backed column.
     /// </summary>
     /// <param name="codec">The target column's codec.</param>
     /// <returns>The write types, possibly none.</returns>
@@ -81,10 +35,7 @@ internal static class PocoWriteConversion
         return accepted;
     }
 
-    /// <summary>
-    /// Picks the CLR type a column is written in to carry <paramref name="memberType"/>: the codec's most preferred
-    /// accepted write type the property converts to.
-    /// </summary>
+    /// <summary>Chooses the codec's preferred write type compatible with <paramref name="memberType"/>.</summary>
     /// <param name="codec">The target column's codec.</param>
     /// <param name="memberType">The property type the values come from.</param>
     /// <param name="writeType">The chosen write type, or null when none applies.</param>
@@ -105,10 +56,7 @@ internal static class PocoWriteConversion
         return false;
     }
 
-    /// <summary>
-    /// Builds the conversion from one property value to one value of <paramref name="writeType"/>. Only ever called
-    /// for a pair <see cref="TryChooseWriteType"/> accepted.
-    /// </summary>
+    /// <summary>Builds the conversion for a property/write-type pair accepted by <see cref="TryChooseWriteType"/>.</summary>
     /// <param name="value">An expression yielding the property's value for one row.</param>
     /// <param name="writeType">The CLR type the column is written in.</param>
     /// <param name="targetTakesNull">Whether the target column has a NULL of its own — see
@@ -119,10 +67,7 @@ internal static class PocoWriteConversion
     {
         Type memberType = value.Type;
 
-        // A reference-typed property holds null whatever its type, and a target with no NULL of its own has nowhere
-        // to put one: the value would reach the codec, which faults part-way through a block and takes the
-        // connection with it. Tested here instead, before any byte goes out, naming the row — the same contract a
-        // nullable value-typed property gets below (D6a).
+        // Reject null before writing so the error identifies the property and row without breaking the connection.
         if (!targetTakesNull && !memberType.IsValueType)
         {
             value = RequireNotNull(value, site);
@@ -138,10 +83,7 @@ internal static class PocoWriteConversion
 
         if (memberUnderlying is not null)
         {
-            // Bound to a local first: HasValue and Value both read it, and it is a property access, which must not
-            // run twice. A null row passes through as the write type's own null when the target has one to write
-            // and the write type can carry it — a Nullable spelling, or the object a Variant or Dynamic column is
-            // written from.
+            // Evaluate the property once; a supported null becomes the write type's default value.
             bool nullSurvives = targetTakesNull && (writeUnderlying is not null || !writeType.IsValueType);
             ParameterExpression source = Expression.Variable(memberType, "nullable");
             Expression present = Convert(Expression.Property(source, "Value"), writeUnderlying ?? writeType, targetTakesNull, site);
@@ -160,19 +102,13 @@ internal static class PocoWriteConversion
     }
 
     /// <summary>
-    /// Whether a column of this type can carry a row with no value. True exactly for the types that have a NULL of
-    /// their own — <c>Nullable</c>, a nullable <c>LowCardinality</c>, <c>Variant</c> and <c>Dynamic</c> — which is
-    /// what a null placeholder of <see langword="null"/> means: every other codec answers with the zero value it
-    /// would encode instead, so a real null reaching it is an error rather than an absence.
+    /// Returns whether the codec has a true NULL representation rather than a non-null placeholder.
     /// </summary>
     /// <param name="codec">The target column's codec.</param>
     /// <returns>Whether a null can be written to it.</returns>
     public static bool TakesNull(IColumnCodec codec) => codec.NullPlaceholder is null;
 
-    /// <summary>
-    /// The exception a gather throws when a null property value reaches a column that cannot hold one. Called from
-    /// compiled code, so the constant parts arrive as arguments rather than being formatted at build time.
-    /// </summary>
+    /// <summary>Builds the runtime error for a null property mapped to a non-nullable column.</summary>
     /// <param name="columnName">The target column's name.</param>
     /// <param name="columnType">The target column's ClickHouse type.</param>
     /// <param name="pocoType">The POCO type's name.</param>
@@ -184,11 +120,7 @@ internal static class PocoWriteConversion
             $"Property '{pocoType}.{memberName}' is null at row {row} of the insert, but it maps to column '{columnName}' ({columnType}), which cannot hold null. " +
             $"Make the column Nullable(...), or leave out the rows with no value.");
 
-    /// <summary>
-    /// Whether a plain cast converts one type to the other. The same rule the read side applies in reverse: a CLR
-    /// <c>enum</c> over its own ordinal type, or a target the source is assignable to. Nullability is transparent —
-    /// each side is unwrapped and the underlying types decide — because a null is carried, not converted.
-    /// </summary>
+    /// <summary>Tests identity, nullable lifting, enum ordinal casts and reference assignability.</summary>
     /// <param name="from">The property type.</param>
     /// <param name="to">The candidate write type.</param>
     /// <returns>Whether the conversion applies.</returns>
@@ -211,8 +143,7 @@ internal static class PocoWriteConversion
             return CanConvert(from, toUnderlying);
         }
 
-        // The ordinal cast is unchecked, matching (sbyte)value in C#: the column's declared labels are not consulted
-        // (D6b), so an enum member the column does not name is written as its ordinal rather than being rejected.
+        // Enum labels are not consulted; writing uses the underlying ordinal.
         return (from.IsEnum && Enum.GetUnderlyingType(from) == to) || to.IsAssignableFrom(from);
     }
 
@@ -234,10 +165,7 @@ internal static class PocoWriteConversion
     private static Expression Lift(Expression value, Type target)
         => value.Type == target ? value : Expression.Convert(value, target);
 
-    /// <summary>
-    /// Wraps a reference-typed expression in a null test that throws. Bound to a local, because the test and the
-    /// result both read it and it is a property access, which must not run twice.
-    /// </summary>
+    /// <summary>Adds a null check while evaluating the source expression only once.</summary>
     /// <param name="value">An expression of a reference type.</param>
     /// <param name="site">The column/property names the failure reports.</param>
     /// <returns>An expression of the same type, throwing where that would be null.</returns>
@@ -265,8 +193,7 @@ internal static class PocoWriteConversion
 }
 
 /// <summary>
-/// What a gather needs to name in a runtime failure: which column, which property, and which row. The row is an
-/// expression because it is the gather's loop counter, not a constant.
+/// Identifies the property, target column and row used in gather-time errors.
 /// </summary>
 internal readonly struct PocoGatherSite
 {
@@ -282,9 +209,6 @@ internal readonly struct PocoGatherSite
     /// <summary>The property's name.</summary>
     public string MemberName { get; init; }
 
-    /// <summary>
-    /// A <see cref="long"/> expression yielding the row being gathered, counted over the whole insert — the caller
-    /// hands over all their rows at once, so this is the index into what they passed.
-    /// </summary>
+    /// <summary>The zero-based row index expression.</summary>
     public Expression Row { get; init; }
 }

--- a/ClickHouse.Driver.Tcp/Poco/PocoWritePlan.cs
+++ b/ClickHouse.Driver.Tcp/Poco/PocoWritePlan.cs
@@ -76,33 +76,16 @@ internal sealed class PocoWritePlan<T>
         return new PocoWritePlan<T>(builders);
     }
 
-    /// <summary>Gathers one column per target in sample-block order.</summary>
-    /// <param name="rows">The rows, each non-null; at least <paramref name="rowCount"/> long.</param>
-    /// <param name="rowCount">The number of rows to insert.</param>
-    /// <returns>The columns, each owning a pooled buffer it returns when disposed.</returns>
-    /// <exception cref="InvalidOperationException">A row has no value for a column that cannot hold null.</exception>
-    public IReadOnlyList<IColumn> BuildColumns(T[] rows, int rowCount)
-    {
-        var columns = new IColumn[builders.Length];
-        int built = 0;
-        try
-        {
-            for (; built < builders.Length; built++)
-            {
-                columns[built] = builders[built].Build(rows, rowCount);
-            }
-        }
-        catch
-        {
-            // Dispose columns built before a later gather failed.
-            for (int i = 0; i < built; i++)
-            {
-                columns[i].Dispose();
-            }
-
-            throw;
-        }
-
-        return columns;
-    }
+    /// <summary>
+    /// Opens one insert over this plan: a column per target in sample-block order, gathered a block at a time.
+    /// </summary>
+    /// <remarks>
+    /// The plan is cached and shared between inserts, so the buffers belong to the returned source rather than
+    /// to the plan.
+    /// </remarks>
+    /// <param name="rows">The insert's rows; not owned by the source.</param>
+    /// <param name="blockRows">The most rows one wire block will hold.</param>
+    /// <returns>The source, owning its gather buffers until it is disposed.</returns>
+    public PocoInsertSource<T> CreateSource(PocoRowBuffer<T> rows, int blockRows)
+        => new(builders, rows, blockRows);
 }

--- a/ClickHouse.Driver.Tcp/Poco/PocoWritePlan.cs
+++ b/ClickHouse.Driver.Tcp/Poco/PocoWritePlan.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Collections.Generic;
+using ClickHouse.Driver.Tcp.Format;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Poco;
+
+/// <summary>
+/// The schema identity a <see cref="PocoWritePlan{T}"/> is built against: the INSERT's sample block, keyed by
+/// <see cref="PocoBlockSignature"/>.
+/// </summary>
+internal static class PocoWritePlan
+{
+    /// <summary>
+    /// The cache key for the shape of an INSERT's sample block. See <see cref="PocoBlockSignature.Of"/>.
+    /// </summary>
+    /// <param name="schema">The sample block whose target columns to key on.</param>
+    /// <returns>The key.</returns>
+    /// <remarks>
+    /// Keyed in <see cref="ResolveContext.ForWrite"/> rather than the context the sample block was decoded with,
+    /// because that is the context the plan resolves its codecs in — so two inserts of one target shape share a plan
+    /// whatever the session's timezone is. Note what that means for a <c>DateTime</c> column whose type string names
+    /// no timezone: the write resolves against no session timezone at all and so treats an <c>Unspecified</c>
+    /// <see cref="DateTime"/> as UTC, while the read presents the same column in the session timezone. That
+    /// divergence is the write path's, not this key's, and it predates the POCO layer.
+    /// </remarks>
+    public static string SignatureOf(Block schema) => PocoBlockSignature.Of(schema, ResolveContext.ForWrite);
+}
+
+/// <summary>
+/// The compiled write plan for one POCO type over one INSERT target: a builder per target column, each gathering
+/// one property of every row into the buffer that column is written from. Built once per (type, target shape) and
+/// cached, because the target types come from the server's sample block and so cannot be known from the type alone.
+///
+/// <para>
+/// Every target column must be filled — the server expects a value for each column of the INSERT's column list — so
+/// a target column that maps to no property fails the build. A property no target column maps to is simply not
+/// inserted, which is what lets one POCO insert into a narrower column list.
+/// </para>
+/// </summary>
+/// <typeparam name="T">The row type.</typeparam>
+internal sealed class PocoWritePlan<T>
+    where T : class
+{
+    private readonly PocoColumnBuilder<T>[] builders;
+
+    private PocoWritePlan(PocoColumnBuilder<T>[] builders) => this.builders = builders;
+
+    /// <summary>
+    /// Compiles the plan for <paramref name="schema"/>'s target columns. Everything that can fail — an unreadable
+    /// property, a target no property fills, a property type the target cannot be written from — fails here, before
+    /// any row is gathered.
+    /// </summary>
+    /// <param name="descriptor">The POCO type's mapping.</param>
+    /// <param name="schema">The server's sample block, naming and typing the target columns.</param>
+    /// <returns>The plan.</returns>
+    /// <exception cref="InvalidOperationException">A target column maps to no property or to one that cannot be
+    /// read, two target columns map to one property, or a property cannot be written as its target's type.</exception>
+    public static PocoWritePlan<T> Build(PocoTypeDescriptor<T> descriptor, Block schema)
+    {
+        var builders = new PocoColumnBuilder<T>[schema.ColumnCount];
+        var claimedBy = new Dictionary<string, string>(schema.ColumnCount, StringComparer.Ordinal);
+
+        for (int i = 0; i < schema.ColumnCount; i++)
+        {
+            IColumn column = schema[i];
+
+            if (!descriptor.TryMatchColumn(column.Name, out PocoMember member))
+            {
+                throw new InvalidOperationException(
+                    $"The target column '{column.Name}' ({column.TypeName}) maps to no property of '{typeof(T).Name}', which has {descriptor.DescribeMappedColumns()}. " +
+                    $"Add a property for it, point one at it with [ClickHouseTcpColumn(Name = \"{column.Name}\")], or leave the column out by naming the ones to insert in the statement (INSERT INTO t (a, b) VALUES).");
+            }
+
+            if (!member.CanGet)
+            {
+                throw new InvalidOperationException(
+                    $"The target column '{column.Name}' maps to property '{typeof(T).Name}.{member.MemberName}', which an insert cannot read: it has no public getter. " +
+                    $"Give it one, or exclude it with [ClickHouseTcpNotMapped] and leave the column out of the statement.");
+            }
+
+            if (claimedBy.TryGetValue(member.MemberName, out string claimed))
+            {
+                // Two target columns reaching one property through the matcher's looser tiers, e.g. 'user_id' and
+                // 'userId'. Writing one property into both is almost certainly not what was meant, and the read side
+                // refuses the mirror of it, so the caller has to say which is which.
+                throw new InvalidOperationException(
+                    $"Target columns '{claimed}' and '{column.Name}' both map to property '{typeof(T).Name}.{member.MemberName}'. " +
+                    $"Point one of them at a property of its own with [ClickHouseTcpColumn(Name = \"...\")], or insert only one of them.");
+            }
+
+            claimedBy[member.MemberName] = column.Name;
+
+            // Resolved in the write context, which is how the insert's own alignment resolves it. Resolving it any
+            // other way would let the plan choose a write type for one codec and the insert write through another.
+            IColumnCodec codec = schema.Codecs.Resolve(column.TypeName, ResolveContext.ForWrite);
+            builders[i] = PocoColumnBuilderFactory.Create<T>(column, codec, member);
+        }
+
+        return new PocoWritePlan<T>(builders);
+    }
+
+    /// <summary>
+    /// Gathers the rows into one column per target, in the sample block's order.
+    /// </summary>
+    /// <param name="rows">The rows, each non-null; at least <paramref name="rowCount"/> long.</param>
+    /// <param name="rowCount">The number of rows to insert.</param>
+    /// <returns>The columns, each owning a pooled buffer it returns when disposed.</returns>
+    /// <exception cref="InvalidOperationException">A row has no value for a column that cannot hold null.</exception>
+    public IReadOnlyList<IColumn> BuildColumns(T[] rows, int rowCount)
+    {
+        var columns = new IColumn[builders.Length];
+        int built = 0;
+        try
+        {
+            for (; built < builders.Length; built++)
+            {
+                columns[built] = builders[built].Build(rows, rowCount);
+            }
+        }
+        catch
+        {
+            // A later column throwing (a null row for a non-nullable target) must not strand the buffers the
+            // earlier ones already rented.
+            for (int i = 0; i < built; i++)
+            {
+                columns[i].Dispose();
+            }
+
+            throw;
+        }
+
+        return columns;
+    }
+}

--- a/ClickHouse.Driver.Tcp/Poco/PocoWritePlan.cs
+++ b/ClickHouse.Driver.Tcp/Poco/PocoWritePlan.cs
@@ -6,34 +6,18 @@ using ClickHouse.Driver.Tcp.Types;
 namespace ClickHouse.Driver.Tcp.Poco;
 
 /// <summary>
-/// The schema identity a <see cref="PocoWritePlan{T}"/> is built against: the INSERT's sample block, keyed by
-/// <see cref="PocoBlockSignature"/>.
+/// Builds cache keys for POCO write plans.
 /// </summary>
 internal static class PocoWritePlan
 {
-    /// <summary>
-    /// The cache key for the shape of an INSERT's sample block. See <see cref="PocoBlockSignature.Of"/>.
-    /// </summary>
+    /// <summary>Returns the sample block's shape and codec-resolution context.</summary>
     /// <param name="schema">The sample block whose target columns to key on.</param>
     /// <returns>The key.</returns>
-    /// <remarks>
-    /// Includes the context the sample block was decoded with because a timezone-less <c>DateTime</c> or
-    /// <c>DateTime64</c> target resolves against the session timezone. Reusing a plan from another timezone would
-    /// give an <see cref="DateTimeKind.Unspecified"/> property a different instant from the one that session names.
-    /// </remarks>
     public static string SignatureOf(Block schema) => PocoBlockSignature.Of(schema, schema.Context);
 }
 
 /// <summary>
-/// The compiled write plan for one POCO type over one INSERT target: a builder per target column, each gathering
-/// one property of every row into the buffer that column is written from. Built once per (type, target shape) and
-/// cached, because the target types come from the server's sample block and so cannot be known from the type alone.
-///
-/// <para>
-/// Every target column must be filled — the server expects a value for each column of the INSERT's column list — so
-/// a target column that maps to no property fails the build. A property no target column maps to is simply not
-/// inserted, which is what lets one POCO insert into a narrower column list.
-/// </para>
+/// A cached set of property gathers, one for each target column in an INSERT sample block.
 /// </summary>
 /// <typeparam name="T">The row type.</typeparam>
 internal sealed class PocoWritePlan<T>
@@ -44,9 +28,7 @@ internal sealed class PocoWritePlan<T>
     private PocoWritePlan(PocoColumnBuilder<T>[] builders) => this.builders = builders;
 
     /// <summary>
-    /// Compiles the plan for <paramref name="schema"/>'s target columns. Everything that can fail — an unreadable
-    /// property, a target no property fills, a property type the target cannot be written from — fails here, before
-    /// any row is gathered.
+    /// Compiles and validates the property mapping for <paramref name="schema"/>.
     /// </summary>
     /// <param name="descriptor">The POCO type's mapping.</param>
     /// <param name="schema">The server's sample block, naming and typing the target columns.</param>
@@ -78,9 +60,7 @@ internal sealed class PocoWritePlan<T>
 
             if (claimedBy.TryGetValue(member.MemberName, out string claimed))
             {
-                // Two target columns reaching one property through the matcher's looser tiers, e.g. 'user_id' and
-                // 'userId'. Writing one property into both is almost certainly not what was meant, and the read side
-                // refuses the mirror of it, so the caller has to say which is which.
+                // Loose name matching must not map one property to two target columns.
                 throw new InvalidOperationException(
                     $"Target columns '{claimed}' and '{column.Name}' both map to property '{typeof(T).Name}.{member.MemberName}'. " +
                     $"Point one of them at a property of its own with [ClickHouseTcpColumn(Name = \"...\")], or insert only one of them.");
@@ -88,9 +68,7 @@ internal sealed class PocoWritePlan<T>
 
             claimedBy[member.MemberName] = column.Name;
 
-            // Use the registry and context that decoded the sample block. The insert's final alignment does the
-            // same, so the plan chooses a write type for the exact codec that will serialize it. In particular, a
-            // timezone-less DateTime target must interpret an Unspecified value in this operation's session zone.
+            // Resolve through the sample context so timezone-less values use this operation's session zone.
             IColumnCodec codec = schema.Codecs.Resolve(column.TypeName, schema.Context);
             builders[i] = PocoColumnBuilderFactory.Create<T>(column, codec, member);
         }
@@ -98,9 +76,7 @@ internal sealed class PocoWritePlan<T>
         return new PocoWritePlan<T>(builders);
     }
 
-    /// <summary>
-    /// Gathers the rows into one column per target, in the sample block's order.
-    /// </summary>
+    /// <summary>Gathers one column per target in sample-block order.</summary>
     /// <param name="rows">The rows, each non-null; at least <paramref name="rowCount"/> long.</param>
     /// <param name="rowCount">The number of rows to insert.</param>
     /// <returns>The columns, each owning a pooled buffer it returns when disposed.</returns>
@@ -118,8 +94,7 @@ internal sealed class PocoWritePlan<T>
         }
         catch
         {
-            // A later column throwing (a null row for a non-nullable target) must not strand the buffers the
-            // earlier ones already rented.
+            // Dispose columns built before a later gather failed.
             for (int i = 0; i < built; i++)
             {
                 columns[i].Dispose();

--- a/ClickHouse.Driver.Tcp/Poco/PocoWritePlan.cs
+++ b/ClickHouse.Driver.Tcp/Poco/PocoWritePlan.cs
@@ -17,14 +17,11 @@ internal static class PocoWritePlan
     /// <param name="schema">The sample block whose target columns to key on.</param>
     /// <returns>The key.</returns>
     /// <remarks>
-    /// Keyed in <see cref="ResolveContext.ForWrite"/> rather than the context the sample block was decoded with,
-    /// because that is the context the plan resolves its codecs in — so two inserts of one target shape share a plan
-    /// whatever the session's timezone is. Note what that means for a <c>DateTime</c> column whose type string names
-    /// no timezone: the write resolves against no session timezone at all and so treats an <c>Unspecified</c>
-    /// <see cref="DateTime"/> as UTC, while the read presents the same column in the session timezone. That
-    /// divergence is the write path's, not this key's, and it predates the POCO layer.
+    /// Includes the context the sample block was decoded with because a timezone-less <c>DateTime</c> or
+    /// <c>DateTime64</c> target resolves against the session timezone. Reusing a plan from another timezone would
+    /// give an <see cref="DateTimeKind.Unspecified"/> property a different instant from the one that session names.
     /// </remarks>
-    public static string SignatureOf(Block schema) => PocoBlockSignature.Of(schema, ResolveContext.ForWrite);
+    public static string SignatureOf(Block schema) => PocoBlockSignature.Of(schema, schema.Context);
 }
 
 /// <summary>
@@ -91,9 +88,10 @@ internal sealed class PocoWritePlan<T>
 
             claimedBy[member.MemberName] = column.Name;
 
-            // Resolved in the write context, which is how the insert's own alignment resolves it. Resolving it any
-            // other way would let the plan choose a write type for one codec and the insert write through another.
-            IColumnCodec codec = schema.Codecs.Resolve(column.TypeName, ResolveContext.ForWrite);
+            // Use the registry and context that decoded the sample block. The insert's final alignment does the
+            // same, so the plan chooses a write type for the exact codec that will serialize it. In particular, a
+            // timezone-less DateTime target must interpret an Unspecified value in this operation's session zone.
+            IColumnCodec codec = schema.Codecs.Resolve(column.TypeName, schema.Context);
             builders[i] = PocoColumnBuilderFactory.Create<T>(column, codec, member);
         }
 

--- a/ClickHouse.Driver.Tcp/Poco/UntypedRowColumns.cs
+++ b/ClickHouse.Driver.Tcp/Poco/UntypedRowColumns.cs
@@ -7,25 +7,15 @@ using ClickHouse.Driver.Tcp.Types;
 namespace ClickHouse.Driver.Tcp.Poco;
 
 /// <summary>
-/// Transposes boxed <c>object[]</c> rows into the insert's target columns — the dynamic tier, positional by the
-/// sample block's order, which is the order of the statement's column list (D6e).
-///
-/// <para>
-/// Unlike the POCO path there is no plan to cache: nothing here is compiled, and the CLR type each column is
-/// written in is decided by the values rather than by a type's properties. That choice is what lets one
-/// <c>object[]</c> row source serve two callers whose rows mean the same thing in different spellings — a
-/// <c>DateTime</c> column takes hand-written <see cref="DateTime"/> values as readily as the raw epoch seconds the
-/// untyped <em>read</em> produces, so a read-then-reinsert round trip needs no conversion by the caller.
-/// </para>
+/// Transposes positional <c>object[]</c> rows into typed columns. Values select the codec's CLR write type, allowing
+/// both convenience values such as <see cref="DateTime"/> and canonical values returned by an untyped read.
 /// </summary>
-internal static class PocoUntypedColumns
+internal static class UntypedRowColumns
 {
     private static readonly MethodInfo CreateBuilderMethod =
-        typeof(PocoUntypedColumns).GetMethod(nameof(CreateBuilder), BindingFlags.NonPublic | BindingFlags.Static);
+        typeof(UntypedRowColumns).GetMethod(nameof(CreateBuilder), BindingFlags.NonPublic | BindingFlags.Static);
 
-    /// <summary>
-    /// Builds one column per target, each filled from its own position in every row.
-    /// </summary>
+    /// <summary>Builds one column per target from the corresponding value in each row.</summary>
     /// <param name="schema">The server's sample block, naming and typing the target columns.</param>
     /// <param name="rows">The rows, each non-null; at least <paramref name="rowCount"/> long.</param>
     /// <param name="rowCount">The number of rows to insert.</param>
@@ -57,8 +47,7 @@ internal static class PocoUntypedColumns
                 IColumnCodec codec = schema.Codecs.Resolve(target.TypeName, schema.Context);
                 Type writeType = ChooseWriteType(codec, target, rows, rowCount, built);
 
-                // Reflection constructs the builder and no more: the fill runs outside the Invoke, so a bad value
-                // surfaces as its own exception rather than wrapped in a TargetInvocationException.
+                // Invoke only constructs the builder, so fill errors are not reflection-wrapped.
                 var builder = (PocoColumnBuilder<object[]>)CreateBuilderMethod
                     .MakeGenericMethod(writeType)
                     .Invoke(null, new object[] { target.Name, target.TypeName, built, PocoWriteConversion.TakesNull(codec) });
@@ -80,15 +69,8 @@ internal static class PocoUntypedColumns
     }
 
     /// <summary>
-    /// Picks the CLR type a column is written in: the one the values themselves are in, matched against the types
-    /// the target accepts.
-    ///
-    /// <para>
-    /// Decided by the first row that has a value, because a boxed value knows its own type and nothing else here
-    /// does. A column of nothing but nulls falls back to the target's canonical type, which is right either way — a
-    /// <c>Nullable</c> target takes the nulls, and a non-nullable one has to report them, which the fill does
-    /// naming the row.
-    /// </para>
+    /// Chooses the target's compatible CLR write type from the first non-null value. An all-null column uses the
+    /// target's preferred type.
     /// </summary>
     /// <param name="codec">The target column's codec.</param>
     /// <param name="target">The target column, for diagnostics.</param>
@@ -119,8 +101,7 @@ internal static class PocoUntypedColumns
 
         for (int i = 0; i < accepted.Count; i++)
         {
-            // A boxed value is never a boxed Nullable<T> — the CLR boxes the underlying value — so a nullable write
-            // type is matched by the type it wraps.
+            // Nullable<T> boxes as T, so compare the underlying type.
             if ((Nullable.GetUnderlyingType(accepted[i]) ?? accepted[i]).IsAssignableFrom(present))
             {
                 return accepted[i];
@@ -138,10 +119,7 @@ internal static class PocoUntypedColumns
             $"It accepts {string.Join(" or ", offered)}.");
     }
 
-    /// <summary>
-    /// Builds the column builder for one position of every row, now that the write type is a type argument. The
-    /// same builder the POCO path uses, over an unboxing fill rather than a compiled gather.
-    /// </summary>
+    /// <summary>Builds the typed column gather for one position in each row.</summary>
     /// <typeparam name="TWrite">The CLR type the target column is written in.</typeparam>
     /// <param name="name">The target column's name.</param>
     /// <param name="typeName">The target column's ClickHouse type.</param>
@@ -150,14 +128,10 @@ internal static class PocoUntypedColumns
     /// <returns>The builder.</returns>
     private static PocoColumnBuilder<object[]> CreateBuilder<TWrite>(string name, string typeName, int index, bool targetTakesNull)
     {
-        // Both halves are needed. A target with no NULL of its own cannot take one however the write type spells it
-        // — a String column rejects a null string, which would otherwise reach the codec and fault mid-block — and a
-        // bare value type has nowhere to put one even where the target would accept it.
+        // Both the target and the CLR write type must represent null.
         bool acceptsNull = targetTakesNull && default(TWrite) is null;
 
-        // A boxed value is never a boxed Nullable<T>, so a value is tested against the type the write type wraps —
-        // the same rule that chose the write type. The cast itself is fine either way: unboxing to Nullable<T> from
-        // a boxed T is exactly what unbox.any does.
+        // Nullable<T> values arrive boxed as T but can still be unboxed into Nullable<T>.
         Type expected = Nullable.GetUnderlyingType(typeof(TWrite)) ?? typeof(TWrite);
         return new PocoColumnBuilder<object[], TWrite>(name, typeName, (source, count, destination) =>
         {
@@ -174,8 +148,7 @@ internal static class PocoUntypedColumns
                     continue;
                 }
 
-                // The write type was chosen from the first row that had a value, so a later row in another type is
-                // the caller mixing types in one column. Reported by row rather than left to an unbox failure.
+                // Report mixed types with the offending row instead of a bare unbox failure.
                 if (!expected.IsInstanceOfType(value))
                 {
                     throw new InvalidOperationException(

--- a/ClickHouse.Driver.Tcp/Poco/UntypedRowColumns.cs
+++ b/ClickHouse.Driver.Tcp/Poco/UntypedRowColumns.cs
@@ -15,57 +15,37 @@ internal static class UntypedRowColumns
     private static readonly MethodInfo CreateBuilderMethod =
         typeof(UntypedRowColumns).GetMethod(nameof(CreateBuilder), BindingFlags.NonPublic | BindingFlags.Static);
 
-    /// <summary>Builds one column per target from the corresponding value in each row.</summary>
+    /// <summary>
+    /// Opens one insert: a column per target, filled from the corresponding value in each row, a block at a time.
+    /// </summary>
+    /// <remarks>
+    /// Each column's CLR write type is chosen once for the whole insert, from the first row that has a value for
+    /// it, because one buffer serves every block. A later value of another type is reported when its block is
+    /// gathered.
+    /// </remarks>
     /// <param name="schema">The server's sample block, naming and typing the target columns.</param>
-    /// <param name="rows">The rows, each non-null; at least <paramref name="rowCount"/> long.</param>
-    /// <param name="rowCount">The number of rows to insert.</param>
-    /// <returns>The columns, each owning a pooled buffer it returns when disposed.</returns>
-    /// <exception cref="ArgumentException">A row has the wrong number of values.</exception>
-    /// <exception cref="InvalidOperationException">A value's CLR type is not one the target column accepts, or a
-    /// value is null for a column that cannot hold null.</exception>
-    public static IReadOnlyList<IColumn> Build(Block schema, object[][] rows, int rowCount)
+    /// <param name="rows">The insert's rows; not owned by the source.</param>
+    /// <param name="blockRows">The most rows one wire block will hold.</param>
+    /// <returns>The source, owning its gather buffers until it is disposed.</returns>
+    /// <exception cref="InvalidOperationException">A value's CLR type is not one the target column accepts, or the
+    /// target cannot be built from rows at all.</exception>
+    public static PocoInsertSource<object[]> CreateSource(Block schema, PocoRowBuffer<object[]> rows, int blockRows)
     {
         int columnCount = schema.ColumnCount;
-        for (int row = 0; row < rowCount; row++)
+        var builders = new PocoColumnBuilder<object[]>[columnCount];
+
+        for (int i = 0; i < columnCount; i++)
         {
-            if (rows[row].Length != columnCount)
-            {
-                throw new ArgumentException(
-                    $"Row {row} has {rows[row].Length} values, but the insert targets {columnCount} column(s) ({DescribeTargets(schema)}). " +
-                    $"Untyped rows are matched to the target columns by position, so every row must have one value per column.",
-                    nameof(rows));
-            }
+            IColumn target = schema[i];
+            IColumnCodec codec = schema.Codecs.Resolve(target.TypeName, schema.Context);
+            Type writeType = ChooseWriteType(codec, target, rows, i);
+
+            builders[i] = (PocoColumnBuilder<object[]>)CreateBuilderMethod
+                .MakeGenericMethod(writeType)
+                .Invoke(null, new object[] { target.Name, target.TypeName, i, PocoWriteConversion.TakesNull(codec) });
         }
 
-        var columns = new IColumn[columnCount];
-        int built = 0;
-        try
-        {
-            for (; built < columnCount; built++)
-            {
-                IColumn target = schema[built];
-                IColumnCodec codec = schema.Codecs.Resolve(target.TypeName, schema.Context);
-                Type writeType = ChooseWriteType(codec, target, rows, rowCount, built);
-
-                // Invoke only constructs the builder, so fill errors are not reflection-wrapped.
-                var builder = (PocoColumnBuilder<object[]>)CreateBuilderMethod
-                    .MakeGenericMethod(writeType)
-                    .Invoke(null, new object[] { target.Name, target.TypeName, built, PocoWriteConversion.TakesNull(codec) });
-
-                columns[built] = builder.Build(rows, rowCount);
-            }
-        }
-        catch
-        {
-            for (int i = 0; i < built; i++)
-            {
-                columns[i].Dispose();
-            }
-
-            throw;
-        }
-
-        return columns;
+        return new UntypedInsertSource(builders, rows, blockRows, columnCount, rows.ParameterName);
     }
 
     /// <summary>
@@ -74,12 +54,11 @@ internal static class UntypedRowColumns
     /// </summary>
     /// <param name="codec">The target column's codec.</param>
     /// <param name="target">The target column, for diagnostics.</param>
-    /// <param name="rows">The rows.</param>
-    /// <param name="rowCount">The number of rows.</param>
+    /// <param name="rows">The insert's rows.</param>
     /// <param name="index">The column's position in every row.</param>
     /// <returns>The write type.</returns>
     /// <exception cref="InvalidOperationException">The values' type is not one the target accepts.</exception>
-    private static Type ChooseWriteType(IColumnCodec codec, IColumn target, object[][] rows, int rowCount, int index)
+    private static Type ChooseWriteType(IColumnCodec codec, IColumn target, PocoRowBuffer<object[]> rows, int index)
     {
         IReadOnlyList<Type> accepted = PocoWriteConversion.AcceptedWriteTypes(codec);
         if (accepted.Count == 0)
@@ -89,9 +68,11 @@ internal static class UntypedRowColumns
         }
 
         Type present = null;
-        for (int row = 0; row < rowCount && present is null; row++)
+        for (int row = 0; row < rows.Count && present is null; row++)
         {
-            present = rows[row][index]?.GetType();
+            // A null or short row is reported when its block is gathered; here it simply holds no value.
+            object[] values = rows.RowAt(row);
+            present = values is not null && index < values.Length ? values[index]?.GetType() : null;
         }
 
         if (present is null)
@@ -133,17 +114,17 @@ internal static class UntypedRowColumns
 
         // Nullable<T> values arrive boxed as T but can still be unboxed into Nullable<T>.
         Type expected = Nullable.GetUnderlyingType(typeof(TWrite)) ?? typeof(TWrite);
-        return new PocoColumnBuilder<object[], TWrite>(name, typeName, (source, count, destination) =>
+        return new PocoColumnBuilder<object[], TWrite>(name, typeName, (source, start, rowNumber, count, destination) =>
         {
-            for (int row = 0; row < count; row++)
+            for (int slot = 0; slot < count; slot++)
             {
-                object value = source[row][index];
+                object value = source[start + slot][index];
                 if (value is null)
                 {
-                    destination[row] = acceptsNull
+                    destination[slot] = acceptsNull
                         ? default
                         : throw new InvalidOperationException(
-                            $"Column {index} ('{name}', {typeName}) is null at row {row} of the insert, but it cannot hold null. " +
+                            $"Column {index} ('{name}', {typeName}) is null at row {rowNumber + slot} of the insert, but it cannot hold null. " +
                             $"Make the column Nullable(...), or leave out the rows with no value.");
                     continue;
                 }
@@ -152,23 +133,60 @@ internal static class UntypedRowColumns
                 if (!expected.IsInstanceOfType(value))
                 {
                     throw new InvalidOperationException(
-                        $"Column {index} ('{name}', {typeName}) is written as {typeof(TWrite)}, but row {row} holds a {value.GetType()}. " +
+                        $"Column {index} ('{name}', {typeName}) is written as {typeof(TWrite)}, but row {rowNumber + slot} holds a {value.GetType()}. " +
                         $"Every value of one column must have the same CLR type.");
                 }
 
-                destination[row] = (TWrite)value;
+                destination[slot] = (TWrite)value;
             }
         });
     }
 
-    private static string DescribeTargets(Block schema)
+    /// <summary>
+    /// Matches every row of a block to the target columns by position, before any column reads it.
+    /// </summary>
+    private sealed class UntypedInsertSource : PocoInsertSource<object[]>
     {
-        var names = new string[schema.ColumnCount];
-        for (int i = 0; i < names.Length; i++)
+        private readonly int columnCount;
+        private readonly string parameterName;
+
+        public UntypedInsertSource(
+            PocoColumnBuilder<object[]>[] builders,
+            PocoRowBuffer<object[]> rows,
+            int blockRows,
+            int columnCount,
+            string parameterName)
+            : base(builders, rows, blockRows)
         {
-            names[i] = schema[i].Name;
+            this.columnCount = columnCount;
+            this.parameterName = parameterName;
         }
 
-        return string.Join(", ", names);
+        /// <inheritdoc/>
+        protected override void CheckBlock(object[][] window, int offset, int rowNumber, int count)
+        {
+            for (int i = 0; i < count; i++)
+            {
+                int length = window[offset + i].Length;
+                if (length != columnCount)
+                {
+                    throw new ArgumentException(
+                        $"Row {rowNumber + i} has {length} values, but the insert targets {columnCount} column(s) ({DescribeTargets()}). " +
+                        $"Untyped rows are matched to the target columns by position, so every row must have one value per column.",
+                        parameterName);
+                }
+            }
+        }
+
+        private string DescribeTargets()
+        {
+            var names = new string[Columns.Count];
+            for (int i = 0; i < names.Length; i++)
+            {
+                names[i] = Columns[i].Name;
+            }
+
+            return string.Join(", ", names);
+        }
     }
 }

--- a/ClickHouse.Driver.Tcp/Protocol/ClickHouseBinaryWriter.cs
+++ b/ClickHouse.Driver.Tcp/Protocol/ClickHouseBinaryWriter.cs
@@ -24,10 +24,13 @@ internal sealed class ClickHouseBinaryWriter : IDisposable
 
     /// <summary>Initializes a new writer over <paramref name="stream"/>.</summary>
     /// <param name="stream">The destination stream to write to.</param>
-    /// <param name="bufferSize">Initial buffer capacity in bytes; must be at least 32. Buffer can grow if necessary.</param>
+    /// <param name="bufferSize">Initial buffer capacity in bytes; must be at least 32. The buffer grows by
+    /// doubling when a write does not fit, so a larger start means fewer grow-and-copy steps before an insert
+    /// reaches its flush threshold. The default (64 KiB) is the largest that stays off the large-object
+    /// heap.</param>
     /// <exception cref="ArgumentNullException"><paramref name="stream"/> is null.</exception>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="bufferSize"/> is below 32.</exception>
-    public ClickHouseBinaryWriter(Stream stream, int bufferSize = 16384)
+    public ClickHouseBinaryWriter(Stream stream, int bufferSize = 65536)
     {
         this.stream = stream ?? throw new ArgumentNullException(nameof(stream));
         if (bufferSize < 32)

--- a/ClickHouse.Driver.Tcp/Protocol/ClickHouseTcpConnection.cs
+++ b/ClickHouse.Driver.Tcp/Protocol/ClickHouseTcpConnection.cs
@@ -12,16 +12,7 @@ using ClickHouse.Driver.Tcp.Types;
 namespace ClickHouse.Driver.Tcp.Protocol;
 
 /// <summary>
-/// Builds the columns of one INSERT from the server's sample block — the seam a row-oriented insert needs, since
-/// the target types arrive only once the statement has been sent and rows cannot be transposed into typed columns
-/// before then.
-///
-/// <para>
-/// The columns it returns are owned by the insert: they are disposed once the row data has been written, so a
-/// factory is free to hand over columns backed by pooled buffers. It runs while the connection is mid-INSERT, so a
-/// factory that throws does not fail the connection — the insert closes its row stream with no rows and the
-/// exception surfaces afterwards.
-/// </para>
+/// Builds row-oriented columns after the server supplies the INSERT schema. The insert owns the returned columns.
 /// </summary>
 /// <param name="schema">The server's sample block, naming and typing the target columns. Valid only for the call.</param>
 /// <returns>The columns to insert, matched to the target by name.</returns>
@@ -429,28 +420,12 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
     }
 
     /// <summary>
-    /// Runs an INSERT whose columns are built from the server's sample block, for a caller holding rows rather than
-    /// columns: the target types are known only mid-INSERT, so the transposition happens there.
+    /// Runs an INSERT whose columns are built from the server's sample block.
     /// </summary>
     /// <remarks>
-    /// Behaves in every other way like the column-taking overload — see it for how columns are matched to the target
-    /// and how large inserts are split. The columns <paramref name="buildColumns"/> returns are disposed once they
-    /// have been written. A factory that throws writes no rows and leaves the connection usable, and its exception
-    /// is rethrown once the server has acknowledged the empty insert.
+    /// The returned columns are disposed after writing. A factory failure sends no rows and leaves the connection
+    /// reusable.
     /// </remarks>
-    /// <param name="sql">The <c>INSERT INTO … VALUES</c> statement, with no inline <c>VALUES (...)</c> literal.</param>
-    /// <param name="rowCount">The number of rows the factory's columns will hold.</param>
-    /// <param name="buildColumns">Builds the row data from the target schema.</param>
-    /// <param name="settings">Per-query settings as textual values, or null for none.</param>
-    /// <param name="parameters">Query parameter values in SQL representation, or null for none.</param>
-    /// <param name="queryId">The query id, or null to let the server assign one.</param>
-    /// <param name="maxRowsPerBlock">A cap on the rows per wire block, or null for a single block.</param>
-    /// <param name="maxSendBufferBytes">The buffered-byte cap that triggers a between-column flush.</param>
-    /// <param name="handlers">Optional callbacks for the metadata interleaved into the acknowledgement.</param>
-    /// <param name="cancellationToken">A token to observe for cancellation.</param>
-    /// <returns>A task that completes when the server acknowledges the insert with end-of-stream.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="sql"/> or <paramref name="buildColumns"/> is null.</exception>
-    /// <exception cref="ArgumentOutOfRangeException"><paramref name="rowCount"/> is negative, <paramref name="maxRowsPerBlock"/> is zero or negative, or <paramref name="maxSendBufferBytes"/> is not positive.</exception>
     internal ValueTask InsertAsync(
         string sql,
         int rowCount,
@@ -475,15 +450,7 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
     }
 
     /// <summary>
-    /// Runs the INSERT both overloads share: the statement, the sample block, the row stream, and the
-    /// acknowledgement. Exactly one of <paramref name="columns"/> and <paramref name="buildColumns"/> is supplied;
-    /// the factory's columns are owned here and disposed once written, the caller's are not.
-    ///
-    /// <para>
-    /// Every failure that leaves the connection usable is parked until the row stream has been closed and the
-    /// response drained, then thrown in cause order: the column build first, then anything the server reported,
-    /// then a schema mismatch.
-    /// </para>
+    /// Runs the shared INSERT flow. Factory-built columns are owned here; caller-supplied columns are not.
     /// </summary>
     private async ValueTask InsertCoreAsync(
         string sql,
@@ -503,9 +470,7 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
         BeginOperation();
 
         NegotiatedProtocol negotiated = server.Negotiated;
-        // The server interleaves metadata blocks (ProfileEvents, Logs, Totals, Extremes) into the insert
-        // acknowledgement, some of which carry timezone-bearing DateTime/DateTime64 columns. Decode them with the
-        // same session/server timezone a query would use, so a metadata handler sees consistent offsets.
+        // Decode metadata blocks with the operation's session timezone.
         ResolveContext readContext = ReadContextFor(settings);
         ClickHouseServerException pending = null;
         Exception buildFailure = null;
@@ -551,9 +516,7 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
                     }
                     else
                     {
-                        // The first point the target types are known, so the first point rows can become columns.
-                        // A failure here is the caller's shape, not the connection's: park it and close the row
-                        // stream cleanly, exactly as a schema mismatch does.
+                        // Defer caller errors until the row stream is closed cleanly.
                         try
                         {
                             values = buildColumns(schema);
@@ -600,8 +563,7 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
             }
         }
 
-        // A failure to build the columns comes first: it is the cause, and anything the server then said about an
-        // insert that carried no rows is a consequence of it.
+        // Prefer the build failure over the server's response to the resulting empty insert.
         if (buildFailure is not null)
         {
             ExceptionDispatchInfo.Capture(buildFailure).Throw();
@@ -619,10 +581,7 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
     }
 
     /// <summary>
-    /// Validates the arguments that need no server round-trip — non-null inputs, a positive
-    /// <paramref name="maxRowsPerBlock"/>, a consistent row count, and unique column names — and reports that row
-    /// count. Runs before the connection is claimed, so a malformed call leaves it idle. Name-to-schema
-    /// alignment and per-column writability need the sample block and are checked after the query round-trip.
+    /// Validates caller-supplied columns before claiming the connection.
     /// </summary>
     /// <param name="rowCount">Set to the row count every column must share (zero when there are no columns).</param>
     private static void ValidateInsertArguments(
@@ -639,8 +598,7 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
         rowCount = 0;
         for (int i = 0; i < columns.Count; i++)
         {
-            // Reject a null element with a clear error before the connection is claimed, rather than NREing
-            // mid-validation on its RowCount/Name.
+            // Reject null before reading its row count or name.
             IColumn column = columns[i]
                 ?? throw new ArgumentException($"Column at index {i} is null; every supplied column must be non-null.", nameof(columns));
 
@@ -668,9 +626,7 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
         }
     }
 
-    /// <summary>
-    /// Validates the block geometry both insert overloads take, before the connection is claimed.
-    /// </summary>
+    /// <summary>Validates block limits before claiming the connection.</summary>
     /// <param name="maxRowsPerBlock">The cap on the rows per wire block, or null for a single block.</param>
     /// <param name="maxSendBufferBytes">The buffered-byte cap that triggers a between-column flush.</param>
     private static void ValidateInsertGeometry(int? maxRowsPerBlock, int maxSendBufferBytes)
@@ -687,10 +643,7 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
     }
 
     /// <summary>
-    /// Writes the INSERT row stream: the rows as bounded wire blocks (each read straight from the columns'
-    /// spans), then the empty terminator that closes it. A null <paramref name="plan"/> or zero
-    /// <paramref name="rowCount"/> writes only the terminator — a no-op insert. Trims the writer's pooled buffer
-    /// once everything is flushed.
+    /// Writes the row blocks and terminating empty block. A null plan or zero rows writes only the terminator.
     /// </summary>
     /// <param name="plan">The per-column write plan in schema order, or null to write only the terminator.</param>
     /// <param name="flushThresholdBytes">The buffered-byte cap that triggers a between-column flush while a block is written.</param>
@@ -704,9 +657,7 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
     {
         if (rowCount > 0 && plan is not null)
         {
-            // Split into wire blocks by row count alone (each column is written straight from its ergonomic form,
-            // so there is no intermediate dense buffer to build first). The flush threshold — the write memory
-            // backstop the caller's send-buffer cap tunes — is what bounds peak client memory while a block streams.
+            // Row count controls block splitting; the flush threshold bounds buffered output within each block.
             foreach ((int start, int length) in PlanInsertBlocks(rowCount, maxRowsPerBlock))
             {
                 writer.WriteClientPacketType(ClientPacketType.Data);
@@ -725,9 +676,7 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
     }
 
     /// <summary>
-    /// Reads and releases blocks until the response ends, returning the server
-    /// <see cref="ClickHouseServerException"/> that terminated it, or null on a clean end-of-stream. Either way
-    /// the stream is left at a packet boundary, so the connection stays usable.
+    /// Drains the response and returns its server error, if any, while leaving the connection reusable.
     /// </summary>
     /// <param name="negotiated">The negotiated protocol.</param>
     /// <param name="context">The codec-resolution context (timezone) for decoding blocks.</param>
@@ -753,11 +702,7 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
     }
 
     /// <summary>
-    /// Splits <paramref name="rowCount"/> rows into contiguous wire-block ranges of at most
-    /// <paramref name="maxRowsPerBlock"/> rows each — the block geometry is bounded by row count alone. With no
-    /// <paramref name="maxRowsPerBlock"/> the whole insert is a single block; peak client memory while it is
-    /// written is instead bounded by the between-column flush backstop
-    /// (<see cref="BlockWriter.DefaultFlushThresholdBytes"/>), not by splitting the block.
+    /// Splits rows into contiguous ranges of at most <paramref name="maxRowsPerBlock"/> rows.
     /// </summary>
     /// <param name="rowCount">The number of rows to split (assumed greater than zero).</param>
     /// <param name="maxRowsPerBlock">The cap on the rows per block, or null for a single block.</param>
@@ -775,10 +720,7 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
     }
 
     /// <summary>
-    /// Aligns the caller's columns to the schema by name, returning one descriptor per schema column (in schema
-    /// order) that pairs the target's name, resolved type, and codec with the caller's values — the caller's own
-    /// type string is ignored. With <paramref name="validateWritable"/> set, a value column whose CLR type the
-    /// target cannot serialize is rejected. Returns null and sets <paramref name="error"/> on any mismatch.
+    /// Aligns columns to the server schema and resolves the target codecs.
     /// </summary>
     /// <param name="columns">The caller's value columns; names are unique (validated earlier).</param>
     /// <param name="schema">The server's sample block describing the target columns.</param>
@@ -795,8 +737,7 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
             byName[column.Name] = column;
         }
 
-        // Align by name: every schema column must be supplied and every supplied column must exist in the schema.
-        // Both directions are reported so a wrong column set is actionable, not just a count mismatch.
+        // Report both missing and unexpected columns.
         var plan = new InsertColumn[schema.ColumnCount];
         List<string> missing = null;
         int matched = 0;
@@ -820,10 +761,7 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
             return null;
         }
 
-        // Names line up one-to-one; resolve each target type through the same registry and context that decoded the
-        // sample block (the target type, not the caller's), then confirm the value column is writable as it. A
-        // timezone-less DateTime/DateTime64 target needs the session zone to turn an Unspecified wall clock into
-        // the instant the server expects.
+        // Resolve target codecs with the sample block's context, including its session timezone.
         for (int i = 0; i < plan.Length; i++)
         {
             InsertColumn slot = plan[i];

--- a/ClickHouse.Driver.Tcp/Protocol/ClickHouseTcpConnection.cs
+++ b/ClickHouse.Driver.Tcp/Protocol/ClickHouseTcpConnection.cs
@@ -12,11 +12,28 @@ using ClickHouse.Driver.Tcp.Types;
 namespace ClickHouse.Driver.Tcp.Protocol;
 
 /// <summary>
-/// Builds row-oriented columns after the server supplies the INSERT schema. The insert owns the returned columns.
+/// Compiles the row-to-column mapping once the server supplies the INSERT schema. The insert owns the returned
+/// source and disposes it.
 /// </summary>
 /// <param name="schema">The server's sample block, naming and typing the target columns. Valid only for the call.</param>
-/// <returns>The columns to insert, matched to the target by name.</returns>
-internal delegate IReadOnlyList<IColumn> InsertColumnFactory(Block schema);
+/// <returns>The source of the columns to insert, matched to the target by name.</returns>
+internal delegate IInsertColumnSource InsertColumnFactory(Block schema);
+
+/// <summary>
+/// The columns of a row-oriented INSERT, filled one wire block at a time. Created once per insert, against the
+/// server's schema; <see cref="Columns"/> holds the same column objects throughout, and each
+/// <see cref="Gather"/> makes the next range of rows their values.
+/// </summary>
+internal interface IInsertColumnSource : IDisposable
+{
+    /// <summary>The columns, in the schema's order. Empty of rows until the first <see cref="Gather"/>.</summary>
+    IReadOnlyList<IColumn> Columns { get; }
+
+    /// <summary>Makes rows <c>[start, start + length)</c> the values of every column.</summary>
+    /// <param name="start">The zero-based first row of the block.</param>
+    /// <param name="length">The number of rows in the block.</param>
+    void Gather(int start, int length);
+}
 
 /// <summary>
 /// A single raw connection to a ClickHouse server over the native TCP protocol. Owns the socket, the buffered
@@ -358,12 +375,17 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
     }
 
     /// <summary>
-    /// The default cap on the rows per wire block (1,000,000). Block geometry is bounded by row count alone, so
-    /// this cap is what splits a large insert into bounded blocks. Peak buffered bytes while a block is written
-    /// are bounded separately by the between-column flush backstop
+    /// The default cap on the rows per wire block (50,000). Block geometry is bounded by row count alone, so this
+    /// cap is what splits a large insert into bounded blocks. Peak buffered bytes while a block is written are
+    /// bounded separately by the between-column flush backstop
     /// (<see cref="BlockWriter.DefaultFlushThresholdBytes"/>), which flushes mid-block rather than closing it.
+    ///
+    /// <para>
+    /// A row insert converts one block at a time, so for those the cap also bounds the memory the conversion
+    /// holds: one buffer per column, of this many values, rather than one of the whole insert's row count.
+    /// </para>
     /// </summary>
-    public const int DefaultMaxRowsPerBlock = 1_000_000;
+    public const int DefaultMaxRowsPerBlock = 50_000;
 
     /// <summary>
     /// Runs an INSERT, streaming <paramref name="columns"/> as the row data and returning once the server
@@ -420,11 +442,13 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
     }
 
     /// <summary>
-    /// Runs an INSERT whose columns are built from the server's sample block.
+    /// Runs an INSERT whose columns are built from the server's sample block, one wire block of rows at a time.
     /// </summary>
     /// <remarks>
-    /// The returned columns are disposed after writing. A factory failure sends no rows and leaves the connection
-    /// reusable.
+    /// The source is disposed after writing. A failure while the factory compiles the mapping sends no rows. A
+    /// failure while a block is gathered — a value the target cannot take, for one — stops at that block, so the
+    /// blocks before it have been sent and the server keeps them. Either way the row stream is closed cleanly and
+    /// the connection stays reusable, and the failure is thrown once the server has acknowledged the insert.
     /// </remarks>
     internal ValueTask InsertAsync(
         string sql,
@@ -475,6 +499,7 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
         ClickHouseServerException pending = null;
         Exception buildFailure = null;
         IReadOnlyList<IColumn> values = null;
+        IInsertColumnSource source = null;
         bool completed = false;
         string mismatchError = null;
         try
@@ -519,7 +544,8 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
                         // Defer caller errors until the row stream is closed cleanly.
                         try
                         {
-                            values = buildColumns(schema);
+                            source = buildColumns(schema);
+                            values = source.Columns;
                         }
                         catch (Exception failure)
                         {
@@ -529,13 +555,18 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
 
                     if (buildFailure is null)
                     {
+                        // The plan holds the source's columns, which keep their identity as each block refills
+                        // them, so it is built once here rather than per block.
                         plan = values.Count == 0
                             ? null
                             : BuildInsertPlan(values, schema, validateWritable: rowCount > 0, out mismatchError);
                     }
                 }
 
-                await StreamInsertRowsAsync(plan, rowCount, maxRowsPerBlock, maxSendBufferBytes, negotiated, cancellationToken).ConfigureAwait(false);
+                // Always run, even after a factory failure: the row stream has to be closed for the server to
+                // finish the insert. A gather failure is deferred the same way, so the stream still closes cleanly.
+                Exception gatherFailure = await StreamInsertRowsAsync(plan, source, rowCount, maxRowsPerBlock, maxSendBufferBytes, negotiated, cancellationToken).ConfigureAwait(false);
+                buildFailure ??= gatherFailure;
 
                 // Rethrow any server error once the state is back to Ready.
                 pending = await DrainToEndOfStreamAsync(negotiated, readContext, handlers, cancellationToken).ConfigureAwait(false);
@@ -544,14 +575,8 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
         }
         finally
         {
-            // Only the factory's columns are ours to release; a caller's own columns outlive the insert.
-            if (buildColumns is not null && values is not null)
-            {
-                for (int i = 0; i < values.Count; i++)
-                {
-                    values[i]?.Dispose();
-                }
-            }
+            // Only the factory's source is ours to release; a caller's own columns outlive the insert.
+            source?.Dispose();
 
             if (completed)
             {
@@ -646,23 +671,43 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
     /// Writes the row blocks and terminating empty block. A null plan or zero rows writes only the terminator.
     /// </summary>
     /// <param name="plan">The per-column write plan in schema order, or null to write only the terminator.</param>
+    /// <param name="source">The row source to fill the plan's columns from per block, or null when the caller
+    /// supplied whole columns.</param>
     /// <param name="flushThresholdBytes">The buffered-byte cap that triggers a between-column flush while a block is written.</param>
-    private async ValueTask StreamInsertRowsAsync(
+    /// <returns>The gather failure that stopped the row stream, or null if every block was written.</returns>
+    private async ValueTask<Exception> StreamInsertRowsAsync(
         InsertColumn[] plan,
+        IInsertColumnSource source,
         int rowCount,
         int? maxRowsPerBlock,
         int flushThresholdBytes,
         NegotiatedProtocol negotiated,
         CancellationToken cancellationToken)
     {
+        Exception gatherFailure = null;
         if (rowCount > 0 && plan is not null)
         {
             // Row count controls block splitting; the flush threshold bounds buffered output within each block.
             foreach ((int start, int length) in PlanInsertBlocks(rowCount, maxRowsPerBlock))
             {
+                if (source is not null)
+                {
+                    // The block is the conversion unit: fill the columns with these rows, then write them. A
+                    // failure here has not written a byte of the block, so the stream is still at a boundary.
+                    try
+                    {
+                        source.Gather(start, length);
+                    }
+                    catch (Exception failure)
+                    {
+                        gatherFailure = failure;
+                        break;
+                    }
+                }
+
                 writer.WriteClientPacketType(ClientPacketType.Data);
                 await BlockWriter.WriteDataBlockAsync(
-                    writer, negotiated, plan, start, length, flushThresholdBytes, cancellationToken).ConfigureAwait(false);
+                    writer, negotiated, plan, source is null ? start : 0, length, flushThresholdBytes, cancellationToken).ConfigureAwait(false);
                 await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
             }
         }
@@ -673,6 +718,7 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
 
         // Return the pooled buffer to baseline so an idle connection doesn't retain a large insert's peak size.
         writer.TrimBuffer();
+        return gatherFailure;
     }
 
     /// <summary>
@@ -710,7 +756,7 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
     internal static List<(int Start, int Length)> PlanInsertBlocks(int rowCount, int? maxRowsPerBlock)
     {
         var blocks = new List<(int Start, int Length)>();
-        int step = maxRowsPerBlock is int cap && cap > 0 ? cap : rowCount;
+        int step = RowsPerBlock(rowCount, maxRowsPerBlock);
         for (int start = 0; start < rowCount; start += step)
         {
             blocks.Add((start, Math.Min(step, rowCount - start)));
@@ -718,6 +764,16 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
 
         return blocks;
     }
+
+    /// <summary>
+    /// Returns the largest block <see cref="PlanInsertBlocks"/> will produce, which is what a row insert has to
+    /// size its per-column gather buffers for.
+    /// </summary>
+    /// <param name="rowCount">The number of rows to insert.</param>
+    /// <param name="maxRowsPerBlock">The cap on the rows per block, or null for a single block.</param>
+    /// <returns>The rows in the largest block.</returns>
+    internal static int RowsPerBlock(int rowCount, int? maxRowsPerBlock)
+        => maxRowsPerBlock is int cap && cap > 0 ? Math.Min(cap, rowCount) : rowCount;
 
     /// <summary>
     /// Aligns columns to the server schema and resolves the target codecs.

--- a/ClickHouse.Driver.Tcp/Protocol/ClickHouseTcpConnection.cs
+++ b/ClickHouse.Driver.Tcp/Protocol/ClickHouseTcpConnection.cs
@@ -820,16 +820,17 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
             return null;
         }
 
-        // Names line up one-to-one; resolve each target type to its codec (the target type, not the caller's) and
-        // confirm the value column is writable as it. Writing a value uses its own instant, so no server timezone
-        // is needed to resolve the codec.
+        // Names line up one-to-one; resolve each target type through the same registry and context that decoded the
+        // sample block (the target type, not the caller's), then confirm the value column is writable as it. A
+        // timezone-less DateTime/DateTime64 target needs the session zone to turn an Unspecified wall clock into
+        // the instant the server expects.
         for (int i = 0; i < plan.Length; i++)
         {
             InsertColumn slot = plan[i];
             IColumnCodec codec;
             try
             {
-                codec = ColumnCodecRegistry.Default.Resolve(slot.TypeName, ResolveContext.ForWrite);
+                codec = schema.Codecs.Resolve(slot.TypeName, schema.Context);
             }
             catch (Exception ex) when (ex is NotSupportedException or FormatException)
             {

--- a/ClickHouse.Driver.Tcp/Protocol/ClickHouseTcpConnection.cs
+++ b/ClickHouse.Driver.Tcp/Protocol/ClickHouseTcpConnection.cs
@@ -3,12 +3,29 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net.Sockets;
 using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 using ClickHouse.Driver.Tcp.Format;
 using ClickHouse.Driver.Tcp.Types;
 
 namespace ClickHouse.Driver.Tcp.Protocol;
+
+/// <summary>
+/// Builds the columns of one INSERT from the server's sample block — the seam a row-oriented insert needs, since
+/// the target types arrive only once the statement has been sent and rows cannot be transposed into typed columns
+/// before then.
+///
+/// <para>
+/// The columns it returns are owned by the insert: they are disposed once the row data has been written, so a
+/// factory is free to hand over columns backed by pooled buffers. It runs while the connection is mid-INSERT, so a
+/// factory that throws does not fail the connection — the insert closes its row stream with no rows and the
+/// exception surfaces afterwards.
+/// </para>
+/// </summary>
+/// <param name="schema">The server's sample block, naming and typing the target columns. Valid only for the call.</param>
+/// <returns>The columns to insert, matched to the target by name.</returns>
+internal delegate IReadOnlyList<IColumn> InsertColumnFactory(Block schema);
 
 /// <summary>
 /// A single raw connection to a ClickHouse server over the native TCP protocol. Owns the socket, the buffered
@@ -396,7 +413,7 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
     /// <exception cref="ClickHouseServerException">The server reported an error while executing the insert.</exception>
     /// <exception cref="ClickHouseProtocolException">The server sent an unexpected packet, or no schema block.</exception>
     /// <exception cref="OperationCanceledException"><paramref name="cancellationToken"/> was cancelled.</exception>
-    internal async ValueTask InsertAsync(
+    internal ValueTask InsertAsync(
         string sql,
         IReadOnlyList<IColumn> columns,
         IReadOnlyDictionary<string, string> settings = null,
@@ -408,7 +425,79 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
         CancellationToken cancellationToken = default)
     {
         ValidateInsertArguments(sql, columns, maxRowsPerBlock, maxSendBufferBytes, out int rowCount);
+        return InsertCoreAsync(sql, columns, buildColumns: null, rowCount, settings, parameters, queryId, maxRowsPerBlock, maxSendBufferBytes, handlers, cancellationToken);
+    }
 
+    /// <summary>
+    /// Runs an INSERT whose columns are built from the server's sample block, for a caller holding rows rather than
+    /// columns: the target types are known only mid-INSERT, so the transposition happens there.
+    /// </summary>
+    /// <remarks>
+    /// Behaves in every other way like the column-taking overload — see it for how columns are matched to the target
+    /// and how large inserts are split. The columns <paramref name="buildColumns"/> returns are disposed once they
+    /// have been written. A factory that throws writes no rows and leaves the connection usable, and its exception
+    /// is rethrown once the server has acknowledged the empty insert.
+    /// </remarks>
+    /// <param name="sql">The <c>INSERT INTO … VALUES</c> statement, with no inline <c>VALUES (...)</c> literal.</param>
+    /// <param name="rowCount">The number of rows the factory's columns will hold.</param>
+    /// <param name="buildColumns">Builds the row data from the target schema.</param>
+    /// <param name="settings">Per-query settings as textual values, or null for none.</param>
+    /// <param name="parameters">Query parameter values in SQL representation, or null for none.</param>
+    /// <param name="queryId">The query id, or null to let the server assign one.</param>
+    /// <param name="maxRowsPerBlock">A cap on the rows per wire block, or null for a single block.</param>
+    /// <param name="maxSendBufferBytes">The buffered-byte cap that triggers a between-column flush.</param>
+    /// <param name="handlers">Optional callbacks for the metadata interleaved into the acknowledgement.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>A task that completes when the server acknowledges the insert with end-of-stream.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="sql"/> or <paramref name="buildColumns"/> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="rowCount"/> is negative, <paramref name="maxRowsPerBlock"/> is zero or negative, or <paramref name="maxSendBufferBytes"/> is not positive.</exception>
+    internal ValueTask InsertAsync(
+        string sql,
+        int rowCount,
+        InsertColumnFactory buildColumns,
+        IReadOnlyDictionary<string, string> settings = null,
+        IReadOnlyDictionary<string, string> parameters = null,
+        string queryId = null,
+        int? maxRowsPerBlock = DefaultMaxRowsPerBlock,
+        int maxSendBufferBytes = BlockWriter.DefaultFlushThresholdBytes,
+        MetadataHandlers handlers = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(sql);
+        ArgumentNullException.ThrowIfNull(buildColumns);
+        if (rowCount < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(rowCount), rowCount, "The row count must not be negative.");
+        }
+
+        ValidateInsertGeometry(maxRowsPerBlock, maxSendBufferBytes);
+        return InsertCoreAsync(sql, columns: null, buildColumns, rowCount, settings, parameters, queryId, maxRowsPerBlock, maxSendBufferBytes, handlers, cancellationToken);
+    }
+
+    /// <summary>
+    /// Runs the INSERT both overloads share: the statement, the sample block, the row stream, and the
+    /// acknowledgement. Exactly one of <paramref name="columns"/> and <paramref name="buildColumns"/> is supplied;
+    /// the factory's columns are owned here and disposed once written, the caller's are not.
+    ///
+    /// <para>
+    /// Every failure that leaves the connection usable is parked until the row stream has been closed and the
+    /// response drained, then thrown in cause order: the column build first, then anything the server reported,
+    /// then a schema mismatch.
+    /// </para>
+    /// </summary>
+    private async ValueTask InsertCoreAsync(
+        string sql,
+        IReadOnlyList<IColumn> columns,
+        InsertColumnFactory buildColumns,
+        int rowCount,
+        IReadOnlyDictionary<string, string> settings,
+        IReadOnlyDictionary<string, string> parameters,
+        string queryId,
+        int? maxRowsPerBlock,
+        int maxSendBufferBytes,
+        MetadataHandlers handlers,
+        CancellationToken cancellationToken)
+    {
         // Bail on cancellation before claiming the connection, so a pre-cancelled call leaves it idle.
         cancellationToken.ThrowIfCancellationRequested();
         BeginOperation();
@@ -419,6 +508,8 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
         // same session/server timezone a query would use, so a metadata handler sees consistent offsets.
         ResolveContext readContext = ReadContextFor(settings);
         ClickHouseServerException pending = null;
+        Exception buildFailure = null;
+        IReadOnlyList<IColumn> values = null;
         bool completed = false;
         string mismatchError = null;
         try
@@ -451,12 +542,34 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
             {
                 // Align the caller's columns to the schema by name. No columns is the explicit no-op insert; a
                 // mismatch leaves plan null (so only the terminator goes out) and defers the throw until Ready.
-                InsertColumn[] plan;
+                InsertColumn[] plan = null;
                 using (schema)
                 {
-                    plan = columns.Count == 0
-                        ? null
-                        : BuildInsertPlan(columns, schema, validateWritable: rowCount > 0, out mismatchError);
+                    if (buildColumns is null)
+                    {
+                        values = columns;
+                    }
+                    else
+                    {
+                        // The first point the target types are known, so the first point rows can become columns.
+                        // A failure here is the caller's shape, not the connection's: park it and close the row
+                        // stream cleanly, exactly as a schema mismatch does.
+                        try
+                        {
+                            values = buildColumns(schema);
+                        }
+                        catch (Exception failure)
+                        {
+                            buildFailure = failure;
+                        }
+                    }
+
+                    if (buildFailure is null)
+                    {
+                        plan = values.Count == 0
+                            ? null
+                            : BuildInsertPlan(values, schema, validateWritable: rowCount > 0, out mismatchError);
+                    }
                 }
 
                 await StreamInsertRowsAsync(plan, rowCount, maxRowsPerBlock, maxSendBufferBytes, negotiated, cancellationToken).ConfigureAwait(false);
@@ -468,6 +581,15 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
         }
         finally
         {
+            // Only the factory's columns are ours to release; a caller's own columns outlive the insert.
+            if (buildColumns is not null && values is not null)
+            {
+                for (int i = 0; i < values.Count; i++)
+                {
+                    values[i]?.Dispose();
+                }
+            }
+
             if (completed)
             {
                 state = TcpConnectionState.Ready;
@@ -478,6 +600,13 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
             }
         }
 
+        // A failure to build the columns comes first: it is the cause, and anything the server then said about an
+        // insert that carried no rows is a consequence of it.
+        if (buildFailure is not null)
+        {
+            ExceptionDispatchInfo.Capture(buildFailure).Throw();
+        }
+
         if (pending is not null)
         {
             throw pending;
@@ -485,7 +614,7 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
 
         if (mismatchError is not null)
         {
-            throw new ArgumentException(mismatchError, nameof(columns));
+            throw new ArgumentException(mismatchError, buildColumns is null ? nameof(columns) : nameof(buildColumns));
         }
     }
 
@@ -505,15 +634,7 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
     {
         ArgumentNullException.ThrowIfNull(sql);
         ArgumentNullException.ThrowIfNull(columns);
-        if (maxRowsPerBlock is <= 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(maxRowsPerBlock), maxRowsPerBlock, "The rows-per-block cap must be positive.");
-        }
-
-        if (maxSendBufferBytes <= 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(maxSendBufferBytes), maxSendBufferBytes, "The send-buffer cap must be positive.");
-        }
+        ValidateInsertGeometry(maxRowsPerBlock, maxSendBufferBytes);
 
         rowCount = 0;
         for (int i = 0; i < columns.Count; i++)
@@ -544,6 +665,24 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
                     $"Column '{column.Name}' is supplied more than once; column names must be unique.",
                     nameof(columns));
             }
+        }
+    }
+
+    /// <summary>
+    /// Validates the block geometry both insert overloads take, before the connection is claimed.
+    /// </summary>
+    /// <param name="maxRowsPerBlock">The cap on the rows per wire block, or null for a single block.</param>
+    /// <param name="maxSendBufferBytes">The buffered-byte cap that triggers a between-column flush.</param>
+    private static void ValidateInsertGeometry(int? maxRowsPerBlock, int maxSendBufferBytes)
+    {
+        if (maxRowsPerBlock is <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxRowsPerBlock), maxRowsPerBlock, "The rows-per-block cap must be positive.");
+        }
+
+        if (maxSendBufferBytes <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxSendBufferBytes), maxSendBufferBytes, "The send-buffer cap must be positive.");
         }
     }
 

--- a/ClickHouse.Driver.Tcp/Types/ArrayColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/ArrayColumn.cs
@@ -71,15 +71,13 @@ internal sealed class ArrayColumn<T> : IColumn<T>, ISpanColumn<T>, IStoredValues
         => new(name, typeName, buffer, offset: 0, length, pooled: false);
 
     /// <summary>
-    /// Wraps the first <paramref name="length"/> elements of a buffer rented from <see cref="ArrayPool{T}"/>,
-    /// taking ownership: <see cref="Dispose"/> returns it to the pool. For a column built to be written and then
-    /// dropped — a POCO insert's gathered values — where the buffer has no owner but the column.
+    /// Wraps a rented buffer and returns it to <see cref="ArrayPool{T}"/> on disposal.
     /// </summary>
     /// <param name="name">The column name.</param>
     /// <param name="typeName">The ClickHouse type string.</param>
     /// <param name="buffer">The rented backing buffer; only <paramref name="length"/> elements are exposed.</param>
     /// <param name="length">The logical row count.</param>
-    /// <returns>A column owning the buffer.</returns>
+    /// <returns>A column that owns the buffer.</returns>
     internal static ArrayColumn<T> OverPooledBuffer(string name, string typeName, T[] buffer, int length)
         => new(name, typeName, buffer, offset: 0, length, pooled: true);
 

--- a/ClickHouse.Driver.Tcp/Types/ArrayColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/ArrayColumn.cs
@@ -70,6 +70,19 @@ internal sealed class ArrayColumn<T> : IColumn<T>, ISpanColumn<T>, IStoredValues
     internal static ArrayColumn<T> OverBuffer(string name, string typeName, T[] buffer, int length)
         => new(name, typeName, buffer, offset: 0, length, pooled: false);
 
+    /// <summary>
+    /// Wraps the first <paramref name="length"/> elements of a buffer rented from <see cref="ArrayPool{T}"/>,
+    /// taking ownership: <see cref="Dispose"/> returns it to the pool. For a column built to be written and then
+    /// dropped — a POCO insert's gathered values — where the buffer has no owner but the column.
+    /// </summary>
+    /// <param name="name">The column name.</param>
+    /// <param name="typeName">The ClickHouse type string.</param>
+    /// <param name="buffer">The rented backing buffer; only <paramref name="length"/> elements are exposed.</param>
+    /// <param name="length">The logical row count.</param>
+    /// <returns>A column owning the buffer.</returns>
+    internal static ArrayColumn<T> OverPooledBuffer(string name, string typeName, T[] buffer, int length)
+        => new(name, typeName, buffer, offset: 0, length, pooled: true);
+
     /// <inheritdoc/>
     public string Name { get; }
 

--- a/ClickHouse.Driver.Tcp/Types/ArrayColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/ArrayColumn.cs
@@ -70,17 +70,6 @@ internal sealed class ArrayColumn<T> : IColumn<T>, ISpanColumn<T>, IStoredValues
     internal static ArrayColumn<T> OverBuffer(string name, string typeName, T[] buffer, int length)
         => new(name, typeName, buffer, offset: 0, length, pooled: false);
 
-    /// <summary>
-    /// Wraps a rented buffer and returns it to <see cref="ArrayPool{T}"/> on disposal.
-    /// </summary>
-    /// <param name="name">The column name.</param>
-    /// <param name="typeName">The ClickHouse type string.</param>
-    /// <param name="buffer">The rented backing buffer; only <paramref name="length"/> elements are exposed.</param>
-    /// <param name="length">The logical row count.</param>
-    /// <returns>A column that owns the buffer.</returns>
-    internal static ArrayColumn<T> OverPooledBuffer(string name, string typeName, T[] buffer, int length)
-        => new(name, typeName, buffer, offset: 0, length, pooled: true);
-
     /// <inheritdoc/>
     public string Name { get; }
 

--- a/ClickHouse.Driver.Tcp/Types/Codecs/DateTime64ColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/DateTime64ColumnCodec.cs
@@ -9,12 +9,9 @@ using ClickHouse.Driver.Tcp.Protocol;
 namespace ClickHouse.Driver.Tcp.Types.Codecs;
 
 /// <summary>
-/// A codec for the ClickHouse <c>DateTime64(scale[, 'tz'])</c> column: a little-endian <c>Int64</c> tick count
-/// at 10^-<c>scale</c> seconds since the Unix epoch (may be negative), surfaced as the raw <see cref="long"/>
-/// count that retains the exact wire value at any scale (including scales 8 and 9, which are finer than a .NET
-/// tick). The timezone (explicit or the session's) sets the offset a caller's <see cref="DateTimeOffset"/>
-/// projection is presented with and the wall clock an <see cref="DateTimeKind.Unspecified"/> value denotes on
-/// write, resolved per instant so daylight-saving transitions are honored.
+/// Encodes ClickHouse <c>DateTime64</c> as signed counts at its declared scale. Reads preserve the raw
+/// <see cref="long"/> value; the explicit or session timezone controls <see cref="DateTimeOffset"/> projections and
+/// how unspecified <see cref="DateTime"/> values are interpreted.
 /// </summary>
 internal sealed class DateTime64ColumnCodec : IColumnCodec
 {

--- a/ClickHouse.Driver.Tcp/Types/Codecs/DateTime64ColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/DateTime64ColumnCodec.cs
@@ -13,7 +13,8 @@ namespace ClickHouse.Driver.Tcp.Types.Codecs;
 /// at 10^-<c>scale</c> seconds since the Unix epoch (may be negative), surfaced as the raw <see cref="long"/>
 /// count that retains the exact wire value at any scale (including scales 8 and 9, which are finer than a .NET
 /// tick). The timezone (explicit or the session's) sets the offset a caller's <see cref="DateTimeOffset"/>
-/// projection is presented with, resolved per instant so daylight-saving transitions are honored.
+/// projection is presented with and the wall clock an <see cref="DateTimeKind.Unspecified"/> value denotes on
+/// write, resolved per instant so daylight-saving transitions are honored.
 /// </summary>
 internal sealed class DateTime64ColumnCodec : IColumnCodec
 {

--- a/ClickHouse.Driver.Tcp/Types/Codecs/DateTimeColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/DateTimeColumnCodec.cs
@@ -8,12 +8,8 @@ using ClickHouse.Driver.Tcp.Protocol;
 namespace ClickHouse.Driver.Tcp.Types.Codecs;
 
 /// <summary>
-/// A codec for the ClickHouse <c>DateTime</c> / <c>DateTime('tz')</c> column: a little-endian <c>UInt32</c> of
-/// seconds since the Unix epoch per row, surfaced as the raw <see cref="uint"/> second count. The wire value is
-/// a UTC instant; the column's timezone — the type string's explicit argument, or the session timezone when it
-/// has none — determines the offset a caller's <see cref="DateTimeOffset"/> projection is presented with and the
-/// wall clock an <see cref="DateTimeKind.Unspecified"/> value denotes on write (resolved per instant, so
-/// daylight-saving transitions are honored).
+/// Encodes ClickHouse <c>DateTime</c> as Unix seconds. The explicit or session timezone controls
+/// <see cref="DateTimeOffset"/> projections and how unspecified <see cref="DateTime"/> values are interpreted.
 /// </summary>
 internal sealed class DateTimeColumnCodec : IColumnCodec
 {
@@ -109,9 +105,7 @@ internal sealed class DateTimeColumnCodec : IColumnCodec
     /// <inheritdoc/>
     public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
     {
-        // DateTimeOffset and specified DateTime values already name an instant. An Unspecified DateTime instead
-        // names a wall clock in the resolved column/session timezone; either way, the resulting UTC instant is what
-        // the epoch-second column body stores.
+        // Interpret unspecified DateTime values as wall clocks in the resolved timezone.
         switch (column)
         {
             case IColumn<uint> seconds:

--- a/ClickHouse.Driver.Tcp/Types/Codecs/DateTimeColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/DateTimeColumnCodec.cs
@@ -11,8 +11,9 @@ namespace ClickHouse.Driver.Tcp.Types.Codecs;
 /// A codec for the ClickHouse <c>DateTime</c> / <c>DateTime('tz')</c> column: a little-endian <c>UInt32</c> of
 /// seconds since the Unix epoch per row, surfaced as the raw <see cref="uint"/> second count. The wire value is
 /// a UTC instant; the column's timezone — the type string's explicit argument, or the session timezone when it
-/// has none — determines the offset a caller's <see cref="DateTimeOffset"/> projection is presented with
-/// (resolved per instant, so daylight-saving transitions are honored).
+/// has none — determines the offset a caller's <see cref="DateTimeOffset"/> projection is presented with and the
+/// wall clock an <see cref="DateTimeKind.Unspecified"/> value denotes on write (resolved per instant, so
+/// daylight-saving transitions are honored).
 /// </summary>
 internal sealed class DateTimeColumnCodec : IColumnCodec
 {
@@ -108,8 +109,9 @@ internal sealed class DateTimeColumnCodec : IColumnCodec
     /// <inheritdoc/>
     public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
     {
-        // Both a DateTimeOffset and a DateTime resolve to the same UTC instant, which is what the epoch-second
-        // column body stores; the display timezone is irrelevant to the bytes on the wire.
+        // DateTimeOffset and specified DateTime values already name an instant. An Unspecified DateTime instead
+        // names a wall clock in the resolved column/session timezone; either way, the resulting UTC instant is what
+        // the epoch-second column body stores.
         switch (column)
         {
             case IColumn<uint> seconds:

--- a/ClickHouse.Driver.Tcp/Types/Codecs/DateTimeZones.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/DateTimeZones.cs
@@ -7,8 +7,8 @@ namespace ClickHouse.Driver.Tcp.Types.Codecs;
 /// <summary>
 /// Timezone resolution shared by the <c>DateTime</c> / <c>DateTime64</c> codecs. A ClickHouse timezone-bearing
 /// type stores a UTC instant on the wire; the timezone (from the type string, or the session's when the type
-/// omits one) only determines the offset a value is <i>presented</i> with. This resolves that timezone once,
-/// at codec construction, and converts UTC instants into offsets at read time.
+/// omits one) determines both the offset a value is <i>presented</i> with and the wall clock named by an
+/// <see cref="DateTimeKind.Unspecified"/> value on write. This resolves that timezone once at codec construction.
 /// </summary>
 internal static class DateTimeZones
 {
@@ -25,7 +25,7 @@ internal static class DateTimeZones
     /// otherwise the server/session timezone, otherwise UTC.
     /// </summary>
     /// <param name="explicitTimezone">The timezone from the type string (e.g. <c>Europe/London</c>), or null/empty.</param>
-    /// <param name="serverTimezone">The session's timezone, or null/empty when unknown (e.g. the write path).</param>
+    /// <param name="serverTimezone">The session's timezone, or null/empty when unknown.</param>
     /// <returns>The resolved timezone info.</returns>
     /// <exception cref="FormatException">The named timezone is not known to the platform.</exception>
     public static TimeZoneInfo Resolve(string explicitTimezone, string serverTimezone)

--- a/ClickHouse.Driver.Tcp/Types/Codecs/DateTimeZones.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/DateTimeZones.cs
@@ -5,10 +5,8 @@ using System.Text.RegularExpressions;
 namespace ClickHouse.Driver.Tcp.Types.Codecs;
 
 /// <summary>
-/// Timezone resolution shared by the <c>DateTime</c> / <c>DateTime64</c> codecs. A ClickHouse timezone-bearing
-/// type stores a UTC instant on the wire; the timezone (from the type string, or the session's when the type
-/// omits one) determines both the offset a value is <i>presented</i> with and the wall clock named by an
-/// <see cref="DateTimeKind.Unspecified"/> value on write. This resolves that timezone once at codec construction.
+/// Resolves explicit and session timezones for the DateTime codecs. They control calendar projections and the
+/// interpretation of unspecified <see cref="DateTime"/> values; wire values remain UTC instants.
 /// </summary>
 internal static class DateTimeZones
 {

--- a/ClickHouse.Driver.Tcp/Types/Codecs/NullableColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/NullableColumnCodec.cs
@@ -37,11 +37,7 @@ internal sealed class NullableColumnCodec : IColumnCodec
     private readonly (Type Spelling, INullableShape Shape)[] writeShapes;
     private readonly bool innerCanWrite;
 
-    // The inner's write types lifted to this codec's nullable surface. Built on first use rather than in the
-    // constructor: a codec is resolved per column per block, so building it eagerly would put an allocation and a
-    // lookup per write type on the streaming path for every Nullable column that is only ever read. The build is
-    // idempotent, so a race just repeats identical work. The read side needs no counterpart — TryProjectRead answers
-    // per target without materializing a list.
+    // Built lazily to avoid write-shape allocations when the codec is used only for reads. Races are harmless.
     private Type[] writableElementTypes;
 
     private NullableColumnCodec(string typeName, IColumnCodec inner)
@@ -53,9 +49,7 @@ internal sealed class NullableColumnCodec : IColumnCodec
         // canonical ElementType made nullable.
         canonicalShape = NullableShapes.For(inner.ElementType);
 
-        // One shape per CLR write type the inner codec accepts, so a Nullable column can be supplied in any form
-        // the bare inner accepts (e.g. Nullable(DateTime) as DateTimeOffset? or DateTime?). The canonical
-        // ElementType leads the list, so it wins when a column would match more than one write type.
+        // Preserve the inner codec's write-type order; its canonical type remains preferred.
         IReadOnlyList<Type> writeTypes = inner.WritableElementTypes;
         writeShapes = new (Type, INullableShape)[writeTypes.Count];
         for (int i = 0; i < writeTypes.Count; i++)
@@ -63,8 +57,7 @@ internal sealed class NullableColumnCodec : IColumnCodec
             writeShapes[i] = (writeTypes[i], NullableShapes.For(writeTypes[i]));
         }
 
-        // Whether the inner codec can write at all (e.g. Nothing cannot). Computed once so CanWrite can reject a
-        // Nullable(non-writable) column up front rather than letting the write fail mid-stream.
+        // Reject a non-writable inner codec before streaming starts.
         innerCanWrite = canonicalShape.CanInnerWrite(inner);
     }
 
@@ -95,23 +88,17 @@ internal sealed class NullableColumnCodec : IColumnCodec
     }
 
     /// <summary>
-    /// The inner codec's writable types, each made nullable — the list form of what <see cref="CanWrite"/> has always
-    /// accepted, so <c>Nullable(DateTime)</c> advertises <c>uint?</c>, <c>DateTimeOffset?</c> and <c>DateTime?</c>.
-    /// The default would report only the canonical <see cref="ElementType"/> and so hide the other two from a caller
-    /// choosing a write type from the list rather than probing with a column.
+    /// The inner codec's writable CLR types, each made nullable.
     /// </summary>
     public IReadOnlyList<Type> WritableElementTypes => EnsureWritableElementTypes();
 
     /// <summary>
-    /// The placeholder for an absent <c>Nullable(T)</c> value is <see langword="null"/> itself — a null-marked
-    /// row. Relevant only if a future composite nests a <c>Nullable</c> and asks for its placeholder.
+    /// The placeholder for an absent value.
     /// </summary>
     public object NullPlaceholder => null;
 
     /// <summary>
-    /// <see langword="null"/> for every write type this codec accepts, not just the canonical one: a null row of a
-    /// <c>Nullable</c> column is spelled the same whichever CLR type carries the present rows, so the default's
-    /// single-type answer would leave the extra <see cref="WritableElementTypes"/> unanswerable.
+    /// Returns <see langword="null"/> for any writable CLR type.
     /// </summary>
     /// <param name="writeType">The CLR write type to express the placeholder in.</param>
     /// <returns><see langword="null"/>.</returns>
@@ -230,10 +217,7 @@ internal sealed class NullableColumnCodec : IColumnCodec
         return ColumnValueProjections.TryLiftOverAbsent(value, inner, innerTarget, targetType, out projected);
     }
 
-    /// <summary>
-    /// Builds the lifted write types on first use, in the order <see cref="ResolveWriteShape"/> prefers them — so the
-    /// canonical <see cref="ElementType"/> leads, the inner's own list leading with its canonical type.
-    /// </summary>
+    /// <summary>Builds the nullable write-type list on first use.</summary>
     /// <returns>The write types, each the inner's spelling made nullable.</returns>
     private Type[] EnsureWritableElementTypes()
     {

--- a/ClickHouse.Driver.Tcp/Types/Codecs/NullableColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/NullableColumnCodec.cs
@@ -37,6 +37,13 @@ internal sealed class NullableColumnCodec : IColumnCodec
     private readonly (Type Spelling, INullableShape Shape)[] writeShapes;
     private readonly bool innerCanWrite;
 
+    // The inner's write types lifted to this codec's nullable surface. Built on first use rather than in the
+    // constructor: a codec is resolved per column per block, so building it eagerly would put an allocation and a
+    // lookup per write type on the streaming path for every Nullable column that is only ever read. The build is
+    // idempotent, so a race just repeats identical work. The read side needs no counterpart — TryProjectRead answers
+    // per target without materializing a list.
+    private Type[] writableElementTypes;
+
     private NullableColumnCodec(string typeName, IColumnCodec inner)
     {
         TypeName = typeName;
@@ -88,10 +95,39 @@ internal sealed class NullableColumnCodec : IColumnCodec
     }
 
     /// <summary>
+    /// The inner codec's writable types, each made nullable — the list form of what <see cref="CanWrite"/> has always
+    /// accepted, so <c>Nullable(DateTime)</c> advertises <c>uint?</c>, <c>DateTimeOffset?</c> and <c>DateTime?</c>.
+    /// The default would report only the canonical <see cref="ElementType"/> and so hide the other two from a caller
+    /// choosing a write type from the list rather than probing with a column.
+    /// </summary>
+    public IReadOnlyList<Type> WritableElementTypes => EnsureWritableElementTypes();
+
+    /// <summary>
     /// The placeholder for an absent <c>Nullable(T)</c> value is <see langword="null"/> itself — a null-marked
     /// row. Relevant only if a future composite nests a <c>Nullable</c> and asks for its placeholder.
     /// </summary>
     public object NullPlaceholder => null;
+
+    /// <summary>
+    /// <see langword="null"/> for every write type this codec accepts, not just the canonical one: a null row of a
+    /// <c>Nullable</c> column is spelled the same whichever CLR type carries the present rows, so the default's
+    /// single-type answer would leave the extra <see cref="WritableElementTypes"/> unanswerable.
+    /// </summary>
+    /// <param name="writeType">The CLR write type to express the placeholder in.</param>
+    /// <returns><see langword="null"/>.</returns>
+    /// <exception cref="NotSupportedException"><paramref name="writeType"/> is not a writable element type.</exception>
+    public object NullPlaceholderAs(Type writeType)
+    {
+        foreach (Type writable in EnsureWritableElementTypes())
+        {
+            if (writable == writeType)
+            {
+                return null;
+            }
+        }
+
+        throw new NotSupportedException($"The '{TypeName}' codec has no null placeholder for {writeType}.");
+    }
 
     /// <summary>Builds a <c>Nullable(T)</c> codec, resolving the inner type <c>T</c> through the registry.</summary>
     /// <param name="node">The parsed <c>Nullable</c> type node; its single argument is the inner type.</param>
@@ -192,6 +228,29 @@ internal sealed class NullableColumnCodec : IColumnCodec
         }
 
         return ColumnValueProjections.TryLiftOverAbsent(value, inner, innerTarget, targetType, out projected);
+    }
+
+    /// <summary>
+    /// Builds the lifted write types on first use, in the order <see cref="ResolveWriteShape"/> prefers them — so the
+    /// canonical <see cref="ElementType"/> leads, the inner's own list leading with its canonical type.
+    /// </summary>
+    /// <returns>The write types, each the inner's spelling made nullable.</returns>
+    private Type[] EnsureWritableElementTypes()
+    {
+        Type[] surface = writableElementTypes;
+        if (surface is not null)
+        {
+            return surface;
+        }
+
+        surface = new Type[writeShapes.Length];
+        for (int i = 0; i < writeShapes.Length; i++)
+        {
+            surface[i] = writeShapes[i].Shape.NullableElementType;
+        }
+
+        writableElementTypes = surface;
+        return surface;
     }
 
     /// <inheritdoc/>

--- a/ClickHouse.Driver.Tcp/Types/ColumnCodecRegistry.cs
+++ b/ClickHouse.Driver.Tcp/Types/ColumnCodecRegistry.cs
@@ -33,7 +33,8 @@ internal sealed class ColumnCodecRegistry
 
     /// <summary>Resolves the codec for a ClickHouse type string.</summary>
     /// <param name="typeString">The type string from a column header (e.g. <c>UInt64</c>, <c>DateTime('UTC')</c>).</param>
-    /// <param name="context">The resolution context (server timezone, etc.); use <see cref="ResolveContext.ForWrite"/> on the write path.</param>
+    /// <param name="context">The resolution context (server timezone, etc.); use the sample block's context when
+    /// resolving an INSERT target, or <see cref="ResolveContext.ForWrite"/> when no server context exists.</param>
     /// <returns>The codec for that type.</returns>
     /// <exception cref="FormatException"><paramref name="typeString"/> is malformed.</exception>
     /// <exception cref="NotSupportedException">The type is well-formed but not yet supported by this client.</exception>

--- a/ClickHouse.Driver.Tcp/Types/ResolveContext.cs
+++ b/ClickHouse.Driver.Tcp/Types/ResolveContext.cs
@@ -14,9 +14,7 @@ internal readonly struct ResolveContext
     public string ServerTimezone { get; init; }
 
     /// <summary>
-    /// A context with no known server/session timezone. Suitable for self-described writes where no server sample
-    /// block exists; timezone-less columns then fall back to UTC. INSERTs with a sample block use that block's
-    /// context so an <c>Unspecified</c> wall clock is interpreted in the session timezone.
+    /// A context with no server timezone. Timezone-less writes fall back to UTC.
     /// </summary>
     public static ResolveContext ForWrite => default;
 }

--- a/ClickHouse.Driver.Tcp/Types/ResolveContext.cs
+++ b/ClickHouse.Driver.Tcp/Types/ResolveContext.cs
@@ -9,14 +9,14 @@ internal readonly struct ResolveContext
 {
     /// <summary>
     /// The server/session timezone (an IANA id such as <c>UTC</c> or <c>Europe/London</c>), used to resolve the
-    /// offset of a timezone-bearing column whose type string omits an explicit timezone. Empty when unknown or
-    /// on the write path.
+    /// offset of a timezone-bearing column whose type string omits an explicit timezone. Empty when unknown.
     /// </summary>
     public string ServerTimezone { get; init; }
 
     /// <summary>
-    /// The write-path context: no server timezone, because encoding a value uses its own UTC instant rather than
-    /// a display timezone.
+    /// A context with no known server/session timezone. Suitable for self-described writes where no server sample
+    /// block exists; timezone-less columns then fall back to UTC. INSERTs with a sample block use that block's
+    /// context so an <c>Unspecified</c> wall clock is interpreted in the session timezone.
     /// </summary>
     public static ResolveContext ForWrite => default;
 }


### PR DESCRIPTION
**Stacked on #557** (`tcp/epic-n5-poco-read`) — review that one first; this PR's diff is the write half only.

TCP epic **N9**: row-oriented insert, both shapes. The read half of Branch 2 landed in #557; this is the mirror, so a POCO now round-trips through the native protocol.

```csharp
await client.InsertRowsAsync("INSERT INTO t (id, user_name) VALUES", accounts);      // POCO rows
await client.InsertRowsAsync("INSERT INTO t (id, user_name) VALUES", objectRows);    // untyped, positional
```

## What it does

**`InsertRowsAsync<T>(IReadOnlyList<T>)`** — one compiled gather per target column, each pulling one property out of every row into the buffer that column is written from. Box-free (except a `Variant`/`Dynamic` target, written from `object`), no per-row delegate hop, and for a fixed-width column the gathered buffer reaches the wire as a single blit. Names match as the read side's do: case-, then underscore-insensitive, with `[ClickHouseTcpColumn]` / `[ClickHouseTcpNotMapped]`.

**`InsertRowsAsync(IReadOnlyList<object[]>)`** — the dynamic tier, positional by the sample block's order. Each column's CLR type comes from the first row that has a value there, so hand-written `DateTime` values and the raw epoch seconds the untyped *read* produces are both accepted, and a read-then-reinsert needs no conversion by the caller.

Arrays and `List<T>` both pass naturally. Arrays are borrowed for the operation; other `IReadOnlyList<T>` inputs are shallow-copied once into pooled storage so the compiled gathers retain an array fast path. Callers therefore materialize lazy sources before inserting, and must not mutate rows until the operation completes.

**No conversion layer of its own.** The read side must ask the codec for its conversions, because a column decodes to the raw wire value. Write does not: a codec already accepts `DateTime`/`DateTimeOffset`/`TimeSpan` directly, so the only conversions left are the CLR-level ones a cast would do — nullable lift, enum ordinal, reference upcast. Numeric widening is declined in both directions, which is what keeps "inserts" and "reads back" the same set of shapes.

## Decisions worth a look

- **Every target column must map to a property**, unlike a read, where an unmapped column is skipped: the server expects a value for each column of the statement's list. The remedy the message names is the statement's own column list, which is also how one POCO fills part of a table. A *property* with no column stays silent.
- **A mapping error lands mid-INSERT and must not cost the connection.** The target types only arrive in the sample block, so the columns are built there, behind a new internal `InsertColumnFactory` seam. A factory that throws parks its exception, closes the row stream with no rows, drains, and rethrows once the connection is back to `Ready` — the course the schema-mismatch path already took. The columns a factory returns are the insert's to dispose; a caller's own columns are untouched, as before.
- **"Can this column hold a null" is the codec's question.** `NullPlaceholder is null` is true exactly for `Nullable`, a nullable `LowCardinality`, `Variant` and `Dynamic`. Asking the CLR instead (`default(TWrite) is null`) let a null `string` property into a plain `String` column through the gather, to fault inside `WriteColumn` part-way through a block — which terminates the connection. The gather compiles a null test for reference-typed properties too, so it fails before anything is sent, naming the row.
- **`Nullable`'s `WritableElementTypes` was under-reporting.** `CanWrite` has always accepted `DateTime?` for a `Nullable(DateTime)` column, but the list reported only the canonical `uint?` — invisible to a caller who probes with a column, fatal to one that picks a type from the list. Now lifted, along with `NullPlaceholderAs`.
- **Timezone-less calendar writes use the operation's sample context.** The columnar, POCO, and untyped planners all resolve target codecs through the sample block's registry and session/server timezone. An `Unspecified` `DateTime` now denotes the same session wall clock on write that the read path presents, and the POCO plan cache includes that timezone in its key.
- **Rows have a dedicated method name.** Keeping row inserts under `InsertRowsAsync` leaves `InsertAsync` exclusively columnar, so external concrete `IColumn<T>[]` implementations and column lists do not collide with a generic row overload.

## Known follow-up

**`LowCardinality(DateTime)` reads as `DateTime` but is written only from `uint`.** It lifts its inner's *readable* types and not its writable ones, so it is the last codec whose two surfaces disagree. Pre-existing, and the columnar path has always had it, but the POCO layer is what makes it visible. Documented in `PocoWriteConversion` and left as a follow-up, since closing it means giving the `LowCardinality` write path a shape per write type as `Nullable` has.

## Testing

2,124 tests pass on net9 against a real server. Overall TCP coverage is 93.94% line / 88.24% branch / 95.52% method; every changed executable line is covered, and the POCO row-buffer path remains at 100% line and branch coverage.

- **Per-type coverage rides the corpus**: all 203 `InsertRoundTripCase` cases are inserted as `Row<T>` and read back. `Nested` is the one shape rows cannot fill — its writer needs its own column type — so the corpus test asserts the refusal for it rather than skipping.
- POCO→POCO round trip, calendar and enum properties (including the nullable spellings), an insert-only immutable POCO, a narrower column list, a materialized 5,000-row list across several blocks, and the untyped path's positional round trip and read→re-insert.
- Real-server regressions cover timezone-less `DateTime` and `DateTime64(3)` with `session_timezone = Europe/Amsterdam` through columnar, POCO, and untyped row inserts. The columnar case uses an external-style concrete `IColumn<T>[]`, compile-pinning the overload-resolution fix.
- The mid-INSERT refusals all assert the client is still usable afterwards, and the connection-level tests pin that the connection itself stays `Ready` rather than being redialled, plus the factory's ownership (dispose count) and that the factory's own exception comes back with its identity intact.
- Unit tests cover only what a round trip cannot see: write-type selection, plan-build refusals, cache keys, array borrowing, list copying, null validation, cancellation, and pooled-buffer ownership.

Release builds pass for net8.0, net9.0, and net10.0.

No CHANGELOG/RELEASENOTES entry: no TCP epic PR has one, the assembly being unreleased and `[Experimental]`. The epic gets a single entry when it ships.
