### PR TITLE
TCP N11: query parameter binding — {name:Type} values over the native protocol

### DIFF
--- a/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpParameterIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpParameterIntegrationTests.cs
@@ -11,9 +11,7 @@ using ClickHouse.Driver.Tcp.Types;
 
 namespace ClickHouse.Driver.Tcp.Tests.Integration;
 
-// Parameterized queries end to end. These are the cases that prove the wire contract: the server restores the
-// parameter value as a Field before the {name:Type} substitution reads it, so the value crosses two unescape
-// stages. Only a live server can show that the client's escaping survives both.
+// Live-server coverage for the two parsing stages native parameter values cross.
 [TestFixture]
 [Category("Integration")]
 public class ClickHouseTcpParameterIntegrationTests
@@ -33,14 +31,12 @@ public class ClickHouseTcpParameterIntegrationTests
         yield return new TestCaseData("Bool", false).Returns("false").SetName("Bool false");
         yield return new TestCaseData("Decimal64(4)", 1.2345m).Returns("1.2345").SetName("Decimal64");
 
-        // .NET spells these NaN/Infinity and ClickHouse spells them nan/inf. The server's reader accepts both,
-        // so the formatter needs no special case — but only a round-trip can show that.
+        // The server accepts .NET's NaN and Infinity spellings.
         yield return new TestCaseData("Float64", double.NaN).Returns("nan").SetName("Float64 NaN");
         yield return new TestCaseData("Float64", double.PositiveInfinity).Returns("inf").SetName("Float64 +Infinity");
         yield return new TestCaseData("Float64", double.NegativeInfinity).Returns("-inf").SetName("Float64 -Infinity");
 
-        // A Bool inside a composite must stay true/false. The server rejects 1/0 there, though it takes them
-        // for a scalar Bool, so a formatter that emitted digits would pass the scalar case and fail this one.
+        // Composite Bool values require true/false; 1/0 works only for scalars.
         yield return new TestCaseData("Array(Bool)", new[] { true, false }).Returns("[true,false]").SetName("Array of Bool");
 
         yield return new TestCaseData("String", "plain").Returns("plain").SetName("String");
@@ -50,8 +46,7 @@ public class ClickHouseTcpParameterIntegrationTests
         yield return new TestCaseData("String", "a\tb").Returns("a\tb").SetName("String with a tab");
         yield return new TestCaseData("String", string.Empty).Returns(string.Empty).SetName("Empty string");
 
-        // A carriage return and a NUL need no escape, unlike a newline and a tab, which end the server's
-        // reader. Pinned because the escape set is easy to widen or narrow by accident.
+        // Carriage return and NUL are data; newline and tab terminate the reader unless escaped.
         yield return new TestCaseData("String", "a\rb").Returns("a\rb").SetName("String with a carriage return");
         yield return new TestCaseData("String", "a\0b").Returns("a\0b").SetName("String with a NUL");
         yield return new TestCaseData("String", @"ends\").Returns(@"ends\").SetName("String ending in a backslash");
@@ -92,8 +87,7 @@ public class ClickHouseTcpParameterIntegrationTests
         yield return new TestCaseData("Tuple(String, Int32)", ("a", 1)).Returns("('a',1)").SetName("Tuple");
         yield return new TestCaseData("Tuple(String, Int32)", ("O'B", 1)).Returns(@"('O\'B',1)").SetName("Tuple element with a quote");
 
-        // Map shapes past the one-pair case: the empty literal, a key needing escapes, a non-string key, and
-        // two levels of nesting. Each has its own way of producing text the server will not read back.
+        // Covers empty, escaped-key, non-string-key, and nested map literals.
         yield return new TestCaseData("Map(String, String)", new Dictionary<string, string>())
             .Returns("{}").SetName("Empty map");
         yield return new TestCaseData("Map(String, UInt8)", new Dictionary<string, byte> { [@"a'b\c"] = 1 })
@@ -103,8 +97,7 @@ public class ClickHouseTcpParameterIntegrationTests
         yield return new TestCaseData("Map(String, Array(Bool))", new Dictionary<string, bool[]> { ["a"] = [true, false] })
             .Returns("{'a':[true,false]}").SetName("Map holding an array");
 
-        // Types whose text form the unit tests pin but no round-trip reached, so nothing proved the server
-        // reads back what the formatter writes.
+        // Adds live-server coverage for formatter-only unit cases.
         yield return new TestCaseData("Date32", new DateOnly(1950, 3, 4)).Returns("1950-03-04").SetName("Date32");
         yield return new TestCaseData("Time", new TimeSpan(1, 1, 1)).Returns("01:01:01").SetName("Time");
         yield return new TestCaseData("Time64(3)", new TimeSpan(0, 1, 1, 1, 500)).Returns("01:01:01.500").SetName("Time64");
@@ -117,8 +110,7 @@ public class ClickHouseTcpParameterIntegrationTests
         yield return new TestCaseData("Variant(Int64, String)", 7L).Returns("7").SetName("Variant picks the integer");
         yield return new TestCaseData("Variant(Int64, String)", "x").Returns("x").SetName("Variant picks the string");
 
-        // Types the HTTP formatter accepts and this one used to reject. The server takes both JSON spellings,
-        // and the geo names stand for shapes over Point, so each must reach the arm it stands for.
+        // Covers both JSON spellings and geo types backed by tuple/array shapes.
         yield return new TestCaseData("Json", "{\"a\":1}").Returns("{\"a\":1}").SetName("Json in the lowercase spelling");
         yield return new TestCaseData("JSON", "{\"a\":1}").Returns("{\"a\":1}").SetName("JSON in the uppercase spelling");
         yield return new TestCaseData("Point", (10.0, 20.0)).Returns("(10,20)").SetName("Point");
@@ -155,10 +147,7 @@ public class ClickHouseTcpParameterIntegrationTests
             (1, 2, 3, 4, 5, 6, 7, "eight", "nine")).Returns("(1,2,3,4,5,6,7,'eight','nine')").SetName("Tuple of nine");
     }
 
-    // A ClickHouse String holds bytes, not characters, so a value can hold a sequence that is not UTF-8 —
-    // which is exactly what the read path returns for a byte-array column. Decoding it turned every bad byte
-    // into U+FFFD and sent EF BF BD, changing the value with no error. Compared as hex, because the whole
-    // point is the bytes rather than the text.
+    // Compare hex to verify non-UTF-8 bytes survive without replacement-character conversion.
     [TestCase("String", "FFFE41", TestName = "String keeps bytes that are not UTF-8")]
     [TestCase("FixedString(3)", "FFFE41", TestName = "FixedString keeps bytes that are not UTF-8")]
     public async Task QueryAsync_ByteArrayThatIsNotUtf8_ArrivesByteForByte(string clickHouseType, string expectedHex)
@@ -206,8 +195,7 @@ public class ClickHouseTcpParameterIntegrationTests
     [Test]
     public async Task QueryAsync_MapReadBackAsPairs_CanBeBoundAgain()
     {
-        // A Map column reads back as KeyValuePair[] so duplicate keys and pair order survive. Binding that
-        // value straight back used to hit the "cannot convert" arm, because only IDictionary was accepted.
+        // Map reads as KeyValuePair[] to preserve order and duplicate keys; that shape must be reusable.
         await using var client = TcpServerFixture.CreateClient();
         KeyValuePair<string, int>[] pairs = [new("b", 2), new("a", 1)];
         var options = new ClickHouseTcpQueryOptions
@@ -223,9 +211,7 @@ public class ClickHouseTcpParameterIntegrationTests
     [Test]
     public async Task QueryAsync_SqlStringHoldingABackslashEscapedQuote_RunsAsWritten()
     {
-        // Coverage of the scanner fix itself lives in SqlParameterTypeExtractorTests, where the mis-scan is
-        // observable. It is not observable here: whichever type the client resolves, a plain value formats to
-        // the same text, so this only pins that the server accepts the query and the escape survives it.
+        // Scanner unit tests cover hint detection; this verifies the escaped SQL reaches the server unchanged.
         await using var client = TcpServerFixture.CreateClient();
         var options = new ClickHouseTcpQueryOptions
         {
@@ -240,8 +226,7 @@ public class ClickHouseTcpParameterIntegrationTests
     [Test]
     public async Task QueryAsync_KindedDateTimeWithATimezoneInTheHint_KeepsTheInstant()
     {
-        // The safe form. The client moves the instant into the timezone the hint declares, and the server reads
-        // the wall-clock text back in that same timezone, so the two agree whatever the session is set to.
+        // A declared timezone keeps the instant independent of the session timezone.
         await using var client = TcpServerFixture.CreateClient();
         var instant = new DateTimeOffset(2020, 1, 2, 12, 0, 0, TimeSpan.FromHours(9));
         var options = new ClickHouseTcpQueryOptions
@@ -258,9 +243,7 @@ public class ClickHouseTcpParameterIntegrationTests
     [Test]
     public async Task QueryAsync_KindedDateTimeWithABareHint_IsRefusedBeforeItReachesTheServer()
     {
-        // A bare {d:DateTime} hint names no timezone, so the server would read the wall-clock text in
-        // session_timezone and the instant would move with no error raised. The client refuses instead. This
-        // runs against the server to prove the refusal happens first, so no wrong value is ever stored.
+        // Refuse before the server can reinterpret the instant in its session timezone.
         await using var client = TcpServerFixture.CreateClient();
         var options = new ClickHouseTcpQueryOptions
         {
@@ -280,9 +263,7 @@ public class ClickHouseTcpParameterIntegrationTests
     [Test]
     public async Task QueryAsync_UnspecifiedDateTimeWithABareHint_IsReadInTheSessionTimezone()
     {
-        // The other half, and the reason the refusal above is limited to a value that names an instant. An
-        // unspecified DateTime is a wall-clock time with no instant attached, so reading it in the session
-        // timezone is what the caller asked for. It stays legal.
+        // An unspecified DateTime is wall-clock time, so the session timezone may interpret it.
         await using var client = TcpServerFixture.CreateClient();
         var wallClock = new DateTime(2020, 1, 2, 12, 0, 0, DateTimeKind.Unspecified);
         var options = new ClickHouseTcpQueryOptions
@@ -315,10 +296,8 @@ public class ClickHouseTcpParameterIntegrationTests
     [TestCase("offset")]
     public async Task QueryAsync_ParameterNamedAfterAServerSetting_NeverBindsToTheWrongValue(string name)
     {
-        // The parameter list is the settings list, so a server that reads the name as that setting applies it
-        // instead of binding it. Whether it does is version-dependent: 25.8 through 26.6 reject the query, and
-        // newer servers bind it correctly. Both are acceptable; a wrong count is not, and that is the outcome
-        // this pins. See the remark on ClickHouseTcpQueryOptions.Parameters.
+        // ClickHouse 25.8 through 26.6 may treat this as a setting and reject it; newer versions bind it.
+        // Either result is safe, but binding the wrong value is not.
         await using var client = TcpServerFixture.CreateClient();
         var options = new ClickHouseTcpQueryOptions
         {
@@ -355,9 +334,7 @@ public class ClickHouseTcpParameterIntegrationTests
     [Test]
     public async Task QueryAsync_LazySequenceParameter_ReachesTheServerWhole()
     {
-        // A lazy sequence must reach the server whole. The placeholder here means inference does not run, so
-        // this covers the formatter's own single pass; BuildParametersTests covers the inference pass, which
-        // needs SQL that does not name the parameter and so cannot be observed through a query at all.
+        // A typed placeholder must enumerate the lazy value only once.
         await using var client = TcpServerFixture.CreateClient();
         IEnumerable<int> lazy = Enumerable.Range(1, 3).Select(i => i);
         var options = new ClickHouseTcpQueryOptions
@@ -459,7 +436,7 @@ public class ClickHouseTcpParameterIntegrationTests
         await using var client = TcpServerFixture.CreateClient();
         var options = new ClickHouseTcpQueryOptions
         {
-            Parameters = new ClickHouseTcpParameterCollection { { "used", 1 }, { "unused", "spare" } },
+            Parameters = new ClickHouseTcpParameterCollection { { "used", 1 }, { "unused", "spare", "String" } },
         };
 
         object value = await ScalarAsync(client, "SELECT {used:Int32}", options);
@@ -507,10 +484,7 @@ public class ClickHouseTcpParameterIntegrationTests
         }
     }
 
-    // The insert methods take their own options type and their own call paths, so the test above — which goes
-    // through ExecuteAsync — proves nothing about them. A dropped parameters argument here would have
-    // passed the whole suite. The target table is the parameter, which is the only place one fits in an
-    // INSERT whose values arrive as a data block.
+    // Exercise both insert paths by parameterizing the target; ExecuteAsync uses a different path.
     [Test]
     public async Task InsertRowsAsync_ParameterizedTarget_WritesToTheNamedTable()
     {

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpParameterIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpParameterIntegrationTests.cs
@@ -172,24 +172,44 @@ public class ClickHouseTcpParameterIntegrationTests
     }
 
     [Test]
-    public async Task QueryAsync_KindedDateTimeWithABareHint_ReadsTheTextInTheSessionTimezone()
+    public async Task QueryAsync_KindedDateTimeWithABareHint_IsRefusedBeforeItReachesTheServer()
     {
-        // The foot-gun, shared with the HTTP transport and pinned here so a change to it is deliberate. A bare
-        // {d:DateTime} hint names no timezone, so the server reads the wall-clock text in session_timezone. The
-        // client wrote that text in UTC, so the instant moves by the session's offset. Put the timezone in the
-        // hint, as the test above does. Only the text is agreed here; the instant is not.
+        // A bare {d:DateTime} hint names no timezone, so the server would read the wall-clock text in
+        // session_timezone and the instant would move with no error raised. The client refuses instead. This
+        // runs against the server to prove the refusal happens first, so no wrong value is ever stored.
         await using var client = TcpServerFixture.CreateClient();
-        var instant = new DateTimeOffset(2020, 1, 2, 12, 0, 0, TimeSpan.FromHours(9));
         var options = new ClickHouseTcpQueryOptions
         {
             Settings = new Dictionary<string, string> { ["session_timezone"] = "Asia/Tokyo" },
-            Parameters = new ClickHouseTcpParameterCollection { { "d", instant } },
+            Parameters = new ClickHouseTcpParameterCollection
+            {
+                { "d", new DateTimeOffset(2020, 1, 2, 12, 0, 0, TimeSpan.FromHours(9)) },
+            },
         };
 
-        object epoch = await ScalarAsync(client, "SELECT toUnixTimestamp({d:DateTime})", options);
+        var exception = Assert.ThrowsAsync<ArgumentException>(
+            async () => await ScalarAsync(client, "SELECT toUnixTimestamp({d:DateTime})", options));
 
-        // The UTC wall clock of the instant, read back as if it were Tokyo local time: nine hours earlier.
-        Assert.That(Convert.ToInt64(epoch), Is.EqualTo(instant.ToUnixTimeSeconds() - (9 * 3600)));
+        Assert.That(exception.Message, Does.Contain("declares no timezone"));
+    }
+
+    [Test]
+    public async Task QueryAsync_UnspecifiedDateTimeWithABareHint_IsReadInTheSessionTimezone()
+    {
+        // The other half, and the reason the refusal above is limited to a value that names an instant. An
+        // unspecified DateTime is a wall-clock time with no instant attached, so reading it in the session
+        // timezone is what the caller asked for. It stays legal.
+        await using var client = TcpServerFixture.CreateClient();
+        var wallClock = new DateTime(2020, 1, 2, 12, 0, 0, DateTimeKind.Unspecified);
+        var options = new ClickHouseTcpQueryOptions
+        {
+            Settings = new Dictionary<string, string> { ["session_timezone"] = "Asia/Tokyo" },
+            Parameters = new ClickHouseTcpParameterCollection { { "d", wallClock } },
+        };
+
+        object read = await ScalarAsync(client, "SELECT toString({d:DateTime})", options);
+
+        Assert.That(read, Is.EqualTo("2020-01-02 12:00:00"));
     }
 
     [Test]

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpParameterIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpParameterIntegrationTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Net;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using ClickHouse.Driver.Tcp.Protocol;
@@ -62,6 +63,89 @@ public class ClickHouseTcpParameterIntegrationTests
         yield return new TestCaseData("Array(Array(Int32))", new[] { new[] { 1, 2 }, new[] { 3 } }).Returns("[[1,2],[3]]").SetName("Jagged array");
         yield return new TestCaseData("Array(Nullable(Int32))", new int?[] { 1, null, 3 }).Returns("[1,NULL,3]").SetName("Array with a null element");
         yield return new TestCaseData("Tuple(String, Int32)", ("a", 1)).Returns("('a',1)").SetName("Tuple");
+        yield return new TestCaseData("Tuple(String, Int32)", ("O'B", 1)).Returns(@"('O\'B',1)").SetName("Tuple element with a quote");
+
+        // Types whose text form the unit tests pin but no round-trip reached, so nothing proved the server
+        // reads back what the formatter writes.
+        yield return new TestCaseData("Date32", new DateOnly(1950, 3, 4)).Returns("1950-03-04").SetName("Date32");
+        yield return new TestCaseData("Time", new TimeSpan(1, 1, 1)).Returns("01:01:01").SetName("Time");
+        yield return new TestCaseData("Time64(3)", new TimeSpan(0, 1, 1, 1, 500)).Returns("01:01:01.500").SetName("Time64");
+        yield return new TestCaseData("FixedString(3)", Encoding.UTF8.GetBytes("abc")).Returns("abc").SetName("FixedString from bytes");
+        yield return new TestCaseData("Nested(a UInt8, b String)", new object[] { (1, "x"), (2, "y") })
+            .Returns("[(1,'x'),(2,'y')]").SetName("Nested rows");
+        yield return new TestCaseData("Variant(Int64, String)", 7L).Returns("7").SetName("Variant picks the integer");
+        yield return new TestCaseData("Variant(Int64, String)", "x").Returns("x").SetName("Variant picks the string");
+    }
+
+    [Test]
+    public async Task QueryAsync_MapWithSpecialCharacters_RoundTripsThroughTheServer()
+    {
+        await using var client = TcpServerFixture.CreateClient();
+        var value = new Dictionary<string, string> { ["k'1"] = @"v\1" };
+        var options = new ClickHouseTcpQueryOptions
+        {
+            Parameters = new ClickHouseTcpParameterCollection { { "p", value } },
+        };
+
+        object read = await ScalarAsync(client, "SELECT toString({p:Map(String, String)})", options);
+
+        Assert.That(read, Is.EqualTo(@"{'k\'1':'v\\1'}"));
+    }
+
+    [Test]
+    public async Task QueryAsync_ParameterNamedAfterAServerSetting_IsRejectedByTheServer()
+    {
+        // The parameter list is the settings list, so the server applies a name it knows as that setting rather
+        // than binding it. Pinned because the error names neither the parameter nor the cause, and because
+        // "limit" is a name a caller reaches for. See the remark on ClickHouseTcpQueryOptions.Parameters.
+        await using var client = TcpServerFixture.CreateClient();
+        var options = new ClickHouseTcpQueryOptions
+        {
+            Parameters = new ClickHouseTcpParameterCollection { { "limit", 3 } },
+        };
+
+        Assert.ThrowsAsync<ClickHouseServerException>(async () => await ScalarAsync(
+            client, "SELECT count() FROM (SELECT number FROM numbers(10) LIMIT {limit:UInt64})", options));
+    }
+
+    [Test]
+    public async Task QueryAsync_SameParameterRenamedOffASettingName_Works()
+    {
+        // The other half of the case above: the query is fine, only the name was.
+        await using var client = TcpServerFixture.CreateClient();
+        var options = new ClickHouseTcpQueryOptions
+        {
+            Parameters = new ClickHouseTcpParameterCollection { { "row_limit", 3 } },
+        };
+
+        object value = await ScalarAsync(
+            client, "SELECT count() FROM (SELECT number FROM numbers(10) LIMIT {row_limit:UInt64})", options);
+
+        Assert.That(value, Is.EqualTo(3UL));
+    }
+
+    [Test]
+    public async Task QueryAsync_SequenceReadableOnlyOnce_IsNotConsumedByTypeInference()
+    {
+        // With no placeholder the client infers the type, which reads the sequence, and then formats it, which
+        // reads it again. A one-shot sequence would arrive empty the second time.
+        await using var client = TcpServerFixture.CreateClient();
+        IEnumerable<int> once = OneShot();
+        var options = new ClickHouseTcpQueryOptions
+        {
+            Parameters = new ClickHouseTcpParameterCollection { { "p", once } },
+        };
+
+        object value = await ScalarAsync(client, "SELECT toString({p:Array(Int32)})", options);
+
+        Assert.That(value, Is.EqualTo("[1,2,3]"));
+
+        static IEnumerable<int> OneShot()
+        {
+            yield return 1;
+            yield return 2;
+            yield return 3;
+        }
     }
 
     [TestCaseSource(nameof(RoundTripCases))]

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpParameterIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpParameterIntegrationTests.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using ClickHouse.Driver.Tcp.Protocol;
+using ClickHouse.Driver.Tcp.Tests.Utilities;
 
 namespace ClickHouse.Driver.Tcp.Tests.Integration;
 
@@ -125,7 +126,11 @@ public class ClickHouseTcpParameterIntegrationTests
             .Returns("[[(0,0),(1,0),(1,1)]]").SetName("Polygon");
         yield return new TestCaseData("MultiPolygon", new[] { new[] { new[] { (0.0, 0.0), (1.0, 0.0), (1.0, 1.0) } } })
             .Returns("[[[(0,0),(1,0),(1,1)]]]").SetName("MultiPolygon");
-        yield return new TestCaseData("QBit(Float32, 4)", new[] { 1f, 2f, 3f, 4f }).Returns("[1,2,3,4]").SetName("QBit");
+
+        if (TcpServerFeatures.Has(TcpFeature.QBit))
+        {
+            yield return new TestCaseData("QBit(Float32, 4)", new[] { 1f, 2f, 3f, 4f }).Returns("[1,2,3,4]").SetName("QBit");
+        }
 
         // An Enum bound by its numeric value rather than its label. Neither transport had a case for it.
         yield return new TestCaseData("Enum8('a' = 1, 'b' = 2)", 2).Returns("b").SetName("Enum by number");

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpParameterIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpParameterIntegrationTests.cs
@@ -33,6 +33,12 @@ public class ClickHouseTcpParameterIntegrationTests
         yield return new TestCaseData("String", "a\nb").Returns("a\nb").SetName("String with a newline");
         yield return new TestCaseData("String", "a\tb").Returns("a\tb").SetName("String with a tab");
         yield return new TestCaseData("String", string.Empty).Returns(string.Empty).SetName("Empty string");
+
+        // A carriage return and a NUL need no escape, unlike a newline and a tab, which end the server's
+        // reader. Pinned because the escape set is easy to widen or narrow by accident.
+        yield return new TestCaseData("String", "a\rb").Returns("a\rb").SetName("String with a carriage return");
+        yield return new TestCaseData("String", "a\0b").Returns("a\0b").SetName("String with a NUL");
+        yield return new TestCaseData("String", @"ends\").Returns(@"ends\").SetName("String ending in a backslash");
         yield return new TestCaseData("String", "héllo").Returns("héllo").SetName("String with non-ASCII");
         yield return new TestCaseData("String", "' OR 1=1 --").Returns("' OR 1=1 --").SetName("Injection attempt stays data");
         yield return new TestCaseData("LowCardinality(String)", "x").Returns("x").SetName("LowCardinality");

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpParameterIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpParameterIntegrationTests.cs
@@ -25,8 +25,20 @@ public class ClickHouseTcpParameterIntegrationTests
         yield return new TestCaseData("UInt64", ulong.MaxValue).Returns("18446744073709551615").SetName("UInt64 max");
         yield return new TestCaseData("Int128", Int128.MinValue).Returns("-170141183460469231731687303715884105728").SetName("Int128 min");
         yield return new TestCaseData("Float64", 1.5d).Returns("1.5").SetName("Float64");
+        yield return new TestCaseData("Float32", 1.5f).Returns("1.5").SetName("Float32");
         yield return new TestCaseData("Bool", true).Returns("true").SetName("Bool");
+        yield return new TestCaseData("Bool", false).Returns("false").SetName("Bool false");
         yield return new TestCaseData("Decimal64(4)", 1.2345m).Returns("1.2345").SetName("Decimal64");
+
+        // .NET spells these NaN/Infinity and ClickHouse spells them nan/inf. The server's reader accepts both,
+        // so the formatter needs no special case — but only a round-trip can show that.
+        yield return new TestCaseData("Float64", double.NaN).Returns("nan").SetName("Float64 NaN");
+        yield return new TestCaseData("Float64", double.PositiveInfinity).Returns("inf").SetName("Float64 +Infinity");
+        yield return new TestCaseData("Float64", double.NegativeInfinity).Returns("-inf").SetName("Float64 -Infinity");
+
+        // A Bool inside a composite must stay true/false. The server rejects 1/0 there, though it takes them
+        // for a scalar Bool, so a formatter that emitted digits would pass the scalar case and fail this one.
+        yield return new TestCaseData("Array(Bool)", new[] { true, false }).Returns("[true,false]").SetName("Array of Bool");
 
         yield return new TestCaseData("String", "plain").Returns("plain").SetName("String");
         yield return new TestCaseData("String", "O'Brien").Returns("O'Brien").SetName("String with a quote");
@@ -56,6 +68,18 @@ public class ClickHouseTcpParameterIntegrationTests
         yield return new TestCaseData("DateTime64(3)", new DateTime(2024, 1, 2, 3, 4, 5, 123, DateTimeKind.Unspecified))
             .Returns("2024-01-02 03:04:05.123").SetName("DateTime64");
 
+        // The range ends, where a formatter that overflows or clamps shows it.
+        yield return new TestCaseData("Date", new DateOnly(1970, 1, 1)).Returns("1970-01-01").SetName("Date epoch");
+        yield return new TestCaseData("Date", new DateOnly(2149, 6, 6)).Returns("2149-06-06").SetName("Date maximum");
+        yield return new TestCaseData("Date32", new DateOnly(1900, 1, 1)).Returns("1900-01-01").SetName("Date32 minimum");
+        yield return new TestCaseData("Date32", new DateOnly(2299, 12, 31)).Returns("2299-12-31").SetName("Date32 maximum");
+
+        // Pre-epoch, where a naive seconds-and-fraction split puts the sign on the wrong part.
+        yield return new TestCaseData("DateTime64(3, 'UTC')", new DateTime(1969, 12, 31, 23, 59, 59, 500, DateTimeKind.Utc))
+            .Returns("1969-12-31 23:59:59.500").SetName("DateTime64 just before the epoch");
+        yield return new TestCaseData("DateTime64(9)", new DateTime(2024, 1, 2, 3, 4, 5, DateTimeKind.Unspecified).AddTicks(1234567))
+            .Returns("2024-01-02 03:04:05.123456700").SetName("DateTime64 at scale 9");
+
         yield return new TestCaseData("Array(Int32)", new[] { 1, 2, 3 }).Returns("[1,2,3]").SetName("Array of Int32");
         yield return new TestCaseData("Array(String)", new[] { "a", "b" }).Returns("['a','b']").SetName("Array of String");
         yield return new TestCaseData("Array(String)", new[] { "O'B" }).Returns(@"['O\'B']").SetName("Array element with a quote");
@@ -64,6 +88,17 @@ public class ClickHouseTcpParameterIntegrationTests
         yield return new TestCaseData("Array(Nullable(Int32))", new int?[] { 1, null, 3 }).Returns("[1,NULL,3]").SetName("Array with a null element");
         yield return new TestCaseData("Tuple(String, Int32)", ("a", 1)).Returns("('a',1)").SetName("Tuple");
         yield return new TestCaseData("Tuple(String, Int32)", ("O'B", 1)).Returns(@"('O\'B',1)").SetName("Tuple element with a quote");
+
+        // Map shapes past the one-pair case: the empty literal, a key needing escapes, a non-string key, and
+        // two levels of nesting. Each has its own way of producing text the server will not read back.
+        yield return new TestCaseData("Map(String, String)", new Dictionary<string, string>())
+            .Returns("{}").SetName("Empty map");
+        yield return new TestCaseData("Map(String, UInt8)", new Dictionary<string, byte> { [@"a'b\c"] = 1 })
+            .Returns(@"{'a\'b\\c':1}").SetName("Map key needing escapes");
+        yield return new TestCaseData("Map(Bool, String)", new Dictionary<bool, string> { [true] = "x" })
+            .Returns("{true:'x'}").SetName("Map with a Bool key");
+        yield return new TestCaseData("Map(String, Array(Bool))", new Dictionary<string, bool[]> { ["a"] = [true, false] })
+            .Returns("{'a':[true,false]}").SetName("Map holding an array");
 
         // Types whose text form the unit tests pin but no round-trip reached, so nothing proved the server
         // reads back what the formatter writes.
@@ -78,6 +113,78 @@ public class ClickHouseTcpParameterIntegrationTests
             .Returns("[(1,'x'),(2,'y')]").SetName("Nested rows");
         yield return new TestCaseData("Variant(Int64, String)", 7L).Returns("7").SetName("Variant picks the integer");
         yield return new TestCaseData("Variant(Int64, String)", "x").Returns("x").SetName("Variant picks the string");
+
+        // Types the HTTP formatter accepts and this one used to reject. The server takes both JSON spellings,
+        // and the geo names stand for shapes over Point, so each must reach the arm it stands for.
+        yield return new TestCaseData("Json", "{\"a\":1}").Returns("{\"a\":1}").SetName("Json in the lowercase spelling");
+        yield return new TestCaseData("JSON", "{\"a\":1}").Returns("{\"a\":1}").SetName("JSON in the uppercase spelling");
+        yield return new TestCaseData("Point", (10.0, 20.0)).Returns("(10,20)").SetName("Point");
+        yield return new TestCaseData("Ring", new[] { (0.0, 0.0), (1.0, 1.0) }).Returns("[(0,0),(1,1)]").SetName("Ring");
+        yield return new TestCaseData("LineString", new[] { (0.0, 0.0), (1.0, 1.0) }).Returns("[(0,0),(1,1)]").SetName("LineString");
+        yield return new TestCaseData("Polygon", new[] { new[] { (0.0, 0.0), (1.0, 0.0), (1.0, 1.0) } })
+            .Returns("[[(0,0),(1,0),(1,1)]]").SetName("Polygon");
+        yield return new TestCaseData("MultiPolygon", new[] { new[] { new[] { (0.0, 0.0), (1.0, 0.0), (1.0, 1.0) } } })
+            .Returns("[[[(0,0),(1,0),(1,1)]]]").SetName("MultiPolygon");
+        yield return new TestCaseData("QBit(Float32, 4)", new[] { 1f, 2f, 3f, 4f }).Returns("[1,2,3,4]").SetName("QBit");
+
+        // An Enum bound by its numeric value rather than its label. Neither transport had a case for it.
+        yield return new TestCaseData("Enum8('a' = 1, 'b' = 2)", 2).Returns("b").SetName("Enum by number");
+
+        // A wide decimal past what a CLR decimal can hold, so the BigInteger path is the one under test.
+        yield return new TestCaseData("Decimal128(0)", new string('1', 30)).Returns(new string('1', 30)).SetName("Decimal128 of 30 digits");
+        yield return new TestCaseData("Decimal256(0)", new string('1', 50)).Returns(new string('1', 50)).SetName("Decimal256 of 50 digits");
+
+        // Negative and past-24h durations, where the sign belongs on the whole value and not on one part.
+        yield return new TestCaseData("Time", new TimeSpan(-5, -25, -5)).Returns("-05:25:05").SetName("Time negative");
+        yield return new TestCaseData("Time", new TimeSpan(55, 25, 5)).Returns("55:25:05").SetName("Time past 24 hours");
+        yield return new TestCaseData("Time64(6)", new TimeSpan(-(new TimeSpan(5, 25, 5) + TimeSpan.FromTicks(1234560)).Ticks))
+            .Returns("-05:25:05.123456").SetName("Time64 negative");
+
+        // A surrogate pair, which a formatter that walks chars rather than runes can split.
+        yield return new TestCaseData("String", "a\U0001F600b").Returns("a\U0001F600b").SetName("String with an emoji");
+
+        // A ValueTuple past 7 elements nests its tail in TRest, which ITuple flattens back out.
+        yield return new TestCaseData("Tuple(Int32, Int32, Int32, Int32, Int32, Int32, Int32, String, String)",
+            (1, 2, 3, 4, 5, 6, 7, "eight", "nine")).Returns("(1,2,3,4,5,6,7,'eight','nine')").SetName("Tuple of nine");
+    }
+
+    [Test]
+    public async Task QueryAsync_KindedDateTimeWithATimezoneInTheHint_KeepsTheInstant()
+    {
+        // The safe form. The client moves the instant into the timezone the hint declares, and the server reads
+        // the wall-clock text back in that same timezone, so the two agree whatever the session is set to.
+        await using var client = TcpServerFixture.CreateClient();
+        var instant = new DateTimeOffset(2020, 1, 2, 12, 0, 0, TimeSpan.FromHours(9));
+        var options = new ClickHouseTcpQueryOptions
+        {
+            Settings = new Dictionary<string, string> { ["session_timezone"] = "Asia/Tokyo" },
+            Parameters = new ClickHouseTcpParameterCollection { { "d", instant } },
+        };
+
+        object epoch = await ScalarAsync(client, "SELECT toUnixTimestamp({d:DateTime('UTC')})", options);
+
+        Assert.That(Convert.ToInt64(epoch), Is.EqualTo(instant.ToUnixTimeSeconds()));
+    }
+
+    [Test]
+    public async Task QueryAsync_KindedDateTimeWithABareHint_ReadsTheTextInTheSessionTimezone()
+    {
+        // The foot-gun, shared with the HTTP transport and pinned here so a change to it is deliberate. A bare
+        // {d:DateTime} hint names no timezone, so the server reads the wall-clock text in session_timezone. The
+        // client wrote that text in UTC, so the instant moves by the session's offset. Put the timezone in the
+        // hint, as the test above does. Only the text is agreed here; the instant is not.
+        await using var client = TcpServerFixture.CreateClient();
+        var instant = new DateTimeOffset(2020, 1, 2, 12, 0, 0, TimeSpan.FromHours(9));
+        var options = new ClickHouseTcpQueryOptions
+        {
+            Settings = new Dictionary<string, string> { ["session_timezone"] = "Asia/Tokyo" },
+            Parameters = new ClickHouseTcpParameterCollection { { "d", instant } },
+        };
+
+        object epoch = await ScalarAsync(client, "SELECT toUnixTimestamp({d:DateTime})", options);
+
+        // The UTC wall clock of the instant, read back as if it were Tokyo local time: nine hours earlier.
+        Assert.That(Convert.ToInt64(epoch), Is.EqualTo(instant.ToUnixTimeSeconds() - (9 * 3600)));
     }
 
     [Test]

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpParameterIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpParameterIntegrationTests.cs
@@ -507,12 +507,12 @@ public class ClickHouseTcpParameterIntegrationTests
         }
     }
 
-    // InsertAsync takes its own options type and its own call path, so the test above — which goes through
-    // ExecuteAsync — proves nothing about it. A dropped parameters argument in these overloads would have
+    // The insert methods take their own options type and their own call paths, so the test above — which goes
+    // through ExecuteAsync — proves nothing about them. A dropped parameters argument here would have
     // passed the whole suite. The target table is the parameter, which is the only place one fits in an
     // INSERT whose values arrive as a data block.
     [Test]
-    public async Task InsertAsync_RowsWithAParameterizedTarget_WritesToTheNamedTable()
+    public async Task InsertRowsAsync_ParameterizedTarget_WritesToTheNamedTable()
     {
         await using var client = TcpServerFixture.CreateClient();
         string table = $"tcp_param_rows_{Guid.NewGuid():N}";
@@ -525,7 +525,7 @@ public class ClickHouseTcpParameterIntegrationTests
             };
             object[][] rows = [[1], [2], [3]];
 
-            await client.InsertAsync("INSERT INTO {target:Identifier} (id) VALUES", rows, options, None);
+            await client.InsertRowsAsync("INSERT INTO {target:Identifier} (id) VALUES", rows, options, None);
 
             object sum = await ScalarAsync(client, $"SELECT sum(id) FROM {table}", null);
             Assert.That(Convert.ToInt64(sum), Is.EqualTo(6));

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpParameterIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpParameterIntegrationTests.cs
@@ -125,6 +125,16 @@ public class ClickHouseTcpParameterIntegrationTests
         yield return new TestCaseData("MultiPolygon", new[] { new[] { new[] { (0.0, 0.0), (1.0, 0.0), (1.0, 1.0) } } })
             .Returns("[[[(0,0),(1,0),(1,1)]]]").SetName("MultiPolygon");
 
+        // A geo alternative is matched by the shape its name stands for; the name alone fits no CLR value.
+        yield return new TestCaseData("Variant(Point, String)", (10.0, 20.0)).Returns("(10,20)")
+            .SetName("Variant holding a Point");
+        yield return new TestCaseData("Variant(Ring, String)", new[] { (0.0, 0.0), (1.0, 1.0) }).Returns("[(0,0),(1,1)]")
+            .SetName("Variant holding a Ring");
+
+        // Bytes reach the String arm from a ReadOnlyMemory as well, which used to print the CLR type name.
+        yield return new TestCaseData("String", new ReadOnlyMemory<byte>(Encoding.UTF8.GetBytes("héllo"))).Returns("héllo")
+            .SetName("String from a ReadOnlyMemory of bytes");
+
         if (TcpServerFeatures.Has(TcpFeature.QBit))
         {
             yield return new TestCaseData("QBit(Float32, 4)", new[] { 1f, 2f, 3f, 4f }).Returns("[1,2,3,4]").SetName("QBit");
@@ -550,6 +560,30 @@ public class ClickHouseTcpParameterIntegrationTests
 
         Assert.ThrowsAsync<ClickHouseServerException>(
             async () => await ScalarAsync(client, "SELECT {p:Int32}", options));
+    }
+
+    // Each of these is a query the server runs, holding a brace the scanner must not read as a placeholder.
+    // Reaching past the brace for a colon took the hint of the parameter after it, and binding then failed
+    // on a query the server would have answered.
+    [TestCase("SELECT 1 AS \"col{x}\", {p:Int32}", TestName = "brace inside a double-quoted identifier")]
+    [TestCase("SELECT 1 AS `col{x}`, {p:Int32}", TestName = "brace inside a backtick-quoted identifier")]
+    [TestCase("SELECT $$ {x} $$ != '', {p:Int32}", TestName = "brace inside a heredoc")]
+    [TestCase("SELECT 1 // {x}\n, {p:Int32}", TestName = "brace inside a double-slash comment")]
+    public async Task QueryAsync_BraceThatIsNotAPlaceholder_StillBindsTheRealParameter(string sql)
+    {
+        await using var client = TcpServerFixture.CreateClient();
+        var options = new ClickHouseTcpQueryOptions
+        {
+            Parameters = new ClickHouseTcpParameterCollection { { "p", 7 } },
+        };
+
+        object read = null;
+        await foreach (object[] row in client.QueryAsync(sql, options, None))
+        {
+            read = row[1];
+        }
+
+        Assert.That(read, Is.EqualTo(7));
     }
 
     private static async Task<object> ScalarAsync(ClickHouseTcpClient client, string sql, ClickHouseTcpQueryOptions options)

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpParameterIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpParameterIntegrationTests.cs
@@ -71,6 +71,9 @@ public class ClickHouseTcpParameterIntegrationTests
         yield return new TestCaseData("Time", new TimeSpan(1, 1, 1)).Returns("01:01:01").SetName("Time");
         yield return new TestCaseData("Time64(3)", new TimeSpan(0, 1, 1, 1, 500)).Returns("01:01:01.500").SetName("Time64");
         yield return new TestCaseData("FixedString(3)", Encoding.UTF8.GetBytes("abc")).Returns("abc").SetName("FixedString from bytes");
+        yield return new TestCaseData("String", Encoding.UTF8.GetBytes("abc")).Returns("abc").SetName("String from bytes");
+        yield return new TestCaseData("IntervalSecond", 5L).Returns("5").SetName("IntervalSecond");
+        yield return new TestCaseData("IntervalDay", -3L).Returns("-3").SetName("IntervalDay negative");
         yield return new TestCaseData("Nested(a UInt8, b String)", new object[] { (1, "x"), (2, "y") })
             .Returns("[(1,'x'),(2,'y')]").SetName("Nested rows");
         yield return new TestCaseData("Variant(Int64, String)", 7L).Returns("7").SetName("Variant picks the integer");

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpParameterIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpParameterIntegrationTests.cs
@@ -1,0 +1,220 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Protocol;
+
+namespace ClickHouse.Driver.Tcp.Tests.Integration;
+
+// Parameterized queries end to end. These are the cases that prove the wire contract: the server restores the
+// parameter value as a Field before the {name:Type} substitution reads it, so the value crosses two unescape
+// stages. Only a live server can show that the client's escaping survives both.
+[TestFixture]
+[Category("Integration")]
+public class ClickHouseTcpParameterIntegrationTests
+{
+    private static readonly CancellationToken None = CancellationToken.None;
+
+    private static IEnumerable<TestCaseData> RoundTripCases()
+    {
+        yield return new TestCaseData("Int32", 42).Returns("42").SetName("Int32");
+        yield return new TestCaseData("UInt8", (byte)7).Returns("7").SetName("UInt8");
+        yield return new TestCaseData("Int64", long.MinValue).Returns("-9223372036854775808").SetName("Int64 min");
+        yield return new TestCaseData("UInt64", ulong.MaxValue).Returns("18446744073709551615").SetName("UInt64 max");
+        yield return new TestCaseData("Int128", Int128.MinValue).Returns("-170141183460469231731687303715884105728").SetName("Int128 min");
+        yield return new TestCaseData("Float64", 1.5d).Returns("1.5").SetName("Float64");
+        yield return new TestCaseData("Bool", true).Returns("true").SetName("Bool");
+        yield return new TestCaseData("Decimal64(4)", 1.2345m).Returns("1.2345").SetName("Decimal64");
+
+        yield return new TestCaseData("String", "plain").Returns("plain").SetName("String");
+        yield return new TestCaseData("String", "O'Brien").Returns("O'Brien").SetName("String with a quote");
+        yield return new TestCaseData("String", @"a\b").Returns(@"a\b").SetName("String with a backslash");
+        yield return new TestCaseData("String", "a\nb").Returns("a\nb").SetName("String with a newline");
+        yield return new TestCaseData("String", "a\tb").Returns("a\tb").SetName("String with a tab");
+        yield return new TestCaseData("String", string.Empty).Returns(string.Empty).SetName("Empty string");
+        yield return new TestCaseData("String", "héllo").Returns("héllo").SetName("String with non-ASCII");
+        yield return new TestCaseData("String", "' OR 1=1 --").Returns("' OR 1=1 --").SetName("Injection attempt stays data");
+        yield return new TestCaseData("LowCardinality(String)", "x").Returns("x").SetName("LowCardinality");
+        yield return new TestCaseData("Enum8('a' = 1, 'b' = 2)", "a").Returns("a").SetName("Enum label");
+
+        yield return new TestCaseData("UUID", Guid.Parse("61f0c404-5cb3-11e7-907b-a6006ad3dba0"))
+            .Returns("61f0c404-5cb3-11e7-907b-a6006ad3dba0").SetName("UUID");
+        yield return new TestCaseData("IPv4", IPAddress.Parse("192.168.1.1")).Returns("192.168.1.1").SetName("IPv4");
+        yield return new TestCaseData("IPv6", IPAddress.Parse("::1")).Returns("::1").SetName("IPv6");
+
+        yield return new TestCaseData("Date", new DateOnly(2024, 1, 2)).Returns("2024-01-02").SetName("Date");
+        yield return new TestCaseData("DateTime", new DateTime(2024, 1, 2, 3, 4, 5, DateTimeKind.Unspecified))
+            .Returns("2024-01-02 03:04:05").SetName("DateTime");
+        yield return new TestCaseData("DateTime64(3)", new DateTime(2024, 1, 2, 3, 4, 5, 123, DateTimeKind.Unspecified))
+            .Returns("2024-01-02 03:04:05.123").SetName("DateTime64");
+
+        yield return new TestCaseData("Array(Int32)", new[] { 1, 2, 3 }).Returns("[1,2,3]").SetName("Array of Int32");
+        yield return new TestCaseData("Array(String)", new[] { "a", "b" }).Returns("['a','b']").SetName("Array of String");
+        yield return new TestCaseData("Array(String)", new[] { "O'B" }).Returns(@"['O\'B']").SetName("Array element with a quote");
+        yield return new TestCaseData("Array(Int32)", Array.Empty<int>()).Returns("[]").SetName("Empty array");
+        yield return new TestCaseData("Array(Array(Int32))", new[] { new[] { 1, 2 }, new[] { 3 } }).Returns("[[1,2],[3]]").SetName("Jagged array");
+        yield return new TestCaseData("Array(Nullable(Int32))", new int?[] { 1, null, 3 }).Returns("[1,NULL,3]").SetName("Array with a null element");
+        yield return new TestCaseData("Tuple(String, Int32)", ("a", 1)).Returns("('a',1)").SetName("Tuple");
+    }
+
+    [TestCaseSource(nameof(RoundTripCases))]
+    public async Task<string> QueryAsync_ParameterOfDeclaredType_RoundTripsThroughTheServer(string clickHouseType, object value)
+    {
+        await using var client = TcpServerFixture.CreateClient();
+        var options = new ClickHouseTcpQueryOptions
+        {
+            Parameters = new ClickHouseTcpParameterCollection { { "p", value } },
+        };
+
+        return (string)await ScalarAsync(client, "SELECT toString({p:" + clickHouseType + "})", options);
+    }
+
+    [Test]
+    public async Task QueryAsync_MapParameter_RoundTripsThroughTheServer()
+    {
+        await using var client = TcpServerFixture.CreateClient();
+        var options = new ClickHouseTcpQueryOptions
+        {
+            Parameters = new ClickHouseTcpParameterCollection { { "p", new Dictionary<string, int> { ["a"] = 1 } } },
+        };
+
+        object value = await ScalarAsync(client, "SELECT toString({p:Map(String, Int32)})", options);
+
+        Assert.That(value, Is.EqualTo("{'a':1}"));
+    }
+
+    [Test]
+    public async Task QueryAsync_NullParameter_ArrivesAsNull()
+    {
+        await using var client = TcpServerFixture.CreateClient();
+        var options = new ClickHouseTcpQueryOptions
+        {
+            Parameters = new ClickHouseTcpParameterCollection { { "p", null } },
+        };
+
+        object value = await ScalarAsync(client, "SELECT isNull({p:Nullable(String)})", options);
+
+        Assert.That(value, Is.EqualTo((byte)1));
+    }
+
+    [Test]
+    public async Task QueryAsync_StringParameterHoldingTheNullMarker_StaysText()
+    {
+        // The marker only means null when the client wrote it for a null value; a caller's own backslash-N is data.
+        await using var client = TcpServerFixture.CreateClient();
+        var options = new ClickHouseTcpQueryOptions
+        {
+            Parameters = new ClickHouseTcpParameterCollection { { "p", @"\N" } },
+        };
+
+        object value = await ScalarAsync(client, "SELECT toString({p:String})", options);
+
+        Assert.That(value, Is.EqualTo(@"\N"));
+    }
+
+    [Test]
+    public async Task QueryAsync_IdentifierParameter_NamesAColumn()
+    {
+        await using var client = TcpServerFixture.CreateClient();
+        var options = new ClickHouseTcpQueryOptions
+        {
+            Parameters = new ClickHouseTcpParameterCollection { { "column", "value" } },
+        };
+
+        object value = await ScalarAsync(client, "SELECT {column:Identifier} FROM (SELECT 'found' AS value)", options);
+
+        Assert.That(value, Is.EqualTo("found"));
+    }
+
+    [Test]
+    public async Task QueryAsync_SeveralParameters_AllReachTheServer()
+    {
+        await using var client = TcpServerFixture.CreateClient();
+        var options = new ClickHouseTcpQueryOptions
+        {
+            Parameters = new ClickHouseTcpParameterCollection { { "a", "x" }, { "b", 7 } },
+        };
+
+        object value = await ScalarAsync(client, "SELECT concat({a:String}, toString({b:Int32}))", options);
+
+        Assert.That(value, Is.EqualTo("x7"));
+    }
+
+    [Test]
+    public async Task QueryAsync_ParameterTheQueryDoesNotName_IsIgnoredByTheServer()
+    {
+        await using var client = TcpServerFixture.CreateClient();
+        var options = new ClickHouseTcpQueryOptions
+        {
+            Parameters = new ClickHouseTcpParameterCollection { { "used", 1 }, { "unused", "spare" } },
+        };
+
+        object value = await ScalarAsync(client, "SELECT {used:Int32}", options);
+
+        Assert.That(value, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task QueryAsync_ExplicitTypeOverride_FormatsAsTheOverride()
+    {
+        // The value is a DateTimeOffset naming an instant; the override moves it into the declared zone.
+        await using var client = TcpServerFixture.CreateClient();
+        var instant = new DateTimeOffset(2024, 1, 2, 3, 4, 5, TimeSpan.Zero);
+        var options = new ClickHouseTcpQueryOptions
+        {
+            Parameters = new ClickHouseTcpParameterCollection { { "p", instant, "DateTime('Europe/Amsterdam')" } },
+        };
+
+        object value = await ScalarAsync(client, "SELECT toString({p:DateTime('Europe/Amsterdam')})", options);
+
+        Assert.That(value, Is.EqualTo("2024-01-02 04:04:05"));
+    }
+
+    [Test]
+    public async Task InsertAsync_ParameterizedTarget_WritesToTheNamedTable()
+    {
+        await using var client = TcpServerFixture.CreateClient();
+        string table = $"tcp_param_test_{Guid.NewGuid():N}";
+        await client.ExecuteAsync($"CREATE TABLE {table} (id Int32) ENGINE = Memory", cancellationToken: None);
+        try
+        {
+            var options = new ClickHouseTcpQueryOptions
+            {
+                Parameters = new ClickHouseTcpParameterCollection { { "threshold", 2 } },
+            };
+
+            await client.ExecuteAsync($"INSERT INTO {table} SELECT number FROM numbers(5) WHERE number > {{threshold:Int32}}", options, None);
+            object count = await ScalarAsync(client, $"SELECT count() FROM {table}", null);
+
+            Assert.That(count, Is.EqualTo(2UL));
+        }
+        finally
+        {
+            await client.ExecuteAsync($"DROP TABLE IF EXISTS {table}", cancellationToken: None);
+        }
+    }
+
+    [Test]
+    public async Task QueryAsync_ParameterValueTheDeclaredTypeRejects_ReportsTheServerError()
+    {
+        await using var client = TcpServerFixture.CreateClient();
+        var options = new ClickHouseTcpQueryOptions
+        {
+            Parameters = new ClickHouseTcpParameterCollection { { "p", "not-a-number" } },
+        };
+
+        Assert.ThrowsAsync<ClickHouseServerException>(
+            async () => await ScalarAsync(client, "SELECT {p:Int32}", options));
+    }
+
+    private static async Task<object> ScalarAsync(ClickHouseTcpClient client, string sql, ClickHouseTcpQueryOptions options)
+    {
+        await foreach (object[] row in client.QueryAsync(sql, options, None))
+        {
+            return row[0];
+        }
+
+        return null;
+    }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpParameterIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpParameterIntegrationTests.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using ClickHouse.Driver.Tcp.Protocol;
 using ClickHouse.Driver.Tcp.Tests.Utilities;
+using ClickHouse.Driver.Tcp.Types;
 
 namespace ClickHouse.Driver.Tcp.Tests.Integration;
 
@@ -153,6 +155,88 @@ public class ClickHouseTcpParameterIntegrationTests
             (1, 2, 3, 4, 5, 6, 7, "eight", "nine")).Returns("(1,2,3,4,5,6,7,'eight','nine')").SetName("Tuple of nine");
     }
 
+    // A ClickHouse String holds bytes, not characters, so a value can hold a sequence that is not UTF-8 —
+    // which is exactly what the read path returns for a byte-array column. Decoding it turned every bad byte
+    // into U+FFFD and sent EF BF BD, changing the value with no error. Compared as hex, because the whole
+    // point is the bytes rather than the text.
+    [TestCase("String", "FFFE41", TestName = "String keeps bytes that are not UTF-8")]
+    [TestCase("FixedString(3)", "FFFE41", TestName = "FixedString keeps bytes that are not UTF-8")]
+    public async Task QueryAsync_ByteArrayThatIsNotUtf8_ArrivesByteForByte(string clickHouseType, string expectedHex)
+    {
+        await using var client = TcpServerFixture.CreateClient();
+        var options = new ClickHouseTcpQueryOptions
+        {
+            Parameters = new ClickHouseTcpParameterCollection { { "p", new byte[] { 0xFF, 0xFE, 0x41 } } },
+        };
+
+        object read = await ScalarAsync(client, "SELECT hex({p:" + clickHouseType + "})", options);
+
+        Assert.That(read, Is.EqualTo(expectedHex));
+    }
+
+    [Test]
+    public async Task QueryAsync_ByteArrayHoldingANulAndHighBytes_ArrivesByteForByte()
+    {
+        await using var client = TcpServerFixture.CreateClient();
+        var options = new ClickHouseTcpQueryOptions
+        {
+            Parameters = new ClickHouseTcpParameterCollection { { "p", new byte[] { 0x00, 0x01, 0xFF, 0x80 } } },
+        };
+
+        object read = await ScalarAsync(client, "SELECT hex({p:String})", options);
+
+        Assert.That(read, Is.EqualTo("0001FF80"));
+    }
+
+    [Test]
+    public async Task QueryAsync_ByteArrayThatIsValidUtf8_KeepsTheReadableForm()
+    {
+        // The fallback must not swallow the common case: valid UTF-8 still travels as text, not as \xHH.
+        await using var client = TcpServerFixture.CreateClient();
+        var options = new ClickHouseTcpQueryOptions
+        {
+            Parameters = new ClickHouseTcpParameterCollection { { "p", Encoding.UTF8.GetBytes("héllo") } },
+        };
+
+        object read = await ScalarAsync(client, "SELECT {p:String}", options);
+
+        Assert.That(read, Is.EqualTo("héllo"));
+    }
+
+    [Test]
+    public async Task QueryAsync_MapReadBackAsPairs_CanBeBoundAgain()
+    {
+        // A Map column reads back as KeyValuePair[] so duplicate keys and pair order survive. Binding that
+        // value straight back used to hit the "cannot convert" arm, because only IDictionary was accepted.
+        await using var client = TcpServerFixture.CreateClient();
+        KeyValuePair<string, int>[] pairs = [new("b", 2), new("a", 1)];
+        var options = new ClickHouseTcpQueryOptions
+        {
+            Parameters = new ClickHouseTcpParameterCollection { { "p", pairs } },
+        };
+
+        object read = await ScalarAsync(client, "SELECT toString({p:Map(String, Int32)})", options);
+
+        Assert.That(read, Is.EqualTo("{'b':2,'a':1}"));
+    }
+
+    [Test]
+    public async Task QueryAsync_SqlStringHoldingABackslashEscapedQuote_RunsAsWritten()
+    {
+        // Coverage of the scanner fix itself lives in SqlParameterTypeExtractorTests, where the mis-scan is
+        // observable. It is not observable here: whichever type the client resolves, a plain value formats to
+        // the same text, so this only pins that the server accepts the query and the escape survives it.
+        await using var client = TcpServerFixture.CreateClient();
+        var options = new ClickHouseTcpQueryOptions
+        {
+            Parameters = new ClickHouseTcpParameterCollection { { "p", 7 } },
+        };
+
+        object read = await ScalarAsync(client, @"SELECT concat('it\'s ', toString({p:Int32}))", options);
+
+        Assert.That(read, Is.EqualTo("it's 7"));
+    }
+
     [Test]
     public async Task QueryAsync_KindedDateTimeWithATimezoneInTheHint_KeepsTheInstant()
     {
@@ -269,27 +353,21 @@ public class ClickHouseTcpParameterIntegrationTests
     }
 
     [Test]
-    public async Task QueryAsync_SequenceReadableOnlyOnce_IsNotConsumedByTypeInference()
+    public async Task QueryAsync_LazySequenceParameter_ReachesTheServerWhole()
     {
-        // With no placeholder the client infers the type, which reads the sequence, and then formats it, which
-        // reads it again. A one-shot sequence would arrive empty the second time.
+        // A lazy sequence must reach the server whole. The placeholder here means inference does not run, so
+        // this covers the formatter's own single pass; BuildParametersTests covers the inference pass, which
+        // needs SQL that does not name the parameter and so cannot be observed through a query at all.
         await using var client = TcpServerFixture.CreateClient();
-        IEnumerable<int> once = OneShot();
+        IEnumerable<int> lazy = Enumerable.Range(1, 3).Select(i => i);
         var options = new ClickHouseTcpQueryOptions
         {
-            Parameters = new ClickHouseTcpParameterCollection { { "p", once } },
+            Parameters = new ClickHouseTcpParameterCollection { { "p", lazy } },
         };
 
         object value = await ScalarAsync(client, "SELECT toString({p:Array(Int32)})", options);
 
         Assert.That(value, Is.EqualTo("[1,2,3]"));
-
-        static IEnumerable<int> OneShot()
-        {
-            yield return 1;
-            yield return 2;
-            yield return 3;
-        }
     }
 
     [TestCaseSource(nameof(RoundTripCases))]
@@ -406,7 +484,7 @@ public class ClickHouseTcpParameterIntegrationTests
     }
 
     [Test]
-    public async Task InsertAsync_ParameterizedTarget_WritesToTheNamedTable()
+    public async Task ExecuteAsync_ParameterizedInsertSelect_WritesOnlyTheMatchingRows()
     {
         await using var client = TcpServerFixture.CreateClient();
         string table = $"tcp_param_test_{Guid.NewGuid():N}";
@@ -422,6 +500,60 @@ public class ClickHouseTcpParameterIntegrationTests
             object count = await ScalarAsync(client, $"SELECT count() FROM {table}", null);
 
             Assert.That(count, Is.EqualTo(2UL));
+        }
+        finally
+        {
+            await client.ExecuteAsync($"DROP TABLE IF EXISTS {table}", cancellationToken: None);
+        }
+    }
+
+    // InsertAsync takes its own options type and its own call path, so the test above — which goes through
+    // ExecuteAsync — proves nothing about it. A dropped parameters argument in these overloads would have
+    // passed the whole suite. The target table is the parameter, which is the only place one fits in an
+    // INSERT whose values arrive as a data block.
+    [Test]
+    public async Task InsertAsync_RowsWithAParameterizedTarget_WritesToTheNamedTable()
+    {
+        await using var client = TcpServerFixture.CreateClient();
+        string table = $"tcp_param_rows_{Guid.NewGuid():N}";
+        await client.ExecuteAsync($"CREATE TABLE {table} (id Int32) ENGINE = Memory", cancellationToken: None);
+        try
+        {
+            var options = new ClickHouseTcpInsertOptions
+            {
+                Parameters = new ClickHouseTcpParameterCollection { { "target", table, "Identifier" } },
+            };
+            object[][] rows = [[1], [2], [3]];
+
+            await client.InsertAsync("INSERT INTO {target:Identifier} (id) VALUES", rows, options, None);
+
+            object sum = await ScalarAsync(client, $"SELECT sum(id) FROM {table}", null);
+            Assert.That(Convert.ToInt64(sum), Is.EqualTo(6));
+        }
+        finally
+        {
+            await client.ExecuteAsync($"DROP TABLE IF EXISTS {table}", cancellationToken: None);
+        }
+    }
+
+    [Test]
+    public async Task InsertAsync_ColumnsWithAParameterizedTarget_WritesToTheNamedTable()
+    {
+        await using var client = TcpServerFixture.CreateClient();
+        string table = $"tcp_param_cols_{Guid.NewGuid():N}";
+        await client.ExecuteAsync($"CREATE TABLE {table} (id Int32) ENGINE = Memory", cancellationToken: None);
+        try
+        {
+            var options = new ClickHouseTcpInsertOptions
+            {
+                Parameters = new ClickHouseTcpParameterCollection { { "target", table, "Identifier" } },
+            };
+            IReadOnlyList<IColumn> columns = [new ArrayColumn<int>("id", "Int32", new[] { 4, 5 })];
+
+            await client.InsertAsync("INSERT INTO {target:Identifier} (id) VALUES", columns, options, None);
+
+            object sum = await ScalarAsync(client, $"SELECT sum(id) FROM {table}", null);
+            Assert.That(Convert.ToInt64(sum), Is.EqualTo(9));
         }
         finally
         {

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpParameterIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpParameterIntegrationTests.cs
@@ -113,6 +113,10 @@ public class ClickHouseTcpParameterIntegrationTests
         // Covers both JSON spellings and geo types backed by tuple/array shapes.
         yield return new TestCaseData("Json", "{\"a\":1}").Returns("{\"a\":1}").SetName("Json in the lowercase spelling");
         yield return new TestCaseData("JSON", "{\"a\":1}").Returns("{\"a\":1}").SetName("JSON in the uppercase spelling");
+        yield return new TestCaseData("JSON", "{\n\t\"a\": 1,\n\t\"b\": \"x\"\n}")
+            .Returns("{\"a\":1,\"b\":\"x\"}").SetName("JSON with formatting whitespace");
+        yield return new TestCaseData("Variant(JSON, UInt64)", new Dictionary<string, int> { ["a"] = 1 })
+            .Returns("{\"a\":1}").SetName("Variant picks the JSON alternative");
         yield return new TestCaseData("Point", (10.0, 20.0)).Returns("(10,20)").SetName("Point");
         yield return new TestCaseData("Ring", new[] { (0.0, 0.0), (1.0, 1.0) }).Returns("[(0,0),(1,1)]").SetName("Ring");
         yield return new TestCaseData("LineString", new[] { (0.0, 0.0), (1.0, 1.0) }).Returns("[(0,0),(1,1)]").SetName("LineString");

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpParameterIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpParameterIntegrationTests.cs
@@ -92,20 +92,29 @@ public class ClickHouseTcpParameterIntegrationTests
         Assert.That(read, Is.EqualTo(@"{'k\'1':'v\\1'}"));
     }
 
-    [Test]
-    public async Task QueryAsync_ParameterNamedAfterAServerSetting_IsRejectedByTheServer()
+    [TestCase("limit")]
+    [TestCase("offset")]
+    public async Task QueryAsync_ParameterNamedAfterAServerSetting_NeverBindsToTheWrongValue(string name)
     {
-        // The parameter list is the settings list, so the server applies a name it knows as that setting rather
-        // than binding it. Pinned because the error names neither the parameter nor the cause, and because
-        // "limit" is a name a caller reaches for. See the remark on ClickHouseTcpQueryOptions.Parameters.
+        // The parameter list is the settings list, so a server that reads the name as that setting applies it
+        // instead of binding it. Whether it does is version-dependent: 25.8 through 26.6 reject the query, and
+        // newer servers bind it correctly. Both are acceptable; a wrong count is not, and that is the outcome
+        // this pins. See the remark on ClickHouseTcpQueryOptions.Parameters.
         await using var client = TcpServerFixture.CreateClient();
         var options = new ClickHouseTcpQueryOptions
         {
-            Parameters = new ClickHouseTcpParameterCollection { { "limit", 3 } },
+            Parameters = new ClickHouseTcpParameterCollection { { name, 3 } },
         };
+        string sql = $"SELECT count() FROM (SELECT number FROM numbers(10) LIMIT {{{name}:UInt64}})";
 
-        Assert.ThrowsAsync<ClickHouseServerException>(async () => await ScalarAsync(
-            client, "SELECT count() FROM (SELECT number FROM numbers(10) LIMIT {limit:UInt64})", options));
+        try
+        {
+            Assert.That(await ScalarAsync(client, sql, options), Is.EqualTo(3UL));
+        }
+        catch (ClickHouseServerException)
+        {
+            Assert.Pass($"The server applied '{name}' as a setting and rejected the query, which is the older behaviour.");
+        }
     }
 
     [Test]

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpParameterIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpParameterIntegrationTests.cs
@@ -2,9 +2,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Numerics;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Numerics;
 using ClickHouse.Driver.Tcp.Protocol;
 using ClickHouse.Driver.Tcp.Tests.Utilities;
 using ClickHouse.Driver.Tcp.Types;
@@ -25,16 +27,53 @@ public class ClickHouseTcpParameterIntegrationTests
         yield return new TestCaseData("Int64", long.MinValue).Returns("-9223372036854775808").SetName("Int64 min");
         yield return new TestCaseData("UInt64", ulong.MaxValue).Returns("18446744073709551615").SetName("UInt64 max");
         yield return new TestCaseData("Int128", Int128.MinValue).Returns("-170141183460469231731687303715884105728").SetName("Int128 min");
+        yield return new TestCaseData("Int8", sbyte.MinValue).Returns("-128").SetName("Int8 min");
+        yield return new TestCaseData("Int16", short.MinValue).Returns("-32768").SetName("Int16 min");
+        yield return new TestCaseData("UInt16", ushort.MaxValue).Returns("65535").SetName("UInt16 max");
+        yield return new TestCaseData("UInt32", uint.MaxValue).Returns("4294967295").SetName("UInt32 max");
+        yield return new TestCaseData("UInt128", UInt128.MaxValue)
+            .Returns("340282366920938463463374607431768211455").SetName("UInt128 max");
+
+        // Int256 and UInt256 are this client's own structs, so their invariant text is the client's to get right.
+        yield return new TestCaseData("Int256", Int256.FromBigInteger(-BigInteger.Pow(2, 255)))
+            .Returns("-57896044618658097711785492504343953926634992332820282019728792003956564819968")
+            .SetName("Int256 min");
+        yield return new TestCaseData("UInt256", UInt256.FromBigInteger(BigInteger.Pow(2, 256) - 1))
+            .Returns("115792089237316195423570985008687907853269984665640564039457584007913129639935")
+            .SetName("UInt256 max");
+
         yield return new TestCaseData("Float64", 1.5d).Returns("1.5").SetName("Float64");
         yield return new TestCaseData("Float32", 1.5f).Returns("1.5").SetName("Float32");
         yield return new TestCaseData("Bool", true).Returns("true").SetName("Bool");
         yield return new TestCaseData("Bool", false).Returns("false").SetName("Bool false");
         yield return new TestCaseData("Decimal64(4)", 1.2345m).Returns("1.2345").SetName("Decimal64");
+        yield return new TestCaseData("Decimal32(2)", 1.25m).Returns("1.25").SetName("Decimal32");
+        yield return new TestCaseData("Decimal(10, 2)", 1.25m).Returns("1.25").SetName("Decimal with a precision and a scale");
+        yield return new TestCaseData("Decimal64(4)", new ClickHouseDecimal(12345, 4)).Returns("1.2345")
+            .SetName("Decimal from a ClickHouseDecimal");
+
+        // Wider than a CLR decimal and carrying a fraction, so the BigInteger text path must keep the scale.
+        yield return new TestCaseData("Decimal256(4)", "12345678901234567890123456789012345.6789")
+            .Returns("12345678901234567890123456789012345.6789").SetName("Decimal256 wider than a CLR decimal");
 
         // The server accepts .NET's NaN and Infinity spellings.
         yield return new TestCaseData("Float64", double.NaN).Returns("nan").SetName("Float64 NaN");
         yield return new TestCaseData("Float64", double.PositiveInfinity).Returns("inf").SetName("Float64 +Infinity");
         yield return new TestCaseData("Float64", double.NegativeInfinity).Returns("-inf").SetName("Float64 -Infinity");
+
+        // BFloat16 takes a float and nothing else, so these are the only values it can be given. The
+        // narrowing to 7 mantissa bits is the server's, which is why every value here is one it holds exactly.
+        yield return new TestCaseData("BFloat16", 1.5f).Returns("1.5").SetName("BFloat16");
+        yield return new TestCaseData("BFloat16", -2.5f).Returns("-2.5").SetName("BFloat16 negative");
+        yield return new TestCaseData("BFloat16", 0f).Returns("0").SetName("BFloat16 zero");
+        yield return new TestCaseData("BFloat16", 256f).Returns("256").SetName("BFloat16 power of two");
+        yield return new TestCaseData("BFloat16", float.PositiveInfinity).Returns("inf").SetName("BFloat16 +Infinity");
+        yield return new TestCaseData("Array(BFloat16)", new[] { 0f, 0.5f, -1f }).Returns("[0,0.5,-1]")
+            .SetName("Array of BFloat16");
+        yield return new TestCaseData("Map(String, BFloat16)", new Dictionary<string, float> { ["a"] = 0.5f })
+            .Returns("{'a':0.5}").SetName("Map holding a BFloat16");
+        yield return new TestCaseData("Variant(BFloat16, String)", 1.5f).Returns("1.5")
+            .SetName("Variant holding a BFloat16");
 
         // Composite Bool values require true/false; 1/0 works only for scalars.
         yield return new TestCaseData("Array(Bool)", new[] { true, false }).Returns("[true,false]").SetName("Array of Bool");
@@ -53,7 +92,10 @@ public class ClickHouseTcpParameterIntegrationTests
         yield return new TestCaseData("String", "héllo").Returns("héllo").SetName("String with non-ASCII");
         yield return new TestCaseData("String", "' OR 1=1 --").Returns("' OR 1=1 --").SetName("Injection attempt stays data");
         yield return new TestCaseData("LowCardinality(String)", "x").Returns("x").SetName("LowCardinality");
+        yield return new TestCaseData("Array(LowCardinality(String))", new[] { "a" }).Returns("['a']")
+            .SetName("Array of LowCardinality");
         yield return new TestCaseData("Enum8('a' = 1, 'b' = 2)", "a").Returns("a").SetName("Enum label");
+        yield return new TestCaseData("Enum16('a' = 1, 'b' = 2000)", "b").Returns("b").SetName("Enum16 label");
 
         yield return new TestCaseData("UUID", Guid.Parse("61f0c404-5cb3-11e7-907b-a6006ad3dba0"))
             .Returns("61f0c404-5cb3-11e7-907b-a6006ad3dba0").SetName("UUID");
@@ -83,13 +125,23 @@ public class ClickHouseTcpParameterIntegrationTests
         yield return new TestCaseData("Array(String)", new[] { "O'B" }).Returns(@"['O\'B']").SetName("Array element with a quote");
         yield return new TestCaseData("Array(Int32)", Array.Empty<int>()).Returns("[]").SetName("Empty array");
         yield return new TestCaseData("Array(Array(Int32))", new[] { new[] { 1, 2 }, new[] { 3 } }).Returns("[[1,2],[3]]").SetName("Jagged array");
+
+        // A rank-2 CLR array carries the same shape as a jagged one, and iterates flattened unless the
+        // formatter walks its axes.
+        yield return new TestCaseData("Array(Array(Int32))", new int[,] { { 1, 2 }, { 3, 4 } }).Returns("[[1,2],[3,4]]")
+            .SetName("Rank-2 array");
         yield return new TestCaseData("Array(Nullable(Int32))", new int?[] { 1, null, 3 }).Returns("[1,NULL,3]").SetName("Array with a null element");
         yield return new TestCaseData("Tuple(String, Int32)", ("a", 1)).Returns("('a',1)").SetName("Tuple");
+        yield return new TestCaseData("Tuple(x String, y Int32)", ("a", 1)).Returns("('a',1)").SetName("Named tuple");
         yield return new TestCaseData("Tuple(String, Int32)", ("O'B", 1)).Returns(@"('O\'B',1)").SetName("Tuple element with a quote");
 
-        // Covers empty, escaped-key, non-string-key, and nested map literals.
+        // Covers plain, empty, escaped key, escaped value, non-string-key, and nested map literals.
+        yield return new TestCaseData("Map(String, Int32)", new Dictionary<string, int> { ["a"] = 1 })
+            .Returns("{'a':1}").SetName("Map");
         yield return new TestCaseData("Map(String, String)", new Dictionary<string, string>())
             .Returns("{}").SetName("Empty map");
+        yield return new TestCaseData("Map(String, String)", new Dictionary<string, string> { ["k'1"] = @"v\1" })
+            .Returns(@"{'k\'1':'v\\1'}").SetName("Map with an escaped key and value");
         yield return new TestCaseData("Map(String, UInt8)", new Dictionary<string, byte> { [@"a'b\c"] = 1 })
             .Returns(@"{'a\'b\\c':1}").SetName("Map key needing escapes");
         yield return new TestCaseData("Map(Bool, String)", new Dictionary<bool, string> { [true] = "x" })
@@ -97,24 +149,41 @@ public class ClickHouseTcpParameterIntegrationTests
         yield return new TestCaseData("Map(String, Array(Bool))", new Dictionary<string, bool[]> { ["a"] = [true, false] })
             .Returns("{'a':[true,false]}").SetName("Map holding an array");
 
-        // Adds live-server coverage for formatter-only unit cases.
+        // The remaining type names, and the CLR shapes that reach one type by a second route.
         yield return new TestCaseData("Date32", new DateOnly(1950, 3, 4)).Returns("1950-03-04").SetName("Date32");
         yield return new TestCaseData("Time", new TimeSpan(1, 1, 1)).Returns("01:01:01").SetName("Time");
+        yield return new TestCaseData("Time", 3723).Returns("01:02:03").SetName("Time from whole seconds");
         yield return new TestCaseData("Time64(3)", new TimeSpan(0, 1, 1, 1, 500)).Returns("01:01:01.500").SetName("Time64");
         yield return new TestCaseData("FixedString(3)", Encoding.UTF8.GetBytes("abc")).Returns("abc").SetName("FixedString from bytes");
         yield return new TestCaseData("String", Encoding.UTF8.GetBytes("abc")).Returns("abc").SetName("String from bytes");
-        yield return new TestCaseData("IntervalSecond", 5L).Returns("5").SetName("IntervalSecond");
         yield return new TestCaseData("IntervalDay", -3L).Returns("-3").SetName("IntervalDay negative");
+        yield return new TestCaseData("Array(IntervalMonth)", new[] { 1L, 2L }).Returns("[1,2]")
+            .SetName("Array of IntervalMonth");
         yield return new TestCaseData("Nested(a UInt8, b String)", new object[] { (1, "x"), (2, "y") })
             .Returns("[(1,'x'),(2,'y')]").SetName("Nested rows");
         yield return new TestCaseData("Variant(Int64, String)", 7L).Returns("7").SetName("Variant picks the integer");
         yield return new TestCaseData("Variant(Int64, String)", "x").Returns("x").SetName("Variant picks the string");
+
+        // One CLR type reaches several ClickHouse types, so these alternatives are matched on the type name.
+        yield return new TestCaseData("Variant(DateTime('UTC'), String)", new DateTimeOffset(2024, 1, 2, 3, 4, 5, TimeSpan.Zero))
+            .Returns("2024-01-02 03:04:05").SetName("Variant picks the date and time");
+        yield return new TestCaseData("Variant(Decimal64(4), String)", 1.2345m).Returns("1.2345")
+            .SetName("Variant picks the decimal");
+
+        // A null element must not decide against the alternative that declares it nullable, however the
+        // alternative wraps it.
+        yield return new TestCaseData("Variant(Array(Nullable(Int32)), String)", new int?[] { 1, null, 3 })
+            .Returns("[1,NULL,3]").SetName("Variant holding an array with a null element");
+        yield return new TestCaseData("Variant(Array(LowCardinality(Nullable(String))), Int64)", new[] { "a", null })
+            .Returns("['a',NULL]").SetName("Variant holding a low-cardinality array with a null element");
 
         // Covers both JSON spellings and geo types backed by tuple/array shapes.
         yield return new TestCaseData("Json", "{\"a\":1}").Returns("{\"a\":1}").SetName("Json in the lowercase spelling");
         yield return new TestCaseData("JSON", "{\"a\":1}").Returns("{\"a\":1}").SetName("JSON in the uppercase spelling");
         yield return new TestCaseData("JSON", "{\n\t\"a\": 1,\n\t\"b\": \"x\"\n}")
             .Returns("{\"a\":1,\"b\":\"x\"}").SetName("JSON with formatting whitespace");
+        yield return new TestCaseData("JSON", new Dictionary<string, int> { ["a"] = 1 })
+            .Returns("{\"a\":1}").SetName("JSON serialized from an object");
         yield return new TestCaseData("Variant(JSON, UInt64)", new Dictionary<string, int> { ["a"] = 1 })
             .Returns("{\"a\":1}").SetName("Variant picks the JSON alternative");
         yield return new TestCaseData("Point", (10.0, 20.0)).Returns("(10,20)").SetName("Point");
@@ -122,6 +191,8 @@ public class ClickHouseTcpParameterIntegrationTests
         yield return new TestCaseData("LineString", new[] { (0.0, 0.0), (1.0, 1.0) }).Returns("[(0,0),(1,1)]").SetName("LineString");
         yield return new TestCaseData("Polygon", new[] { new[] { (0.0, 0.0), (1.0, 0.0), (1.0, 1.0) } })
             .Returns("[[(0,0),(1,0),(1,1)]]").SetName("Polygon");
+        yield return new TestCaseData("MultiLineString", new[] { new[] { (0.0, 0.0), (1.0, 1.0) }, new[] { (2.0, 2.0), (3.0, 3.0) } })
+            .Returns("[[(0,0),(1,1)],[(2,2),(3,3)]]").SetName("MultiLineString");
         yield return new TestCaseData("MultiPolygon", new[] { new[] { new[] { (0.0, 0.0), (1.0, 0.0), (1.0, 1.0) } } })
             .Returns("[[[(0,0),(1,0),(1,1)]]]").SetName("MultiPolygon");
 
@@ -134,6 +205,8 @@ public class ClickHouseTcpParameterIntegrationTests
         // Bytes reach the String arm from a ReadOnlyMemory as well, which used to print the CLR type name.
         yield return new TestCaseData("String", new ReadOnlyMemory<byte>(Encoding.UTF8.GetBytes("héllo"))).Returns("héllo")
             .SetName("String from a ReadOnlyMemory of bytes");
+        yield return new TestCaseData("FixedString(6)", new ReadOnlyMemory<byte>(Encoding.UTF8.GetBytes("héllo"))).Returns("héllo")
+            .SetName("FixedString from a ReadOnlyMemory of bytes");
 
         if (TcpServerFeatures.Has(TcpFeature.QBit))
         {
@@ -291,19 +364,47 @@ public class ClickHouseTcpParameterIntegrationTests
         Assert.That(read, Is.EqualTo("2020-01-02 12:00:00"));
     }
 
-    [Test]
-    public async Task QueryAsync_MapWithSpecialCharacters_RoundTripsThroughTheServer()
+    // Every unit rides as its underlying Int64 count, and the client routes it there only if the name is in
+    // its own list of Interval names. A unit missing from that list fails here and nowhere else.
+    [TestCase("IntervalNanosecond")]
+    [TestCase("IntervalMicrosecond")]
+    [TestCase("IntervalMillisecond")]
+    [TestCase("IntervalSecond")]
+    [TestCase("IntervalMinute")]
+    [TestCase("IntervalHour")]
+    [TestCase("IntervalDay")]
+    [TestCase("IntervalWeek")]
+    [TestCase("IntervalMonth")]
+    [TestCase("IntervalQuarter")]
+    [TestCase("IntervalYear")]
+    public async Task QueryAsync_IntervalParameterOfAnyUnit_ArrivesAsItsCount(string clickHouseType)
     {
         await using var client = TcpServerFixture.CreateClient();
-        var value = new Dictionary<string, string> { ["k'1"] = @"v\1" };
         var options = new ClickHouseTcpQueryOptions
         {
-            Parameters = new ClickHouseTcpParameterCollection { { "p", value } },
+            Parameters = new ClickHouseTcpParameterCollection { { "p", 5L } },
         };
 
-        object read = await ScalarAsync(client, "SELECT toString({p:Map(String, String)})", options);
+        object read = await ScalarAsync(client, "SELECT toString({p:" + clickHouseType + "})", options);
 
-        Assert.That(read, Is.EqualTo(@"{'k\'1':'v\\1'}"));
+        Assert.That(read, Is.EqualTo("5"));
+    }
+
+    [Test]
+    public async Task QueryAsync_DoubleForABFloat16_IsRefusedBeforeItReachesTheServer()
+    {
+        // The server narrows a double to BFloat16 with no error, and a value outside the float range arrives
+        // as an infinity, so the client refuses it instead.
+        await using var client = TcpServerFixture.CreateClient();
+        var options = new ClickHouseTcpQueryOptions
+        {
+            Parameters = new ClickHouseTcpParameterCollection { { "p", double.MaxValue } },
+        };
+
+        var exception = Assert.ThrowsAsync<ArgumentException>(
+            async () => await ScalarAsync(client, "SELECT toString({p:BFloat16})", options));
+
+        Assert.That(exception.Message, Does.Contain("Pass a float"));
     }
 
     [TestCase("limit")]
@@ -371,20 +472,6 @@ public class ClickHouseTcpParameterIntegrationTests
         };
 
         return (string)await ScalarAsync(client, "SELECT toString({p:" + clickHouseType + "})", options);
-    }
-
-    [Test]
-    public async Task QueryAsync_MapParameter_RoundTripsThroughTheServer()
-    {
-        await using var client = TcpServerFixture.CreateClient();
-        var options = new ClickHouseTcpQueryOptions
-        {
-            Parameters = new ClickHouseTcpParameterCollection { { "p", new Dictionary<string, int> { ["a"] = 1 } } },
-        };
-
-        object value = await ScalarAsync(client, "SELECT toString({p:Map(String, Int32)})", options);
-
-        Assert.That(value, Is.EqualTo("{'a':1}"));
     }
 
     [Test]

--- a/ClickHouse.Driver.Tcp.Tests/Parameters/ClickHouseTcpParameterCollectionTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Parameters/ClickHouseTcpParameterCollectionTests.cs
@@ -116,8 +116,7 @@ public class ClickHouseTcpParameterCollectionTests
     }
 }
 
-// The resolution chain that turns bound values into the wire parameter list: the parameter's own type first,
-// then the query's {name:Type} placeholder, then the value's CLR type.
+// Type precedence: parameter override, then SQL hint.
 [TestFixture]
 public class BuildParametersTests
 {
@@ -158,31 +157,40 @@ public class BuildParametersTests
     }
 
     [Test]
-    public void BuildParameters_NoPlaceholderForTheName_FallsBackToTheValueType()
+    public void BuildParameters_NoExplicitTypeOrSqlHint_ThrowsNamingTheParameter()
     {
-        // A parameter the query never names still has to format, because the server ignores the extra entry.
-        IReadOnlyDictionary<string, string> wire = Build(
-            "SELECT 1",
-            new ClickHouseTcpParameterCollection { { "unused", 42 } });
+        var parameters = new ClickHouseTcpParameterCollection { { "unused", 42 } };
 
-        Assert.That(wire["unused"], Is.EqualTo("'42'"));
+        var exception = Assert.Throws<ArgumentException>(() => Build("SELECT 1", parameters));
+
+        Assert.That(exception.Message, Does.Contain("unused").And.Contain("{unused:Type}"));
+    }
+
+    [TestCase("")]
+    [TestCase(" ")]
+    public void BuildParameters_ExplicitTypeIsEmpty_ThrowsEvenWhenSqlHasAHint(string clickHouseType)
+    {
+        var parameters = new ClickHouseTcpParameterCollection { { "p", 42, clickHouseType } };
+
+        var exception = Assert.Throws<ArgumentException>(() => Build("SELECT {p:Int32}", parameters));
+
+        Assert.That(exception.Message, Does.Contain("p").And.Contain("empty ClickHouseType"));
     }
 
     [Test]
     public void BuildParameters_PlaceholderInsideAComment_IsNotUsedAsAHint()
     {
-        // The scanner skips comments, so this falls through to the value's CLR type rather than to Date.
-        IReadOnlyDictionary<string, string> wire = Build(
-            "SELECT 1 -- {p:Date}\n",
-            new ClickHouseTcpParameterCollection { { "p", 7 } });
+        var parameters = new ClickHouseTcpParameterCollection { { "p", 7 } };
 
-        Assert.That(wire["p"], Is.EqualTo("'7'"));
+        var exception = Assert.Throws<ArgumentException>(() => Build("SELECT 1 -- {p:Date}\n", parameters));
+
+        Assert.That(exception.Message, Does.Contain("p").And.Contain("no ClickHouse type"));
     }
 
     [Test]
     public void BuildParameters_ValueOfAnUnmappableType_ThrowsNamingTheParameter()
     {
-        var parameters = new ClickHouseTcpParameterCollection { { "p", new object() } };
+        var parameters = new ClickHouseTcpParameterCollection { { "p", new object(), "DateTime" } };
 
         var exception = Assert.Throws<ArgumentException>(() => Build("SELECT 1", parameters));
 
@@ -190,29 +198,24 @@ public class BuildParametersTests
     }
 
     [Test]
-    public void BuildParameters_SequenceReadableOnlyOnce_IsNotConsumedByTypeInference()
+    public void BuildParameters_SequenceReadableOnlyOnceWithAnExplicitType_IsReadOnce()
     {
-        // Inference reads the sequence to find the element type and formatting reads it again, so a sequence
-        // that can only be read once used to arrive empty. The SQL must not name the parameter: a placeholder
-        // supplies the type and inference never runs, which is what made the earlier version of this test pass
-        // against the unfixed code.
         var once = new SingleUseSequence(1, 2, 3);
 
         IReadOnlyDictionary<string, string> wire = Build(
             "SELECT 1",
-            new ClickHouseTcpParameterCollection { { "p", once } });
+            new ClickHouseTcpParameterCollection { { "p", once, "Array(Int32)" } });
 
         Assert.Multiple(() =>
         {
             Assert.That(wire["p"], Is.EqualTo("'[1,2,3]'"));
-            Assert.That(once.EnumerationCount, Is.EqualTo(1), "the sequence was copied, so it was read once");
+            Assert.That(once.EnumerationCount, Is.EqualTo(1));
         });
     }
 
     [Test]
     public void BuildParameters_SequenceReadableOnlyOnceWithAPlaceholder_IsAlsoSafe()
     {
-        // With a placeholder there is no inference pass, so the sequence is read only by the formatter.
         var once = new SingleUseSequence(4, 5);
 
         IReadOnlyDictionary<string, string> wire = Build(
@@ -225,10 +228,7 @@ public class BuildParametersTests
     private static IReadOnlyDictionary<string, string> Build(string sql, ClickHouseTcpParameterCollection parameters)
         => ClickHouseTcpClient.BuildParameters(sql, new ClickHouseTcpQueryOptions { Parameters = parameters });
 
-    /// <summary>
-    /// A sequence that yields its values once and is empty afterwards. An iterator method will not do: it
-    /// returns a fresh enumerator per enumeration, so it survives being read twice and hides the defect.
-    /// </summary>
+    /// <summary>A sequence that returns its values only on the first enumeration.</summary>
     private sealed class SingleUseSequence(params int[] values) : IEnumerable<int>
     {
         private bool consumed;

--- a/ClickHouse.Driver.Tcp.Tests/Parameters/ClickHouseTcpParameterCollectionTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Parameters/ClickHouseTcpParameterCollectionTests.cs
@@ -46,6 +46,53 @@ public class ClickHouseTcpParameterCollectionTests
     }
 
     [Test]
+    public void Constructor_FromASequence_AddsThemInOrder()
+    {
+        var parameters = new ClickHouseTcpParameterCollection(
+        [
+            new ClickHouseTcpParameter("a", 1),
+            new ClickHouseTcpParameter("b", 2, "UInt8"),
+        ]);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(parameters.Count, Is.EqualTo(2));
+            Assert.That(parameters["b"].ClickHouseType, Is.EqualTo("UInt8"));
+        });
+    }
+
+    [Test]
+    public void Constructor_FromASequenceRepeatingAName_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => new ClickHouseTcpParameterCollection(
+        [
+            new ClickHouseTcpParameter("a", 1),
+            new ClickHouseTcpParameter("a", 2),
+        ]));
+    }
+
+    [Test]
+    public void Constructor_FromNull_Throws()
+        => Assert.Throws<ArgumentNullException>(() => new ClickHouseTcpParameterCollection(null));
+
+    [Test]
+    public void Add_NullParameter_Throws()
+        => Assert.Throws<ArgumentNullException>(() => new ClickHouseTcpParameterCollection().Add(null));
+
+    [Test]
+    public void Contains_BoundAndUnboundNames_AnswersForBoth()
+    {
+        var parameters = new ClickHouseTcpParameterCollection { { "id", 1 } };
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(parameters.Contains("id"), Is.True);
+            Assert.That(parameters.Contains("other"), Is.False);
+            Assert.That(parameters.Contains(null), Is.False);
+        });
+    }
+
+    [Test]
     public void Indexer_UnboundName_Throws()
     {
         var parameters = new ClickHouseTcpParameterCollection();

--- a/ClickHouse.Driver.Tcp.Tests/Parameters/ClickHouseTcpParameterCollectionTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Parameters/ClickHouseTcpParameterCollectionTests.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace ClickHouse.Driver.Tcp.Tests.Parameters;
 
@@ -187,6 +189,64 @@ public class BuildParametersTests
         Assert.That(exception.Message, Does.Contain("p"));
     }
 
+    [Test]
+    public void BuildParameters_SequenceReadableOnlyOnce_IsNotConsumedByTypeInference()
+    {
+        // Inference reads the sequence to find the element type and formatting reads it again, so a sequence
+        // that can only be read once used to arrive empty. The SQL must not name the parameter: a placeholder
+        // supplies the type and inference never runs, which is what made the earlier version of this test pass
+        // against the unfixed code.
+        var once = new SingleUseSequence(1, 2, 3);
+
+        IReadOnlyDictionary<string, string> wire = Build(
+            "SELECT 1",
+            new ClickHouseTcpParameterCollection { { "p", once } });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(wire["p"], Is.EqualTo("'[1,2,3]'"));
+            Assert.That(once.EnumerationCount, Is.EqualTo(1), "the sequence was copied, so it was read once");
+        });
+    }
+
+    [Test]
+    public void BuildParameters_SequenceReadableOnlyOnceWithAPlaceholder_IsAlsoSafe()
+    {
+        // With a placeholder there is no inference pass, so the sequence is read only by the formatter.
+        var once = new SingleUseSequence(4, 5);
+
+        IReadOnlyDictionary<string, string> wire = Build(
+            "SELECT {p:Array(Int32)}",
+            new ClickHouseTcpParameterCollection { { "p", once } });
+
+        Assert.That(wire["p"], Is.EqualTo("'[4,5]'"));
+    }
+
     private static IReadOnlyDictionary<string, string> Build(string sql, ClickHouseTcpParameterCollection parameters)
         => ClickHouseTcpClient.BuildParameters(sql, new ClickHouseTcpQueryOptions { Parameters = parameters });
+
+    /// <summary>
+    /// A sequence that yields its values once and is empty afterwards. An iterator method will not do: it
+    /// returns a fresh enumerator per enumeration, so it survives being read twice and hides the defect.
+    /// </summary>
+    private sealed class SingleUseSequence(params int[] values) : IEnumerable<int>
+    {
+        private bool consumed;
+
+        public int EnumerationCount { get; private set; }
+
+        public IEnumerator<int> GetEnumerator()
+        {
+            EnumerationCount++;
+            if (consumed)
+            {
+                return Enumerable.Empty<int>().GetEnumerator();
+            }
+
+            consumed = true;
+            return ((IEnumerable<int>)values).GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
 }

--- a/ClickHouse.Driver.Tcp.Tests/Parameters/ClickHouseTcpParameterCollectionTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Parameters/ClickHouseTcpParameterCollectionTests.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Collections.Generic;
+
+namespace ClickHouse.Driver.Tcp.Tests.Parameters;
+
+[TestFixture]
+public class ClickHouseTcpParameterCollectionTests
+{
+    [Test]
+    public void Add_TwoParameters_KeepsThemInInsertionOrder()
+    {
+        var parameters = new ClickHouseTcpParameterCollection { { "b", 1 }, { "a", 2 } };
+
+        Assert.That(parameters, Is.EqualTo(new[]
+        {
+            new ClickHouseTcpParameter("b", 1),
+            new ClickHouseTcpParameter("a", 2),
+        }));
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    public void Add_NullOrEmptyName_Throws(string name)
+    {
+        // An empty name would collide with the empty key that terminates the wire parameter list.
+        var parameters = new ClickHouseTcpParameterCollection();
+
+        Assert.Throws<ArgumentException>(() => parameters.Add(name, 1));
+    }
+
+    [Test]
+    public void Add_NameAlreadyBound_Throws()
+    {
+        var parameters = new ClickHouseTcpParameterCollection { { "id", 1 } };
+
+        Assert.Throws<ArgumentException>(() => parameters.Add("id", 2));
+    }
+
+    [Test]
+    public void Add_NamesDifferingOnlyByCase_AreDistinct()
+    {
+        // ClickHouse parameter names are case-sensitive.
+        var parameters = new ClickHouseTcpParameterCollection { { "id", 1 }, { "ID", 2 } };
+
+        Assert.That(parameters.Count, Is.EqualTo(2));
+    }
+
+    [Test]
+    public void Indexer_UnboundName_Throws()
+    {
+        var parameters = new ClickHouseTcpParameterCollection();
+
+        Assert.Throws<KeyNotFoundException>(() => _ = parameters["missing"]);
+    }
+
+    [Test]
+    public void TryGetValue_BoundName_ReturnsTheParameter()
+    {
+        var parameters = new ClickHouseTcpParameterCollection { { "id", 42, "UInt8" } };
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(parameters.TryGetValue("id", out ClickHouseTcpParameter parameter), Is.True);
+            Assert.That(parameter.ClickHouseType, Is.EqualTo("UInt8"));
+            Assert.That(parameters.TryGetValue("other", out _), Is.False);
+        });
+    }
+}
+
+// The resolution chain that turns bound values into the wire parameter list: the parameter's own type first,
+// then the query's {name:Type} placeholder, then the value's CLR type.
+[TestFixture]
+public class BuildParametersTests
+{
+    [Test]
+    public void BuildParameters_NoParameters_ReturnsNull()
+    {
+        // Null keeps the caller from sending an empty list where none was asked for.
+        Assert.Multiple(() =>
+        {
+            Assert.That(ClickHouseTcpClient.BuildParameters("SELECT 1", null), Is.Null);
+            Assert.That(ClickHouseTcpClient.BuildParameters("SELECT 1", new ClickHouseTcpQueryOptions()), Is.Null);
+            Assert.That(
+                ClickHouseTcpClient.BuildParameters("SELECT 1", new ClickHouseTcpQueryOptions { Parameters = new ClickHouseTcpParameterCollection() }),
+                Is.Null);
+        });
+    }
+
+    [Test]
+    public void BuildParameters_TypeFromThePlaceholder_FormatsAsThatType()
+    {
+        // A string bound to a Date placeholder proves the placeholder drove the formatting, not the CLR type.
+        IReadOnlyDictionary<string, string> wire = Build(
+            "SELECT {d:Date}",
+            new ClickHouseTcpParameterCollection { { "d", new DateOnly(2024, 1, 2) } });
+
+        Assert.That(wire["d"], Is.EqualTo("'2024-01-02'"));
+    }
+
+    [Test]
+    public void BuildParameters_ExplicitType_WinsOverThePlaceholder()
+    {
+        IReadOnlyDictionary<string, string> wire = Build(
+            "SELECT {p:String}",
+            new ClickHouseTcpParameterCollection { { "p", "a'b", "Identifier" } });
+
+        // Identifier is the only type left unescaped, so an unescaped quote shows the override was used.
+        Assert.That(wire["p"], Is.EqualTo(@"'a\'b'"));
+    }
+
+    [Test]
+    public void BuildParameters_NoPlaceholderForTheName_FallsBackToTheValueType()
+    {
+        // A parameter the query never names still has to format, because the server ignores the extra entry.
+        IReadOnlyDictionary<string, string> wire = Build(
+            "SELECT 1",
+            new ClickHouseTcpParameterCollection { { "unused", 42 } });
+
+        Assert.That(wire["unused"], Is.EqualTo("'42'"));
+    }
+
+    [Test]
+    public void BuildParameters_PlaceholderInsideAComment_IsNotUsedAsAHint()
+    {
+        // The scanner skips comments, so this falls through to the value's CLR type rather than to Date.
+        IReadOnlyDictionary<string, string> wire = Build(
+            "SELECT 1 -- {p:Date}\n",
+            new ClickHouseTcpParameterCollection { { "p", 7 } });
+
+        Assert.That(wire["p"], Is.EqualTo("'7'"));
+    }
+
+    [Test]
+    public void BuildParameters_ValueOfAnUnmappableType_ThrowsNamingTheParameter()
+    {
+        var parameters = new ClickHouseTcpParameterCollection { { "p", new object() } };
+
+        var exception = Assert.Throws<ArgumentException>(() => Build("SELECT 1", parameters));
+
+        Assert.That(exception.Message, Does.Contain("p"));
+    }
+
+    private static IReadOnlyDictionary<string, string> Build(string sql, ClickHouseTcpParameterCollection parameters)
+        => ClickHouseTcpClient.BuildParameters(sql, new ClickHouseTcpQueryOptions { Parameters = parameters });
+}

--- a/ClickHouse.Driver.Tcp.Tests/Parameters/SqlParameterTypeExtractorTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Parameters/SqlParameterTypeExtractorTests.cs
@@ -142,7 +142,6 @@ public class SqlParameterTypeExtractorTests
     [TestCase("SELECT {val:Int32} -- {val:String}")]
     [TestCase("SELECT {val:Int32} --{val:String}")]
     [TestCase("SELECT {val:Int32} # {val:String}")]
-    [TestCase("SELECT {val:Int32} #{val:String}")]
     [TestCase("SELECT {val:Int32} #! {val:String}")]
     [TestCase("SELECT {val:Int32} #!{val:String}")]
     [TestCase("SELECT {val:Int32} -- /* {val:String} */")]
@@ -226,6 +225,119 @@ public class SqlParameterTypeExtractorTests
         {
             Assert.That(hints, Has.Count.EqualTo(1));
             Assert.That(hints["other"], Is.EqualTo("String"));
+        });
+    }
+
+    [Test]
+    public void ExtractTypeHints_BareHash_NotTreatedAsComment()
+    {
+        // Only "# " and "#!" start a comment; the server rejects a query holding a bare "#" token.
+        Dictionary<string, string> hints = SqlParameterTypeExtractor.ExtractTypeHints("SELECT {val:Int32} #{other:String}");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(hints, Has.Count.EqualTo(2));
+            Assert.That(hints["val"], Is.EqualTo("Int32"));
+            Assert.That(hints["other"], Is.EqualTo("String"));
+        });
+    }
+
+    // A brace that is not a type hint must not reach past its own name for a colon, or it takes the colon of
+    // the parameter after it and that parameter loses its hint. Every one of these is a query the server runs.
+    [TestCase("SELECT 1 AS \"col{x}\", {p:Int32}")]
+    [TestCase("SELECT 1 AS `col{x}`, {p:Int32}")]
+    [TestCase("SELECT $$ {x} $$, {p:Int32}")]
+    public void ExtractTypeHints_BraceThatIsNotATypeHint_KeepsTheLaterHint(string sql)
+    {
+        Dictionary<string, string> hints = SqlParameterTypeExtractor.ExtractTypeHints(sql);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(hints, Has.Count.EqualTo(1));
+            Assert.That(hints["p"], Is.EqualTo("Int32"));
+        });
+    }
+
+    // A name is a bare word, so anything else before the colon means this brace is not a placeholder at all.
+    [TestCase("SELECT {x}, {p:Int32}")]
+    [TestCase("SELECT {}, {p:Int32}")]
+    [TestCase("SELECT {a b:Int32}, {p:Int32}")]
+    [TestCase("SELECT {'a':1}, {p:Int32}")]
+    public void ExtractTypeHints_BraceWithoutAParameterName_YieldsOnlyTheRealHint(string sql)
+    {
+        Dictionary<string, string> hints = SqlParameterTypeExtractor.ExtractTypeHints(sql);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(hints, Has.Count.EqualTo(1));
+            Assert.That(hints["p"], Is.EqualTo("Int32"));
+        });
+    }
+
+    // A quoted identifier, a heredoc and a // comment each hide their contents, as a string literal does.
+    [TestCase("SELECT 1 AS \"a{val:Int32}b\", {other:String}")]
+    [TestCase("SELECT 1 AS `a{val:Int32}b`, {other:String}")]
+    [TestCase("SELECT $tag$ {val:Int32} $tag$, {other:String}")]
+    [TestCase("SELECT 1 // {val:Int32}\n, {other:String}")]
+    [TestCase("SELECT /* /* {val:Int32} */ */ {other:String}")]
+    public void ExtractTypeHints_HintInsideAHiddenToken_IsSkipped(string sql)
+    {
+        Dictionary<string, string> hints = SqlParameterTypeExtractor.ExtractTypeHints(sql);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(hints, Has.Count.EqualTo(1));
+            Assert.That(hints["other"], Is.EqualTo("String"));
+        });
+    }
+
+    // A $ opens a heredoc only at a token boundary and only when a closing tag follows. The server lexes
+    // a$b$ as one identifier, so neither dollar there starts one even though the tag repeats later.
+    [TestCase("SELECT $x, {p:Int32}")]
+    [TestCase("SELECT 1 AS a$b$, {p:Int32}, 2 AS c$b$")]
+    public void ExtractTypeHints_DollarThatOpensNoHeredoc_IsAnOrdinaryCharacter(string sql)
+    {
+        Dictionary<string, string> hints = SqlParameterTypeExtractor.ExtractTypeHints(sql);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(hints, Has.Count.EqualTo(1));
+            Assert.That(hints["p"], Is.EqualTo("Int32"));
+        });
+    }
+
+    // Shapes that end the scan without a hint: no colon before the end, an unterminated quote, and a brace
+    // inside what would be the type, which no type definition contains.
+    [TestCase("SELECT {abc", TestName = "name runs to the end with no colon")]
+    [TestCase("SELECT 'abc", TestName = "unterminated string literal")]
+    [TestCase("SELECT \"abc", TestName = "unterminated quoted identifier")]
+    [TestCase("SELECT {p:Int{32}", TestName = "brace inside the type")]
+    public void ExtractTypeHints_ScanThatNeverCompletesAHint_ReturnsEmptyDictionary(string sql)
+    {
+        Assert.That(SqlParameterTypeExtractor.ExtractTypeHints(sql), Is.Empty);
+    }
+
+    [Test]
+    public void ExtractTypeHints_BraceInsideTheType_LeavesALaterHintVisible()
+    {
+        Dictionary<string, string> hints = SqlParameterTypeExtractor.ExtractTypeHints("SELECT {p:Int{32}, {q:Int32}");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(hints, Has.Count.EqualTo(1));
+            Assert.That(hints["q"], Is.EqualTo("Int32"));
+        });
+    }
+
+    [Test]
+    public void ExtractTypeHints_UnterminatedHeredoc_DoesNotSwallowTheRestOfTheQuery()
+    {
+        Dictionary<string, string> hints = SqlParameterTypeExtractor.ExtractTypeHints("SELECT $tag$ oops, {p:Int32}");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(hints, Has.Count.EqualTo(1));
+            Assert.That(hints["p"], Is.EqualTo("Int32"));
         });
     }
 }

--- a/ClickHouse.Driver.Tcp.Tests/Parameters/SqlParameterTypeExtractorTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Parameters/SqlParameterTypeExtractorTests.cs
@@ -29,9 +29,7 @@ public class SqlParameterTypeExtractorTests
         });
     }
 
-    // ClickHouse accepts a backslash-escaped quote in a string literal as well as a doubled one. Treating \'
-    // as the end of the string made everything after it look like SQL, so the real placeholder was skipped
-    // and its type was silently lost.
+    // Backslash-escaped quotes must not hide a later placeholder.
     [TestCase(@"SELECT 'it\'s', {p:Int32}", TestName = "A backslash-escaped quote in a literal")]
     [TestCase(@"SELECT 'ends with a backslash\\', {p:Int32}", TestName = "An escaped backslash at the end of a literal")]
     [TestCase(@"SELECT 'a\'b\'c', {p:Int32}", TestName = "Several escaped quotes")]

--- a/ClickHouse.Driver.Tcp.Tests/Parameters/SqlParameterTypeExtractorTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Parameters/SqlParameterTypeExtractorTests.cs
@@ -29,6 +29,30 @@ public class SqlParameterTypeExtractorTests
         });
     }
 
+    // ClickHouse accepts a backslash-escaped quote in a string literal as well as a doubled one. Treating \'
+    // as the end of the string made everything after it look like SQL, so the real placeholder was skipped
+    // and its type was silently lost.
+    [TestCase(@"SELECT 'it\'s', {p:Int32}", TestName = "A backslash-escaped quote in a literal")]
+    [TestCase(@"SELECT 'ends with a backslash\\', {p:Int32}", TestName = "An escaped backslash at the end of a literal")]
+    [TestCase(@"SELECT 'a\'b\'c', {p:Int32}", TestName = "Several escaped quotes")]
+    [TestCase(@"SELECT 'brace \' {p:Wrong}', {p:Int32}", TestName = "A decoy placeholder inside the literal")]
+    public void ExtractTypeHints_LiteralWithABackslashEscape_StillFindsTheHintAfterIt(string sql)
+    {
+        Dictionary<string, string> hints = SqlParameterTypeExtractor.ExtractTypeHints(sql);
+
+        Assert.That(hints["p"], Is.EqualTo("Int32"));
+    }
+
+    [Test]
+    public void ExtractTypeHints_EnumLabelWithABackslashEscapedQuote_KeepsTheWholeType()
+    {
+        const string type = @"Enum8('it\'s' = 1, 'b' = 2)";
+
+        Dictionary<string, string> hints = SqlParameterTypeExtractor.ExtractTypeHints("SELECT {p:" + type + "}");
+
+        Assert.That(hints["p"], Is.EqualTo(type));
+    }
+
     [TestCase(null)]
     [TestCase("")]
     [TestCase("SELECT 1")]

--- a/ClickHouse.Driver.Tcp.Tests/Parameters/SqlParameterTypeExtractorTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Parameters/SqlParameterTypeExtractorTests.cs
@@ -1,0 +1,209 @@
+using System;
+using System.Collections.Generic;
+using ClickHouse.Driver.Tcp.Parameters;
+
+namespace ClickHouse.Driver.Tcp.Tests.Parameters;
+
+[TestFixture]
+public class SqlParameterTypeExtractorTests
+{
+    [TestCase("UInt64")]
+    [TestCase("String")]
+    [TestCase("DateTime('Europe/Amsterdam')")]
+    [TestCase("DateTime64(3, 'UTC')")]
+    [TestCase("Array(Nullable(String))")]
+    [TestCase("Array(Tuple(String, Array(Nullable(Int32))))")]
+    [TestCase("Map(String, Int32)")]
+    [TestCase("Enum8('a' = 1, 'b' = 2)")]
+    [TestCase("Enum8('it''s' = 1, 'hello' = 2)")]
+    [TestCase("Enum8('}' = 1, '{' = 2)")]
+    [TestCase("Enum8('{type:value}' = 1, '{' = 2)")]
+    public void ExtractTypeHints_SingleParameter_ReturnsWholeType(string type)
+    {
+        Dictionary<string, string> hints = SqlParameterTypeExtractor.ExtractTypeHints("SELECT {p:" + type + "}");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(hints, Has.Count.EqualTo(1));
+            Assert.That(hints["p"], Is.EqualTo(type));
+        });
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase("SELECT 1")]
+    [TestCase("SELECT {id}")]
+    [TestCase("SELECT {id:}")]
+    [TestCase("SELECT {id: }")]
+    [TestCase("SELECT {:Int32}")]
+    [TestCase("SELECT { :Int32}")]
+    [TestCase("SELECT {id:Int32")]
+    public void ExtractTypeHints_NoUsableHint_ReturnsEmptyDictionary(string sql)
+    {
+        Assert.That(SqlParameterTypeExtractor.ExtractTypeHints(sql), Is.Empty);
+    }
+
+    [TestCase("SELECT {a:Int32 }")]
+    [TestCase("SELECT {a : Int32}")]
+    [TestCase("SELECT { a:Int32}")]
+    [TestCase("SELECT {  a  :  Int32  }")]
+    public void ExtractTypeHints_WhitespaceAroundNameAndType_TrimsBoth(string sql)
+    {
+        Dictionary<string, string> hints = SqlParameterTypeExtractor.ExtractTypeHints(sql);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(hints, Has.Count.EqualTo(1));
+            Assert.That(hints["a"], Is.EqualTo("Int32"));
+        });
+    }
+
+    [Test]
+    public void ExtractTypeHints_MultipleParameters_ReturnsAllTypes()
+    {
+        Dictionary<string, string> hints = SqlParameterTypeExtractor.ExtractTypeHints(
+            "SELECT {id:UInt64}, {name:String}, {dt:DateTime('UTC')}");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(hints, Has.Count.EqualTo(3));
+            Assert.That(hints["id"], Is.EqualTo("UInt64"));
+            Assert.That(hints["name"], Is.EqualTo("String"));
+            Assert.That(hints["dt"], Is.EqualTo("DateTime('UTC')"));
+        });
+    }
+
+    [Test]
+    public void ExtractTypeHints_MultilineInsertQuery_ReturnsAllTypes()
+    {
+        Dictionary<string, string> hints = SqlParameterTypeExtractor.ExtractTypeHints(
+            "INSERT INTO test_table (id, name, created_at, tags)\n" +
+            "VALUES ({id:UInt64}, {name:String}, {created_at:DateTime('Europe/London')}, {tags:Array(String)})");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(hints, Has.Count.EqualTo(4));
+            Assert.That(hints["id"], Is.EqualTo("UInt64"));
+            Assert.That(hints["name"], Is.EqualTo("String"));
+            Assert.That(hints["created_at"], Is.EqualTo("DateTime('Europe/London')"));
+            Assert.That(hints["tags"], Is.EqualTo("Array(String)"));
+        });
+    }
+
+    [Test]
+    public void ExtractTypeHints_SameParameterWithSameType_ReturnsOneHint()
+    {
+        Dictionary<string, string> hints = SqlParameterTypeExtractor.ExtractTypeHints("SELECT {val:Int32}, {val:Int32}");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(hints, Has.Count.EqualTo(1));
+            Assert.That(hints["val"], Is.EqualTo("Int32"));
+        });
+    }
+
+    [Test]
+    public void ExtractTypeHints_SameParameterWithDifferentTypes_ThrowsArgumentException()
+    {
+        ArgumentException ex = Assert.Throws<ArgumentException>(
+            () => SqlParameterTypeExtractor.ExtractTypeHints("SELECT {val:Int32}, {val:String}"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(ex.Message, Does.Contain("Parameter 'val' has conflicting type hints"));
+            Assert.That(ex.Message, Does.Contain("Int32"));
+            Assert.That(ex.Message, Does.Contain("String"));
+        });
+    }
+
+    // A commented-out hint must not override, or conflict with, the real one.
+    [TestCase("SELECT {val:Int32} -- {val:String}")]
+    [TestCase("SELECT {val:Int32} --{val:String}")]
+    [TestCase("SELECT {val:Int32} # {val:String}")]
+    [TestCase("SELECT {val:Int32} #{val:String}")]
+    [TestCase("SELECT {val:Int32} #! {val:String}")]
+    [TestCase("SELECT {val:Int32} #!{val:String}")]
+    [TestCase("SELECT {val:Int32} -- /* {val:String} */")]
+    [TestCase("SELECT {val:Int32} /* {val:String} */")]
+    [TestCase("SELECT {val:Int32} /*{val:String}*/")]
+    [TestCase("SELECT {val:Int32}\n/*\n{val:String}\n*/")]
+    [TestCase("SELECT {val:Int32} /* {val:String}")]
+    public void ExtractTypeHints_ParameterInsideComment_IgnoresCommentedParameter(string sql)
+    {
+        Dictionary<string, string> hints = SqlParameterTypeExtractor.ExtractTypeHints(sql);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(hints, Has.Count.EqualTo(1));
+            Assert.That(hints["val"], Is.EqualTo("Int32"));
+        });
+    }
+
+    [TestCase("-- comment\nSELECT {val:Int32}")]
+    [TestCase("# comment\nSELECT {val:Int32}")]
+    [TestCase("SELECT /**/{val:Int32}")]
+    [TestCase("SELECT /* comment */ {val:Int32}")]
+    public void ExtractTypeHints_CommentBeforeParameter_ParsesParameter(string sql)
+    {
+        Dictionary<string, string> hints = SqlParameterTypeExtractor.ExtractTypeHints(sql);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(hints, Has.Count.EqualTo(1));
+            Assert.That(hints["val"], Is.EqualTo("Int32"));
+        });
+    }
+
+    [TestCase("SELECT {val:Int32} -- comment\n, {other:String}")]
+    [TestCase("SELECT {val:Int32} /* comment */ , {other:String}")]
+    public void ExtractTypeHints_ParameterAfterComment_ParsesBothParameters(string sql)
+    {
+        Dictionary<string, string> hints = SqlParameterTypeExtractor.ExtractTypeHints(sql);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(hints, Has.Count.EqualTo(2));
+            Assert.That(hints["val"], Is.EqualTo("Int32"));
+            Assert.That(hints["other"], Is.EqualTo("String"));
+        });
+    }
+
+    [TestCase("-- {val:Int32}")]
+    [TestCase("# {val:Int32}")]
+    [TestCase("/* {val:Int32} */")]
+    [TestCase("/* {val:Int32}")]
+    public void ExtractTypeHints_OnlyCommentedParameter_ReturnsEmptyDictionary(string sql)
+    {
+        Assert.That(SqlParameterTypeExtractor.ExtractTypeHints(sql), Is.Empty);
+    }
+
+    // A comment marker inside a string literal starts no comment, so the parameter after it stays visible.
+    [TestCase("SELECT {val:String} WHERE name = '--not a comment' AND {other:String}")]
+    [TestCase("SELECT {val:String} WHERE name = '#not a comment' AND {other:String}")]
+    [TestCase("SELECT {val:String} WHERE name = '/* not a comment' AND {other:String}")]
+    [TestCase("SELECT {val:String} WHERE name = '/* not a comment */' AND {other:String}")]
+    [TestCase("SELECT {val:String} WHERE name = 'it''s -- not a comment' AND {other:String}")]
+    public void ExtractTypeHints_CommentMarkerInsideStringLiteral_NotTreatedAsComment(string sql)
+    {
+        Dictionary<string, string> hints = SqlParameterTypeExtractor.ExtractTypeHints(sql);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(hints, Has.Count.EqualTo(2));
+            Assert.That(hints["val"], Is.EqualTo("String"));
+            Assert.That(hints["other"], Is.EqualTo("String"));
+        });
+    }
+
+    [Test]
+    public void ExtractTypeHints_ParameterInsideStringLiteral_IsSkipped()
+    {
+        Dictionary<string, string> hints = SqlParameterTypeExtractor.ExtractTypeHints("SELECT '{val:Int32}', {other:String}");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(hints, Has.Count.EqualTo(1));
+            Assert.That(hints["other"], Is.EqualTo("String"));
+        });
+    }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterEdgeCaseTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterEdgeCaseTests.cs
@@ -35,6 +35,19 @@ public class TcpParameterFormatterEdgeCaseTests
     }
 
     [Test]
+    public void FormatSqlText_StringFromBytes_DecodesAsUtf8()
+    {
+        // Only FixedString read the bytes, so a String parameter printed the CLR type name instead.
+        Assert.That(Format(Encoding.UTF8.GetBytes("héllo"), "String"), Is.EqualTo("héllo"));
+    }
+
+    [Test]
+    public void FormatSqlText_StringFromBytesInsideAnArray_IsEscapedAndQuoted()
+    {
+        Assert.That(Format(new[] { Encoding.UTF8.GetBytes(@"a'b\c") }, "Array(String)"), Is.EqualTo(@"['a\'b\\c']"));
+    }
+
+    [Test]
     public void FormatSqlText_DateFromADateTime_DropsTheTimeOfDay()
     {
         Assert.That(Format(new DateTime(2024, 1, 2, 3, 4, 5), "Date"), Is.EqualTo("2024-01-02"));

--- a/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterEdgeCaseTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterEdgeCaseTests.cs
@@ -173,6 +173,17 @@ public class TcpParameterFormatterEdgeCaseTests
         });
     }
 
+    [TestCase("Array(Array(Array(Int32)))", "deeper", TestName = "Declared deeper than the CLR rank")]
+    [TestCase("Array(Int32)", "shallower", TestName = "Declared shallower than the CLR rank")]
+    public void FormatSqlText_MultidimensionalArrayOfTheWrongDepth_SaysWhichWayToChangeIt(string typeName, string suggestion)
+    {
+        // Without this check the rank-3 case would emit three bracket levels for a two-level type and only the
+        // server would notice.
+        var exception = Assert.Throws<ArgumentException>(() => Format(new int[,] { { 1, 2 }, { 3, 4 } }, typeName));
+
+        Assert.That(exception.Message, Does.Contain(suggestion));
+    }
+
     [Test]
     public void FormatSqlText_UnsupportedTypeName_ThrowsNamingTheType()
     {

--- a/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterEdgeCaseTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterEdgeCaseTests.cs
@@ -136,6 +136,37 @@ public class TcpParameterFormatterEdgeCaseTests
         Assert.That(Format(value, "Array(Nullable(DateTime))"), Is.EqualTo("['2024-01-02T03:04:05',null]"));
     }
 
+    // A rank-2 array whose indices do not start at zero. GetLowerBound must drive the walk; using 0..Length
+    // reads outside the array and throws, and the emitted text must not differ from the zero-based equivalent.
+    [Test]
+    public void FormatSqlText_ArrayWithANonZeroLowerBound_ReadsFromItsOwnBounds()
+    {
+        var value = Array.CreateInstance(typeof(int), [2, 3], [5, 10]);
+        for (int i = 0; i < 2; i++)
+        {
+            for (int j = 0; j < 3; j++)
+            {
+                value.SetValue((i * 3) + j, 5 + i, 10 + j);
+            }
+        }
+
+        Assert.That(Format(value, "Array(Array(Int32))"), Is.EqualTo("[[0,1,2],[3,4,5]]"));
+    }
+
+    [TestCase(0, 5, ExpectedResult = "[]", TestName = "Rank-2 array with no rows")]
+    [TestCase(3, 0, ExpectedResult = "[[],[],[]]", TestName = "Rank-2 array of empty rows")]
+    public string FormatSqlText_ArrayWithAZeroLengthAxis_KeepsTheOtherAxis(int rows, int columns)
+        => Format(new int[rows, columns], "Array(Array(Int32))");
+
+    [Test]
+    public void FormatSqlText_MapWithKeysDifferingOnlyByCase_KeepsBoth()
+    {
+        // A ClickHouse Map is an Array(Tuple(..)), so it does not collapse keys. The formatter must not either.
+        var value = new Dictionary<string, int> { ["A"] = 1, ["a"] = 2 };
+
+        Assert.That(Format(value, "Map(String, Int32)"), Is.EqualTo("{'A' : 1,'a' : 2}"));
+    }
+
     [Test]
     public void FormatSqlText_VariantWithNoMatchingAlternative_Throws()
     {

--- a/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterEdgeCaseTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterEdgeCaseTests.cs
@@ -132,6 +132,46 @@ public class TcpParameterFormatterEdgeCaseTests
     }
 
     [Test]
+    public void FormatSqlText_VariantHoldingAByteArray_PrefersTheArrayAlternative()
+    {
+        // A byte array matched the string alternatives first, and the string arm prints the CLR type name, so
+        // the value silently became "System.Byte[]" instead of its contents.
+        Assert.That(Format(new byte[] { 1, 2 }, "Variant(Array(UInt8), String)"), Is.EqualTo("[1,2]"));
+    }
+
+    [Test]
+    public void FormatSqlText_VariantHoldingAnUnmappableValue_NamesTheVariantNotAnInventedParameter()
+    {
+        // Matching an alternative used to infer with a placeholder name, so an unmappable value reported advice
+        // about a parameter the caller never wrote.
+        var exception = Assert.Throws<ArgumentException>(() => Format(new object(), "Variant(Int64, String)"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(exception.Message, Does.Contain("no alternative"));
+            Assert.That(exception.Message, Does.Not.Contain("{variant:"));
+        });
+    }
+
+    [TestCase("1E2", ExpectedResult = "100", TestName = "Decimal in exponent form")]
+    [TestCase("1,234.50", ExpectedResult = "1234.50", TestName = "Decimal with thousands separators")]
+    [TestCase("(5)", ExpectedResult = "-5", TestName = "Decimal in accounting parentheses")]
+    [TestCase("1.2345", ExpectedResult = "1.2345", TestName = "Decimal in plain form")]
+    public string FormatSqlText_DecimalStringForm_AcceptsWhatTheHttpFormatterAccepts(string text)
+        => Format(text, "Decimal64(4)");
+
+    [Test]
+    public void FormatSqlText_Time64AtAMidpoint_RoundsToEven()
+    {
+        // decimal.ToString rounds away from zero, which put a midpoint one tick above the HTTP formatter.
+        Assert.Multiple(() =>
+        {
+            Assert.That(Format(TimeSpan.FromSeconds(0.5), "Time64(0)"), Is.EqualTo("0:00:00"));
+            Assert.That(Format(TimeSpan.FromSeconds(1.5), "Time64(0)"), Is.EqualTo("0:00:02"));
+        });
+    }
+
+    [Test]
     public void FormatSqlText_VariantHoldingANullableAlternative_MatchesThroughTheWrapper()
     {
         Assert.That(Format(7L, "Variant(Nullable(Int64), String)"), Is.EqualTo("7"));

--- a/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterEdgeCaseTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterEdgeCaseTests.cs
@@ -1,0 +1,252 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Text;
+using ClickHouse.Driver.Tcp.Numerics;
+using ClickHouse.Driver.Tcp.Parameters;
+
+namespace ClickHouse.Driver.Tcp.Tests.Parameters;
+
+// The arms a per-type round-trip does not reach: types the server never sends back as themselves, the error
+// paths, and the CLR shapes that map onto one type in more than one way.
+[TestFixture]
+public class TcpParameterFormatterEdgeCaseTests
+{
+    private static string Format(object value, string typeName)
+        => TcpParameterFormatter.FormatSqlText(value, typeName, "p");
+
+    [Test]
+    public void FormatSqlText_NothingType_ProducesTheNullMarker()
+    {
+        // Nothing holds no value, so whatever arrives formats as null.
+        Assert.That(Format("ignored", "Nothing"), Is.EqualTo(@"\N"));
+    }
+
+    [Test]
+    public void FormatSqlText_FixedStringFromBytes_DecodesAsUtf8()
+    {
+        Assert.That(Format(Encoding.UTF8.GetBytes("héllo"), "FixedString(8)"), Is.EqualTo("héllo"));
+    }
+
+    [Test]
+    public void FormatSqlText_FixedStringFromBytesInsideAnArray_IsQuoted()
+    {
+        Assert.That(Format(new[] { Encoding.UTF8.GetBytes("a'b") }, "Array(FixedString(4))"), Is.EqualTo(@"['a\'b']"));
+    }
+
+    [Test]
+    public void FormatSqlText_DateFromADateTime_DropsTheTimeOfDay()
+    {
+        Assert.That(Format(new DateTime(2024, 1, 2, 3, 4, 5), "Date"), Is.EqualTo("2024-01-02"));
+    }
+
+    [Test]
+    public void FormatSqlText_DateFromADateTimeOffset_DropsTheTimeOfDay()
+    {
+        Assert.That(Format(new DateTimeOffset(2024, 1, 2, 3, 4, 5, TimeSpan.Zero), "Date32"), Is.EqualTo("2024-01-02"));
+    }
+
+    [TestCase(3723, ExpectedResult = "1:02:03", TestName = "Time from whole seconds")]
+    [TestCase(-3723, ExpectedResult = "-1:02:03", TestName = "Time negative")]
+    [TestCase(0, ExpectedResult = "0:00:00", TestName = "Time zero")]
+    public string FormatSqlText_TimeFromSeconds_UsesTheHourMinuteSecondForm(int seconds)
+        => Format(seconds, "Time");
+
+    [Test]
+    public void FormatSqlText_TimeFromATimeSpan_RoundsToWholeSeconds()
+    {
+        Assert.That(Format(new TimeSpan(0, 1, 2, 3, 600), "Time"), Is.EqualTo("1:02:04"));
+    }
+
+    [Test]
+    public void FormatSqlText_Time64_KeepsTheDeclaredScale()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(Format(new TimeSpan(0, 1, 2, 3, 123), "Time64(3)"), Is.EqualTo("1:02:03.123"));
+            Assert.That(Format(new TimeSpan(0, 1, 2, 3, 123), "Time64(1)"), Is.EqualTo("1:02:03.1"));
+            Assert.That(Format(-new TimeSpan(0, 1, 2, 3, 123), "Time64(3)"), Is.EqualTo("-1:02:03.123"));
+        });
+    }
+
+    [Test]
+    public void FormatSqlText_NestedRows_WrapsTupleRowsInAnArray()
+    {
+        object[] rows = [(1, "x"), (2, "y")];
+
+        Assert.That(Format(rows, "Nested(a UInt8, b String)"), Is.EqualTo("[(1,'x'),(2,'y')]"));
+    }
+
+    [Test]
+    public void FormatSqlText_NestedSingleRow_FormatsAsOneTuple()
+    {
+        Assert.That(Format((1, "x"), "Nested(a UInt8, b String)"), Is.EqualTo("(1,'x')"));
+    }
+
+    [Test]
+    public void FormatSqlText_TupleFromAList_ReadsElementsByPosition()
+    {
+        Assert.That(Format(new List<object> { "a", 1 }, "Tuple(String, Int32)"), Is.EqualTo("('a',1)"));
+    }
+
+    [Test]
+    public void FormatSqlText_JsonFromAString_PassesTheTextThrough()
+    {
+        Assert.That(Format(@"{""a"":1}", "JSON"), Is.EqualTo(@"{""a"":1}"));
+    }
+
+    [Test]
+    public void FormatSqlText_JsonFromAnObject_SerializesIt()
+    {
+        Assert.That(Format(new Dictionary<string, int> { ["a"] = 1 }, "JSON"), Is.EqualTo(@"{""a"":1}"));
+    }
+
+    [Test]
+    public void FormatSqlText_NullInsideAMap_ProducesTheLiteralNull()
+    {
+        var value = new Dictionary<string, string> { ["k"] = null };
+
+        Assert.That(Format(value, "Map(String, Nullable(String))"), Is.EqualTo("{'k' : null}"));
+    }
+
+    [Test]
+    public void FormatSqlText_LowCardinalityInsideAnArray_QuotesTheInnerValue()
+    {
+        Assert.That(Format(new[] { "a" }, "Array(LowCardinality(String))"), Is.EqualTo("['a']"));
+    }
+
+    [Test]
+    public void FormatSqlText_NullableDateTimeInsideAnArray_IsQuoted()
+    {
+        object[] value = [new DateTime(2024, 1, 2, 3, 4, 5, DateTimeKind.Unspecified), null];
+
+        Assert.That(Format(value, "Array(Nullable(DateTime))"), Is.EqualTo("['2024-01-02T03:04:05',null]"));
+    }
+
+    [Test]
+    public void FormatSqlText_VariantWithNoMatchingAlternative_Throws()
+    {
+        var exception = Assert.Throws<ArgumentException>(() => Format(IPAddress.Loopback, "Variant(Int64, String)"));
+
+        Assert.That(exception.Message, Does.Contain("Variant"));
+    }
+
+    [Test]
+    public void FormatSqlText_VariantHoldingANullableAlternative_MatchesThroughTheWrapper()
+    {
+        Assert.That(Format(7L, "Variant(Nullable(Int64), String)"), Is.EqualTo("7"));
+    }
+
+    [Test]
+    public void FormatSqlText_DecimalFromAnUnparsableString_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => Format("not-a-decimal", "Decimal64(4)"));
+    }
+
+    [Test]
+    public void FormatSqlText_DateTimeFromANonDateValue_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => Format(new object(), "DateTime"));
+    }
+
+    [Test]
+    public void FormatSqlText_DateTime64WithATimezoneAndAPrecision_ReadsTheTimezoneNotThePrecision()
+    {
+        // The timezone is the last argument, so the precision digit must not be mistaken for one.
+        var instant = new DateTimeOffset(2024, 1, 2, 3, 4, 5, TimeSpan.Zero);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(Format(instant, "DateTime64(3, 'Europe/Amsterdam')"), Is.EqualTo("2024-01-02 04:04:05.0000000"));
+            Assert.That(Format(instant, "DateTime64(3)"), Is.EqualTo("2024-01-02 03:04:05.0000000"));
+        });
+    }
+
+    [Test]
+    public void FormatSqlText_BFloat16AndWideIntegers_UseInvariantText()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(Format(1.5f, "BFloat16"), Is.EqualTo("1.5"));
+            Assert.That(Format(UInt128.MaxValue, "UInt128"), Is.EqualTo("340282366920938463463374607431768211455"));
+            Assert.That(Format(new Int256(1, 0, 0, 0), "Int256"), Is.Not.Empty);
+        });
+    }
+
+    [Test]
+    public void FormatSqlText_UnsupportedTypeName_ThrowsNamingTheType()
+    {
+        var exception = Assert.Throws<ArgumentException>(() => Format(1, "Point"));
+
+        Assert.That(exception.Message, Does.Contain("Point"));
+    }
+}
+
+// The last rung of type resolution: what a value formats as when the query names no type for it.
+[TestFixture]
+public class ParameterTypeInferenceTests
+{
+    private static IEnumerable<TestCaseData> InferenceCases()
+    {
+        yield return new TestCaseData(null).Returns("Nullable(Nothing)").SetName("null");
+        yield return new TestCaseData(true).Returns("Bool").SetName("bool");
+        yield return new TestCaseData((byte)1).Returns("UInt8").SetName("byte");
+        yield return new TestCaseData((sbyte)1).Returns("Int8").SetName("sbyte");
+        yield return new TestCaseData((ushort)1).Returns("UInt16").SetName("ushort");
+        yield return new TestCaseData((short)1).Returns("Int16").SetName("short");
+        yield return new TestCaseData(1u).Returns("UInt32").SetName("uint");
+        yield return new TestCaseData(1).Returns("Int32").SetName("int");
+        yield return new TestCaseData(1ul).Returns("UInt64").SetName("ulong");
+        yield return new TestCaseData(1L).Returns("Int64").SetName("long");
+        yield return new TestCaseData((UInt128)1).Returns("UInt128").SetName("UInt128");
+        yield return new TestCaseData((Int128)1).Returns("Int128").SetName("Int128");
+        yield return new TestCaseData(1.5f).Returns("Float32").SetName("float");
+        yield return new TestCaseData(1.5d).Returns("Float64").SetName("double");
+        yield return new TestCaseData(1.2345m).Returns("Decimal128(4)").SetName("decimal keeps its scale");
+        yield return new TestCaseData("x").Returns("String").SetName("string");
+        yield return new TestCaseData('c').Returns("String").SetName("char");
+        yield return new TestCaseData(new byte[] { 1 }).Returns("String").SetName("byte array");
+        yield return new TestCaseData(Guid.Empty).Returns("UUID").SetName("Guid");
+        yield return new TestCaseData(new DateOnly(2024, 1, 2)).Returns("Date").SetName("DateOnly");
+        yield return new TestCaseData(TimeSpan.Zero).Returns("Time64(9)").SetName("TimeSpan");
+        yield return new TestCaseData(new DateTime(2024, 1, 2)).Returns("DateTime64(7, 'UTC')").SetName("DateTime");
+        yield return new TestCaseData(IPAddress.Parse("1.2.3.4")).Returns("IPv4").SetName("IPv4 address");
+        yield return new TestCaseData(IPAddress.Parse("::1")).Returns("IPv6").SetName("IPv6 address");
+        yield return new TestCaseData(new[] { 1, 2 }).Returns("Array(Int32)").SetName("array");
+        yield return new TestCaseData(Array.Empty<int>()).Returns("Array(Nullable(String))").SetName("empty array");
+        yield return new TestCaseData(new int?[] { null, 5 }).Returns("Array(Int32)").SetName("array skips leading nulls");
+        yield return new TestCaseData(("a", 1)).Returns("Tuple(String, Int32)").SetName("tuple");
+    }
+
+    [TestCaseSource(nameof(InferenceCases))]
+    public string Infer_ValueWithNoDeclaredType_MapsToItsClickHouseType(object value)
+        => ParameterTypeInference.Infer(value, "p");
+
+    [Test]
+    public void Infer_Dictionary_MapsToAMapOfTheFirstPairsTypes()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(ParameterTypeInference.Infer(new Dictionary<string, int> { ["a"] = 1 }, "p"), Is.EqualTo("Map(String, Int32)"));
+            Assert.That(ParameterTypeInference.Infer(new Dictionary<string, int>(), "p"), Is.EqualTo("Map(String, String)"));
+        });
+    }
+
+    [Test]
+    public void Infer_ClickHouseDecimal_KeepsItsOwnScale()
+    {
+        Assert.That(ParameterTypeInference.Infer(new ClickHouseDecimal(12345, 4), "p"), Is.EqualTo("Decimal128(4)"));
+    }
+
+    [Test]
+    public void Infer_UnmappableValue_ThrowsNamingTheParameterAndTheRemedies()
+    {
+        var exception = Assert.Throws<ArgumentException>(() => ParameterTypeInference.Infer(new object(), "widget"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(exception.Message, Does.Contain("widget"));
+            Assert.That(exception.Message, Does.Contain("ClickHouseType"));
+        });
+    }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterEdgeCaseTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterEdgeCaseTests.cs
@@ -136,8 +136,7 @@ public class TcpParameterFormatterEdgeCaseTests
         Assert.That(Format(value, "Array(Nullable(DateTime))"), Is.EqualTo("['2024-01-02T03:04:05',null]"));
     }
 
-    // A rank-2 array whose indices do not start at zero. GetLowerBound must drive the walk; using 0..Length
-    // reads outside the array and throws, and the emitted text must not differ from the zero-based equivalent.
+    // Non-zero lower bounds require GetLowerBound; zero-based indexing would throw.
     [Test]
     public void FormatSqlText_ArrayWithANonZeroLowerBound_ReadsFromItsOwnBounds()
     {
@@ -167,8 +166,7 @@ public class TcpParameterFormatterEdgeCaseTests
         Assert.That(Format(value, "Map(String, Int32)"), Is.EqualTo("{'A' : 1,'a' : 2}"));
     }
 
-    // A value that names an instant cannot go into a type with no timezone without the instant moving, so the
-    // formatter refuses instead of guessing. See RequireDeclaredTimezone.
+    // Refuse instants without a declared timezone rather than guessing the session timezone.
     private static IEnumerable<TestCaseData> InstantWithoutATimezoneCases()
     {
         yield return new TestCaseData(new DateTime(2024, 1, 2, 3, 4, 5, DateTimeKind.Utc), "DateTime")
@@ -239,16 +237,14 @@ public class TcpParameterFormatterEdgeCaseTests
     [Test]
     public void FormatSqlText_VariantHoldingAByteArray_PrefersTheArrayAlternative()
     {
-        // A byte array matched the string alternatives first, and the string arm prints the CLR type name, so
-        // the value silently became "System.Byte[]" instead of its contents.
+        // Prefer Array for byte[] so String does not format the CLR type name.
         Assert.That(Format(new byte[] { 1, 2 }, "Variant(Array(UInt8), String)"), Is.EqualTo("[1,2]"));
     }
 
     [Test]
     public void FormatSqlText_VariantHoldingAnUnmappableValue_NamesTheVariantNotAnInventedParameter()
     {
-        // Matching an alternative used to infer with a placeholder name, so an unmappable value reported advice
-        // about a parameter the caller never wrote.
+        // Report the declared Variant, not an internal placeholder used during matching.
         var exception = Assert.Throws<ArgumentException>(() => Format(new object(), "Variant(Int64, String)"));
 
         Assert.Multiple(() =>
@@ -268,7 +264,7 @@ public class TcpParameterFormatterEdgeCaseTests
     [Test]
     public void FormatSqlText_Time64AtAMidpoint_RoundsToEven()
     {
-        // decimal.ToString rounds away from zero, which put a midpoint one tick above the HTTP formatter.
+        // Explicit pre-rounding is required because decimal formatting rounds midpoints away from zero.
         Assert.Multiple(() =>
         {
             Assert.That(Format(TimeSpan.FromSeconds(0.5), "Time64(0)"), Is.EqualTo("0:00:00"));
@@ -276,8 +272,7 @@ public class TcpParameterFormatterEdgeCaseTests
         });
     }
 
-    // Matching an alternative on its outer name alone let the first Array arm take any sequence, so a
-    // string[] was formatted as Array(Int32) and every element went out unquoted.
+    // Match Array alternatives by element type, not only by the outer name.
     [TestCase("Variant(Array(Int32), Array(String))", ExpectedResult = "['a','b']", TestName = "Array picks by element type")]
     [TestCase("Variant(Array(String), Array(Int32))", ExpectedResult = "['a','b']", TestName = "Array picks by element type, declared the other way round")]
     public string FormatSqlText_VariantOfTwoArrays_PicksTheOneWhoseElementsFit(string typeName)
@@ -321,8 +316,7 @@ public class TcpParameterFormatterEdgeCaseTests
     [Test]
     public void FormatSqlText_VariantWithAnEmptyArray_TakesTheFirstArrayAlternative()
     {
-        // Nothing in an empty sequence can contradict an element type, so the first Array arm is as good as
-        // any. Pinned so the recursive match does not start rejecting empties.
+        // An empty sequence fits any element type, so select the first Array alternative.
         Assert.That(Format(Array.Empty<string>(), "Variant(Array(Int32), Array(String))"), Is.EqualTo("[]"));
     }
 
@@ -384,8 +378,7 @@ public class TcpParameterFormatterEdgeCaseTests
     [Test]
     public void FormatSqlText_MapGivenAsKeyValuePairs_FormatsInSequenceOrder()
     {
-        // The shape a Map column reads back as. Order is kept, and duplicate keys are not collapsed, which is
-        // why the read path uses pairs rather than a dictionary in the first place.
+        // Preserve the ordered, duplicate-key Map shape returned by the read path.
         KeyValuePair<string, int>[] pairs = [new("b", 2), new("a", 1), new("b", 3)];
 
         Assert.That(Format(pairs, "Map(String, Int32)"), Is.EqualTo("{'b' : 2,'a' : 1,'b' : 3}"));
@@ -418,9 +411,7 @@ public class TcpParameterFormatterEdgeCaseTests
     [Test]
     public void FormatSqlText_DateTime64WithATimezoneAndAPrecision_ReadsTheTimezoneNotThePrecision()
     {
-        // The timezone is the last argument, so the precision digit must not be mistaken for one. The pair
-        // shows both halves: the named zone shifts the value, and the lone digit counts as no zone at all —
-        // if it were read as one, the second call would format instead of refusing.
+        // The final argument is a timezone only when it is not the precision.
         var instant = new DateTimeOffset(2024, 1, 2, 3, 4, 5, TimeSpan.Zero);
 
         Assert.Multiple(() =>
@@ -461,7 +452,7 @@ public class TcpParameterFormatterEdgeCaseTests
     }
 }
 
-// The last rung of type resolution: what a value formats as when the query names no type for it.
+// Retained for future client-side placeholders and used today for Variant matching.
 [TestFixture]
 public class ParameterTypeInferenceTests
 {

--- a/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterEdgeCaseTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterEdgeCaseTests.cs
@@ -355,6 +355,20 @@ public class TcpParameterFormatterEdgeCaseTests
         });
     }
 
+    // Accepts saw no byte payload in a ReadOnlyMemory, so a text alternative refused it. With a JSON
+    // alternative present the fallback took it instead and serialized it as base64.
+    [TestCase("Variant(String, Int64)", ExpectedResult = "AB", TestName = "Variant holding a ReadOnlyMemory")]
+    [TestCase("Variant(Int64, FixedString(2))", ExpectedResult = "AB", TestName = "Variant with only a FixedString alternative")]
+    [TestCase("Variant(String, JSON)", ExpectedResult = "AB", TestName = "Variant preferring String to the JSON fallback")]
+    public string FormatSqlText_VariantHoldingAReadOnlyMemory_PicksTheTextAlternative(string typeName)
+        => Format(new ReadOnlyMemory<byte>(Encoding.UTF8.GetBytes("AB")), typeName);
+
+    [Test]
+    public void Infer_ReadOnlyMemory_MapsToStringAsAByteArrayDoes()
+    {
+        Assert.That(ParameterTypeInference.Infer(new ReadOnlyMemory<byte>(new byte[] { 1 }), "p"), Is.EqualTo("String"));
+    }
+
     [Test]
     public void FormatSqlText_ReadOnlyMemoryThatIsNotValidUtf8_UsesByteEscapes()
     {

--- a/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterEdgeCaseTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterEdgeCaseTests.cs
@@ -276,6 +276,72 @@ public class TcpParameterFormatterEdgeCaseTests
         });
     }
 
+    // Matching an alternative on its outer name alone let the first Array arm take any sequence, so a
+    // string[] was formatted as Array(Int32) and every element went out unquoted.
+    [TestCase("Variant(Array(Int32), Array(String))", ExpectedResult = "['a','b']", TestName = "Array picks by element type")]
+    [TestCase("Variant(Array(String), Array(Int32))", ExpectedResult = "['a','b']", TestName = "Array picks by element type, declared the other way round")]
+    public string FormatSqlText_VariantOfTwoArrays_PicksTheOneWhoseElementsFit(string typeName)
+        => Format(new[] { "a", "b" }, typeName);
+
+    [Test]
+    public void FormatSqlText_VariantOfTwoArraysHoldingIntegers_PicksTheIntegerArray()
+    {
+        Assert.That(Format(new[] { 1, 2 }, "Variant(Array(String), Array(Int32))"), Is.EqualTo("[1,2]"));
+    }
+
+    [Test]
+    public void FormatSqlText_VariantOfTwoMaps_PicksTheOneWhoseValuesFit()
+    {
+        var value = new Dictionary<string, string> { ["k"] = "v" };
+
+        Assert.That(Format(value, "Variant(Map(String, Int32), Map(String, String))"), Is.EqualTo("{'k' : 'v'}"));
+    }
+
+    [Test]
+    public void FormatSqlText_VariantOfTwoTuples_PicksTheOneWhoseElementsFit()
+    {
+        Assert.That(Format(("a", 1), "Variant(Tuple(Int32, Int32), Tuple(String, Int32))"), Is.EqualTo("('a',1)"));
+    }
+
+    [Test]
+    public void FormatSqlText_VariantOfTuplesOfDifferentArity_PicksTheMatchingArity()
+    {
+        Assert.That(Format((1, 2), "Variant(Tuple(Int32, Int32, Int32), Tuple(Int32, Int32))"), Is.EqualTo("(1,2)"));
+    }
+
+    [Test]
+    public void FormatSqlText_VariantWhereNoArrayElementTypeFits_Throws()
+    {
+        var exception = Assert.Throws<ArgumentException>(
+            () => Format(new[] { "a" }, "Variant(Array(Int32), Array(Date))"));
+
+        Assert.That(exception.Message, Does.Contain("no alternative"));
+    }
+
+    [Test]
+    public void FormatSqlText_VariantWithAnEmptyArray_TakesTheFirstArrayAlternative()
+    {
+        // Nothing in an empty sequence can contradict an element type, so the first Array arm is as good as
+        // any. Pinned so the recursive match does not start rejecting empties.
+        Assert.That(Format(Array.Empty<string>(), "Variant(Array(Int32), Array(String))"), Is.EqualTo("[]"));
+    }
+
+    [Test]
+    public void FormatSqlText_MapGivenAsKeyValuePairs_FormatsInSequenceOrder()
+    {
+        // The shape a Map column reads back as. Order is kept, and duplicate keys are not collapsed, which is
+        // why the read path uses pairs rather than a dictionary in the first place.
+        KeyValuePair<string, int>[] pairs = [new("b", 2), new("a", 1), new("b", 3)];
+
+        Assert.That(Format(pairs, "Map(String, Int32)"), Is.EqualTo("{'b' : 2,'a' : 1,'b' : 3}"));
+    }
+
+    [Test]
+    public void FormatSqlText_EmptyKeyValuePairsForAMap_ProducesTheEmptyLiteral()
+    {
+        Assert.That(Format(Array.Empty<KeyValuePair<string, int>>(), "Map(String, Int32)"), Is.EqualTo("{}"));
+    }
+
     [Test]
     public void FormatSqlText_VariantHoldingANullableAlternative_MatchesThroughTheWrapper()
     {

--- a/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterEdgeCaseTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterEdgeCaseTests.cs
@@ -300,6 +300,70 @@ public class TcpParameterFormatterEdgeCaseTests
     }
 
     [Test]
+    public void FormatSqlText_VariantHoldingAByteArray_ChecksTheArrayElementType()
+    {
+        // Matching an Array alternative by name alone let Array(String) take the bytes and print them as
+        // quoted decimals, which the server stores without complaint because it is a valid Array(String).
+        Assert.That(Format(new byte[] { 65, 66 }, "Variant(Array(String), Array(UInt8))"), Is.EqualTo("[65,66]"));
+    }
+
+    [Test]
+    public void FormatSqlText_VariantWithOnlyATextArrayAlternative_RejectsAByteArray()
+    {
+        var exception = Assert.Throws<ArgumentException>(() => Format(new byte[] { 65 }, "Variant(Array(String), Int64)"));
+
+        Assert.That(exception.Message, Does.Contain("no alternative"));
+    }
+
+    // A geo name stands for a Tuple/Array shape, so matching it by name rejected every value even though the
+    // formatter writes that shape. Ring nests, which checks that the expansion recurses.
+    [TestCase("Variant(Point, String)", ExpectedResult = "(1.5,2.5)", TestName = "Variant holding a Point")]
+    [TestCase("Variant(String, Point)", ExpectedResult = "(1.5,2.5)", TestName = "Variant holding a Point declared last")]
+    public string FormatSqlText_VariantHoldingAPoint_PicksTheGeoAlternative(string typeName)
+        => Format((1.5, 2.5), typeName);
+
+    [Test]
+    public void FormatSqlText_VariantHoldingARing_PicksTheGeoAlternative()
+    {
+        Assert.That(Format(new[] { (1.0, 2.0), (3.0, 4.0) }, "Variant(Ring, String)"), Is.EqualTo("[(1,2),(3,4)]"));
+    }
+
+    [Test]
+    public void FormatSqlText_VariantHoldingAQBit_PicksTheQBitAlternative()
+    {
+        Assert.That(Format(new[] { 1f, 2f }, "Variant(QBit(Float32, 2), String)"), Is.EqualTo("[1,2]"));
+    }
+
+    [Test]
+    public void FormatSqlText_VariantWithAQBitOfAnotherElementType_RejectsTheValue()
+    {
+        var exception = Assert.Throws<ArgumentException>(() => Format(new[] { 1f, 2f }, "Variant(QBit(Int8, 2), Int64)"));
+
+        Assert.That(exception.Message, Does.Contain("no alternative"));
+    }
+
+    [Test]
+    public void FormatSqlText_StringFromReadOnlyMemory_ReadsTheBytes()
+    {
+        // Only byte[] was read, so a ReadOnlyMemory<byte> printed the CLR type name instead of its contents.
+        ReadOnlyMemory<byte> memory = Encoding.UTF8.GetBytes("héllo");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(Format(memory, "String"), Is.EqualTo("héllo"));
+            Assert.That(Format(memory, "FixedString(8)"), Is.EqualTo("héllo"));
+        });
+    }
+
+    [Test]
+    public void FormatSqlText_ReadOnlyMemoryThatIsNotValidUtf8_UsesByteEscapes()
+    {
+        ReadOnlyMemory<byte> memory = new byte[] { 0xFF, 0xFE, 0x41 };
+
+        Assert.That(Format(memory, "String"), Is.EqualTo(@"\xff\xfe\x41"));
+    }
+
+    [Test]
     public void FormatSqlText_VariantHoldingAnUnmappableValue_NamesTheVariantNotAnInventedParameter()
     {
         // Report the declared Variant, not an internal placeholder used during matching.

--- a/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterEdgeCaseTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterEdgeCaseTests.cs
@@ -167,6 +167,67 @@ public class TcpParameterFormatterEdgeCaseTests
         Assert.That(Format(value, "Map(String, Int32)"), Is.EqualTo("{'A' : 1,'a' : 2}"));
     }
 
+    // A value that names an instant cannot go into a type with no timezone without the instant moving, so the
+    // formatter refuses instead of guessing. See RequireDeclaredTimezone.
+    private static IEnumerable<TestCaseData> InstantWithoutATimezoneCases()
+    {
+        yield return new TestCaseData(new DateTime(2024, 1, 2, 3, 4, 5, DateTimeKind.Utc), "DateTime")
+            .SetName("DateTime of Kind Utc");
+        yield return new TestCaseData(new DateTime(2024, 1, 2, 3, 4, 5, DateTimeKind.Local), "DateTime")
+            .SetName("DateTime of Kind Local");
+        yield return new TestCaseData(new DateTimeOffset(2024, 1, 2, 3, 4, 5, TimeSpan.FromHours(9)), "DateTime")
+            .SetName("DateTimeOffset");
+        yield return new TestCaseData(new DateTime(2024, 1, 2, 3, 4, 5, DateTimeKind.Utc), "DateTime64(3)")
+            .SetName("DateTime64, whose digit is a precision and not a timezone");
+        yield return new TestCaseData(new[] { new DateTime(2024, 1, 2, 3, 4, 5, DateTimeKind.Utc) }, "Array(DateTime)")
+            .SetName("Inside a composite");
+        yield return new TestCaseData(new DateTime(2024, 1, 2, 3, 4, 5, DateTimeKind.Utc), "Nullable(DateTime)")
+            .SetName("Through a Nullable");
+    }
+
+    [TestCaseSource(nameof(InstantWithoutATimezoneCases))]
+    public void FormatSqlText_InstantForATypeWithNoTimezone_ThrowsAndSaysHowToFixIt(object value, string typeName)
+    {
+        var exception = Assert.Throws<ArgumentException>(() => Format(value, typeName));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(exception.Message, Does.Contain("names an instant"), "says what about the value is the problem");
+            Assert.That(exception.Message, Does.Contain("declares no timezone"), "says what about the type is the problem");
+            Assert.That(exception.Message, Does.Contain("session timezone"), "says what the server would do instead");
+            Assert.That(exception.Message, Does.Contain("'UTC'"), "shows the type to write");
+            Assert.That(exception.Message, Does.Contain("Kind=Unspecified"), "offers the other way out");
+            Assert.That(exception.Message, Does.Contain("Parameter 'p'"), "names the parameter");
+        });
+    }
+
+    [Test]
+    public void FormatSqlText_InstantForADateTime64WithNoTimezone_SuggestsAScaleAndATimezone()
+    {
+        // The suggestion has to stay valid for the type it is about: DateTime64('UTC') is not a type.
+        var exception = Assert.Throws<ArgumentException>(
+            () => Format(new DateTime(2024, 1, 2, 0, 0, 0, DateTimeKind.Utc), "DateTime64(3)"));
+
+        Assert.That(exception.Message, Does.Contain("DateTime64(3, 'UTC')"));
+    }
+
+    [TestCase("DateTime('UTC')", TestName = "A named timezone")]
+    [TestCase("DateTime('Europe/Amsterdam')", TestName = "A timezone that is not UTC")]
+    [TestCase("DateTime64(3, 'UTC')", TestName = "A scale and a timezone")]
+    public void FormatSqlText_InstantForATypeThatDeclaresATimezone_IsAccepted(string typeName)
+    {
+        Assert.DoesNotThrow(() => Format(new DateTime(2024, 1, 2, 3, 4, 5, DateTimeKind.Utc), typeName));
+    }
+
+    [TestCase("DateTime", ExpectedResult = "2024-01-02T03:04:05", TestName = "DateTime keeps the wall clock")]
+    [TestCase("DateTime64(3)", ExpectedResult = "2024-01-02 03:04:05.0000000", TestName = "DateTime64 keeps the wall clock")]
+    public string FormatSqlText_UnspecifiedKindForATypeWithNoTimezone_StillPasses(string typeName)
+    {
+        // Unspecified means a wall-clock time with no instant attached, which is exactly what a type with no
+        // timezone carries. Nothing is lost, so this stays legal.
+        return Format(new DateTime(2024, 1, 2, 3, 4, 5, DateTimeKind.Unspecified), typeName);
+    }
+
     [Test]
     public void FormatSqlText_VariantWithNoMatchingAlternative_Throws()
     {
@@ -236,13 +297,15 @@ public class TcpParameterFormatterEdgeCaseTests
     [Test]
     public void FormatSqlText_DateTime64WithATimezoneAndAPrecision_ReadsTheTimezoneNotThePrecision()
     {
-        // The timezone is the last argument, so the precision digit must not be mistaken for one.
+        // The timezone is the last argument, so the precision digit must not be mistaken for one. The pair
+        // shows both halves: the named zone shifts the value, and the lone digit counts as no zone at all —
+        // if it were read as one, the second call would format instead of refusing.
         var instant = new DateTimeOffset(2024, 1, 2, 3, 4, 5, TimeSpan.Zero);
 
         Assert.Multiple(() =>
         {
             Assert.That(Format(instant, "DateTime64(3, 'Europe/Amsterdam')"), Is.EqualTo("2024-01-02 04:04:05.0000000"));
-            Assert.That(Format(instant, "DateTime64(3)"), Is.EqualTo("2024-01-02 03:04:05.0000000"));
+            Assert.Throws<ArgumentException>(() => Format(instant, "DateTime64(3)"));
         });
     }
 

--- a/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterEdgeCaseTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterEdgeCaseTests.cs
@@ -327,6 +327,61 @@ public class TcpParameterFormatterEdgeCaseTests
     }
 
     [Test]
+    public void FormatSqlText_VariantHoldingKeyValuePairs_PicksTheMapAlternative()
+    {
+        // A pair sequence is also an IEnumerable, so without its own arm the Array alternative would claim it.
+        KeyValuePair<string, int>[] pairs = [new("a", 1)];
+
+        Assert.That(Format(pairs, "Variant(Array(String), Map(String, Int32))"), Is.EqualTo("{'a' : 1}"));
+    }
+
+    [Test]
+    public void FormatSqlText_VariantHoldingKeyValuePairsWhoseValuesDoNotFit_Throws()
+    {
+        KeyValuePair<string, string>[] pairs = [new("a", "b")];
+
+        var exception = Assert.Throws<ArgumentException>(() => Format(pairs, "Variant(Map(String, Int32), Int64)"));
+
+        Assert.That(exception.Message, Does.Contain("no alternative"));
+    }
+
+    [TestCase("Variant(Int64, String)", TestName = "A dictionary where no alternative is a Map")]
+    public void FormatSqlText_VariantWhereACompositeMatchesNoAlternative_Throws(string typeName)
+    {
+        var value = new Dictionary<string, int> { ["a"] = 1 };
+
+        var exception = Assert.Throws<ArgumentException>(() => Format(value, typeName));
+
+        Assert.That(exception.Message, Does.Contain("no alternative"));
+    }
+
+    [Test]
+    public void FormatSqlText_VariantHoldingATupleWhereNoAlternativeIsATuple_Throws()
+    {
+        var exception = Assert.Throws<ArgumentException>(() => Format(("a", 1), "Variant(Int64, String)"));
+
+        Assert.That(exception.Message, Does.Contain("no alternative"));
+    }
+
+    [Test]
+    public void FormatSqlText_VariantHoldingASequenceWhereNoAlternativeIsAnArray_Throws()
+    {
+        // The sequence never reaches the recursive Array arm, so the fallback name comparison is what has to
+        // reject it.
+        var exception = Assert.Throws<ArgumentException>(() => Format(new[] { 1, 2 }, "Variant(Int64, String)"));
+
+        Assert.That(exception.Message, Does.Contain("no alternative"));
+    }
+
+    [Test]
+    public void FormatSqlText_MapTypeGivenAValueThatIsNeitherDictionaryNorPairs_Throws()
+    {
+        var exception = Assert.Throws<ArgumentException>(() => Format(42, "Map(String, Int32)"));
+
+        Assert.That(exception.Message, Does.Contain("Map(String, Int32)"));
+    }
+
+    [Test]
     public void FormatSqlText_MapGivenAsKeyValuePairs_FormatsInSequenceOrder()
     {
         // The shape a Map column reads back as. Order is kept, and duplicate keys are not collapsed, which is

--- a/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterEdgeCaseTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterEdgeCaseTests.cs
@@ -115,6 +115,64 @@ public class TcpParameterFormatterEdgeCaseTests
     }
 
     [Test]
+    public void FormatSqlText_VariantHoldingJson_PicksTheJsonAlternative()
+    {
+        var value = new Dictionary<string, int> { ["a"] = 1 };
+
+        Assert.That(Format(value, "Variant(JSON, UInt64)"), Is.EqualTo(@"{""a"":1}"));
+    }
+
+    [Test]
+    public void FormatSqlText_VariantHoldingAMap_PrefersItToJson()
+    {
+        var value = new Dictionary<string, int> { ["a"] = 1 };
+
+        Assert.That(
+            Format(value, "Variant(JSON, Map(String, Int32))"),
+            Is.EqualTo("{'a' : 1}"));
+    }
+
+    [Test]
+    public void FormatSqlText_VariantHoldingAMapThatDoesNotFit_FallsBackToJson()
+    {
+        var value = new Dictionary<string, string> { ["a"] = "x" };
+
+        Assert.That(
+            Format(value, "Variant(Map(String, Int32), JSON)"),
+            Is.EqualTo(@"{""a"":""x""}"));
+    }
+
+    [Test]
+    public void FormatSqlText_VariantWithAnUnrelatedArrayAlternative_PreservesTheJsonTupleShape()
+    {
+        object value = Tuple.Create(1, "x");
+
+        Assert.That(
+            Format(value, "Variant(JSON, Array(Int32))"),
+            Is.EqualTo(@"{""Item1"":1,""Item2"":""x""}"));
+    }
+
+    [Test]
+    public void FormatSqlText_VariantWithARejectedMapAlternative_PreservesTheNestedJsonTupleShape()
+    {
+        var value = new Dictionary<string, Tuple<int, string>> { ["a"] = Tuple.Create(1, "x") };
+
+        Assert.That(
+            Format(value, "Variant(Map(String, Int32), JSON)"),
+            Is.EqualTo(@"{""a"":{""Item1"":1,""Item2"":""x""}}"));
+    }
+
+    [Test]
+    public void FormatSqlText_VariantWithARejectedArrayAlternative_PreservesTheNestedJsonTupleShape()
+    {
+        Tuple<int, string>[] value = [Tuple.Create(1, "x")];
+
+        Assert.That(
+            Format(value, "Variant(Array(Int32), JSON)"),
+            Is.EqualTo(@"[{""Item1"":1,""Item2"":""x""}]"));
+    }
+
+    [Test]
     public void FormatSqlText_NullInsideAMap_ProducesTheLiteralNull()
     {
         var value = new Dictionary<string, string> { ["k"] = null };
@@ -450,6 +508,7 @@ public class TcpParameterFormatterEdgeCaseTests
 
         Assert.That(exception.Message, Does.Contain("Point"));
     }
+
 }
 
 // Retained for future client-side placeholders and used today for Variant matching.

--- a/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterEdgeCaseTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterEdgeCaseTests.cs
@@ -22,30 +22,11 @@ public class TcpParameterFormatterEdgeCaseTests
         Assert.That(Format("ignored", "Nothing"), Is.EqualTo(@"\N"));
     }
 
-    [Test]
-    public void FormatSqlText_FixedStringFromBytes_DecodesAsUtf8()
-    {
-        Assert.That(Format(Encoding.UTF8.GetBytes("héllo"), "FixedString(8)"), Is.EqualTo("héllo"));
-    }
-
-    [Test]
-    public void FormatSqlText_FixedStringFromBytesInsideAnArray_IsQuoted()
-    {
-        Assert.That(Format(new[] { Encoding.UTF8.GetBytes("a'b") }, "Array(FixedString(4))"), Is.EqualTo(@"['a\'b']"));
-    }
-
-    [Test]
-    public void FormatSqlText_StringFromBytes_DecodesAsUtf8()
-    {
-        // Only FixedString read the bytes, so a String parameter printed the CLR type name instead.
-        Assert.That(Format(Encoding.UTF8.GetBytes("héllo"), "String"), Is.EqualTo("héllo"));
-    }
-
-    [Test]
-    public void FormatSqlText_StringFromBytesInsideAnArray_IsEscapedAndQuoted()
-    {
-        Assert.That(Format(new[] { Encoding.UTF8.GetBytes(@"a'b\c") }, "Array(String)"), Is.EqualTo(@"['a\'b\\c']"));
-    }
+    // A byte payload inside a composite is escaped and quoted like text, under either of the two text names.
+    [TestCase("Array(String)", ExpectedResult = @"['a\'b\\c']", TestName = "String elements from bytes")]
+    [TestCase("Array(FixedString(5))", ExpectedResult = @"['a\'b\\c']", TestName = "FixedString elements from bytes")]
+    public string FormatSqlText_ByteArrayInsideAnArray_IsEscapedAndQuoted(string typeName)
+        => Format(new[] { Encoding.UTF8.GetBytes(@"a'b\c") }, typeName);
 
     [Test]
     public void FormatSqlText_DateFromADateTime_DropsTheTimeOfDay()
@@ -83,14 +64,6 @@ public class TcpParameterFormatterEdgeCaseTests
     }
 
     [Test]
-    public void FormatSqlText_NestedRows_WrapsTupleRowsInAnArray()
-    {
-        object[] rows = [(1, "x"), (2, "y")];
-
-        Assert.That(Format(rows, "Nested(a UInt8, b String)"), Is.EqualTo("[(1,'x'),(2,'y')]"));
-    }
-
-    [Test]
     public void FormatSqlText_NestedSingleRow_FormatsAsOneTuple()
     {
         Assert.That(Format((1, "x"), "Nested(a UInt8, b String)"), Is.EqualTo("(1,'x')"));
@@ -100,26 +73,6 @@ public class TcpParameterFormatterEdgeCaseTests
     public void FormatSqlText_TupleFromAList_ReadsElementsByPosition()
     {
         Assert.That(Format(new List<object> { "a", 1 }, "Tuple(String, Int32)"), Is.EqualTo("('a',1)"));
-    }
-
-    [Test]
-    public void FormatSqlText_JsonFromAString_PassesTheTextThrough()
-    {
-        Assert.That(Format(@"{""a"":1}", "JSON"), Is.EqualTo(@"{""a"":1}"));
-    }
-
-    [Test]
-    public void FormatSqlText_JsonFromAnObject_SerializesIt()
-    {
-        Assert.That(Format(new Dictionary<string, int> { ["a"] = 1 }, "JSON"), Is.EqualTo(@"{""a"":1}"));
-    }
-
-    [Test]
-    public void FormatSqlText_VariantHoldingJson_PicksTheJsonAlternative()
-    {
-        var value = new Dictionary<string, int> { ["a"] = 1 };
-
-        Assert.That(Format(value, "Variant(JSON, UInt64)"), Is.EqualTo(@"{""a"":1}"));
     }
 
     [Test]
@@ -178,12 +131,6 @@ public class TcpParameterFormatterEdgeCaseTests
         var value = new Dictionary<string, string> { ["k"] = null };
 
         Assert.That(Format(value, "Map(String, Nullable(String))"), Is.EqualTo("{'k' : null}"));
-    }
-
-    [Test]
-    public void FormatSqlText_LowCardinalityInsideAnArray_QuotesTheInnerValue()
-    {
-        Assert.That(Format(new[] { "a" }, "Array(LowCardinality(String))"), Is.EqualTo("['a']"));
     }
 
     [Test]
@@ -267,23 +214,6 @@ public class TcpParameterFormatterEdgeCaseTests
         Assert.That(exception.Message, Does.Contain("DateTime64(3, 'UTC')"));
     }
 
-    [TestCase("DateTime('UTC')", TestName = "A named timezone")]
-    [TestCase("DateTime('Europe/Amsterdam')", TestName = "A timezone that is not UTC")]
-    [TestCase("DateTime64(3, 'UTC')", TestName = "A scale and a timezone")]
-    public void FormatSqlText_InstantForATypeThatDeclaresATimezone_IsAccepted(string typeName)
-    {
-        Assert.DoesNotThrow(() => Format(new DateTime(2024, 1, 2, 3, 4, 5, DateTimeKind.Utc), typeName));
-    }
-
-    [TestCase("DateTime", ExpectedResult = "2024-01-02T03:04:05", TestName = "DateTime keeps the wall clock")]
-    [TestCase("DateTime64(3)", ExpectedResult = "2024-01-02 03:04:05.0000000", TestName = "DateTime64 keeps the wall clock")]
-    public string FormatSqlText_UnspecifiedKindForATypeWithNoTimezone_StillPasses(string typeName)
-    {
-        // Unspecified means a wall-clock time with no instant attached, which is exactly what a type with no
-        // timezone carries. Nothing is lost, so this stays legal.
-        return Format(new DateTime(2024, 1, 2, 3, 4, 5, DateTimeKind.Unspecified), typeName);
-    }
-
     [Test]
     public void FormatSqlText_VariantWithNoMatchingAlternative_Throws()
     {
@@ -315,17 +245,12 @@ public class TcpParameterFormatterEdgeCaseTests
         Assert.That(exception.Message, Does.Contain("no alternative"));
     }
 
-    // A geo name stands for a Tuple/Array shape, so matching it by name rejected every value even though the
-    // formatter writes that shape. Ring nests, which checks that the expansion recurses.
-    [TestCase("Variant(Point, String)", ExpectedResult = "(1.5,2.5)", TestName = "Variant holding a Point")]
-    [TestCase("Variant(String, Point)", ExpectedResult = "(1.5,2.5)", TestName = "Variant holding a Point declared last")]
-    public string FormatSqlText_VariantHoldingAPoint_PicksTheGeoAlternative(string typeName)
-        => Format((1.5, 2.5), typeName);
-
     [Test]
-    public void FormatSqlText_VariantHoldingARing_PicksTheGeoAlternative()
+    public void FormatSqlText_VariantHoldingAPointDeclaredLast_StillPicksTheGeoAlternative()
     {
-        Assert.That(Format(new[] { (1.0, 2.0), (3.0, 4.0) }, "Variant(Ring, String)"), Is.EqualTo("[(1,2),(3,4)]"));
+        // A geo name stands for a Tuple/Array shape, and no CLR type infers to "Point", so matching has to
+        // compare shapes. Declaration order must not decide it either.
+        Assert.That(Format((1.5, 2.5), "Variant(String, Point)"), Is.EqualTo("(1.5,2.5)"));
     }
 
     [Test]
@@ -340,19 +265,6 @@ public class TcpParameterFormatterEdgeCaseTests
         var exception = Assert.Throws<ArgumentException>(() => Format(new[] { 1f, 2f }, "Variant(QBit(Int8, 2), Int64)"));
 
         Assert.That(exception.Message, Does.Contain("no alternative"));
-    }
-
-    [Test]
-    public void FormatSqlText_StringFromReadOnlyMemory_ReadsTheBytes()
-    {
-        // Only byte[] was read, so a ReadOnlyMemory<byte> printed the CLR type name instead of its contents.
-        ReadOnlyMemory<byte> memory = Encoding.UTF8.GetBytes("héllo");
-
-        Assert.Multiple(() =>
-        {
-            Assert.That(Format(memory, "String"), Is.EqualTo("héllo"));
-            Assert.That(Format(memory, "FixedString(8)"), Is.EqualTo("héllo"));
-        });
     }
 
     // Accepts saw no byte payload in a ReadOnlyMemory, so a text alternative refused it. With a JSON
@@ -557,14 +469,44 @@ public class TcpParameterFormatterEdgeCaseTests
         });
     }
 
-    [Test]
-    public void FormatSqlText_BFloat16AndWideIntegers_UseInvariantText()
+    // A BFloat16 holds the top 16 bits of a 32-bit float, so only a float reaches the server intact. The
+    // server refuses none of these: it narrows a wider value with no error, and turns a value outside the
+    // float range into an infinity, which is why the client is the layer that has to reject them.
+    private static IEnumerable<TestCaseData> BFloat16RejectionCases()
     {
+        yield return new TestCaseData(1.5d, "BFloat16").SetName("A double");
+        yield return new TestCaseData(double.MaxValue, "BFloat16").SetName("A double outside the float range");
+        yield return new TestCaseData(1.5m, "BFloat16").SetName("A decimal");
+        yield return new TestCaseData(1, "BFloat16").SetName("An integer");
+        yield return new TestCaseData("1.5", "BFloat16").SetName("The text of a float");
+        yield return new TestCaseData(new[] { 1.5d }, "Array(BFloat16)").SetName("Inside a composite");
+        yield return new TestCaseData(1.5d, "Nullable(BFloat16)").SetName("Through a Nullable");
+    }
+
+    [TestCaseSource(nameof(BFloat16RejectionCases))]
+    public void FormatSqlText_BFloat16FromAnythingButAFloat_ThrowsAndSaysWhatToPass(object value, string typeName)
+    {
+        var exception = Assert.Throws<ArgumentException>(() => Format(value, typeName));
+
         Assert.Multiple(() =>
         {
-            Assert.That(Format(1.5f, "BFloat16"), Is.EqualTo("1.5"));
-            Assert.That(Format(UInt128.MaxValue, "UInt128"), Is.EqualTo("340282366920938463463374607431768211455"));
-            Assert.That(Format(new Int256(1, 0, 0, 0), "Int256"), Is.Not.Empty);
+            Assert.That(exception.Message, Does.Contain("BFloat16"), "names the type");
+            Assert.That(exception.Message, Does.Contain("Pass a float"), "says what to pass instead");
+            Assert.That(exception.Message, Does.Contain("Parameter 'p'"), "names the parameter");
+        });
+    }
+
+    [Test]
+    public void FormatSqlText_VariantHoldingADouble_KeepsItOutOfTheBFloat16Alternative()
+    {
+        // Alternative matching has to refuse what the formatter refuses, or the Variant picks an arm that
+        // then throws for a value another arm would have taken.
+        Assert.Multiple(() =>
+        {
+            Assert.That(Format(1.5d, "Variant(BFloat16, Float64)"), Is.EqualTo("1.5"));
+            Assert.That(
+                Assert.Throws<ArgumentException>(() => Format(1.5d, "Variant(BFloat16, String)")).Message,
+                Does.Contain("no alternative"));
         });
     }
 

--- a/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterEdgeCaseTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterEdgeCaseTests.cs
@@ -204,14 +204,19 @@ public class TcpParameterFormatterEdgeCaseTests
         });
     }
 
-    [Test]
-    public void FormatSqlText_InstantForADateTime64WithNoTimezone_SuggestsAScaleAndATimezone()
+    // The suggestion has to stay valid for the type it is about: DateTime64('UTC') is not a type, and a
+    // suggestion naming another scale would change the precision the caller declared.
+    [TestCase("DateTime64(3)", "DateTime64(3, 'UTC')", TestName = "Scale three")]
+    [TestCase("DateTime64(9)", "DateTime64(9, 'UTC')", TestName = "Scale nine")]
+    [TestCase("DateTime64(0)", "DateTime64(0, 'UTC')", TestName = "Scale zero")]
+    [TestCase("DateTime64", "DateTime64(3, 'UTC')", TestName = "No scale takes the server default")]
+    public void FormatSqlText_InstantForADateTime64WithNoTimezone_SuggestsTheDeclaredScaleAndATimezone(
+        string typeName, string suggestion)
     {
-        // The suggestion has to stay valid for the type it is about: DateTime64('UTC') is not a type.
         var exception = Assert.Throws<ArgumentException>(
-            () => Format(new DateTime(2024, 1, 2, 0, 0, 0, DateTimeKind.Utc), "DateTime64(3)"));
+            () => Format(new DateTime(2024, 1, 2, 0, 0, 0, DateTimeKind.Utc), typeName));
 
-        Assert.That(exception.Message, Does.Contain("DateTime64(3, 'UTC')"));
+        Assert.That(exception.Message, Does.Contain(suggestion));
     }
 
     [Test]
@@ -413,6 +418,25 @@ public class TcpParameterFormatterEdgeCaseTests
         var exception = Assert.Throws<ArgumentException>(() => Format(new[] { 1, 2 }, "Variant(Int64, String)"));
 
         Assert.That(exception.Message, Does.Contain("no alternative"));
+    }
+
+    // A string is a sequence of chars, so a container arm that takes any IEnumerable sends one element per
+    // character and the server stores it without complaint. Every container arm has to refuse it instead.
+    [TestCase("Array(String)", TestName = "Bound as an Array")]
+    [TestCase("QBit(Float32, 3)", TestName = "Bound as a QBit")]
+    [TestCase("Nested(a String)", TestName = "Bound as Nested")]
+    public void FormatSqlText_StringBoundToAContainerType_ThrowsInsteadOfSplittingIntoCharacters(string typeName)
+    {
+        var exception = Assert.Throws<ArgumentException>(() => Format("abc", typeName));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(exception.Message, Does.Contain(typeName), "names the type");
+            Assert.That(
+                exception.Message,
+                Does.Contain("System.String"),
+                "names the value the caller passed, not one of its characters");
+        });
     }
 
     [Test]

--- a/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterTests.cs
@@ -6,7 +6,7 @@ using ClickHouse.Driver.Tcp.Parameters;
 
 namespace ClickHouse.Driver.Tcp.Tests.Parameters;
 
-// Covers the inner SQL representation shared with the HTTP formatter; wire escaping is tested separately.
+// Covers the inner SQL representation shared with HTTP, except for documented transport differences.
 [TestFixture]
 public class TcpParameterFormatterTests
 {

--- a/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterTests.cs
@@ -52,8 +52,8 @@ public class TcpParameterFormatterTests
         // A kinded value names an instant, so it is moved into the type's timezone to keep that instant.
         yield return new TestCaseData(new DateTime(2024, 1, 2, 3, 4, 5, DateTimeKind.Utc), "DateTime('Europe/Amsterdam')")
             .Returns("2024-01-02T04:04:05").SetName("DateTime shifted into the type timezone");
-        yield return new TestCaseData(new DateTimeOffset(2024, 1, 2, 3, 4, 5, TimeSpan.Zero), "DateTime")
-            .Returns("2024-01-02T03:04:05").SetName("DateTimeOffset defaults to UTC");
+        yield return new TestCaseData(new DateTimeOffset(2024, 1, 2, 3, 4, 5, TimeSpan.Zero), "DateTime('UTC')")
+            .Returns("2024-01-02T03:04:05").SetName("DateTimeOffset in a UTC type");
 
         // Composites quote their string-like elements; that is the only place quoting appears.
         yield return new TestCaseData(new[] { 1, 2, 3 }, "Array(Int32)").Returns("[1,2,3]").SetName("Array of Int32");

--- a/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterTests.cs
@@ -40,6 +40,11 @@ public class TcpParameterFormatterTests
         yield return new TestCaseData(IPAddress.Parse("192.168.1.1"), "IPv4").Returns("192.168.1.1").SetName("IPv4");
         yield return new TestCaseData(IPAddress.Parse("::1"), "IPv6").Returns("::1").SetName("IPv6");
 
+        // Interval<Unit> carries its underlying Int64 count, the same form the codecs surface it as.
+        yield return new TestCaseData(5L, "IntervalSecond").Returns("5").SetName("IntervalSecond");
+        yield return new TestCaseData(-3, "IntervalDay").Returns("-3").SetName("IntervalDay negative");
+        yield return new TestCaseData(new[] { 1L, 2L }, "Array(IntervalMonth)").Returns("[1,2]").SetName("Array of IntervalMonth");
+
         yield return new TestCaseData(new DateOnly(2024, 1, 2), "Date").Returns("2024-01-02").SetName("Date");
         yield return new TestCaseData(Unspecified, "DateTime").Returns("2024-01-02T03:04:05").SetName("DateTime unspecified");
         yield return new TestCaseData(Unspecified, "DateTime64(3)").Returns("2024-01-02 03:04:05.0000000").SetName("DateTime64 unspecified");

--- a/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterTests.cs
@@ -6,9 +6,7 @@ using ClickHouse.Driver.Tcp.Parameters;
 
 namespace ClickHouse.Driver.Tcp.Tests.Parameters;
 
-// The SQL-text half of the formatter: the representation the server parses against the declared type. This is
-// also the text the HTTP transport sends verbatim, so these expectations are the parity contract between the
-// two formatters. The native protocol's extra escape and quote is covered separately below.
+// Covers the inner SQL representation shared with the HTTP formatter; wire escaping is tested separately.
 [TestFixture]
 public class TcpParameterFormatterTests
 {
@@ -97,8 +95,7 @@ public class TcpParameterFormatterTests
     [Test]
     public void FormatSqlText_IdentifierType_LeavesTheValueUnescaped()
     {
-        // The server substitutes an Identifier as a bare SQL name and quotes it itself, so escaping here would
-        // corrupt it. This is the one type whose text is not escaped.
+        // The server quotes Identifier values, so client-side escaping would change the name.
         Assert.That(TcpParameterFormatter.FormatSqlText(@"we'ird\name", "Identifier", "p"), Is.EqualTo(@"we'ird\name"));
     }
 
@@ -146,9 +143,7 @@ public class TcpParameterFormatterTests
     public void FormatSqlText_MalformedTypeName_ThrowsFormatException()
         => Assert.Throws<FormatException>(() => TcpParameterFormatter.FormatSqlText(1, "Array(", "p"));
 
-    // The native protocol's own layer. A parameter value crosses two server-side unescape stages, so the SQL
-    // text above is escaped a second time and quoted as a whole. Every expectation here was confirmed against a
-    // live server by reading the value back with hex().
+    // Native parameter values add a second escape pass and an outer quote.
     private static IEnumerable<TestCaseData> WireValueCases()
     {
         yield return new TestCaseData(42, "Int32").Returns("'42'").SetName("Int32 is quoted too");

--- a/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterTests.cs
@@ -1,0 +1,163 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using ClickHouse.Driver.Tcp.Numerics;
+using ClickHouse.Driver.Tcp.Parameters;
+
+namespace ClickHouse.Driver.Tcp.Tests.Parameters;
+
+// The SQL-text half of the formatter: the representation the server parses against the declared type. This is
+// also the text the HTTP transport sends verbatim, so these expectations are the parity contract between the
+// two formatters. The native protocol's extra escape and quote is covered separately below.
+[TestFixture]
+public class TcpParameterFormatterTests
+{
+    private static readonly DateTime Unspecified = new(2024, 1, 2, 3, 4, 5, DateTimeKind.Unspecified);
+
+    private static IEnumerable<TestCaseData> SqlTextCases()
+    {
+        yield return new TestCaseData(42, "Int32").Returns("42").SetName("Int32");
+        yield return new TestCaseData((byte)7, "UInt8").Returns("7").SetName("UInt8");
+        yield return new TestCaseData(long.MinValue, "Int64").Returns("-9223372036854775808").SetName("Int64 min");
+        yield return new TestCaseData(ulong.MaxValue, "UInt64").Returns("18446744073709551615").SetName("UInt64 max");
+        yield return new TestCaseData(1.5d, "Float64").Returns("1.5").SetName("Float64");
+        yield return new TestCaseData(true, "Bool").Returns("true").SetName("Bool");
+        yield return new TestCaseData(1.2345m, "Decimal64(4)").Returns("1.2345").SetName("Decimal from decimal");
+        yield return new TestCaseData("1.2345", "Decimal64(4)").Returns("1.2345").SetName("Decimal from string");
+
+        // A top-level string is escaped but not quoted; the quoting is the composite's job.
+        yield return new TestCaseData("plain", "String").Returns("plain").SetName("String");
+        yield return new TestCaseData("O'Brien", "String").Returns(@"O\'Brien").SetName("String with a quote");
+        yield return new TestCaseData(@"a\b", "String").Returns(@"a\\b").SetName("String with a backslash");
+        yield return new TestCaseData("a\nb", "String").Returns(@"a\nb").SetName("String with a newline");
+        yield return new TestCaseData("a\tb", "String").Returns(@"a\tb").SetName("String with a tab");
+        yield return new TestCaseData(string.Empty, "String").Returns(string.Empty).SetName("Empty string");
+        yield return new TestCaseData("x", "LowCardinality(String)").Returns("x").SetName("LowCardinality unwraps");
+        yield return new TestCaseData("a", "Enum8('a' = 1, 'b' = 2)").Returns("a").SetName("Enum label");
+
+        yield return new TestCaseData(Guid.Parse("61f0c404-5cb3-11e7-907b-a6006ad3dba0"), "UUID")
+            .Returns("61f0c404-5cb3-11e7-907b-a6006ad3dba0").SetName("UUID");
+        yield return new TestCaseData(IPAddress.Parse("192.168.1.1"), "IPv4").Returns("192.168.1.1").SetName("IPv4");
+        yield return new TestCaseData(IPAddress.Parse("::1"), "IPv6").Returns("::1").SetName("IPv6");
+
+        yield return new TestCaseData(new DateOnly(2024, 1, 2), "Date").Returns("2024-01-02").SetName("Date");
+        yield return new TestCaseData(Unspecified, "DateTime").Returns("2024-01-02T03:04:05").SetName("DateTime unspecified");
+        yield return new TestCaseData(Unspecified, "DateTime64(3)").Returns("2024-01-02 03:04:05.0000000").SetName("DateTime64 unspecified");
+
+        // A kinded value names an instant, so it is moved into the type's timezone to keep that instant.
+        yield return new TestCaseData(new DateTime(2024, 1, 2, 3, 4, 5, DateTimeKind.Utc), "DateTime('Europe/Amsterdam')")
+            .Returns("2024-01-02T04:04:05").SetName("DateTime shifted into the type timezone");
+        yield return new TestCaseData(new DateTimeOffset(2024, 1, 2, 3, 4, 5, TimeSpan.Zero), "DateTime")
+            .Returns("2024-01-02T03:04:05").SetName("DateTimeOffset defaults to UTC");
+
+        // Composites quote their string-like elements; that is the only place quoting appears.
+        yield return new TestCaseData(new[] { 1, 2, 3 }, "Array(Int32)").Returns("[1,2,3]").SetName("Array of Int32");
+        yield return new TestCaseData(new[] { "a", "b" }, "Array(String)").Returns("['a','b']").SetName("Array of String");
+        yield return new TestCaseData(new[] { "O'B" }, "Array(String)").Returns(@"['O\'B']").SetName("Array element with a quote");
+        yield return new TestCaseData(Array.Empty<int>(), "Array(Int32)").Returns("[]").SetName("Empty array");
+        yield return new TestCaseData(new int?[] { 1, null, 3 }, "Array(Nullable(Int32))").Returns("[1,null,3]").SetName("Array with a null element");
+        yield return new TestCaseData(new[] { new[] { 1, 2 }, new[] { 3 } }, "Array(Array(Int32))").Returns("[[1,2],[3]]").SetName("Jagged array");
+        yield return new TestCaseData(new int[,] { { 1, 2 }, { 3, 4 } }, "Array(Array(Int32))").Returns("[[1,2],[3,4]]").SetName("Rank-2 array");
+        yield return new TestCaseData(("a", 1), "Tuple(String, Int32)").Returns("('a',1)").SetName("Tuple");
+        yield return new TestCaseData(("a", 1), "Tuple(x String, y Int32)").Returns("('a',1)").SetName("Named tuple");
+    }
+
+    [TestCaseSource(nameof(SqlTextCases))]
+    public string FormatSqlText_ValueOfDeclaredType_ProducesTheServersTextForm(object value, string typeName)
+        => TcpParameterFormatter.FormatSqlText(value, typeName, "p");
+
+    [Test]
+    public void FormatSqlText_MapValue_SpacesTheKeyFromTheValue()
+    {
+        var value = new Dictionary<string, int> { ["a"] = 1 };
+
+        Assert.That(TcpParameterFormatter.FormatSqlText(value, "Map(String, Int32)", "p"), Is.EqualTo("{'a' : 1}"));
+    }
+
+    [TestCase(null)]
+    public void FormatSqlText_NullValue_ProducesTheNullMarker(object value)
+        => Assert.That(TcpParameterFormatter.FormatSqlText(value, "Nullable(String)", "p"), Is.EqualTo(@"\N"));
+
+    [Test]
+    public void FormatSqlText_DBNullValue_ProducesTheNullMarker()
+        => Assert.That(TcpParameterFormatter.FormatSqlText(DBNull.Value, "Nullable(String)", "p"), Is.EqualTo(@"\N"));
+
+    [Test]
+    public void FormatSqlText_NullInsideAComposite_ProducesTheLiteralNull()
+    {
+        // Nested in a composite the marker would be read as text, so the literal null is used instead.
+        Assert.That(TcpParameterFormatter.FormatSqlText(new string[] { null }, "Array(Nullable(String))", "p"), Is.EqualTo("[null]"));
+    }
+
+    [Test]
+    public void FormatSqlText_IdentifierType_LeavesTheValueUnescaped()
+    {
+        // The server substitutes an Identifier as a bare SQL name and quotes it itself, so escaping here would
+        // corrupt it. This is the one type whose text is not escaped.
+        Assert.That(TcpParameterFormatter.FormatSqlText(@"we'ird\name", "Identifier", "p"), Is.EqualTo(@"we'ird\name"));
+    }
+
+    [Test]
+    public void FormatSqlText_WideDecimalString_KeepsEveryDigit()
+    {
+        // Wider than decimal can hold, so the text path must not go through decimal.
+        const string wide = "12345678901234567890123456789012345.6789";
+
+        Assert.That(TcpParameterFormatter.FormatSqlText(wide, "Decimal256(4)", "p"), Is.EqualTo(wide));
+    }
+
+    [Test]
+    public void FormatSqlText_ClickHouseDecimal_UsesItsOwnScale()
+    {
+        var value = new ClickHouseDecimal(12345, 4);
+
+        Assert.That(TcpParameterFormatter.FormatSqlText(value, "Decimal64(4)", "p"), Is.EqualTo("1.2345"));
+    }
+
+    [Test]
+    public void FormatSqlText_VariantValue_PicksTheAlternativeMatchingTheValue()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(TcpParameterFormatter.FormatSqlText("x", "Variant(Int64, String)", "p"), Is.EqualTo("x"));
+            Assert.That(TcpParameterFormatter.FormatSqlText(7L, "Variant(Int64, String)", "p"), Is.EqualTo("7"));
+        });
+    }
+
+    [Test]
+    public void FormatSqlText_ValueOfAnIncompatibleType_ThrowsNamingTheParameter()
+    {
+        var exception = Assert.Throws<ArgumentException>(
+            () => TcpParameterFormatter.FormatSqlText(new object(), "Array(Int32)", "ids"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(exception.Message, Does.Contain("ids"));
+            Assert.That(exception.Message, Does.Contain("Array(Int32)"));
+        });
+    }
+
+    [Test]
+    public void FormatSqlText_MalformedTypeName_ThrowsFormatException()
+        => Assert.Throws<FormatException>(() => TcpParameterFormatter.FormatSqlText(1, "Array(", "p"));
+
+    // The native protocol's own layer. A parameter value crosses two server-side unescape stages, so the SQL
+    // text above is escaped a second time and quoted as a whole. Every expectation here was confirmed against a
+    // live server by reading the value back with hex().
+    private static IEnumerable<TestCaseData> WireValueCases()
+    {
+        yield return new TestCaseData(42, "Int32").Returns("'42'").SetName("Int32 is quoted too");
+        yield return new TestCaseData("plain", "String").Returns("'plain'").SetName("Plain string");
+        yield return new TestCaseData("O'Brien", "String").Returns(@"'O\\\'Brien'").SetName("Quote is escaped twice");
+        yield return new TestCaseData(@"a\b", "String").Returns(@"'a\\\\b'").SetName("Backslash is escaped twice");
+        yield return new TestCaseData("a\nb", "String").Returns(@"'a\\nb'").SetName("Newline survives as an escape");
+        yield return new TestCaseData("a\tb", "String").Returns(@"'a\\tb'").SetName("Tab survives as an escape");
+        yield return new TestCaseData("' OR 1=1 --", "String").Returns(@"'\\\' OR 1=1 --'").SetName("Injection attempt stays data");
+        yield return new TestCaseData(new[] { "a" }, "Array(String)").Returns(@"'[\'a\']'").SetName("Array element quotes are escaped");
+        yield return new TestCaseData(null, "Nullable(String)").Returns(@"'\\N'").SetName("Null marker is escaped");
+    }
+
+    [TestCaseSource(nameof(WireValueCases))]
+    public string Format_AnyValue_EscapesAndQuotesForTheFieldStage(object value, string typeName)
+        => TcpParameterFormatter.Format(value, typeName, "p");
+}

--- a/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterTests.cs
@@ -1,49 +1,27 @@
 using System;
 using System.Collections.Generic;
-using System.Net;
-using ClickHouse.Driver.Tcp.Numerics;
 using ClickHouse.Driver.Tcp.Parameters;
 
 namespace ClickHouse.Driver.Tcp.Tests.Parameters;
 
-// Covers the inner SQL representation shared with HTTP, except for documented transport differences.
+// Covers the inner SQL representation shared with HTTP, and the wire value the native protocol wraps it in.
 [TestFixture]
 public class TcpParameterFormatterTests
 {
     private static readonly DateTime Unspecified = new(2024, 1, 2, 3, 4, 5, DateTimeKind.Unspecified);
 
+    // Only the forms a round-trip cannot show: text the server rewrites when it reads the value back, and the
+    // escaping it undoes. Every value form itself has a live case in ClickHouseTcpParameterIntegrationTests.
     private static IEnumerable<TestCaseData> SqlTextCases()
     {
-        yield return new TestCaseData(42, "Int32").Returns("42").SetName("Int32");
-        yield return new TestCaseData((byte)7, "UInt8").Returns("7").SetName("UInt8");
-        yield return new TestCaseData(long.MinValue, "Int64").Returns("-9223372036854775808").SetName("Int64 min");
-        yield return new TestCaseData(ulong.MaxValue, "UInt64").Returns("18446744073709551615").SetName("UInt64 max");
-        yield return new TestCaseData(1.5d, "Float64").Returns("1.5").SetName("Float64");
-        yield return new TestCaseData(true, "Bool").Returns("true").SetName("Bool");
-        yield return new TestCaseData(1.2345m, "Decimal64(4)").Returns("1.2345").SetName("Decimal from decimal");
-        yield return new TestCaseData("1.2345", "Decimal64(4)").Returns("1.2345").SetName("Decimal from string");
-
         // A top-level string is escaped but not quoted; the quoting is the composite's job.
-        yield return new TestCaseData("plain", "String").Returns("plain").SetName("String");
         yield return new TestCaseData("O'Brien", "String").Returns(@"O\'Brien").SetName("String with a quote");
         yield return new TestCaseData(@"a\b", "String").Returns(@"a\\b").SetName("String with a backslash");
         yield return new TestCaseData("a\nb", "String").Returns(@"a\nb").SetName("String with a newline");
         yield return new TestCaseData("a\tb", "String").Returns(@"a\tb").SetName("String with a tab");
-        yield return new TestCaseData(string.Empty, "String").Returns(string.Empty).SetName("Empty string");
-        yield return new TestCaseData("x", "LowCardinality(String)").Returns("x").SetName("LowCardinality unwraps");
-        yield return new TestCaseData("a", "Enum8('a' = 1, 'b' = 2)").Returns("a").SetName("Enum label");
 
-        yield return new TestCaseData(Guid.Parse("61f0c404-5cb3-11e7-907b-a6006ad3dba0"), "UUID")
-            .Returns("61f0c404-5cb3-11e7-907b-a6006ad3dba0").SetName("UUID");
-        yield return new TestCaseData(IPAddress.Parse("192.168.1.1"), "IPv4").Returns("192.168.1.1").SetName("IPv4");
-        yield return new TestCaseData(IPAddress.Parse("::1"), "IPv6").Returns("::1").SetName("IPv6");
-
-        // Interval<Unit> carries its underlying Int64 count, the same form the codecs surface it as.
-        yield return new TestCaseData(5L, "IntervalSecond").Returns("5").SetName("IntervalSecond");
-        yield return new TestCaseData(-3, "IntervalDay").Returns("-3").SetName("IntervalDay negative");
-        yield return new TestCaseData(new[] { 1L, 2L }, "Array(IntervalMonth)").Returns("[1,2]").SetName("Array of IntervalMonth");
-
-        yield return new TestCaseData(new DateOnly(2024, 1, 2), "Date").Returns("2024-01-02").SetName("Date");
+        // An Unspecified DateTime is a wall clock with no instant attached, which is what a type declaring no
+        // timezone carries, so it stays legal. The ISO separator and the fixed fraction are the client's form.
         yield return new TestCaseData(Unspecified, "DateTime").Returns("2024-01-02T03:04:05").SetName("DateTime unspecified");
         yield return new TestCaseData(Unspecified, "DateTime64(3)").Returns("2024-01-02 03:04:05.0000000").SetName("DateTime64 unspecified");
 
@@ -53,20 +31,12 @@ public class TcpParameterFormatterTests
         yield return new TestCaseData(new DateTimeOffset(2024, 1, 2, 3, 4, 5, TimeSpan.Zero), "DateTime('UTC')")
             .Returns("2024-01-02T03:04:05").SetName("DateTimeOffset in a UTC type");
 
-        // Composites quote their string-like elements; that is the only place quoting appears.
-        yield return new TestCaseData(new[] { 1, 2, 3 }, "Array(Int32)").Returns("[1,2,3]").SetName("Array of Int32");
-        yield return new TestCaseData(new[] { "a", "b" }, "Array(String)").Returns("['a','b']").SetName("Array of String");
-        yield return new TestCaseData(new[] { "O'B" }, "Array(String)").Returns(@"['O\'B']").SetName("Array element with a quote");
-        yield return new TestCaseData(Array.Empty<int>(), "Array(Int32)").Returns("[]").SetName("Empty array");
+        // A composite writes null as the literal the server reads inside one, and prints it back as NULL.
         yield return new TestCaseData(new int?[] { 1, null, 3 }, "Array(Nullable(Int32))").Returns("[1,null,3]").SetName("Array with a null element");
-        yield return new TestCaseData(new[] { new[] { 1, 2 }, new[] { 3 } }, "Array(Array(Int32))").Returns("[[1,2],[3]]").SetName("Jagged array");
-        yield return new TestCaseData(new int[,] { { 1, 2 }, { 3, 4 } }, "Array(Array(Int32))").Returns("[[1,2],[3,4]]").SetName("Rank-2 array");
-        yield return new TestCaseData(("a", 1), "Tuple(String, Int32)").Returns("('a',1)").SetName("Tuple");
-        yield return new TestCaseData(("a", 1), "Tuple(x String, y Int32)").Returns("('a',1)").SetName("Named tuple");
     }
 
     [TestCaseSource(nameof(SqlTextCases))]
-    public string FormatSqlText_ValueOfDeclaredType_ProducesTheServersTextForm(object value, string typeName)
+    public string FormatSqlText_ValueOfDeclaredType_ProducesTheInnerSqlText(object value, string typeName)
         => TcpParameterFormatter.FormatSqlText(value, typeName, "p");
 
     [Test]
@@ -97,33 +67,6 @@ public class TcpParameterFormatterTests
     {
         // The server quotes Identifier values, so client-side escaping would change the name.
         Assert.That(TcpParameterFormatter.FormatSqlText(@"we'ird\name", "Identifier", "p"), Is.EqualTo(@"we'ird\name"));
-    }
-
-    [Test]
-    public void FormatSqlText_WideDecimalString_KeepsEveryDigit()
-    {
-        // Wider than decimal can hold, so the text path must not go through decimal.
-        const string wide = "12345678901234567890123456789012345.6789";
-
-        Assert.That(TcpParameterFormatter.FormatSqlText(wide, "Decimal256(4)", "p"), Is.EqualTo(wide));
-    }
-
-    [Test]
-    public void FormatSqlText_ClickHouseDecimal_UsesItsOwnScale()
-    {
-        var value = new ClickHouseDecimal(12345, 4);
-
-        Assert.That(TcpParameterFormatter.FormatSqlText(value, "Decimal64(4)", "p"), Is.EqualTo("1.2345"));
-    }
-
-    [Test]
-    public void FormatSqlText_VariantValue_PicksTheAlternativeMatchingTheValue()
-    {
-        Assert.Multiple(() =>
-        {
-            Assert.That(TcpParameterFormatter.FormatSqlText("x", "Variant(Int64, String)", "p"), Is.EqualTo("x"));
-            Assert.That(TcpParameterFormatter.FormatSqlText(7L, "Variant(Int64, String)", "p"), Is.EqualTo("7"));
-        });
     }
 
     [Test]

--- a/ClickHouse.Driver.Tcp.Tests/Protocol/QueryPacketTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Protocol/QueryPacketTests.cs
@@ -67,6 +67,31 @@ public class QueryPacketTests
         Assert.That(ms.Length, Is.GreaterThan(0));
     }
 
+    [Test]
+    public async Task Write_WithParameters_EndsWithTheNameFlagsValueTripleAndTerminator()
+    {
+        // The parameter list is the packet's last field, so the expected triple can be matched at the tail:
+        // name, the Custom flag (0x02), the value, then the empty key that ends the list.
+        using var ms = new MemoryStream();
+        using (var writer = new ClickHouseBinaryWriter(ms))
+        {
+            var parameters = new Dictionary<string, string> { ["id"] = "'42'" };
+            Query.Write(writer, new NegotiatedProtocol(54460), Client, "qid", "SELECT {id:Int32}", settings: null, parameters);
+            await writer.FlushAsync(None);
+        }
+
+        byte[] expected =
+        [
+            2, (byte)'i', (byte)'d',                                        // name, length-prefixed
+            0x02,                                                           // flags: Custom
+            4, (byte)'\'', (byte)'4', (byte)'2', (byte)'\'',                // value, length-prefixed
+            0,                                                              // empty key ends the list
+        ];
+
+        byte[] packet = ms.ToArray();
+        Assert.That(packet[^expected.Length..], Is.EqualTo(expected));
+    }
+
     private static async Task<byte[]> WriteQueryAsync(IReadOnlyDictionary<string, string> settings)
     {
         using var ms = new MemoryStream();

--- a/ClickHouse.Driver.Tcp.Tests/Protocol/QueryPacketTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Protocol/QueryPacketTests.cs
@@ -70,8 +70,7 @@ public class QueryPacketTests
     [Test]
     public async Task Write_WithParameters_EndsWithTheNameFlagsValueTripleAndTerminator()
     {
-        // The parameter list is the packet's last field, so the expected triple can be matched at the tail:
-        // name, the Custom flag (0x02), the value, then the empty key that ends the list.
+        // The final field contains name, Custom flag, value, and an empty-key terminator.
         using var ms = new MemoryStream();
         using (var writer = new ClickHouseBinaryWriter(ms))
         {

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/RequiresServerFeatureAttribute.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/RequiresServerFeatureAttribute.cs
@@ -8,10 +8,8 @@ namespace ClickHouse.Driver.Tcp.Tests.Utilities;
 /// Skips a test when the server under test predates the feature it needs, instead of letting it fail.
 /// </summary>
 /// <remarks>
-/// The TCP equivalent of the HTTP suite's <c>RequiredFeatureAttribute</c>. Use it on a whole test; for one
-/// case of a <c>TestCaseSource</c>, guard the <c>yield return</c> with
-/// <see cref="TcpServerFeatures.Has(TcpFeature)"/> instead, because a case that is never yielded cannot carry
-/// an attribute.
+/// Use this on whole tests. For one <c>TestCaseSource</c> case, guard its <c>yield return</c> with
+/// <see cref="TcpServerFeatures.Has(TcpFeature)"/>.
 /// </remarks>
 /// <param name="feature">The feature the test needs.</param>
 [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false, Inherited = false)]

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/RequiresServerFeatureAttribute.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/RequiresServerFeatureAttribute.cs
@@ -1,0 +1,34 @@
+using System;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+
+namespace ClickHouse.Driver.Tcp.Tests.Utilities;
+
+/// <summary>
+/// Skips a test when the server under test predates the feature it needs, instead of letting it fail.
+/// </summary>
+/// <remarks>
+/// The TCP equivalent of the HTTP suite's <c>RequiredFeatureAttribute</c>. Use it on a whole test; for one
+/// case of a <c>TestCaseSource</c>, guard the <c>yield return</c> with
+/// <see cref="TcpServerFeatures.Has(TcpFeature)"/> instead, because a case that is never yielded cannot carry
+/// an attribute.
+/// </remarks>
+/// <param name="feature">The feature the test needs.</param>
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+public sealed class RequiresServerFeatureAttribute(TcpFeature feature) : NUnitAttribute, IApplyToTest
+{
+    /// <summary>Marks the test as ignored when the server does not have the feature.</summary>
+    /// <param name="test">The test being built.</param>
+    public void ApplyToTest(Test test)
+    {
+        if (test.RunState == RunState.NotRunnable || TcpServerFeatures.Has(feature))
+        {
+            return;
+        }
+
+        test.RunState = RunState.Ignored;
+        test.Properties.Set(
+            PropertyNames.SkipReason,
+            $"Needs server feature {feature}; {TcpServerFeatures.Version?.ToString() ?? "the server"} predates it.");
+    }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/TcpFeature.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/TcpFeature.cs
@@ -6,10 +6,7 @@ namespace ClickHouse.Driver.Tcp.Tests.Utilities;
 /// Server capabilities the integration tests gate on, each tagged with the release that introduced it.
 /// </summary>
 /// <remarks>
-/// This mirrors <c>ClickHouse.Driver.ADO.Feature</c> in the HTTP suite, and is a separate copy on purpose: the
-/// TCP projects do not reference <c>ClickHouse.Driver</c>, which is what lets the TCP CI job build and test
-/// only the two TCP projects. Keep the versions here in step with that enum when a shared one changes.
-/// Only add a flag when a test needs it; an unused flag is a version claim nothing checks.
+/// Mirrors <c>ClickHouse.Driver.ADO.Feature</c>; keep shared versions aligned and add only flags used by tests.
 /// </remarks>
 [Flags]
 public enum TcpFeature

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/TcpFeature.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/TcpFeature.cs
@@ -1,0 +1,55 @@
+using System;
+
+namespace ClickHouse.Driver.Tcp.Tests.Utilities;
+
+/// <summary>
+/// Server capabilities the integration tests gate on, each tagged with the release that introduced it.
+/// </summary>
+/// <remarks>
+/// This mirrors <c>ClickHouse.Driver.ADO.Feature</c> in the HTTP suite, and is a separate copy on purpose: the
+/// TCP projects do not reference <c>ClickHouse.Driver</c>, which is what lets the TCP CI job build and test
+/// only the two TCP projects. Keep the versions here in step with that enum when a shared one changes.
+/// Only add a flag when a test needs it; an unused flag is a version claim nothing checks.
+/// </remarks>
+[Flags]
+public enum TcpFeature
+{
+    /// <summary>No capability. The value a server older than every entry below resolves to.</summary>
+    None = 0,
+
+    /// <summary>The <c>Variant</c> type.</summary>
+    [SinceVersion("24.1")]
+    Variant = 1 << 0,
+
+    /// <summary>The rewritten <c>JSON</c> type.</summary>
+    [SinceVersion("24.1")]
+    Json = 1 << 1,
+
+    /// <summary>The <c>Dynamic</c> type.</summary>
+    [SinceVersion("25.1")]
+    Dynamic = 1 << 2,
+
+    /// <summary>The <c>Time</c> and <c>Time64</c> types.</summary>
+    [SinceVersion("25.6")]
+    Time = 1 << 3,
+
+    /// <summary>The <c>QBit</c> type.</summary>
+    [SinceVersion("25.11")] // Technically 25.10, but limitations break testing. Matches the HTTP suite.
+    QBit = 1 << 4,
+
+    /// <summary>The <c>Geometry</c> type, as distinct from the older named geo types.</summary>
+    [SinceVersion("25.11")]
+    Geometry = 1 << 5,
+
+    /// <summary>Every capability. What an unrecognised or unpinned server version resolves to.</summary>
+    All = ~None,
+}
+
+/// <summary>Marks the release a <see cref="TcpFeature"/> became available in.</summary>
+/// <param name="version">The release, as a version string such as <c>25.11</c>.</param>
+[AttributeUsage(AttributeTargets.Field, AllowMultiple = false, Inherited = false)]
+public sealed class SinceVersionAttribute(string version) : Attribute
+{
+    /// <summary>The release the feature became available in.</summary>
+    public Version Version { get; } = Version.Parse(version);
+}

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/TcpServerFeatures.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/TcpServerFeatures.cs
@@ -5,22 +5,11 @@ using System.Reflection;
 namespace ClickHouse.Driver.Tcp.Tests.Utilities;
 
 /// <summary>
-/// Resolves which <see cref="TcpFeature"/> flags the server under test has, so a test for a type the server
-/// predates is skipped rather than failed.
+/// Resolves the <see cref="TcpFeature"/> flags supported by the server under test.
 /// </summary>
 /// <remarks>
-/// <para>
-/// The version comes from <c>CLICKHOUSE_VERSION</c>, which is the same variable the CI matrix sets to choose
-/// the server image and <see cref="Integration.TcpServerFixture"/> reads to tag the container. That is the
-/// only source available here: a <c>TestCaseSource</c> is enumerated while tests are being discovered, before
-/// the fixture has started the container, so asking the server is not an option at the point the answer is
-/// needed. In CI, where the gating has to be right, the variable is always set.
-/// </para>
-/// <para>
-/// Anything the variable cannot be read as a version — unset, <c>latest</c>, <c>head</c>, a digest — resolves
-/// to <see cref="TcpFeature.All"/>. Those all mean a recent server, so assuming full support keeps the tests
-/// running and lets a genuine gap fail loudly instead of being skipped in silence.
-/// </para>
+/// Reads <c>CLICKHOUSE_VERSION</c> because case sources run before the server starts. Unparseable values such as
+/// <c>latest</c> resolve to <see cref="TcpFeature.All"/> so unsupported features fail instead of being skipped.
 /// </remarks>
 public static class TcpServerFeatures
 {

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/TcpServerFeatures.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/TcpServerFeatures.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace ClickHouse.Driver.Tcp.Tests.Utilities;
+
+/// <summary>
+/// Resolves which <see cref="TcpFeature"/> flags the server under test has, so a test for a type the server
+/// predates is skipped rather than failed.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The version comes from <c>CLICKHOUSE_VERSION</c>, which is the same variable the CI matrix sets to choose
+/// the server image and <see cref="Integration.TcpServerFixture"/> reads to tag the container. That is the
+/// only source available here: a <c>TestCaseSource</c> is enumerated while tests are being discovered, before
+/// the fixture has started the container, so asking the server is not an option at the point the answer is
+/// needed. In CI, where the gating has to be right, the variable is always set.
+/// </para>
+/// <para>
+/// Anything the variable cannot be read as a version — unset, <c>latest</c>, <c>head</c>, a digest — resolves
+/// to <see cref="TcpFeature.All"/>. Those all mean a recent server, so assuming full support keeps the tests
+/// running and lets a genuine gap fail loudly instead of being skipped in silence.
+/// </para>
+/// </remarks>
+public static class TcpServerFeatures
+{
+    /// <summary>The server version the gating is based on, or null when it could not be determined.</summary>
+    public static Version Version { get; } = Parse(Environment.GetEnvironmentVariable("CLICKHOUSE_VERSION"));
+
+    /// <summary>The features the server under test supports.</summary>
+    public static TcpFeature Supported { get; } = Resolve(Version);
+
+    /// <summary>Reports whether the server under test has a feature.</summary>
+    /// <param name="feature">The feature to test for.</param>
+    /// <returns>True when the server supports it.</returns>
+    public static bool Has(TcpFeature feature) => Supported.HasFlag(feature);
+
+    /// <summary>Reads a version out of the environment variable's value.</summary>
+    /// <param name="versionString">The value of <c>CLICKHOUSE_VERSION</c>, which may be null or a moving tag.</param>
+    /// <returns>The version, or null when the value does not name one.</returns>
+    internal static Version Parse(string versionString)
+        => Version.TryParse(versionString?.Split(':').Last().Trim(), out Version parsed) ? parsed : null;
+
+    /// <summary>Maps a server version to the features a server of that version has.</summary>
+    /// <param name="version">The server version, or null when it is not known.</param>
+    /// <returns>The supported features.</returns>
+    internal static TcpFeature Resolve(Version version)
+    {
+        // A moving tag names a recent server but not which one, so it cannot gate anything.
+        if (version is null)
+        {
+            return TcpFeature.All;
+        }
+
+        TcpFeature supported = TcpFeature.None;
+        foreach (FieldInfo field in typeof(TcpFeature).GetFields(BindingFlags.Public | BindingFlags.Static))
+        {
+            SinceVersionAttribute since = field.GetCustomAttribute<SinceVersionAttribute>();
+            if (since is not null && version >= since.Version)
+            {
+                supported |= (TcpFeature)field.GetRawConstantValue();
+            }
+        }
+
+        return supported;
+    }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/TcpServerFeaturesTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/TcpServerFeaturesTests.cs
@@ -1,0 +1,42 @@
+using System;
+
+namespace ClickHouse.Driver.Tcp.Tests.Utilities;
+
+// A wrong answer here does not fail a test, it silently skips one, so the mapping is pinned rather than
+// trusted. The versions asserted are the ones the CI matrix actually runs.
+[TestFixture]
+public class TcpServerFeaturesTests
+{
+    [TestCase("25.8", TcpFeature.QBit, ExpectedResult = false, TestName = "The oldest matrix server has no QBit")]
+    [TestCase("25.8", TcpFeature.Time, ExpectedResult = true, TestName = "The oldest matrix server has Time")]
+    [TestCase("25.8", TcpFeature.Json, ExpectedResult = true, TestName = "The oldest matrix server has Json")]
+    [TestCase("25.11", TcpFeature.QBit, ExpectedResult = true, TestName = "QBit arrives in 25.11")]
+    [TestCase("25.10", TcpFeature.QBit, ExpectedResult = false, TestName = "QBit is gated one release later than it shipped")]
+    [TestCase("26.6", TcpFeature.Geometry, ExpectedResult = true, TestName = "A recent server has Geometry")]
+    [TestCase("23.12", TcpFeature.Variant, ExpectedResult = false, TestName = "Variant predates 24.1")]
+    public bool Resolve_ForAPinnedVersion_ReportsTheFeatureAsTheReleaseNotesDo(string version, TcpFeature feature)
+        => TcpServerFeatures.Resolve(TcpServerFeatures.Parse(version)).HasFlag(feature);
+
+    [TestCase(null, TestName = "Unset")]
+    [TestCase("", TestName = "Empty")]
+    [TestCase("latest", TestName = "The latest tag")]
+    [TestCase("head", TestName = "The head tag")]
+    [TestCase("clickhouse/clickhouse-server@sha256:abc", TestName = "A digest")]
+    public void Resolve_WhenTheVersionIsNotPinned_AssumesEverySupported(string version)
+    {
+        // Assuming full support makes a genuine gap fail loudly. Assuming none would skip the whole suite.
+        Assert.That(TcpServerFeatures.Resolve(TcpServerFeatures.Parse(version)), Is.EqualTo(TcpFeature.All));
+    }
+
+    [TestCase("26.6.1.1193", ExpectedResult = true, TestName = "A four-part build version")]
+    [TestCase("  25.11  ", ExpectedResult = true, TestName = "Surrounding whitespace")]
+    [TestCase("clickhouse/clickhouse-server:25.11", ExpectedResult = true, TestName = "A tagged image reference")]
+    public bool Parse_ForTheFormsTheMatrixUses_ReadsAVersion(string version)
+        => TcpServerFeatures.Parse(version) is not null;
+
+    [Test]
+    public void Resolve_ForAServerOlderThanEveryFeature_ReportsNone()
+    {
+        Assert.That(TcpServerFeatures.Resolve(new Version(20, 1)), Is.EqualTo(TcpFeature.None));
+    }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/TcpServerFeaturesTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/TcpServerFeaturesTests.cs
@@ -2,8 +2,7 @@ using System;
 
 namespace ClickHouse.Driver.Tcp.Tests.Utilities;
 
-// A wrong answer here does not fail a test, it silently skips one, so the mapping is pinned rather than
-// trusted. The versions asserted are the ones the CI matrix actually runs.
+// Pin CI-matrix versions because an incorrect feature gate silently skips tests.
 [TestFixture]
 public class TcpServerFeaturesTests
 {

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClient.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClient.cs
@@ -404,17 +404,12 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
     private IReadOnlyDictionary<string, string> BuildSettings(ClickHouseTcpQueryOptions options)
         => MergeSettings(Options.CustomSettings, options?.Settings);
 
-    /// <summary>
-    /// Resolves each bound parameter to the wire text for the Query packet's parameter list.
-    /// </summary>
+    /// <summary>Formats bound parameters for the Query packet.</summary>
     /// <param name="sql">The SQL text, scanned for the <c>{name:Type}</c> placeholders that give the types.</param>
     /// <param name="options">The per-query options carrying the parameters, or null for none.</param>
     /// <returns>The formatted parameters by name, or null when none are bound.</returns>
     /// <remarks>
-    /// The type each value is formatted as comes from, in order: the parameter's own
-    /// <see cref="ClickHouseTcpParameter.ClickHouseType"/>, the query's <c>{name:Type}</c> placeholder, then the
-    /// value's CLR type. The last rung only carries a parameter the query does not name, because a query that
-    /// does name it must declare the type for the server to read.
+    /// Types resolve from <see cref="ClickHouseTcpParameter.ClickHouseType"/>, then the query hint.
     /// </remarks>
     internal static IReadOnlyDictionary<string, string> BuildParameters(string sql, ClickHouseTcpQueryOptions options)
     {
@@ -430,42 +425,26 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
         {
             object value = parameter.Value;
             string typeName = parameter.ClickHouseType;
-            if (string.IsNullOrWhiteSpace(typeName) && !hints.TryGetValue(parameter.Name, out typeName))
+            if (typeName is not null && string.IsNullOrWhiteSpace(typeName))
             {
-                // Inference reads the sequence to find its element type, and formatting reads it again. A
-                // sequence that can only be read once (a LINQ chain, an iterator with side effects) would come
-                // up empty the second time, so take a copy before the first read.
-                value = Materialize(value);
-                typeName = ParameterTypeInference.Infer(value, parameter.Name);
+                throw new ArgumentException(
+                    $"Parameter '{parameter.Name}' has an empty ClickHouseType. Set it to a type name or leave " +
+                    "it null to use the SQL hint.",
+                    parameter.Name);
+            }
+
+            if (typeName is null && !hints.TryGetValue(parameter.Name, out typeName))
+            {
+                throw new ArgumentException(
+                    $"Parameter '{parameter.Name}' has no ClickHouse type. Declare it in the SQL as " +
+                    $"{{{parameter.Name}:Type}}, or set ClickHouseType.",
+                    parameter.Name);
             }
 
             formatted[parameter.Name] = TcpParameterFormatter.Format(value, typeName, parameter.Name);
         }
 
         return formatted;
-    }
-
-    /// <summary>Copies a sequence that may only be readable once, so it can be read twice.</summary>
-    /// <param name="value">The parameter value.</param>
-    /// <returns>The value, or a copy of it when it is a sequence with no known count.</returns>
-    /// <remarks>
-    /// A string is a sequence but is read as one value, and anything with a count (an array, a list, a
-    /// dictionary) is already re-readable, so neither is copied.
-    /// </remarks>
-    private static object Materialize(object value)
-    {
-        if (value is string || value is System.Collections.ICollection || value is not System.Collections.IEnumerable sequence)
-        {
-            return value;
-        }
-
-        var copy = new List<object>();
-        foreach (object element in sequence)
-        {
-            copy.Add(element);
-        }
-
-        return copy;
     }
 
     /// <summary>

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClient.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClient.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using ClickHouse.Driver.Tcp.Client;
 using ClickHouse.Driver.Tcp.Format;
+using ClickHouse.Driver.Tcp.Parameters;
 using ClickHouse.Driver.Tcp.Poco;
 using ClickHouse.Driver.Tcp.Protocol;
 using ClickHouse.Driver.Tcp.Types;
@@ -109,7 +110,7 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
     /// drained, or discarded and redialed when enumeration stopped mid-response.
     /// </remarks>
     /// <param name="sql">The SQL text.</param>
-    /// <param name="options">Per-query options (query id, settings), or null for the client defaults.</param>
+    /// <param name="options">Per-query options (query id, settings, parameters), or null for the client defaults.</param>
     /// <param name="cancellationToken">A token to observe for cancellation.</param>
     /// <returns>An async stream of the result's row-bearing blocks, each valid only for its own iteration.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="sql"/> is null.</exception>
@@ -121,6 +122,7 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
         ArgumentNullException.ThrowIfNull(sql);
 
         IReadOnlyDictionary<string, string> settings = BuildSettings(options);
+        IReadOnlyDictionary<string, string> parameters = BuildParameters(sql, options);
         string queryId = options?.QueryId;
 
         IConnectionLease lease = await source.RentAsync(cancellationToken).ConfigureAwait(false);
@@ -129,7 +131,7 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
             // The connection's own enumerator owns each block's storage and, in its finally, returns the
             // connection to Ready or terminates it. We pass the blocks straight through without disposing them.
             await foreach (Block block in lease.Connection
-                .QueryAsync(sql, settings, parameters: null, queryId, handlers: null, cancellationToken)
+                .QueryAsync(sql, settings, parameters, queryId, handlers: null, cancellationToken)
                 .ConfigureAwait(false))
             {
                 yield return block;
@@ -154,7 +156,7 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
     /// <c>LowCardinality(FixedString(N))</c> <c>byte[]</c> in place because another row may reference it.
     /// </remarks>
     /// <param name="sql">The SQL text.</param>
-    /// <param name="options">Per-query options (query id, settings), or null for the client defaults.</param>
+    /// <param name="options">Per-query options (query id, settings, parameters), or null for the client defaults.</param>
     /// <param name="cancellationToken">A token to observe for cancellation.</param>
     /// <returns>An async stream of result rows.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="sql"/> is null.</exception>
@@ -195,7 +197,7 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
     /// </remarks>
     /// <typeparam name="T">The row type.</typeparam>
     /// <param name="sql">The SQL text.</param>
-    /// <param name="options">Per-query options (query id, settings), or null for the client defaults.</param>
+    /// <param name="options">Per-query options (query id, settings, parameters), or null for the client defaults.</param>
     /// <param name="cancellationToken">A token to observe for cancellation.</param>
     /// <returns>An async stream of result rows.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="sql"/> is null.</exception>
@@ -252,7 +254,7 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
     /// and discarded.
     /// </summary>
     /// <param name="sql">The SQL text.</param>
-    /// <param name="options">Per-query options (query id, settings), or null for the client defaults.</param>
+    /// <param name="options">Per-query options (query id, settings, parameters), or null for the client defaults.</param>
     /// <param name="cancellationToken">A token to observe for cancellation.</param>
     /// <returns>A task that completes when the statement is acknowledged.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="sql"/> is null.</exception>
@@ -274,7 +276,7 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
     /// </summary>
     /// <param name="sql">The <c>INSERT INTO … VALUES</c> statement, with no inline <c>VALUES (...)</c> literal.</param>
     /// <param name="columns">The row data, matched to the target columns by name.</param>
-    /// <param name="options">Per-insert options (query id, settings, block sizing), or null for the client defaults.</param>
+    /// <param name="options">Per-insert options (query id, settings, parameters, block sizing), or null for the client defaults.</param>
     /// <param name="cancellationToken">A token to observe for cancellation.</param>
     /// <returns>A task that completes when the server acknowledges the insert.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="sql"/> or <paramref name="columns"/> is null.</exception>
@@ -289,13 +291,14 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
         ArgumentNullException.ThrowIfNull(columns);
 
         IReadOnlyDictionary<string, string> settings = BuildSettings(options);
+        IReadOnlyDictionary<string, string> parameters = BuildParameters(sql, options);
 
         await using IConnectionLease lease = await source.RentAsync(cancellationToken).ConfigureAwait(false);
         await lease.Connection.InsertAsync(
             sql,
             columns,
             settings,
-            parameters: null,
+            parameters,
             options?.QueryId,
             ResolveMaxRowsPerBlock(options),
             Options.MaxSendBufferBytes,
@@ -323,6 +326,7 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
         }
 
         IReadOnlyDictionary<string, string> settings = BuildSettings(options);
+        IReadOnlyDictionary<string, string> parameters = BuildParameters(sql, options);
 
         int? maxRowsPerBlock = ResolveMaxRowsPerBlock(options);
         int blockRows = ClickHouseTcpConnection.RowsPerBlock(rows.Count, maxRowsPerBlock);
@@ -334,7 +338,7 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
             buffer.Count,
             schema => pocoTypes.WritePlanFor<T>(schema).CreateSource(buffer, blockRows),
             settings,
-            parameters: null,
+            parameters,
             options?.QueryId,
             maxRowsPerBlock,
             Options.MaxSendBufferBytes,
@@ -353,6 +357,7 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
         ArgumentNullException.ThrowIfNull(rows);
 
         IReadOnlyDictionary<string, string> settings = BuildSettings(options);
+        IReadOnlyDictionary<string, string> parameters = BuildParameters(sql, options);
         int? maxRowsPerBlock = ResolveMaxRowsPerBlock(options);
         int blockRows = ClickHouseTcpConnection.RowsPerBlock(rows.Count, maxRowsPerBlock);
         using var buffer = PocoRowBuffer<object[]>.Create(rows, nameof(rows), blockRows, cancellationToken);
@@ -363,7 +368,7 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
             buffer.Count,
             schema => UntypedRowColumns.CreateSource(schema, buffer, blockRows),
             settings,
-            parameters: null,
+            parameters,
             options?.QueryId,
             maxRowsPerBlock,
             Options.MaxSendBufferBytes,
@@ -398,6 +403,42 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
 
     private IReadOnlyDictionary<string, string> BuildSettings(ClickHouseTcpQueryOptions options)
         => MergeSettings(Options.CustomSettings, options?.Settings);
+
+    /// <summary>
+    /// Resolves each bound parameter to the wire text for the Query packet's parameter list.
+    /// </summary>
+    /// <param name="sql">The SQL text, scanned for the <c>{name:Type}</c> placeholders that give the types.</param>
+    /// <param name="options">The per-query options carrying the parameters, or null for none.</param>
+    /// <returns>The formatted parameters by name, or null when none are bound.</returns>
+    /// <remarks>
+    /// The type each value is formatted as comes from, in order: the parameter's own
+    /// <see cref="ClickHouseTcpParameter.ClickHouseType"/>, the query's <c>{name:Type}</c> placeholder, then the
+    /// value's CLR type. The last rung only carries a parameter the query does not name, because a query that
+    /// does name it must declare the type for the server to read.
+    /// </remarks>
+    internal static IReadOnlyDictionary<string, string> BuildParameters(string sql, ClickHouseTcpQueryOptions options)
+    {
+        ClickHouseTcpParameterCollection parameters = options?.Parameters;
+        if (parameters is null || parameters.Count == 0)
+        {
+            return null;
+        }
+
+        Dictionary<string, string> hints = SqlParameterTypeExtractor.ExtractTypeHints(sql);
+        var formatted = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (ClickHouseTcpParameter parameter in parameters)
+        {
+            string typeName = parameter.ClickHouseType;
+            if (string.IsNullOrWhiteSpace(typeName) && !hints.TryGetValue(parameter.Name, out typeName))
+            {
+                typeName = ParameterTypeInference.Infer(parameter.Value, parameter.Name);
+            }
+
+            formatted[parameter.Name] = TcpParameterFormatter.Format(parameter.Value, typeName, parameter.Name);
+        }
+
+        return formatted;
+    }
 
     /// <summary>
     /// Merges the settings for one operation: the client-level custom settings, overlaid by the per-query

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClient.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClient.cs
@@ -428,16 +428,44 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
         var formatted = new Dictionary<string, string>(StringComparer.Ordinal);
         foreach (ClickHouseTcpParameter parameter in parameters)
         {
+            object value = parameter.Value;
             string typeName = parameter.ClickHouseType;
             if (string.IsNullOrWhiteSpace(typeName) && !hints.TryGetValue(parameter.Name, out typeName))
             {
-                typeName = ParameterTypeInference.Infer(parameter.Value, parameter.Name);
+                // Inference reads the sequence to find its element type, and formatting reads it again. A
+                // sequence that can only be read once (a LINQ chain, an iterator with side effects) would come
+                // up empty the second time, so take a copy before the first read.
+                value = Materialize(value);
+                typeName = ParameterTypeInference.Infer(value, parameter.Name);
             }
 
-            formatted[parameter.Name] = TcpParameterFormatter.Format(parameter.Value, typeName, parameter.Name);
+            formatted[parameter.Name] = TcpParameterFormatter.Format(value, typeName, parameter.Name);
         }
 
         return formatted;
+    }
+
+    /// <summary>Copies a sequence that may only be readable once, so it can be read twice.</summary>
+    /// <param name="value">The parameter value.</param>
+    /// <returns>The value, or a copy of it when it is a sequence with no known count.</returns>
+    /// <remarks>
+    /// A string is a sequence but is read as one value, and anything with a count (an array, a list, a
+    /// dictionary) is already re-readable, so neither is copied.
+    /// </remarks>
+    private static object Materialize(object value)
+    {
+        if (value is string || value is System.Collections.ICollection || value is not System.Collections.IEnumerable sequence)
+        {
+            return value;
+        }
+
+        var copy = new List<object>();
+        foreach (object element in sequence)
+        {
+            copy.Add(element);
+        }
+
+        return copy;
     }
 
     /// <summary>

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpParameter.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpParameter.cs
@@ -1,0 +1,18 @@
+namespace ClickHouse.Driver.Tcp;
+
+/// <summary>
+/// One value bound to a <c>{name:Type}</c> placeholder in a parameterized query.
+/// </summary>
+/// <param name="Name">The parameter name, without braces or a type. Must not be null or empty.</param>
+/// <param name="Value">The value. Null and <see cref="System.DBNull"/> both send the null marker.</param>
+/// <param name="ClickHouseType">
+/// The ClickHouse type to format the value as, or null to take the type from the query's <c>{Name:Type}</c>
+/// placeholder. Set this only when the placeholder does not give the type the value should be formatted as —
+/// most queries need no override, because the placeholder the server reads is the same one the client reads.
+/// </param>
+/// <remarks>
+/// The type does not travel on the wire. The server takes it from the query text, and the client uses it only
+/// to choose how to write the value, so an override that disagrees with the placeholder makes the server parse
+/// text it did not expect.
+/// </remarks>
+public sealed record ClickHouseTcpParameter(string Name, object Value, string ClickHouseType = null);

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpParameter.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpParameter.cs
@@ -4,7 +4,12 @@ namespace ClickHouse.Driver.Tcp;
 /// One value bound to a <c>{name:Type}</c> placeholder in a parameterized query.
 /// </summary>
 /// <param name="Name">The parameter name, without braces or a type. Must not be null or empty.</param>
-/// <param name="Value">The value. Null and <see cref="System.DBNull"/> both send the null marker.</param>
+/// <param name="Value">
+/// The value. Null and <see cref="System.DBNull"/> both send the null marker. A sequence must be replayable:
+/// picking a <c>Variant</c> alternative reads it once to decide, and formatting reads it again. A one-shot
+/// sequence such as a LINQ query or an iterator is empty on the second read and sends <c>[]</c>. Pass an array
+/// or a materialized collection.
+/// </param>
 /// <param name="ClickHouseType">
 /// The type used to format the value, or null to use the query's <c>{Name:Type}</c> placeholder. Must not be
 /// empty.

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpParameter.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpParameter.cs
@@ -6,13 +6,11 @@ namespace ClickHouse.Driver.Tcp;
 /// <param name="Name">The parameter name, without braces or a type. Must not be null or empty.</param>
 /// <param name="Value">The value. Null and <see cref="System.DBNull"/> both send the null marker.</param>
 /// <param name="ClickHouseType">
-/// The ClickHouse type to format the value as, or null to take the type from the query's <c>{Name:Type}</c>
-/// placeholder. Set this only when the placeholder does not give the type the value should be formatted as —
-/// most queries need no override, because the placeholder the server reads is the same one the client reads.
+/// The type used to format the value, or null to use the query's <c>{Name:Type}</c> placeholder. Must not be
+/// empty.
 /// </param>
 /// <remarks>
-/// The type does not travel on the wire. The server takes it from the query text, and the client uses it only
-/// to choose how to write the value, so an override that disagrees with the placeholder makes the server parse
-/// text it did not expect.
+/// This override affects formatting only; the server still uses the type declared in the query. A mismatch may
+/// fail to parse or change the value.
 /// </remarks>
 public sealed record ClickHouseTcpParameter(string Name, object Value, string ClickHouseType = null);

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpParameterCollection.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpParameterCollection.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace ClickHouse.Driver.Tcp;
+
+/// <summary>
+/// The parameters bound to one query, keyed by name and kept in the order they were added.
+/// </summary>
+/// <remarks>
+/// Names are matched with ordinal comparison, because ClickHouse parameter names are case-sensitive. A name may
+/// appear only once: the wire format is a name/value list, so a repeated name has no defined meaning.
+/// </remarks>
+public sealed class ClickHouseTcpParameterCollection : IEnumerable<ClickHouseTcpParameter>
+{
+    private readonly List<ClickHouseTcpParameter> parameters = [];
+    private readonly Dictionary<string, int> indexByName = new(StringComparer.Ordinal);
+
+    /// <summary>Initializes a new empty instance of the <see cref="ClickHouseTcpParameterCollection"/> class.</summary>
+    public ClickHouseTcpParameterCollection()
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="ClickHouseTcpParameterCollection"/> class with the given parameters.</summary>
+    /// <param name="parameters">The parameters to add, in order.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="parameters"/> is null.</exception>
+    /// <exception cref="ArgumentException">A parameter name is null or empty, or repeats an earlier one.</exception>
+    public ClickHouseTcpParameterCollection(IEnumerable<ClickHouseTcpParameter> parameters)
+    {
+        ArgumentNullException.ThrowIfNull(parameters);
+        foreach (ClickHouseTcpParameter parameter in parameters)
+        {
+            Add(parameter);
+        }
+    }
+
+    /// <summary>The number of parameters.</summary>
+    public int Count => parameters.Count;
+
+    /// <summary>Gets the parameter with the given name.</summary>
+    /// <param name="name">The parameter name.</param>
+    /// <returns>The parameter.</returns>
+    /// <exception cref="KeyNotFoundException">No parameter has that name.</exception>
+    public ClickHouseTcpParameter this[string name]
+        => indexByName.TryGetValue(name ?? string.Empty, out int index)
+            ? parameters[index]
+            : throw new KeyNotFoundException($"No parameter named '{name}' is bound to this query.");
+
+    /// <summary>Adds a parameter whose type comes from the query's <c>{name:Type}</c> placeholder.</summary>
+    /// <param name="name">The parameter name.</param>
+    /// <param name="value">The value.</param>
+    /// <exception cref="ArgumentException"><paramref name="name"/> is null or empty, or already added.</exception>
+    public void Add(string name, object value) => Add(new ClickHouseTcpParameter(name, value));
+
+    /// <summary>Adds a parameter, overriding the type the value is formatted as.</summary>
+    /// <param name="name">The parameter name.</param>
+    /// <param name="value">The value.</param>
+    /// <param name="clickHouseType">The ClickHouse type to format the value as.</param>
+    /// <exception cref="ArgumentException"><paramref name="name"/> is null or empty, or already added.</exception>
+    public void Add(string name, object value, string clickHouseType)
+        => Add(new ClickHouseTcpParameter(name, value, clickHouseType));
+
+    /// <summary>Adds a parameter.</summary>
+    /// <param name="parameter">The parameter.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="parameter"/> is null.</exception>
+    /// <exception cref="ArgumentException">The name is null or empty, or already added.</exception>
+    public void Add(ClickHouseTcpParameter parameter)
+    {
+        ArgumentNullException.ThrowIfNull(parameter);
+
+        // An empty name would collide with the empty key that terminates the wire parameter list.
+        if (string.IsNullOrEmpty(parameter.Name))
+        {
+            throw new ArgumentException("A query parameter name must not be null or empty.", nameof(parameter));
+        }
+
+        if (indexByName.ContainsKey(parameter.Name))
+        {
+            throw new ArgumentException($"A parameter named '{parameter.Name}' is already bound to this query.", nameof(parameter));
+        }
+
+        indexByName[parameter.Name] = parameters.Count;
+        parameters.Add(parameter);
+    }
+
+    /// <summary>Reports whether a parameter with the given name is bound.</summary>
+    /// <param name="name">The parameter name.</param>
+    /// <returns>True when the name is bound.</returns>
+    public bool Contains(string name) => indexByName.ContainsKey(name ?? string.Empty);
+
+    /// <summary>Gets the parameter with the given name, if it is bound.</summary>
+    /// <param name="name">The parameter name.</param>
+    /// <param name="parameter">The parameter, or null when the name is not bound.</param>
+    /// <returns>True when the name is bound.</returns>
+    public bool TryGetValue(string name, out ClickHouseTcpParameter parameter)
+    {
+        if (indexByName.TryGetValue(name ?? string.Empty, out int index))
+        {
+            parameter = parameters[index];
+            return true;
+        }
+
+        parameter = null;
+        return false;
+    }
+
+    /// <inheritdoc/>
+    public IEnumerator<ClickHouseTcpParameter> GetEnumerator() => parameters.GetEnumerator();
+
+    /// <inheritdoc/>
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpParameterCollection.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpParameterCollection.cs
@@ -10,6 +10,11 @@ namespace ClickHouse.Driver.Tcp;
 /// <remarks>
 /// Names are matched with ordinal comparison, because ClickHouse parameter names are case-sensitive. A name may
 /// appear only once: the wire format is a name/value list, so a repeated name has no defined meaning.
+/// <para>
+/// This type is mutable and is not thread-safe. A <see cref="ClickHouseTcpClient"/> is meant to be shared, so
+/// build a collection and then leave it alone: adding to one while an operation reads it is a data race. To
+/// vary the values per operation, build a collection per operation.
+/// </para>
 /// </remarks>
 public sealed class ClickHouseTcpParameterCollection : IEnumerable<ClickHouseTcpParameter>
 {

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpParameterCollection.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpParameterCollection.cs
@@ -8,13 +8,8 @@ namespace ClickHouse.Driver.Tcp;
 /// The parameters bound to one query, keyed by name and kept in the order they were added.
 /// </summary>
 /// <remarks>
-/// Names are matched with ordinal comparison, because ClickHouse parameter names are case-sensitive. A name may
-/// appear only once: the wire format is a name/value list, so a repeated name has no defined meaning.
-/// <para>
-/// This type is mutable and is not thread-safe. A <see cref="ClickHouseTcpClient"/> is meant to be shared, so
-/// build a collection and then leave it alone: adding to one while an operation reads it is a data race. To
-/// vary the values per operation, build a collection per operation.
-/// </para>
+/// Names are case-sensitive and must be unique. This mutable collection is not thread-safe; do not modify it
+/// while an operation is using it.
 /// </remarks>
 public sealed class ClickHouseTcpParameterCollection : IEnumerable<ClickHouseTcpParameter>
 {

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpQueryOptions.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpQueryOptions.cs
@@ -29,34 +29,19 @@ public record ClickHouseTcpQueryOptions
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Each value is formatted as the type its placeholder declares, so the query text must carry the type —
-    /// <c>SELECT * FROM t WHERE id = {id:Int32}</c>. A parameter can override that type; see
-    /// <see cref="ClickHouseTcpParameter.ClickHouseType"/>. Parameters need a server whose protocol revision is
-    /// 54459 or above; an older one rejects the query rather than running it without them.
+    /// Each parameter needs a type from its placeholder, for example <c>{id:Int32}</c>, or from
+    /// <see cref="ClickHouseTcpParameter.ClickHouseType"/>. The operation throws when neither supplies one.
     /// </para>
     /// <para>
-    /// <b>Declare a timezone when the value names an instant.</b> A <see cref="DateTime"/> whose
-    /// <see cref="DateTime.Kind"/> is <see cref="DateTimeKind.Utc"/> or <see cref="DateTimeKind.Local"/>, and
-    /// any <see cref="DateTimeOffset"/>, names a point in time. The wire carries a wall-clock time and no
-    /// timezone, so the server reads it in its session timezone: a type that declares none moves the instant
-    /// whenever that session is not UTC, and reports no error. The client refuses such a parameter rather than
-    /// send it. Write <c>{t:DateTime('UTC')}</c> or <c>{t:DateTime64(3, 'UTC')}</c>, or pass a
-    /// <see cref="DateTime"/> of <see cref="DateTimeKind.Unspecified"/> when you do mean a wall-clock time for
-    /// the server to read in its own timezone.
+    /// Declare a timezone for <see cref="DateTimeOffset"/> and for <see cref="DateTime"/> values whose
+    /// <see cref="DateTime.Kind"/> is not <see cref="DateTimeKind.Unspecified"/>, for example
+    /// <c>{t:DateTime('UTC')}</c>. Without one, the client refuses the value to prevent the server's session
+    /// timezone from changing the instant. Use <see cref="DateTimeKind.Unspecified"/> only for wall-clock time.
     /// </para>
     /// <para>
-    /// <b>Avoid naming a parameter after a server setting.</b> The native protocol carries parameters in the
-    /// settings list, so a server that reads the name as a setting applies it as that setting instead of
-    /// binding it. The query then fails with a parse error about a quoted string, which names neither the
-    /// parameter nor the cause. The common traps are <c>limit</c> and <c>offset</c>; <c>max_threads</c>,
-    /// <c>readonly</c> and <c>log_comment</c> behave the same way. Rename the parameter (<c>row_limit</c>) and
-    /// the query works.
-    /// </para>
-    /// <para>
-    /// This is the server's behaviour, not this client's — <c>clickhouse-client --param_limit=</c> fails the
-    /// same way — and it is version-dependent: it affects 25.8 through 26.6, while newer servers bind such a
-    /// name correctly. It does not affect this driver's HTTP transport, which carries the name separately.
-    /// Rename the parameter if you support any server in that range.
+    /// On ClickHouse 25.8 through 26.6, names matching server settings, such as <c>limit</c> or <c>offset</c>,
+    /// may be treated as settings and rejected. Rename them (for example, <c>row_limit</c>) when supporting
+    /// those versions. Newer servers and this driver's HTTP transport are unaffected.
     /// </para>
     /// </remarks>
     public ClickHouseTcpParameterCollection Parameters { get; init; }

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpQueryOptions.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpQueryOptions.cs
@@ -35,13 +35,18 @@ public record ClickHouseTcpQueryOptions
     /// 54459 or above; an older one rejects the query rather than running it without them.
     /// </para>
     /// <para>
-    /// <b>A parameter must not be named after a server setting.</b> The native protocol carries parameters in
-    /// the settings list, so the server applies a name it recognizes as that setting instead of binding it. The
-    /// common traps are <c>limit</c> and <c>offset</c>; <c>max_threads</c>, <c>readonly</c> and
-    /// <c>log_comment</c> behave the same way. The query then fails with a parse error about a quoted string,
-    /// which does not name the parameter. Rename it (<c>row_limit</c>) and the query works. This is a limit of
-    /// the protocol, not of this client — <c>clickhouse-client --param_limit=</c> fails the same way — but it
-    /// does differ from this driver's HTTP transport, where the name is carried separately and works.
+    /// <b>Avoid naming a parameter after a server setting.</b> The native protocol carries parameters in the
+    /// settings list, so a server that reads the name as a setting applies it as that setting instead of
+    /// binding it. The query then fails with a parse error about a quoted string, which names neither the
+    /// parameter nor the cause. The common traps are <c>limit</c> and <c>offset</c>; <c>max_threads</c>,
+    /// <c>readonly</c> and <c>log_comment</c> behave the same way. Rename the parameter (<c>row_limit</c>) and
+    /// the query works.
+    /// </para>
+    /// <para>
+    /// This is the server's behaviour, not this client's — <c>clickhouse-client --param_limit=</c> fails the
+    /// same way — and it is version-dependent: it affects 25.8 through 26.6, while newer servers bind such a
+    /// name correctly. It does not affect this driver's HTTP transport, which carries the name separately.
+    /// Rename the parameter if you support any server in that range.
     /// </para>
     /// </remarks>
     public ClickHouseTcpParameterCollection Parameters { get; init; }

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpQueryOptions.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpQueryOptions.cs
@@ -23,4 +23,15 @@ public record ClickHouseTcpQueryOptions
     /// <see cref="ClickHouseTcpClientOptions.CustomSettings"/> for any key present in both. Null means none.
     /// </summary>
     public IReadOnlyDictionary<string, string> Settings { get; init; }
+
+    /// <summary>
+    /// The values bound to the query's <c>{name:Type}</c> placeholders. Null means none.
+    /// </summary>
+    /// <remarks>
+    /// Each value is formatted as the type its placeholder declares, so the query text must carry the type —
+    /// <c>SELECT * FROM t WHERE id = {id:Int32}</c>. A parameter can override that type; see
+    /// <see cref="ClickHouseTcpParameter.ClickHouseType"/>. Parameters need a server whose protocol revision is
+    /// 54459 or above; an older one rejects the query rather than running it without them.
+    /// </remarks>
+    public ClickHouseTcpParameterCollection Parameters { get; init; }
 }

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpQueryOptions.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpQueryOptions.cs
@@ -35,6 +35,16 @@ public record ClickHouseTcpQueryOptions
     /// 54459 or above; an older one rejects the query rather than running it without them.
     /// </para>
     /// <para>
+    /// <b>Declare a timezone when the value names an instant.</b> A <see cref="DateTime"/> whose
+    /// <see cref="DateTime.Kind"/> is <see cref="DateTimeKind.Utc"/> or <see cref="DateTimeKind.Local"/>, and
+    /// any <see cref="DateTimeOffset"/>, names a point in time. The wire carries a wall-clock time and no
+    /// timezone, so the server reads it in its session timezone: a type that declares none moves the instant
+    /// whenever that session is not UTC, and reports no error. The client refuses such a parameter rather than
+    /// send it. Write <c>{t:DateTime('UTC')}</c> or <c>{t:DateTime64(3, 'UTC')}</c>, or pass a
+    /// <see cref="DateTime"/> of <see cref="DateTimeKind.Unspecified"/> when you do mean a wall-clock time for
+    /// the server to read in its own timezone.
+    /// </para>
+    /// <para>
     /// <b>Avoid naming a parameter after a server setting.</b> The native protocol carries parameters in the
     /// settings list, so a server that reads the name as a setting applies it as that setting instead of
     /// binding it. The query then fails with a parse error about a quoted string, which names neither the

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpQueryOptions.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpQueryOptions.cs
@@ -28,10 +28,21 @@ public record ClickHouseTcpQueryOptions
     /// The values bound to the query's <c>{name:Type}</c> placeholders. Null means none.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Each value is formatted as the type its placeholder declares, so the query text must carry the type —
     /// <c>SELECT * FROM t WHERE id = {id:Int32}</c>. A parameter can override that type; see
     /// <see cref="ClickHouseTcpParameter.ClickHouseType"/>. Parameters need a server whose protocol revision is
     /// 54459 or above; an older one rejects the query rather than running it without them.
+    /// </para>
+    /// <para>
+    /// <b>A parameter must not be named after a server setting.</b> The native protocol carries parameters in
+    /// the settings list, so the server applies a name it recognizes as that setting instead of binding it. The
+    /// common traps are <c>limit</c> and <c>offset</c>; <c>max_threads</c>, <c>readonly</c> and
+    /// <c>log_comment</c> behave the same way. The query then fails with a parse error about a quoted string,
+    /// which does not name the parameter. Rename it (<c>row_limit</c>) and the query works. This is a limit of
+    /// the protocol, not of this client — <c>clickhouse-client --param_limit=</c> fails the same way — but it
+    /// does differ from this driver's HTTP transport, where the name is carried separately and works.
+    /// </para>
     /// </remarks>
     public ClickHouseTcpParameterCollection Parameters { get; init; }
 }

--- a/ClickHouse.Driver.Tcp/Client/IClickHouseTcpClient.cs
+++ b/ClickHouse.Driver.Tcp/Client/IClickHouseTcpClient.cs
@@ -39,7 +39,7 @@ public interface IClickHouseTcpClient : IAsyncDisposable
     /// this contract.
     /// </remarks>
     /// <param name="sql">The SQL text.</param>
-    /// <param name="options">Per-query options (query id, settings), or null for the client defaults.</param>
+    /// <param name="options">Per-query options (query id, settings, parameters), or null for the client defaults.</param>
     /// <param name="cancellationToken">A token to observe for cancellation.</param>
     /// <returns>An async stream of the result's row-bearing blocks, each valid only for its own iteration.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="sql"/> is null.</exception>
@@ -56,7 +56,7 @@ public interface IClickHouseTcpClient : IAsyncDisposable
     /// <c>LowCardinality</c> values may be shared within a block; array-valued entries must not be mutated in place.
     /// </remarks>
     /// <param name="sql">The SQL text.</param>
-    /// <param name="options">Per-query options (query id, settings), or null for the client defaults.</param>
+    /// <param name="options">Per-query options (query id, settings, parameters), or null for the client defaults.</param>
     /// <param name="cancellationToken">A token to observe for cancellation.</param>
     /// <returns>An async stream of result rows.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="sql"/> is null.</exception>
@@ -76,7 +76,7 @@ public interface IClickHouseTcpClient : IAsyncDisposable
     /// </remarks>
     /// <typeparam name="T">The row type.</typeparam>
     /// <param name="sql">The SQL text.</param>
-    /// <param name="options">Per-query options (query id, settings), or null for the client defaults.</param>
+    /// <param name="options">Per-query options (query id, settings, parameters), or null for the client defaults.</param>
     /// <param name="cancellationToken">A token to observe for cancellation.</param>
     /// <returns>An async stream of result rows.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="sql"/> is null.</exception>
@@ -92,7 +92,7 @@ public interface IClickHouseTcpClient : IAsyncDisposable
     /// returns once the server acknowledges it. Any result blocks are drained and discarded.
     /// </summary>
     /// <param name="sql">The SQL text.</param>
-    /// <param name="options">Per-query options (query id, settings), or null for the client defaults.</param>
+    /// <param name="options">Per-query options (query id, settings, parameters), or null for the client defaults.</param>
     /// <param name="cancellationToken">A token to observe for cancellation.</param>
     /// <returns>A task that completes when the statement is acknowledged.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="sql"/> is null.</exception>
@@ -108,7 +108,7 @@ public interface IClickHouseTcpClient : IAsyncDisposable
     /// </summary>
     /// <param name="sql">The <c>INSERT INTO … VALUES</c> statement, with no inline <c>VALUES (...)</c> literal.</param>
     /// <param name="columns">The row data, matched to the target columns by name.</param>
-    /// <param name="options">Per-insert options (query id, settings, block sizing), or null for the client defaults.</param>
+    /// <param name="options">Per-insert options (query id, settings, parameters, block sizing), or null for the client defaults.</param>
     /// <param name="cancellationToken">A token to observe for cancellation.</param>
     /// <returns>A task that completes when the server acknowledges the insert.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="sql"/> or <paramref name="columns"/> is null.</exception>
@@ -139,7 +139,7 @@ public interface IClickHouseTcpClient : IAsyncDisposable
     /// <typeparam name="T">The row type.</typeparam>
     /// <param name="sql">The <c>INSERT INTO … VALUES</c> statement, with no inline <c>VALUES (...)</c> literal.</param>
     /// <param name="rows">The materialized rows to insert, each non-null.</param>
-    /// <param name="options">Per-insert options (query id, settings, block sizing), or null for the client defaults.</param>
+    /// <param name="options">Per-insert options (query id, settings, parameters, block sizing), or null for the client defaults.</param>
     /// <param name="cancellationToken">A token to observe for cancellation.</param>
     /// <returns>A task that completes when the server acknowledges the insert.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="sql"/> or <paramref name="rows"/> is null.</exception>
@@ -165,7 +165,7 @@ public interface IClickHouseTcpClient : IAsyncDisposable
     /// </remarks>
     /// <param name="sql">The <c>INSERT INTO … VALUES</c> statement, with no inline <c>VALUES (...)</c> literal.</param>
     /// <param name="rows">The materialized rows to insert, each non-null and one value long per target column.</param>
-    /// <param name="options">Per-insert options (query id, settings, block sizing), or null for the client defaults.</param>
+    /// <param name="options">Per-insert options (query id, settings, parameters, block sizing), or null for the client defaults.</param>
     /// <param name="cancellationToken">A token to observe for cancellation.</param>
     /// <returns>A task that completes when the server acknowledges the insert.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="sql"/> or <paramref name="rows"/> is null.</exception>

--- a/ClickHouse.Driver.Tcp/Parameters/MapPairs.cs
+++ b/ClickHouse.Driver.Tcp/Parameters/MapPairs.cs
@@ -6,14 +6,8 @@ using System.Linq;
 namespace ClickHouse.Driver.Tcp.Parameters;
 
 /// <summary>
-/// Recognises a Map given as a sequence of key/value pairs, which is the shape this client reads a
-/// <c>Map(K, V)</c> column back as.
+/// Recognises the key/value sequence returned for a Map column, preserving pair order and duplicate keys.
 /// </summary>
-/// <remarks>
-/// <c>MapColumnCodec</c> surfaces a row as <c>KeyValuePair&lt;K, V&gt;[]</c> rather than a dictionary so that
-/// duplicate keys and pair order survive the read. A value taken from a Map column therefore has to be
-/// bindable as a parameter in that same shape, or reading a row and sending it back would fail.
-/// </remarks>
 internal static class MapPairs
 {
     /// <summary>Reports whether a value is a sequence of <see cref="KeyValuePair{TKey, TValue}"/>.</summary>
@@ -35,13 +29,9 @@ internal static class MapPairs
                 && element.GetGenericTypeDefinition() == typeof(KeyValuePair<,>));
     }
 
-    /// <summary>Reads the key and the value out of a pair of any two types.</summary>
+    /// <summary>Reads a key/value pair whose generic types are known only at runtime.</summary>
     /// <param name="pair">The pair.</param>
     /// <returns>The key and the value.</returns>
-    /// <remarks>
-    /// Reflection rather than a generic overload, because the caller reaches the pair as <c>object</c> through
-    /// a non-generic <see cref="IEnumerable"/> and the two type arguments are not known at this point.
-    /// </remarks>
     public static (object Key, object Value) Read(object pair)
     {
         Type type = pair.GetType();

--- a/ClickHouse.Driver.Tcp/Parameters/MapPairs.cs
+++ b/ClickHouse.Driver.Tcp/Parameters/MapPairs.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ClickHouse.Driver.Tcp.Parameters;
+
+/// <summary>
+/// Recognises a Map given as a sequence of key/value pairs, which is the shape this client reads a
+/// <c>Map(K, V)</c> column back as.
+/// </summary>
+/// <remarks>
+/// <c>MapColumnCodec</c> surfaces a row as <c>KeyValuePair&lt;K, V&gt;[]</c> rather than a dictionary so that
+/// duplicate keys and pair order survive the read. A value taken from a Map column therefore has to be
+/// bindable as a parameter in that same shape, or reading a row and sending it back would fail.
+/// </remarks>
+internal static class MapPairs
+{
+    /// <summary>Reports whether a value is a sequence of <see cref="KeyValuePair{TKey, TValue}"/>.</summary>
+    /// <param name="value">The value to test.</param>
+    /// <returns>True when the value is a pair sequence.</returns>
+    public static bool IsPairSequence(object value)
+    {
+        if (value is not IEnumerable || value is string)
+        {
+            return false;
+        }
+
+        Type type = value.GetType();
+        return type.GetInterfaces()
+            .Append(type)
+            .Any(candidate => candidate.IsGenericType
+                && candidate.GetGenericTypeDefinition() == typeof(IEnumerable<>)
+                && candidate.GetGenericArguments()[0] is { IsGenericType: true } element
+                && element.GetGenericTypeDefinition() == typeof(KeyValuePair<,>));
+    }
+
+    /// <summary>Reads the key and the value out of a pair of any two types.</summary>
+    /// <param name="pair">The pair.</param>
+    /// <returns>The key and the value.</returns>
+    /// <remarks>
+    /// Reflection rather than a generic overload, because the caller reaches the pair as <c>object</c> through
+    /// a non-generic <see cref="IEnumerable"/> and the two type arguments are not known at this point.
+    /// </remarks>
+    public static (object Key, object Value) Read(object pair)
+    {
+        Type type = pair.GetType();
+        return (type.GetProperty("Key").GetValue(pair), type.GetProperty("Value").GetValue(pair));
+    }
+}

--- a/ClickHouse.Driver.Tcp/Parameters/ParameterText.cs
+++ b/ClickHouse.Driver.Tcp/Parameters/ParameterText.cs
@@ -1,0 +1,34 @@
+namespace ClickHouse.Driver.Tcp.Parameters;
+
+/// <summary>
+/// The text escaping the native protocol's parameter list needs.
+/// </summary>
+/// <remarks>
+/// A parameter value passes two server-side text stages. The settings reader restores a Field from the text,
+/// which requires a quoted SQL literal, and the <c>{name:Type}</c> substitution then parses what that Field
+/// holds. Each stage removes one round of backslash escapes, so the formatter escapes the value text once for
+/// the substitution stage and escapes and quotes the whole parameter again for the Field stage.
+/// </remarks>
+internal static class ParameterText
+{
+    /// <summary>Escapes the characters a server text reader treats as an escape sequence or a terminator.</summary>
+    /// <param name="value">The text to escape.</param>
+    /// <returns>The escaped text.</returns>
+    /// <remarks>
+    /// A tab or a newline terminates the substitution stage's reader, so both must arrive as escape sequences
+    /// rather than as themselves. This matches the HTTP transport's escaping — see the note on
+    /// <see cref="TcpParameterFormatter"/>.
+    /// </remarks>
+    public static string Escape(this string value)
+        => value.Replace("\\", "\\\\").Replace("'", "\\'").Replace("\n", "\\n").Replace("\t", "\\t");
+
+    /// <summary>Wraps the text in single quotes.</summary>
+    /// <param name="value">The text to quote.</param>
+    /// <returns>The quoted text.</returns>
+    /// <remarks>
+    /// Unconditional, unlike the HTTP helper of the same name, which leaves already-quoted text alone. Every
+    /// caller here quotes text that <see cref="Escape"/> has just produced, and an escaped string cannot start
+    /// with a bare quote, so the HTTP check could never fire.
+    /// </remarks>
+    public static string QuoteSingle(this string value) => $"'{value}'";
+}

--- a/ClickHouse.Driver.Tcp/Parameters/ParameterText.cs
+++ b/ClickHouse.Driver.Tcp/Parameters/ParameterText.cs
@@ -1,13 +1,11 @@
 namespace ClickHouse.Driver.Tcp.Parameters;
 
 /// <summary>
-/// The text escaping the native protocol's parameter list needs.
+/// Escapes parameter text for the native protocol's two server-side parsing stages.
 /// </summary>
 /// <remarks>
-/// A parameter value passes two server-side text stages. The settings reader restores a Field from the text,
-/// which requires a quoted SQL literal, and the <c>{name:Type}</c> substitution then parses what that Field
-/// holds. Each stage removes one round of backslash escapes, so the formatter escapes the value text once for
-/// the substitution stage and escapes and quotes the whole parameter again for the Field stage.
+/// The formatter first escapes the SQL value for placeholder substitution, then escapes and quotes it for the
+/// settings reader.
 /// </remarks>
 internal static class ParameterText
 {
@@ -15,9 +13,7 @@ internal static class ParameterText
     /// <param name="value">The text to escape.</param>
     /// <returns>The escaped text.</returns>
     /// <remarks>
-    /// A tab or a newline terminates the substitution stage's reader, so both must arrive as escape sequences
-    /// rather than as themselves. This matches the HTTP transport's escaping — see the note on
-    /// <see cref="TcpParameterFormatter"/>.
+    /// Tabs and newlines must be escaped because they terminate the server's text reader.
     /// </remarks>
     public static string Escape(this string value)
         => value.Replace("\\", "\\\\").Replace("'", "\\'").Replace("\n", "\\n").Replace("\t", "\\t");
@@ -25,10 +21,5 @@ internal static class ParameterText
     /// <summary>Wraps the text in single quotes.</summary>
     /// <param name="value">The text to quote.</param>
     /// <returns>The quoted text.</returns>
-    /// <remarks>
-    /// Unconditional, unlike the HTTP helper of the same name, which leaves already-quoted text alone. Every
-    /// caller here quotes text that <see cref="Escape"/> has just produced, and an escaped string cannot start
-    /// with a bare quote, so the HTTP check could never fire.
-    /// </remarks>
     public static string QuoteSingle(this string value) => $"'{value}'";
 }

--- a/ClickHouse.Driver.Tcp/Parameters/ParameterTypeInference.cs
+++ b/ClickHouse.Driver.Tcp/Parameters/ParameterTypeInference.cs
@@ -97,17 +97,40 @@ internal static class ParameterTypeInference
 
         string inferred = value switch
         {
+            // A byte array reads as text or as an array of bytes, so an Array alternative takes it first. The
+            // string arms would otherwise win and print the CLR type name instead of the contents.
+            byte[] => node.Name is "Array" or "String" or "FixedString" ? node.Name : "String",
+
             // These share one CLR type with several ClickHouse types, so the base name alone decides.
-            string or char or byte[] => node.Name is "String" or "FixedString" or "Enum8" or "Enum16" ? node.Name : "String",
+            string or char => node.Name is "String" or "FixedString" or "Enum8" or "Enum16" ? node.Name : "String",
             DateTime or DateTimeOffset => node.Name is "DateTime" or "DateTime64" or "Date" or "Date32" ? node.Name : "DateTime64",
             decimal or ClickHouseDecimal => node.Name.StartsWith("Decimal", StringComparison.Ordinal) ? node.Name : "Decimal128",
             IDictionary => "Map",
             ITuple => "Tuple",
             not string and IEnumerable => "Array",
-            _ => TypeParser.Parse(Infer(value, "variant")).Name,
+            _ => InferOrNothing(value),
         };
 
         return string.Equals(inferred, node.Name, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The type a value maps to, or null when it maps to none. Used only when matching a Variant alternative,
+    /// where an unmappable value must simply fail to match and let the caller report the Variant as a whole. An
+    /// exception here would name a parameter the caller never wrote.
+    /// </summary>
+    /// <param name="value">The value to place.</param>
+    /// <returns>The base type name, or null.</returns>
+    private static string InferOrNothing(object value)
+    {
+        try
+        {
+            return TypeParser.Parse(Infer(value, parameterName: null)).Name;
+        }
+        catch (ArgumentException)
+        {
+            return null;
+        }
     }
 
     private static string InferMap(IDictionary dictionary, string parameterName)

--- a/ClickHouse.Driver.Tcp/Parameters/ParameterTypeInference.cs
+++ b/ClickHouse.Driver.Tcp/Parameters/ParameterTypeInference.cs
@@ -198,15 +198,9 @@ internal static class ParameterTypeInference
     /// <returns>True when the arity and every element fit.</returns>
     private static bool AcceptsTupleElements(TypeNode node, ITuple value)
     {
-        TypeNode[] elementTypes;
-        try
-        {
-            elementTypes = NamedElementParser.Split(node).Select(element => element.Type).ToArray();
-        }
-        catch (FormatException)
-        {
-            return false;
-        }
+        // Split does not validate arity — ElementTypeStrings is what raises FormatException — so there is
+        // nothing to guard against here and the arity check below is the one that matters.
+        TypeNode[] elementTypes = NamedElementParser.Split(node).Select(element => element.Type).ToArray();
 
         if (elementTypes.Length != value.Length)
         {

--- a/ClickHouse.Driver.Tcp/Parameters/ParameterTypeInference.cs
+++ b/ClickHouse.Driver.Tcp/Parameters/ParameterTypeInference.cs
@@ -44,7 +44,7 @@ internal static class ParameterTypeInference
             case decimal d: return $"Decimal128({(decimal.GetBits(d)[3] >> 16) & 0x7F})";
             case ClickHouseDecimal chd: return $"Decimal128({chd.Scale})";
 
-            case string or char or byte[]: return "String";
+            case string or char or byte[] or ReadOnlyMemory<byte>: return "String";
             case Guid: return "UUID";
             case DateOnly: return "Date";
             case TimeSpan: return "Time64(9)";
@@ -128,7 +128,8 @@ internal static class ParameterTypeInference
         string inferred = value switch
         {
             // The Array case above already took a byte[] an element type accepts, so only the text arms remain.
-            byte[] => node.Name is "String" or "FixedString" ? node.Name : "String",
+            // A ReadOnlyMemory is not IEnumerable, so it never reaches that case and only the text arms format it.
+            byte[] or ReadOnlyMemory<byte> => node.Name is "String" or "FixedString" ? node.Name : "String",
 
             // These share one CLR type with several ClickHouse types, so the base name alone decides.
             string or char => node.Name is "String" or "FixedString" or "Enum8" or "Enum16" ? node.Name : "String",

--- a/ClickHouse.Driver.Tcp/Parameters/ParameterTypeInference.cs
+++ b/ClickHouse.Driver.Tcp/Parameters/ParameterTypeInference.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Collections;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Runtime.CompilerServices;
+using ClickHouse.Driver.Tcp.Numerics;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Parameters;
+
+/// <summary>
+/// Infers a ClickHouse type name from a CLR value, for the last rung of the parameter type-resolution chain.
+/// </summary>
+/// <remarks>
+/// This is a fallback, not the normal path. A native-protocol query carries its parameter types in the SQL
+/// (<c>{name:Type}</c>), so the extracted hint almost always answers first and the server parses the value
+/// against the declared type either way. Inference covers the two cases the hint cannot: a parameter that the
+/// SQL does not reference, and SQL whose hint the scanner did not see.
+/// </remarks>
+internal static class ParameterTypeInference
+{
+    /// <summary>Infers the ClickHouse type name to format a value as.</summary>
+    /// <param name="value">The parameter value.</param>
+    /// <param name="parameterName">The parameter name, for the error message.</param>
+    /// <returns>The inferred ClickHouse type name.</returns>
+    /// <exception cref="ArgumentException">The value's CLR type maps to no ClickHouse type.</exception>
+    public static string Infer(object value, string parameterName)
+    {
+        switch (value)
+        {
+            case null or DBNull: return "Nullable(Nothing)";
+            case bool: return "Bool";
+            case byte: return "UInt8";
+            case sbyte: return "Int8";
+            case ushort: return "UInt16";
+            case short: return "Int16";
+            case uint: return "UInt32";
+            case int: return "Int32";
+            case ulong: return "UInt64";
+            case long: return "Int64";
+            case UInt128: return "UInt128";
+            case Int128: return "Int128";
+            case UInt256: return "UInt256";
+            case Int256: return "Int256";
+            case float: return "Float32";
+            case double: return "Float64";
+
+            // The scale is the value's own, so a round trip keeps every digit the caller supplied.
+            case decimal d: return $"Decimal128({(decimal.GetBits(d)[3] >> 16) & 0x7F})";
+            case ClickHouseDecimal chd: return $"Decimal128({chd.Scale})";
+
+            case string or char or byte[]: return "String";
+            case Guid: return "UUID";
+            case DateOnly: return "Date";
+            case TimeSpan: return "Time64(9)";
+
+            // Sub-second precision is kept, and the instant is anchored to UTC rather than to a session zone.
+            case DateTime or DateTimeOffset: return "DateTime64(7, 'UTC')";
+
+            case IPAddress ip:
+                return ip.AddressFamily == AddressFamily.InterNetworkV6 ? "IPv6" : "IPv4";
+
+            case ITuple tuple:
+                return $"Tuple({string.Join(", ", Enumerable.Range(0, tuple.Length).Select(i => Infer(tuple[i], parameterName)))})";
+
+            case IDictionary dictionary:
+                return InferMap(dictionary, parameterName);
+
+            case IEnumerable enumerable:
+                return $"Array({InferElement(enumerable, parameterName)})";
+
+            default:
+                throw new ArgumentException(
+                    $"Parameter '{parameterName}' has value type '{value.GetType().FullName}', which maps to no ClickHouse type. " +
+                    "Add a {" + parameterName + ":Type} hint to the SQL, or set ClickHouseType on the parameter.",
+                    parameterName);
+        }
+    }
+
+    /// <summary>Reports whether a value would be formatted as the given type, used to pick a Variant alternative.</summary>
+    /// <param name="node">The candidate alternative type.</param>
+    /// <param name="value">The value to place.</param>
+    /// <returns>True when the alternative accepts the value.</returns>
+    public static bool Accepts(TypeNode node, object value)
+    {
+        if (value is null or DBNull)
+        {
+            return node.Name is "Nothing";
+        }
+
+        // An alternative may itself be a wrapper; match against what it ultimately holds.
+        if (node.Name is "Nullable" or "LowCardinality" && node.Arguments.Count == 1)
+        {
+            return Accepts(node.Arguments[0], value);
+        }
+
+        string inferred = value switch
+        {
+            // These share one CLR type with several ClickHouse types, so the base name alone decides.
+            string or char or byte[] => node.Name is "String" or "FixedString" or "Enum8" or "Enum16" ? node.Name : "String",
+            DateTime or DateTimeOffset => node.Name is "DateTime" or "DateTime64" or "Date" or "Date32" ? node.Name : "DateTime64",
+            decimal or ClickHouseDecimal => node.Name.StartsWith("Decimal", StringComparison.Ordinal) ? node.Name : "Decimal128",
+            IDictionary => "Map",
+            ITuple => "Tuple",
+            not string and IEnumerable => "Array",
+            _ => TypeParser.Parse(Infer(value, "variant")).Name,
+        };
+
+        return string.Equals(inferred, node.Name, StringComparison.Ordinal);
+    }
+
+    private static string InferMap(IDictionary dictionary, string parameterName)
+    {
+        // An empty map carries no sample value, so fall back to the widest pair the server will accept.
+        foreach (DictionaryEntry entry in dictionary)
+        {
+            return $"Map({Infer(entry.Key, parameterName)}, {Infer(entry.Value, parameterName)})";
+        }
+
+        return "Map(String, String)";
+    }
+
+    private static string InferElement(IEnumerable enumerable, string parameterName)
+    {
+        foreach (object element in enumerable)
+        {
+            if (element is not null and not DBNull)
+            {
+                return Infer(element, parameterName);
+            }
+        }
+
+        // Every element is null, or there are none; String is the type most values print into.
+        return "Nullable(String)";
+    }
+}

--- a/ClickHouse.Driver.Tcp/Parameters/ParameterTypeInference.cs
+++ b/ClickHouse.Driver.Tcp/Parameters/ParameterTypeInference.cs
@@ -95,6 +95,31 @@ internal static class ParameterTypeInference
             return Accepts(node.Arguments[0], value);
         }
 
+        // A composite matches only when its contents do. Comparing the outer name alone would let
+        // Variant(Array(Int32), Array(String)) take a string[] on its first arm and format the strings as
+        // integers, which the server then rejects or, worse, reads as something else.
+        switch (value)
+        {
+            case IDictionary dictionary when node.Name is "Map":
+                return node.Arguments.Count == 2 && AcceptsPairs(node, dictionary);
+
+            // The shape this client reads a Map column back as. It is also an IEnumerable, so it has to be
+            // decided here or the Array arm below would claim it.
+            case not string and IEnumerable pairs when MapPairs.IsPairSequence(value):
+                return node.Name is "Map"
+                    && node.Arguments.Count == 2
+                    && AcceptsPairSequence(node, pairs);
+
+            case ITuple tuple when node.Name is "Tuple":
+                return AcceptsTupleElements(node, tuple);
+
+            case not string and not byte[] and IEnumerable elements when node.Name is "Array":
+                return node.Arguments.Count == 1 && AcceptsElements(node.Arguments[0], elements);
+
+            case IDictionary or ITuple:
+                return false;
+        }
+
         string inferred = value switch
         {
             // A byte array reads as text or as an array of bytes, so an Array alternative takes it first. The
@@ -105,13 +130,98 @@ internal static class ParameterTypeInference
             string or char => node.Name is "String" or "FixedString" or "Enum8" or "Enum16" ? node.Name : "String",
             DateTime or DateTimeOffset => node.Name is "DateTime" or "DateTime64" or "Date" or "Date32" ? node.Name : "DateTime64",
             decimal or ClickHouseDecimal => node.Name.StartsWith("Decimal", StringComparison.Ordinal) ? node.Name : "Decimal128",
-            IDictionary => "Map",
-            ITuple => "Tuple",
             not string and IEnumerable => "Array",
             _ => InferOrNothing(value),
         };
 
         return string.Equals(inferred, node.Name, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Reports whether every element of a sequence fits the element type. An empty sequence fits any element
+    /// type, because there is nothing to contradict it.
+    /// </summary>
+    /// <param name="elementType">The candidate element type.</param>
+    /// <param name="elements">The sequence.</param>
+    /// <returns>True when every element fits.</returns>
+    private static bool AcceptsElements(TypeNode elementType, IEnumerable elements)
+    {
+        foreach (object element in elements)
+        {
+            if (!Accepts(elementType, element))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>Reports whether every pair of a key/value sequence fits a Map's two argument types.</summary>
+    /// <param name="node">The Map type.</param>
+    /// <param name="pairs">The pair sequence.</param>
+    /// <returns>True when every pair fits.</returns>
+    private static bool AcceptsPairSequence(TypeNode node, IEnumerable pairs)
+    {
+        foreach (object pair in pairs)
+        {
+            (object key, object value) = MapPairs.Read(pair);
+            if (!Accepts(node.Arguments[0], key) || !Accepts(node.Arguments[1], value))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>Reports whether every key and value of a dictionary fits a Map's two argument types.</summary>
+    /// <param name="node">The Map type.</param>
+    /// <param name="value">The dictionary.</param>
+    /// <returns>True when every pair fits.</returns>
+    private static bool AcceptsPairs(TypeNode node, IDictionary value)
+    {
+        foreach (DictionaryEntry entry in value)
+        {
+            if (!Accepts(node.Arguments[0], entry.Key) || !Accepts(node.Arguments[1], entry.Value))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>Reports whether a tuple's arity and every element fit a Tuple type.</summary>
+    /// <param name="node">The Tuple type.</param>
+    /// <param name="value">The tuple.</param>
+    /// <returns>True when the arity and every element fit.</returns>
+    private static bool AcceptsTupleElements(TypeNode node, ITuple value)
+    {
+        TypeNode[] elementTypes;
+        try
+        {
+            elementTypes = NamedElementParser.Split(node).Select(element => element.Type).ToArray();
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+
+        if (elementTypes.Length != value.Length)
+        {
+            return false;
+        }
+
+        for (int i = 0; i < elementTypes.Length; i++)
+        {
+            if (!Accepts(elementTypes[i], value[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /// <summary>

--- a/ClickHouse.Driver.Tcp/Parameters/ParameterTypeInference.cs
+++ b/ClickHouse.Driver.Tcp/Parameters/ParameterTypeInference.cs
@@ -89,6 +89,19 @@ internal static class ParameterTypeInference
             return Accepts(node.Arguments[0], value);
         }
 
+        // A geo name stands for a Tuple/Array shape, which is what the formatter writes it as. Matching the
+        // name alone would reject every value, because no CLR type infers to "Point".
+        if (TcpParameterFormatter.TryGeoShapeOf(node.Name, out TypeNode geoShape))
+        {
+            return Accepts(geoShape, value);
+        }
+
+        // A QBit is a fixed-width vector of its element type, so it takes what an Array of that type takes.
+        if (node.Name is "QBit" && node.Arguments.Count == 2)
+        {
+            return value is not string and IEnumerable components && AcceptsElements(node.Arguments[0], components);
+        }
+
         // Match composite alternatives recursively; their outer names are insufficient.
         switch (value)
         {
@@ -104,7 +117,8 @@ internal static class ParameterTypeInference
             case ITuple tuple when node.Name is "Tuple":
                 return AcceptsTupleElements(node, tuple);
 
-            case not string and not byte[] and IEnumerable elements when node.Name is "Array":
+            // A byte[] is checked element by element here too, so it takes Array(UInt8) but not Array(String).
+            case not string and IEnumerable elements when node.Name is "Array":
                 return node.Arguments.Count == 1 && AcceptsElements(node.Arguments[0], elements);
 
             case IDictionary or ITuple:
@@ -113,8 +127,8 @@ internal static class ParameterTypeInference
 
         string inferred = value switch
         {
-            // Prefer Array for byte[] when offered; otherwise treat it as String.
-            byte[] => node.Name is "Array" or "String" or "FixedString" ? node.Name : "String",
+            // The Array case above already took a byte[] an element type accepts, so only the text arms remain.
+            byte[] => node.Name is "String" or "FixedString" ? node.Name : "String",
 
             // These share one CLR type with several ClickHouse types, so the base name alone decides.
             string or char => node.Name is "String" or "FixedString" or "Enum8" or "Enum16" ? node.Name : "String",

--- a/ClickHouse.Driver.Tcp/Parameters/ParameterTypeInference.cs
+++ b/ClickHouse.Driver.Tcp/Parameters/ParameterTypeInference.cs
@@ -10,14 +10,8 @@ using ClickHouse.Driver.Tcp.Types;
 namespace ClickHouse.Driver.Tcp.Parameters;
 
 /// <summary>
-/// Infers a ClickHouse type name from a CLR value, for the last rung of the parameter type-resolution chain.
+/// Retained for future client-side placeholder support and used to match Variant alternatives.
 /// </summary>
-/// <remarks>
-/// This is a fallback, not the normal path. A native-protocol query carries its parameter types in the SQL
-/// (<c>{name:Type}</c>), so the extracted hint almost always answers first and the server parses the value
-/// against the declared type either way. Inference covers the two cases the hint cannot: a parameter that the
-/// SQL does not reference, and SQL whose hint the scanner did not see.
-/// </remarks>
 internal static class ParameterTypeInference
 {
     /// <summary>Infers the ClickHouse type name to format a value as.</summary>
@@ -95,16 +89,13 @@ internal static class ParameterTypeInference
             return Accepts(node.Arguments[0], value);
         }
 
-        // A composite matches only when its contents do. Comparing the outer name alone would let
-        // Variant(Array(Int32), Array(String)) take a string[] on its first arm and format the strings as
-        // integers, which the server then rejects or, worse, reads as something else.
+        // Match composite alternatives recursively; their outer names are insufficient.
         switch (value)
         {
             case IDictionary dictionary when node.Name is "Map":
                 return node.Arguments.Count == 2 && AcceptsPairs(node, dictionary);
 
-            // The shape this client reads a Map column back as. It is also an IEnumerable, so it has to be
-            // decided here or the Array arm below would claim it.
+            // Handle the Map read shape before the general Array case.
             case not string and IEnumerable pairs when MapPairs.IsPairSequence(value):
                 return node.Name is "Map"
                     && node.Arguments.Count == 2
@@ -122,8 +113,7 @@ internal static class ParameterTypeInference
 
         string inferred = value switch
         {
-            // A byte array reads as text or as an array of bytes, so an Array alternative takes it first. The
-            // string arms would otherwise win and print the CLR type name instead of the contents.
+            // Prefer Array for byte[] when offered; otherwise treat it as String.
             byte[] => node.Name is "Array" or "String" or "FixedString" ? node.Name : "String",
 
             // These share one CLR type with several ClickHouse types, so the base name alone decides.
@@ -137,10 +127,7 @@ internal static class ParameterTypeInference
         return string.Equals(inferred, node.Name, StringComparison.Ordinal);
     }
 
-    /// <summary>
-    /// Reports whether every element of a sequence fits the element type. An empty sequence fits any element
-    /// type, because there is nothing to contradict it.
-    /// </summary>
+    /// <summary>Reports whether every element fits; an empty sequence fits any element type.</summary>
     /// <param name="elementType">The candidate element type.</param>
     /// <param name="elements">The sequence.</param>
     /// <returns>True when every element fits.</returns>
@@ -198,8 +185,7 @@ internal static class ParameterTypeInference
     /// <returns>True when the arity and every element fit.</returns>
     private static bool AcceptsTupleElements(TypeNode node, ITuple value)
     {
-        // Split does not validate arity — ElementTypeStrings is what raises FormatException — so there is
-        // nothing to guard against here and the arity check below is the one that matters.
+        // Split does not validate arity, so compare it explicitly.
         TypeNode[] elementTypes = NamedElementParser.Split(node).Select(element => element.Type).ToArray();
 
         if (elementTypes.Length != value.Length)
@@ -218,11 +204,7 @@ internal static class ParameterTypeInference
         return true;
     }
 
-    /// <summary>
-    /// The type a value maps to, or null when it maps to none. Used only when matching a Variant alternative,
-    /// where an unmappable value must simply fail to match and let the caller report the Variant as a whole. An
-    /// exception here would name a parameter the caller never wrote.
-    /// </summary>
+    /// <summary>Infers a Variant candidate, returning null instead of a parameter-level error.</summary>
     /// <param name="value">The value to place.</param>
     /// <returns>The base type name, or null.</returns>
     private static string InferOrNothing(object value)

--- a/ClickHouse.Driver.Tcp/Parameters/ParameterTypeInference.cs
+++ b/ClickHouse.Driver.Tcp/Parameters/ParameterTypeInference.cs
@@ -80,7 +80,9 @@ internal static class ParameterTypeInference
     {
         if (value is null or DBNull)
         {
-            return node.Name is "Nothing";
+            // A null belongs to Nothing and to any Nullable, which is what carries it inside a composite.
+            return node.Name is "Nothing" or "Nullable"
+                || (node.Name is "LowCardinality" && node.Arguments.Count == 1 && Accepts(node.Arguments[0], value));
         }
 
         // An alternative may itself be a wrapper; match against what it ultimately holds.
@@ -133,6 +135,9 @@ internal static class ParameterTypeInference
 
             // These share one CLR type with several ClickHouse types, so the base name alone decides.
             string or char => node.Name is "String" or "FixedString" or "Enum8" or "Enum16" ? node.Name : "String",
+
+            // A float is the only value BFloat16 accepts, so it matches that alternative as well as Float32.
+            float => node.Name is "Float32" or "BFloat16" ? node.Name : "Float32",
             DateTime or DateTimeOffset => node.Name is "DateTime" or "DateTime64" or "Date" or "Date32" ? node.Name : "DateTime64",
             decimal or ClickHouseDecimal => node.Name.StartsWith("Decimal", StringComparison.Ordinal) ? node.Name : "Decimal128",
             not string and IEnumerable => "Array",

--- a/ClickHouse.Driver.Tcp/Parameters/SqlParameterTypeExtractor.cs
+++ b/ClickHouse.Driver.Tcp/Parameters/SqlParameterTypeExtractor.cs
@@ -4,26 +4,18 @@ using System.Collections.Generic;
 namespace ClickHouse.Driver.Tcp.Parameters;
 
 /// <summary>
-/// Extracts parameter type hints from SQL queries using ClickHouse's native parameter syntax, {parameter_name:type}.
-/// This is a port of the HTTP scanner <c>ClickHouse.Driver.ADO.Parameters.SqlParameterTypeExtractor</c>. The TCP
-/// assembly cannot reference <c>ClickHouse.Driver</c>, because the project reference runs the other way. Keep the
-/// two copies in step: a change to one must be applied to the other.
-/// <para>
-/// The two have already diverged in one place. This copy treats a backslash as an escape inside a string
-/// literal, which the HTTP copy does not, so a query holding <c>\'</c> keeps its type hints here and loses
-/// them there. That is a defect in the HTTP copy; fixing it changes a shipped client, so it is filed rather
-/// than done — see the parity-check entry in the TCP TODO.
-/// </para>
+/// Extracts ClickHouse-native <c>{name:Type}</c> hints while ignoring SQL strings and comments.
 /// </summary>
+/// <remarks>
+/// Ported from the HTTP scanner because the TCP assembly cannot reference it. Keep shared behavior aligned;
+/// this copy additionally handles backslash-escaped quotes.
+/// </remarks>
 internal static class SqlParameterTypeExtractor
 {
-    /// <summary>
-    /// Extracts type hints from a SQL query string.
-    /// </summary>
+    /// <summary>Extracts parameter names and types from a SQL query.</summary>
     /// <param name="sql">The SQL query containing parameter placeholders.</param>
     /// <returns>
-    /// A dictionary mapping parameter names to their type definitions.
-    /// Parameters without type hints (e.g., <c>{name}</c>) are not included.
+    /// Parameter names mapped to their types; placeholders without types are omitted.
     /// </returns>
     /// <exception cref="ArgumentException">The same parameter name has two different type hints.</exception>
     public static Dictionary<string, string> ExtractTypeHints(string sql)
@@ -44,8 +36,7 @@ internal static class SqlParameterTypeExtractor
 
             if (inSqlString)
             {
-                // A backslash escapes whatever follows, so \' stays inside the string. Without this the
-                // string appears to end early and the real placeholder after it is never seen.
+                // A backslash escapes the next character, including a quote.
                 if (c == '\\' && i + 1 < sql.Length)
                 {
                     i += 2;
@@ -116,10 +107,7 @@ internal static class SqlParameterTypeExtractor
         return result;
     }
 
-    /// <summary>
-    /// Tries to extract a parameter from the given position.
-    /// Returns (name, type, endIndex) if successful, or (null, null, 0) if not a valid parameter.
-    /// </summary>
+    /// <summary>Extracts a parameter at the given position, or returns null values when it is invalid.</summary>
     /// <param name="sql">The SQL query.</param>
     /// <param name="startIndex">The index of the opening brace.</param>
     /// <returns>The parameter name, its type, and the index after the closing brace.</returns>
@@ -154,8 +142,7 @@ internal static class SqlParameterTypeExtractor
 
             if (inQuote)
             {
-                // A backslash escapes whatever follows, so \' stays inside the quoted argument. Without this
-                // an enum label such as 'it\'s' ends early and the type is truncated.
+                // A backslash escapes the next character inside the type argument.
                 if (c == '\\' && i + 1 < sql.Length)
                 {
                     i += 2;
@@ -203,10 +190,7 @@ internal static class SqlParameterTypeExtractor
         return (null, null, 0);
     }
 
-    /// <summary>
-    /// Skips to the end of a line.
-    /// Returns the index of the first character after the newline, or sql.Length if no newline found.
-    /// </summary>
+    /// <summary>Returns the index after the next newline, or the end of the SQL.</summary>
     /// <param name="sql">The SQL query.</param>
     /// <param name="startIndex">The index to scan from.</param>
     /// <returns>The index after the newline.</returns>
@@ -216,10 +200,7 @@ internal static class SqlParameterTypeExtractor
         return newlineIndex < 0 ? sql.Length : newlineIndex + 1;
     }
 
-    /// <summary>
-    /// Skips a C-style block comment (after /*).
-    /// Returns the index of the first character after */, or sql.Length if not found.
-    /// </summary>
+    /// <summary>Returns the index after the block comment, or the end of the SQL.</summary>
     /// <param name="sql">The SQL query.</param>
     /// <param name="startIndex">The index to scan from.</param>
     /// <returns>The index after the closing marker.</returns>

--- a/ClickHouse.Driver.Tcp/Parameters/SqlParameterTypeExtractor.cs
+++ b/ClickHouse.Driver.Tcp/Parameters/SqlParameterTypeExtractor.cs
@@ -8,6 +8,12 @@ namespace ClickHouse.Driver.Tcp.Parameters;
 /// This is a port of the HTTP scanner <c>ClickHouse.Driver.ADO.Parameters.SqlParameterTypeExtractor</c>. The TCP
 /// assembly cannot reference <c>ClickHouse.Driver</c>, because the project reference runs the other way. Keep the
 /// two copies in step: a change to one must be applied to the other.
+/// <para>
+/// The two have already diverged in one place. This copy treats a backslash as an escape inside a string
+/// literal, which the HTTP copy does not, so a query holding <c>\'</c> keeps its type hints here and loses
+/// them there. That is a defect in the HTTP copy; fixing it changes a shipped client, so it is filed rather
+/// than done — see the parity-check entry in the TCP TODO.
+/// </para>
 /// </summary>
 internal static class SqlParameterTypeExtractor
 {

--- a/ClickHouse.Driver.Tcp/Parameters/SqlParameterTypeExtractor.cs
+++ b/ClickHouse.Driver.Tcp/Parameters/SqlParameterTypeExtractor.cs
@@ -38,6 +38,14 @@ internal static class SqlParameterTypeExtractor
 
             if (inSqlString)
             {
+                // A backslash escapes whatever follows, so \' stays inside the string. Without this the
+                // string appears to end early and the real placeholder after it is never seen.
+                if (c == '\\' && i + 1 < sql.Length)
+                {
+                    i += 2;
+                    continue;
+                }
+
                 // An escaped quote ('') stays inside the string.
                 if (c == '\'' && i + 1 < sql.Length && sql[i + 1] == '\'')
                 {
@@ -140,6 +148,14 @@ internal static class SqlParameterTypeExtractor
 
             if (inQuote)
             {
+                // A backslash escapes whatever follows, so \' stays inside the quoted argument. Without this
+                // an enum label such as 'it\'s' ends early and the type is truncated.
+                if (c == '\\' && i + 1 < sql.Length)
+                {
+                    i += 2;
+                    continue;
+                }
+
                 // An escaped quote ('') stays inside the string.
                 if (c == '\'' && i + 1 < sql.Length && sql[i + 1] == '\'')
                 {

--- a/ClickHouse.Driver.Tcp/Parameters/SqlParameterTypeExtractor.cs
+++ b/ClickHouse.Driver.Tcp/Parameters/SqlParameterTypeExtractor.cs
@@ -4,11 +4,11 @@ using System.Collections.Generic;
 namespace ClickHouse.Driver.Tcp.Parameters;
 
 /// <summary>
-/// Extracts ClickHouse-native <c>{name:Type}</c> hints while ignoring SQL strings and comments.
+/// Extracts ClickHouse-native <c>{name:Type}</c> hints while ignoring SQL strings, quoted identifiers,
+/// heredocs and comments.
 /// </summary>
 /// <remarks>
-/// Ported from the HTTP scanner because the TCP assembly cannot reference it. Keep shared behavior aligned;
-/// this copy additionally handles backslash-escaped quotes.
+/// Ported from the HTTP scanner because the TCP assembly cannot reference it. Keep the two aligned.
 /// </remarks>
 internal static class SqlParameterTypeExtractor
 {
@@ -28,55 +28,39 @@ internal static class SqlParameterTypeExtractor
         }
 
         int i = 0;
-        bool inSqlString = false;
 
         while (i < sql.Length)
         {
             char c = sql[i];
 
-            if (inSqlString)
+            if (c is '\'' or '`' or '"')
             {
-                // A backslash escapes the next character, including a quote.
-                if (c == '\\' && i + 1 < sql.Length)
-                {
-                    i += 2;
-                    continue;
-                }
-
-                // An escaped quote ('') stays inside the string.
-                if (c == '\'' && i + 1 < sql.Length && sql[i + 1] == '\'')
-                {
-                    i += 2;
-                    continue;
-                }
-
-                if (c == '\'')
-                {
-                    inSqlString = false;
-                }
-
-                i++;
-                continue;
+                // String literal or quoted identifier.
+                i = SkipQuotedToken(sql, i);
             }
-
-            if (c == '\'')
+            else if (c == '$' && TrySkipHeredoc(sql, i, out int afterHeredoc))
             {
-                inSqlString = true;
-                i++;
+                // Heredoc: $tag$ ... $tag$.
+                i = afterHeredoc;
             }
             else if (c == '-' && i + 1 < sql.Length && sql[i + 1] == '-')
             {
                 // SQL-style line comment: -- (skip to end of line).
                 i = SkipToEndOfLine(sql, i + 2);
             }
-            else if (c == '#')
+            else if (c == '/' && i + 1 < sql.Length && sql[i + 1] == '/')
             {
-                // SQL-style line comment: # or #! (skip to end of line).
-                i = SkipToEndOfLine(sql, i + 1);
+                // C++-style line comment: // (skip to end of line).
+                i = SkipToEndOfLine(sql, i + 2);
+            }
+            else if (c == '#' && i + 1 < sql.Length && (sql[i + 1] == ' ' || sql[i + 1] == '!'))
+            {
+                // MySQL-style line comment: only "# " and "#!" start one, a bare "#x" does not.
+                i = SkipToEndOfLine(sql, i + 2);
             }
             else if (c == '/' && i + 1 < sql.Length && sql[i + 1] == '*')
             {
-                // C-style block comment: /* ... */ (skip to the closing */).
+                // C-style block comment: /* ... */, nestable (skip to the matching */).
                 i = SkipBlockComment(sql, i + 2);
             }
             else if (c == '{')
@@ -118,15 +102,43 @@ internal static class SqlParameterTypeExtractor
             return (null, null, 0);
         }
 
-        // The colon separates the name from the type.
-        int colonIndex = sql.IndexOf(':', startIndex + 1);
+        // Find the colon that separates name from type, searching only within this parameter's own
+        // name: it must be a single run of parameter name characters, optionally surrounded by
+        // whitespace. Otherwise a brace that is not a type hint, such as one inside a backtick-quoted
+        // alias, would consume the colon of a later parameter and silently drop its hint.
+        int colonIndex = -1;
+        int nameLength = 0;
+        bool afterName = false;
+
+        for (int j = startIndex + 1; j < sql.Length; j++)
+        {
+            char nameChar = sql[j];
+            if (nameChar == ':')
+            {
+                colonIndex = j;
+                break;
+            }
+
+            if (char.IsWhiteSpace(nameChar))
+            {
+                afterName = nameLength > 0;
+                continue;
+            }
+
+            if (afterName || !IsParameterNameChar(nameChar))
+            {
+                return (null, null, 0);
+            }
+
+            nameLength++;
+        }
+
         if (colonIndex < 0)
         {
             return (null, null, 0);
         }
 
-        int nameStart = startIndex + 1;
-        string paramName = sql[nameStart..colonIndex].Trim();
+        string paramName = sql[(startIndex + 1)..colonIndex].Trim();
         if (string.IsNullOrEmpty(paramName))
         {
             return (null, null, 0);
@@ -134,41 +146,21 @@ internal static class SqlParameterTypeExtractor
 
         int i = colonIndex + 1;
         int typeStart = i;
-        bool inQuote = false;
 
         while (i < sql.Length)
         {
             char c = sql[i];
 
-            if (inQuote)
+            if (c is '\'' or '`' or '"')
             {
-                // A backslash escapes the next character inside the type argument.
-                if (c == '\\' && i + 1 < sql.Length)
-                {
-                    i += 2;
-                    continue;
-                }
-
-                // An escaped quote ('') stays inside the string.
-                if (c == '\'' && i + 1 < sql.Length && sql[i + 1] == '\'')
-                {
-                    i += 2;
-                    continue;
-                }
-
-                if (c == '\'')
-                {
-                    inQuote = false;
-                }
-
-                i++;
-                continue;
+                // Quoted token within the type, e.g. an Enum value or a named tuple element.
+                i = SkipQuotedToken(sql, i);
             }
-
-            if (c == '\'')
+            else if (c == '{')
             {
-                inQuote = true;
-                i++;
+                // A type definition never contains an opening brace, so this parameter is
+                // unterminated and the brace starts a new one.
+                return (null, null, 0);
             }
             else if (c == '}')
             {
@@ -190,6 +182,16 @@ internal static class SqlParameterTypeExtractor
         return (null, null, 0);
     }
 
+    /// <summary>
+    /// Reports whether the character can appear in a ClickHouse query parameter name. The server parses
+    /// the name as a bare word, which is narrower than an identifier: a quoted identifier such as
+    /// <c>{`a`:Int32}</c> or <c>{"a":Int32}</c> is rejected as a syntax error. Only ASCII word characters and $.
+    /// </summary>
+    /// <param name="c">The character.</param>
+    /// <returns>True when the character can appear in a parameter name.</returns>
+    private static bool IsParameterNameChar(char c) =>
+        (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_' || c == '$';
+
     /// <summary>Returns the index after the next newline, or the end of the SQL.</summary>
     /// <param name="sql">The SQL query.</param>
     /// <param name="startIndex">The index to scan from.</param>
@@ -200,13 +202,134 @@ internal static class SqlParameterTypeExtractor
         return newlineIndex < 0 ? sql.Length : newlineIndex + 1;
     }
 
-    /// <summary>Returns the index after the block comment, or the end of the SQL.</summary>
+    /// <summary>Skips a nestable C-style block comment, starting after the opening marker.</summary>
     /// <param name="sql">The SQL query.</param>
     /// <param name="startIndex">The index to scan from.</param>
-    /// <returns>The index after the closing marker.</returns>
+    /// <returns>The index after the matching closing marker, or the end of the SQL.</returns>
     private static int SkipBlockComment(string sql, int startIndex)
     {
-        int endIndex = sql.IndexOf("*/", startIndex, StringComparison.Ordinal);
-        return endIndex < 0 ? sql.Length : endIndex + 2;
+        int depth = 1;
+        int i = startIndex;
+
+        while (i + 1 < sql.Length)
+        {
+            if (sql[i] == '/' && sql[i + 1] == '*')
+            {
+                depth++;
+                i += 2;
+            }
+            else if (sql[i] == '*' && sql[i + 1] == '/')
+            {
+                i += 2;
+                if (--depth == 0)
+                {
+                    return i;
+                }
+            }
+            else
+            {
+                i++;
+            }
+        }
+
+        return sql.Length;
     }
+
+    /// <summary>
+    /// Skips a single-quoted string literal or a backtick/double-quote quoted identifier, starting at the
+    /// opening quote. Both doubling (<c>''</c>) and backslash (<c>\'</c>) escapes are honored.
+    /// </summary>
+    /// <param name="sql">The SQL query.</param>
+    /// <param name="startIndex">The index of the opening quote.</param>
+    /// <returns>The index after the closing quote, or the end of the SQL when unterminated.</returns>
+    private static int SkipQuotedToken(string sql, int startIndex)
+    {
+        char quote = sql[startIndex];
+        int i = startIndex + 1;
+
+        while (i < sql.Length)
+        {
+            char c = sql[i];
+
+            if (c == '\\')
+            {
+                i += 2;
+            }
+            else if (c == quote)
+            {
+                if (i + 1 < sql.Length && sql[i + 1] == quote)
+                {
+                    i += 2;
+                    continue;
+                }
+
+                return i + 1;
+            }
+            else
+            {
+                i++;
+            }
+        }
+
+        return sql.Length;
+    }
+
+    /// <summary>
+    /// Tries to skip a heredoc starting at a <c>$</c>: <c>$tag$ ... $tag$</c>, where the tag is empty or
+    /// ASCII word characters. Returns false when this <c>$</c> does not open a terminated heredoc, in which
+    /// case it is an ordinary character. A heredoc can only begin at a token boundary, see <see cref="IsTokenChar"/>.
+    /// </summary>
+    /// <param name="sql">The SQL query.</param>
+    /// <param name="startIndex">The index of the dollar sign.</param>
+    /// <param name="endIndex">The index after the closing tag.</param>
+    /// <returns>True when a terminated heredoc starts here.</returns>
+    private static bool TrySkipHeredoc(string sql, int startIndex, out int endIndex)
+    {
+        endIndex = 0;
+
+        // A $ that continues a token cannot open a heredoc: the server lexes b$c$ as one identifier.
+        if (startIndex > 0 && IsTokenChar(sql[startIndex - 1]))
+        {
+            return false;
+        }
+
+        int i = startIndex + 1;
+        while (i < sql.Length && IsHeredocTagChar(sql[i]))
+        {
+            i++;
+        }
+
+        if (i >= sql.Length || sql[i] != '$')
+        {
+            return false;
+        }
+
+        string tag = sql[startIndex..(i + 1)];
+        int closeIndex = sql.IndexOf(tag, i + 1, StringComparison.Ordinal);
+        if (closeIndex < 0)
+        {
+            return false;
+        }
+
+        endIndex = closeIndex + tag.Length;
+        return true;
+    }
+
+    /// <summary>Reports whether the character can appear in a heredoc tag.</summary>
+    /// <param name="c">The character.</param>
+    /// <returns>True when the character can appear in a heredoc tag.</returns>
+    private static bool IsHeredocTagChar(char c) =>
+        (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_';
+
+    /// <summary>
+    /// Reports whether the character can continue an ordinary token, so that a <c>$</c> following it is part
+    /// of that token rather than the start of a heredoc. The server lexes a word token as a run of ASCII word
+    /// characters and dollar signs, so <c>b$c$</c> is one identifier and not a heredoc opener. Looking only at
+    /// the preceding character misses the case where it ends a literal instead of a word, as in
+    /// <c>1$tag$...$tag$</c>, where the server does open a heredoc. That shape places two literals next to each
+    /// other, which the server rejects as a syntax error, so no query it accepts is affected.
+    /// </summary>
+    /// <param name="c">The character.</param>
+    /// <returns>True when a dollar sign after this character continues a token.</returns>
+    private static bool IsTokenChar(char c) => IsHeredocTagChar(c) || c == '$';
 }

--- a/ClickHouse.Driver.Tcp/Parameters/SqlParameterTypeExtractor.cs
+++ b/ClickHouse.Driver.Tcp/Parameters/SqlParameterTypeExtractor.cs
@@ -1,0 +1,209 @@
+using System;
+using System.Collections.Generic;
+
+namespace ClickHouse.Driver.Tcp.Parameters;
+
+/// <summary>
+/// Extracts parameter type hints from SQL queries using ClickHouse's native parameter syntax, {parameter_name:type}.
+/// This is a port of the HTTP scanner <c>ClickHouse.Driver.ADO.Parameters.SqlParameterTypeExtractor</c>. The TCP
+/// assembly cannot reference <c>ClickHouse.Driver</c>, because the project reference runs the other way. Keep the
+/// two copies in step: a change to one must be applied to the other.
+/// </summary>
+internal static class SqlParameterTypeExtractor
+{
+    /// <summary>
+    /// Extracts type hints from a SQL query string.
+    /// </summary>
+    /// <param name="sql">The SQL query containing parameter placeholders.</param>
+    /// <returns>
+    /// A dictionary mapping parameter names to their type definitions.
+    /// Parameters without type hints (e.g., <c>{name}</c>) are not included.
+    /// </returns>
+    /// <exception cref="ArgumentException">The same parameter name has two different type hints.</exception>
+    public static Dictionary<string, string> ExtractTypeHints(string sql)
+    {
+        var result = new Dictionary<string, string>();
+
+        if (string.IsNullOrEmpty(sql))
+        {
+            return result;
+        }
+
+        int i = 0;
+        bool inSqlString = false;
+
+        while (i < sql.Length)
+        {
+            char c = sql[i];
+
+            if (inSqlString)
+            {
+                // An escaped quote ('') stays inside the string.
+                if (c == '\'' && i + 1 < sql.Length && sql[i + 1] == '\'')
+                {
+                    i += 2;
+                    continue;
+                }
+
+                if (c == '\'')
+                {
+                    inSqlString = false;
+                }
+
+                i++;
+                continue;
+            }
+
+            if (c == '\'')
+            {
+                inSqlString = true;
+                i++;
+            }
+            else if (c == '-' && i + 1 < sql.Length && sql[i + 1] == '-')
+            {
+                // SQL-style line comment: -- (skip to end of line).
+                i = SkipToEndOfLine(sql, i + 2);
+            }
+            else if (c == '#')
+            {
+                // SQL-style line comment: # or #! (skip to end of line).
+                i = SkipToEndOfLine(sql, i + 1);
+            }
+            else if (c == '/' && i + 1 < sql.Length && sql[i + 1] == '*')
+            {
+                // C-style block comment: /* ... */ (skip to the closing */).
+                i = SkipBlockComment(sql, i + 2);
+            }
+            else if (c == '{')
+            {
+                (string paramName, string paramType, int endIndex) = TryExtractParameter(sql, i);
+                if (paramName != null && paramType != null)
+                {
+                    if (result.TryGetValue(paramName, out string existingType) && existingType != paramType)
+                    {
+                        throw new ArgumentException(
+                            $"Parameter '{paramName}' has conflicting type hints: '{existingType}' and '{paramType}'");
+                    }
+
+                    result[paramName] = paramType;
+                    i = endIndex;
+                }
+                else
+                {
+                    i++;
+                }
+            }
+            else
+            {
+                i++;
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Tries to extract a parameter from the given position.
+    /// Returns (name, type, endIndex) if successful, or (null, null, 0) if not a valid parameter.
+    /// </summary>
+    /// <param name="sql">The SQL query.</param>
+    /// <param name="startIndex">The index of the opening brace.</param>
+    /// <returns>The parameter name, its type, and the index after the closing brace.</returns>
+    private static (string Name, string Type, int EndIndex) TryExtractParameter(string sql, int startIndex)
+    {
+        if (sql[startIndex] != '{')
+        {
+            return (null, null, 0);
+        }
+
+        // The colon separates the name from the type.
+        int colonIndex = sql.IndexOf(':', startIndex + 1);
+        if (colonIndex < 0)
+        {
+            return (null, null, 0);
+        }
+
+        int nameStart = startIndex + 1;
+        string paramName = sql[nameStart..colonIndex].Trim();
+        if (string.IsNullOrEmpty(paramName))
+        {
+            return (null, null, 0);
+        }
+
+        int i = colonIndex + 1;
+        int typeStart = i;
+        bool inQuote = false;
+
+        while (i < sql.Length)
+        {
+            char c = sql[i];
+
+            if (inQuote)
+            {
+                // An escaped quote ('') stays inside the string.
+                if (c == '\'' && i + 1 < sql.Length && sql[i + 1] == '\'')
+                {
+                    i += 2;
+                    continue;
+                }
+
+                if (c == '\'')
+                {
+                    inQuote = false;
+                }
+
+                i++;
+                continue;
+            }
+
+            if (c == '\'')
+            {
+                inQuote = true;
+                i++;
+            }
+            else if (c == '}')
+            {
+                string paramType = sql[typeStart..i].Trim();
+                if (!string.IsNullOrEmpty(paramType))
+                {
+                    return (paramName, paramType, i + 1);
+                }
+
+                return (null, null, 0);
+            }
+            else
+            {
+                i++;
+            }
+        }
+
+        // Unterminated parameter.
+        return (null, null, 0);
+    }
+
+    /// <summary>
+    /// Skips to the end of a line.
+    /// Returns the index of the first character after the newline, or sql.Length if no newline found.
+    /// </summary>
+    /// <param name="sql">The SQL query.</param>
+    /// <param name="startIndex">The index to scan from.</param>
+    /// <returns>The index after the newline.</returns>
+    private static int SkipToEndOfLine(string sql, int startIndex)
+    {
+        int newlineIndex = sql.IndexOf('\n', startIndex);
+        return newlineIndex < 0 ? sql.Length : newlineIndex + 1;
+    }
+
+    /// <summary>
+    /// Skips a C-style block comment (after /*).
+    /// Returns the index of the first character after */, or sql.Length if not found.
+    /// </summary>
+    /// <param name="sql">The SQL query.</param>
+    /// <param name="startIndex">The index to scan from.</param>
+    /// <returns>The index after the closing marker.</returns>
+    private static int SkipBlockComment(string sql, int startIndex)
+    {
+        int endIndex = sql.IndexOf("*/", startIndex, StringComparison.Ordinal);
+        return endIndex < 0 ? sql.Length : endIndex + 2;
+    }
+}

--- a/ClickHouse.Driver.Tcp/Parameters/TcpParameterFormatter.cs
+++ b/ClickHouse.Driver.Tcp/Parameters/TcpParameterFormatter.cs
@@ -280,7 +280,7 @@ internal static class TcpParameterFormatter
             return unspecified.ToString("s", CultureInfo.InvariantCulture);
         }
 
-        DateTime local = InTargetTimezone(type, ToOffset(value));
+        DateTime local = InTargetTimezone(ToOffset(value), RequireDeclaredTimezone(type, value));
         return local.ToString("s", CultureInfo.InvariantCulture);
     }
 
@@ -291,8 +291,59 @@ internal static class TcpParameterFormatter
             return unspecified.ToString("yyyy-MM-dd HH:mm:ss.fffffff", CultureInfo.InvariantCulture);
         }
 
-        DateTime local = InTargetTimezone(type, ToOffset(value));
+        DateTime local = InTargetTimezone(ToOffset(value), RequireDeclaredTimezone(type, value));
         return local.ToString("yyyy-MM-dd HH:mm:ss.fffffff", CultureInfo.InvariantCulture);
+    }
+
+    /// <summary>
+    /// Returns the timezone the type declares, and rejects the type that declares none.
+    /// </summary>
+    /// <param name="type">The date-and-time type.</param>
+    /// <param name="value">The value, named in the error so the caller can see which kind caused it.</param>
+    /// <returns>The declared timezone.</returns>
+    /// <exception cref="ArgumentException">The type declares no timezone.</exception>
+    /// <remarks>
+    /// Only a value that names an instant reaches this. Such a value has a timezone and the type must too,
+    /// because the wire carries a wall-clock time and nothing else: the server reads that text in whatever
+    /// <c>session_timezone</c> is in force, so if the two disagree the instant moves and no error is raised.
+    /// Sending the instant as an epoch count instead would avoid the question, but the server rejects a count
+    /// below five digits — it reads it as a year — so that encoding cannot carry the first hours of 1970.
+    /// </remarks>
+    private static string RequireDeclaredTimezone(TypeNode type, object value)
+    {
+        string declared = DeclaredTimezone(type);
+        if (declared is not null)
+        {
+            return declared;
+        }
+
+        string valueDescription = value is DateTimeOffset
+            ? "A DateTimeOffset names an instant"
+            : $"A DateTime with Kind={((DateTime)value).Kind} names an instant";
+
+        throw new ArgumentException(
+            $"{valueDescription}, but the type declares no timezone, so the instant cannot be sent without " +
+            $"loss. The server reads the value in its session timezone, which moves the instant when that is " +
+            $"not UTC, and reports no error. Declare the timezone in the type — {type.Name}" +
+            $"{(type.Name == "DateTime64" ? "(3, 'UTC')" : "('UTC')")} — or pass a DateTime with " +
+            $"Kind=Unspecified to send a wall-clock time for the server to read in its own timezone.");
+    }
+
+    /// <summary>Reads the timezone a date-and-time type declares.</summary>
+    /// <param name="type">The date-and-time type.</param>
+    /// <returns>The timezone name, or null when the type declares none.</returns>
+    private static string DeclaredTimezone(TypeNode type)
+    {
+        // The timezone is the last argument: DateTime('UTC') or DateTime64(3, 'UTC').
+        string declared = type.Arguments.Count > 0
+            ? DateTimeZones.UnquoteTimezone(type.Arguments[^1])
+            : null;
+
+        // A DateTime64 precision digit is not a timezone.
+        return declared is not null
+            && int.TryParse(declared, NumberStyles.None, CultureInfo.InvariantCulture, out _)
+                ? null
+                : declared;
     }
 
     private static DateTimeOffset ToOffset(object value) => value switch
@@ -303,27 +354,13 @@ internal static class TcpParameterFormatter
             $"Cannot convert value of type '{value.GetType().FullName}' ({value}) to a date and time"),
     };
 
-    /// <summary>
-    /// Moves an instant into the type's timezone. The timezone defaults to UTC, not to the session timezone,
-    /// which is what the HTTP formatter does.
-    /// </summary>
-    /// <param name="type">The timezone-bearing type.</param>
+    /// <summary>Moves an instant into the timezone the type declares.</summary>
     /// <param name="value">The instant.</param>
-    /// <returns>The wall-clock time in the type's timezone.</returns>
-    private static DateTime InTargetTimezone(TypeNode type, DateTimeOffset value)
+    /// <param name="declaredTimezone">The timezone the type declares.</param>
+    /// <returns>The wall-clock time in that timezone.</returns>
+    private static DateTime InTargetTimezone(DateTimeOffset value, string declaredTimezone)
     {
-        // The timezone is the last argument: DateTime('UTC') or DateTime64(3, 'UTC').
-        string explicitTimezone = type.Arguments.Count > 0
-            ? DateTimeZones.UnquoteTimezone(type.Arguments[^1])
-            : null;
-
-        // A DateTime64 precision digit is not a timezone.
-        if (explicitTimezone is not null && int.TryParse(explicitTimezone, NumberStyles.None, CultureInfo.InvariantCulture, out _))
-        {
-            explicitTimezone = null;
-        }
-
-        TimeZoneInfo timeZone = DateTimeZones.Resolve(explicitTimezone, serverTimezone: null);
+        TimeZoneInfo timeZone = DateTimeZones.Resolve(declaredTimezone, serverTimezone: null);
         return TimeZoneInfo.ConvertTime(value, timeZone).DateTime;
     }
 

--- a/ClickHouse.Driver.Tcp/Parameters/TcpParameterFormatter.cs
+++ b/ClickHouse.Driver.Tcp/Parameters/TcpParameterFormatter.cs
@@ -188,14 +188,24 @@ internal static class TcpParameterFormatter
     };
 
     /// <summary>
-    /// Reads a decimal from its text, keeping every digit. A <see cref="decimal"/> would cap the value at 29
-    /// digits, which the wider ClickHouse decimals exceed.
+    /// Reads a decimal from its text, keeping every digit.
     /// </summary>
     /// <param name="text">The decimal in invariant form.</param>
     /// <returns>The parsed value.</returns>
     /// <exception cref="ArgumentException"><paramref name="text"/> is not a decimal.</exception>
+    /// <remarks>
+    /// Tries <see cref="decimal"/> first, which accepts the forms the HTTP formatter does — an exponent,
+    /// thousands separators, accounting parentheses. Falls back to reading the digits as a
+    /// <see cref="BigInteger"/>, because a decimal caps at 29 digits and the wider ClickHouse decimals exceed
+    /// that; only the plain form reaches that path, which is the only form that can be that wide.
+    /// </remarks>
     private static ClickHouseDecimal ParseDecimalText(string text)
     {
+        if (decimal.TryParse(text, NumberStyles.Any, CultureInfo.InvariantCulture, out decimal narrow))
+        {
+            return ClickHouseDecimal.FromDecimal(narrow);
+        }
+
         string trimmed = text.Trim();
         int point = trimmed.IndexOf('.');
         string digits = point < 0 ? trimmed : trimmed.Remove(point, 1);
@@ -413,7 +423,10 @@ internal static class TcpParameterFormatter
         int minutes = (int)(remainder / 60m);
         decimal seconds = remainder % 60m;
 
-        string secondsText = seconds.ToString("00." + new string('0', scale), CultureInfo.InvariantCulture);
+        // Round before formatting, and to even, because decimal.ToString rounds away from zero. Without this a
+        // midpoint lands one tick above where the HTTP formatter puts it.
+        string secondsText = Math.Round(seconds, scale, MidpointRounding.ToEven)
+            .ToString("00." + new string('0', scale), CultureInfo.InvariantCulture);
         string text = $"{hours}:{minutes:D2}:{secondsText}";
         return negative ? "-" + text : text;
     }

--- a/ClickHouse.Driver.Tcp/Parameters/TcpParameterFormatter.cs
+++ b/ClickHouse.Driver.Tcp/Parameters/TcpParameterFormatter.cs
@@ -24,16 +24,21 @@ namespace ClickHouse.Driver.Tcp.Parameters;
 /// two must be changed together — see the parity-check entry in the TCP TODO.
 /// </para>
 /// <para>
-/// The first deliberate difference is the outer <see cref="ParameterText.Escape"/> and
+/// The transport difference is the outer <see cref="ParameterText.Escape"/> and
 /// <see cref="ParameterText.QuoteSingle"/> in <see cref="Format"/>. HTTP puts the value in the query string,
 /// where the server reads it directly. The native protocol carries it in the settings list as a custom entry,
 /// which the server first restores as a Field, so the whole value must arrive as a quoted SQL literal — for
 /// every type, not only for strings. An unquoted <c>42</c> for an <c>Int32</c> parameter is rejected.
 /// </para>
 /// <para>
-/// The second is the <c>Interval&lt;Unit&gt;</c> family, which this formatter supports and the HTTP one does
-/// not. The difference is in the type systems, not in the two formatters: the RowBinary tree has no Interval
-/// type, so an HTTP query fails while resolving the name, before any formatter runs.
+/// The rest of the differences are places where this formatter is ahead. <c>Interval&lt;Unit&gt;</c>,
+/// <c>QBit</c> and the six geo names format here and throw there, and <c>Json</c> in its lowercase spelling
+/// works here only. Interval is a type-system difference rather than a formatter one: the RowBinary tree has
+/// no Interval type, so an HTTP query fails while resolving the name. These are defects on the HTTP side:
+/// a <c>byte[]</c> that is not valid UTF-8 is decoded there and loses its bytes, a Variant alternative is
+/// matched on its outer name alone, a Map cannot be given as key/value pairs, and a value naming an instant
+/// is accepted for a type with no timezone and silently moved. Each is fixable, and each changes a shipped
+/// client, so none is fixed here — see the parity-check entry in the TCP TODO.
 /// </para>
 /// </remarks>
 internal static class TcpParameterFormatter
@@ -236,7 +241,8 @@ internal static class TcpParameterFormatter
     /// UTF-8 — the read path returns one whenever <c>ReadAsByteArray</c> is used. Decoding such a sequence
     /// turns every bad byte into U+FFFD and sends <c>EF BF BD</c>, which changes the value with no error. Text
     /// that is valid UTF-8 keeps the readable form; anything else goes out as <c>\xHH</c> per byte, which the
-    /// server's escaped-text reader restores exactly. Probed on 26.6.1 over both transports.
+    /// server's escaped-text reader restores exactly. Probed on 26.6.1. The HTTP formatter still decodes, so
+    /// this is a divergence — see the parity-check entry in the TCP TODO.
     /// </remarks>
     private static string BytesToSqlText(byte[] bytes)
     {

--- a/ClickHouse.Driver.Tcp/Parameters/TcpParameterFormatter.cs
+++ b/ClickHouse.Driver.Tcp/Parameters/TcpParameterFormatter.cs
@@ -60,6 +60,9 @@ internal static class TcpParameterFormatter
         "IntervalHour", "IntervalDay", "IntervalWeek", "IntervalMonth", "IntervalQuarter", "IntervalYear",
     ];
 
+    /// <summary>Decodes UTF-8 and throws on a byte sequence that is not valid UTF-8, rather than substituting.</summary>
+    private static readonly Encoding StrictUtf8 = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+
     /// <summary>Formats a parameter value for the Query packet's parameter list.</summary>
     /// <param name="value">The parameter value.</param>
     /// <param name="typeName">The resolved ClickHouse type name (e.g. <c>DateTime64(3)</c>).</param>
@@ -136,7 +139,7 @@ internal static class TcpParameterFormatter
 
             // Must precede the arm below, which would otherwise print the CLR type name for a byte array.
             case "String" or "FixedString" when value is byte[] bytes:
-                return QuoteIfNeeded(Encoding.UTF8.GetString(bytes).Escape(), quote);
+                return QuoteIfNeeded(BytesToSqlText(bytes), quote);
 
             case "String" or "FixedString" or "Enum8" or "Enum16" or "IPv4" or "IPv6" or "UUID":
                 return QuoteIfNeeded(value.ToString().Escape(), quote);
@@ -186,6 +189,11 @@ internal static class TcpParameterFormatter
             case "Map" when value is IDictionary dictionary && type.Arguments.Count == 2:
                 return FormatMap(type, dictionary);
 
+            // Must follow the dictionary arm, which is the common shape, and precede the Array arm below,
+            // which would otherwise take a pair sequence and write it as a list of tuples.
+            case "Map" when type.Arguments.Count == 2 && MapPairs.IsPairSequence(value):
+                return FormatMapPairs(type, (IEnumerable)value);
+
             case "Variant":
                 return FormatVariant(type, value, quote);
 
@@ -219,6 +227,34 @@ internal static class TcpParameterFormatter
         "MultiPolygon" => "Array(Polygon)",
         _ => throw new ArgumentException($"'{name}' is not a geo type"),
     });
+
+    /// <summary>Writes raw bytes as escaped SQL text without changing any of them.</summary>
+    /// <param name="bytes">The bytes.</param>
+    /// <returns>The escaped text the server reads back as those exact bytes.</returns>
+    /// <remarks>
+    /// A ClickHouse <c>String</c> holds bytes, not characters, so a value can hold a byte sequence that is not
+    /// UTF-8 — the read path returns one whenever <c>ReadAsByteArray</c> is used. Decoding such a sequence
+    /// turns every bad byte into U+FFFD and sends <c>EF BF BD</c>, which changes the value with no error. Text
+    /// that is valid UTF-8 keeps the readable form; anything else goes out as <c>\xHH</c> per byte, which the
+    /// server's escaped-text reader restores exactly. Probed on 26.6.1 over both transports.
+    /// </remarks>
+    private static string BytesToSqlText(byte[] bytes)
+    {
+        try
+        {
+            return StrictUtf8.GetString(bytes).Escape();
+        }
+        catch (DecoderFallbackException)
+        {
+            var builder = new StringBuilder(bytes.Length * 4);
+            foreach (byte b in bytes)
+            {
+                builder.Append("\\x").Append(b.ToString("x2", CultureInfo.InvariantCulture));
+            }
+
+            return builder.ToString();
+        }
+    }
 
     private static string FormatDecimal(object value) => value switch
     {
@@ -455,10 +491,33 @@ internal static class TcpParameterFormatter
     private static string FormatMap(TypeNode type, IDictionary value)
     {
         var pairs = value.Keys.Cast<object>().Select(key =>
-            Format(type.Arguments[0], key, quote: true) + " : " + Format(type.Arguments[1], value[key], quote: true));
+            FormatPair(type, key, value[key]));
 
         return "{" + string.Join(",", pairs) + "}";
     }
+
+    /// <summary>
+    /// Formats a Map given as a sequence of key/value pairs, which is how this client reads one back. The
+    /// codec surfaces a row as <c>KeyValuePair&lt;K, V&gt;[]</c> rather than a dictionary so that duplicate
+    /// keys and pair order survive, so a value read from a Map column must be bindable in that shape.
+    /// </summary>
+    /// <param name="type">The Map type.</param>
+    /// <param name="pairs">The pairs, in order.</param>
+    /// <returns>The map literal.</returns>
+    private static string FormatMapPairs(TypeNode type, IEnumerable pairs)
+    {
+        var formatted = pairs.Cast<object>().Select(pair =>
+        {
+            (object key, object value) = MapPairs.Read(pair);
+            return FormatPair(type, key, value);
+        });
+
+        return "{" + string.Join(",", formatted) + "}";
+    }
+
+    private static string FormatPair(TypeNode type, object key, object value)
+        => Format(type.Arguments[0], key, quote: true) + " : " + Format(type.Arguments[1], value, quote: true);
+
 
     private static string FormatVariant(TypeNode type, object value, bool quote)
     {

--- a/ClickHouse.Driver.Tcp/Parameters/TcpParameterFormatter.cs
+++ b/ClickHouse.Driver.Tcp/Parameters/TcpParameterFormatter.cs
@@ -189,14 +189,36 @@ internal static class TcpParameterFormatter
             case "Variant":
                 return FormatVariant(type, value, quote);
 
-            case "JSON":
+            // The server takes either spelling and reports the type as JSON, so both must format.
+            case "JSON" or "Json":
                 return value is string json ? json : JsonSerializer.Serialize(value);
+
+            // A QBit is a fixed-width vector of its element type, written as an array.
+            case "QBit" when value is IEnumerable components && type.Arguments.Count == 2:
+                return "[" + string.Join(",", components.Cast<object>().Select(c => Format(type.Arguments[0], c, quote: true))) + "]";
+
+            // The geo types are named shapes over Point, which is itself a pair of Float64. Formatting them as
+            // the shape they stand for is what the HTTP formatter does, where they subclass Tuple and Array.
+            case "Point" or "Ring" or "LineString" or "Polygon" or "MultiLineString" or "MultiPolygon":
+                return Format(GeoShapeOf(name), value, quote);
 
             default:
                 throw new ArgumentException(
                     $"Cannot convert value of type '{value.GetType().FullName}' ({value}) to ClickHouse type {type}");
         }
     }
+
+    /// <summary>Expands a geo type name into the Tuple/Array shape it stands for.</summary>
+    /// <param name="name">The geo type name.</param>
+    /// <returns>The parsed structural equivalent.</returns>
+    private static TypeNode GeoShapeOf(string name) => TypeParser.Parse(name switch
+    {
+        "Point" => "Tuple(Float64, Float64)",
+        "Ring" or "LineString" => "Array(Point)",
+        "Polygon" or "MultiLineString" => "Array(Ring)",
+        "MultiPolygon" => "Array(Polygon)",
+        _ => throw new ArgumentException($"'{name}' is not a geo type"),
+    });
 
     private static string FormatDecimal(object value) => value switch
     {

--- a/ClickHouse.Driver.Tcp/Parameters/TcpParameterFormatter.cs
+++ b/ClickHouse.Driver.Tcp/Parameters/TcpParameterFormatter.cs
@@ -17,28 +17,13 @@ namespace ClickHouse.Driver.Tcp.Parameters;
 /// </summary>
 /// <remarks>
 /// <para>
-/// The inner text is the same SQL representation the HTTP transport sends as <c>param_&lt;name&gt;</c>, so this
-/// mirrors <c>HttpParameterFormatter</c> arm for arm. It cannot call it: the project reference runs from
-/// <c>ClickHouse.Driver</c> to <c>ClickHouse.Driver.Tcp</c>, so a reference back would be circular, and the HTTP
-/// formatter is written against the RowBinary <c>ClickHouseType</c> tree, which this assembly does not have. The
-/// two must be changed together — see the parity-check entry in the TCP TODO.
+/// This duplicates <c>HttpParameterFormatter</c> because the assemblies cannot reference each other and use
+/// different type trees. Keep shared cases aligned; known differences are listed in the TCP TODO's
+/// parity check.
 /// </para>
 /// <para>
-/// The transport difference is the outer <see cref="ParameterText.Escape"/> and
-/// <see cref="ParameterText.QuoteSingle"/> in <see cref="Format"/>. HTTP puts the value in the query string,
-/// where the server reads it directly. The native protocol carries it in the settings list as a custom entry,
-/// which the server first restores as a Field, so the whole value must arrive as a quoted SQL literal — for
-/// every type, not only for strings. An unquoted <c>42</c> for an <c>Int32</c> parameter is rejected.
-/// </para>
-/// <para>
-/// The rest of the differences are places where this formatter is ahead. <c>Interval&lt;Unit&gt;</c>,
-/// <c>QBit</c> and the six geo names format here and throw there, and <c>Json</c> in its lowercase spelling
-/// works here only. Interval is a type-system difference rather than a formatter one: the RowBinary tree has
-/// no Interval type, so an HTTP query fails while resolving the name. These are defects on the HTTP side:
-/// a <c>byte[]</c> that is not valid UTF-8 is decoded there and loses its bytes, a Variant alternative is
-/// matched on its outer name alone, a Map cannot be given as key/value pairs, and a value naming an instant
-/// is accepted for a type with no timezone and silently moved. Each is fixable, and each changes a shipped
-/// client, so none is fixed here — see the parity-check entry in the TCP TODO.
+/// Native parameters are custom settings, so <see cref="Format"/> escapes and quotes every value for the
+/// server's outer Field-parsing stage. <see cref="FormatSqlText"/> returns the inner SQL representation.
 /// </para>
 /// </remarks>
 internal static class TcpParameterFormatter
@@ -55,10 +40,7 @@ internal static class TcpParameterFormatter
 
     private static readonly string[] DecimalTypeNames = ["Decimal", "Decimal32", "Decimal64", "Decimal128", "Decimal256"];
 
-    /// <summary>
-    /// The <c>Interval&lt;Unit&gt;</c> family, which the server reads as its underlying <c>Int64</c> count. The
-    /// list mirrors the codec registry's; a unit missing from both is reported as an unformattable type.
-    /// </summary>
+    /// <summary>Interval types, formatted as their underlying <c>Int64</c> count.</summary>
     private static readonly string[] IntervalTypeNames =
     [
         "IntervalNanosecond", "IntervalMicrosecond", "IntervalMillisecond", "IntervalSecond", "IntervalMinute",
@@ -78,10 +60,7 @@ internal static class TcpParameterFormatter
     public static string Format(object value, string typeName, string parameterName)
         => FormatSqlText(value, typeName, parameterName).Escape().QuoteSingle();
 
-    /// <summary>
-    /// Formats the SQL representation alone, without the native protocol's outer escape and quote. This is the
-    /// exact text the HTTP transport sends, and is the level the two formatters are compared at.
-    /// </summary>
+    /// <summary>Formats the inner SQL representation before native-protocol escaping and quoting.</summary>
     /// <param name="value">The parameter value.</param>
     /// <param name="typeName">The resolved ClickHouse type name.</param>
     /// <param name="parameterName">The parameter name, for error messages.</param>
@@ -100,9 +79,7 @@ internal static class TcpParameterFormatter
         }
         catch (ArgumentException ex) when (ex.GetType() == typeof(ArgumentException))
         {
-            // Inner arms describe only the leaf type and value they saw. This is the one place that knows the
-            // parameter name and the outer type. Filter to the exact base type so a subclass propagates as
-            // itself, and forward ParamName so it is not lost.
+            // Add parameter context without wrapping specialized ArgumentException subclasses.
             throw new ArgumentException(
                 $"Parameter '{parameterName}' (type {parsed}): {ex.Message}",
                 ex.ParamName,
@@ -150,9 +127,7 @@ internal static class TcpParameterFormatter
                 return QuoteIfNeeded(value.ToString().Escape(), quote);
 
             case "Identifier":
-                // The server substitutes this as a bare SQL identifier and applies its own backtick quoting, so
-                // the value goes through unescaped. Escaping here would corrupt an identifier that contains a
-                // quote or a backslash, and is not needed for safety because the value is never parsed as SQL.
+                // The server quotes Identifier values; escaping here would change the name.
                 return value.ToString();
 
             case "LowCardinality" when type.Arguments.Count == 1:
@@ -194,8 +169,7 @@ internal static class TcpParameterFormatter
             case "Map" when value is IDictionary dictionary && type.Arguments.Count == 2:
                 return FormatMap(type, dictionary);
 
-            // Must follow the dictionary arm, which is the common shape, and precede the Array arm below,
-            // which would otherwise take a pair sequence and write it as a list of tuples.
+            // Keep pair sequences out of the general Array arm while preferring dictionaries.
             case "Map" when type.Arguments.Count == 2 && MapPairs.IsPairSequence(value):
                 return FormatMapPairs(type, (IEnumerable)value);
 
@@ -210,8 +184,7 @@ internal static class TcpParameterFormatter
             case "QBit" when value is IEnumerable components && type.Arguments.Count == 2:
                 return "[" + string.Join(",", components.Cast<object>().Select(c => Format(type.Arguments[0], c, quote: true))) + "]";
 
-            // The geo types are named shapes over Point, which is itself a pair of Float64. Formatting them as
-            // the shape they stand for is what the HTTP formatter does, where they subclass Tuple and Array.
+            // Geo types format as their underlying tuple/array shapes.
             case "Point" or "Ring" or "LineString" or "Polygon" or "MultiLineString" or "MultiPolygon":
                 return Format(GeoShapeOf(name), value, quote);
 
@@ -237,12 +210,8 @@ internal static class TcpParameterFormatter
     /// <param name="bytes">The bytes.</param>
     /// <returns>The escaped text the server reads back as those exact bytes.</returns>
     /// <remarks>
-    /// A ClickHouse <c>String</c> holds bytes, not characters, so a value can hold a byte sequence that is not
-    /// UTF-8 — the read path returns one whenever <c>ReadAsByteArray</c> is used. Decoding such a sequence
-    /// turns every bad byte into U+FFFD and sends <c>EF BF BD</c>, which changes the value with no error. Text
-    /// that is valid UTF-8 keeps the readable form; anything else goes out as <c>\xHH</c> per byte, which the
-    /// server's escaped-text reader restores exactly. Probed on 26.6.1. The HTTP formatter still decodes, so
-    /// this is a divergence — see the parity-check entry in the TCP TODO.
+    /// ClickHouse strings store bytes. Valid UTF-8 remains readable; invalid UTF-8 uses <c>\xHH</c> escapes to
+    /// avoid replacement-character corruption.
     /// </remarks>
     private static string BytesToSqlText(byte[] bytes)
     {
@@ -276,10 +245,7 @@ internal static class TcpParameterFormatter
     /// <returns>The parsed value.</returns>
     /// <exception cref="ArgumentException"><paramref name="text"/> is not a decimal.</exception>
     /// <remarks>
-    /// Tries <see cref="decimal"/> first, which accepts the forms the HTTP formatter does — an exponent,
-    /// thousands separators, accounting parentheses. Falls back to reading the digits as a
-    /// <see cref="BigInteger"/>, because a decimal caps at 29 digits and the wider ClickHouse decimals exceed
-    /// that; only the plain form reaches that path, which is the only form that can be that wide.
+    /// Uses <see cref="decimal"/> for its supported forms and <see cref="BigInteger"/> for wider plain values.
     /// </remarks>
     private static ClickHouseDecimal ParseDecimalText(string text)
     {
@@ -315,8 +281,7 @@ internal static class TcpParameterFormatter
 
     private static string FormatDateTime(TypeNode type, object value)
     {
-        // A DateTime with no kind is already in the parameter's timezone, so it is sent as it stands. A kinded
-        // value or an offset names an instant, which is moved into that timezone to keep the instant.
+        // Unspecified is a wall clock; kinded values and offsets are instants converted to the declared timezone.
         if (value is DateTime { Kind: DateTimeKind.Unspecified } unspecified)
         {
             return unspecified.ToString("s", CultureInfo.InvariantCulture);
@@ -345,11 +310,9 @@ internal static class TcpParameterFormatter
     /// <returns>The declared timezone.</returns>
     /// <exception cref="ArgumentException">The type declares no timezone.</exception>
     /// <remarks>
-    /// Only a value that names an instant reaches this. Such a value has a timezone and the type must too,
-    /// because the wire carries a wall-clock time and nothing else: the server reads that text in whatever
-    /// <c>session_timezone</c> is in force, so if the two disagree the instant moves and no error is raised.
-    /// Sending the instant as an epoch count instead would avoid the question, but the server rejects a count
-    /// below five digits — it reads it as a year — so that encoding cannot carry the first hours of 1970.
+    /// The wire carries only wall-clock text. Without a declared timezone, the server may silently change the
+    /// instant by interpreting it in <c>session_timezone</c>. Epoch text is not a safe fallback because the
+    /// server parses values of four digits or fewer as years.
     /// </remarks>
     private static string RequireDeclaredTimezone(TypeNode type, object value)
     {
@@ -413,11 +376,7 @@ internal static class TcpParameterFormatter
         return builder.ToString();
     }
 
-    /// <summary>
-    /// Peels the declared array nesting down to the element type, and checks it is as deep as the CLR array's
-    /// rank. A mismatch is reported here, where the two depths can be named, rather than as a value/type error
-    /// from the arm that would otherwise be handed the wrong level.
-    /// </summary>
+    /// <summary>Returns the element type after validating the declared array depth against the CLR rank.</summary>
     /// <param name="outer">The declared array type.</param>
     /// <param name="rank">The CLR array's rank.</param>
     /// <returns>The element type.</returns>
@@ -471,8 +430,7 @@ internal static class TcpParameterFormatter
 
     private static string FormatNested(TypeNode type, object value)
     {
-        // A Nested value is the whole set of rows, so an enumerable is the rows and each row is a tuple of the
-        // declared fields. The result has the same shape as Array(Tuple(...)). A bare tuple is one row.
+        // Nested formats as Array(Tuple(...)); a bare tuple represents one row.
         if (value is IEnumerable rows and not ITuple)
         {
             return "[" + string.Join(",", rows.Cast<object>().Select(row => FormatTuple(type, row))) + "]";
@@ -502,11 +460,7 @@ internal static class TcpParameterFormatter
         return "{" + string.Join(",", pairs) + "}";
     }
 
-    /// <summary>
-    /// Formats a Map given as a sequence of key/value pairs, which is how this client reads one back. The
-    /// codec surfaces a row as <c>KeyValuePair&lt;K, V&gt;[]</c> rather than a dictionary so that duplicate
-    /// keys and pair order survive, so a value read from a Map column must be bindable in that shape.
-    /// </summary>
+    /// <summary>Formats the Map read shape while preserving pair order and duplicate keys.</summary>
     /// <param name="type">The Map type.</param>
     /// <param name="pairs">The pairs, in order.</param>
     /// <returns>The map literal.</returns>
@@ -565,8 +519,7 @@ internal static class TcpParameterFormatter
         int minutes = (int)(remainder / 60m);
         decimal seconds = remainder % 60m;
 
-        // Round before formatting, and to even, because decimal.ToString rounds away from zero. Without this a
-        // midpoint lands one tick above where the HTTP formatter puts it.
+        // Pre-round to even because decimal formatting rounds midpoint digits away from zero.
         string secondsText = Math.Round(seconds, scale, MidpointRounding.ToEven)
             .ToString("00." + new string('0', scale), CultureInfo.InvariantCulture);
         string text = $"{hours}:{minutes:D2}:{secondsText}";

--- a/ClickHouse.Driver.Tcp/Parameters/TcpParameterFormatter.cs
+++ b/ClickHouse.Driver.Tcp/Parameters/TcpParameterFormatter.cs
@@ -279,15 +279,39 @@ internal static class TcpParameterFormatter
 
     private static string FormatMultidimensional(TypeNode type, Array value)
     {
-        TypeNode leaf = type;
-        for (int rank = 0; rank < value.Rank && leaf.Name == "Array" && leaf.Arguments.Count == 1; rank++)
+        var builder = new StringBuilder();
+        AppendAxis(builder, value, new int[value.Rank], dimension: 0, ResolveLeafType(type, value.Rank));
+        return builder.ToString();
+    }
+
+    /// <summary>
+    /// Peels the declared array nesting down to the element type, and checks it is as deep as the CLR array's
+    /// rank. A mismatch is reported here, where the two depths can be named, rather than as a value/type error
+    /// from the arm that would otherwise be handed the wrong level.
+    /// </summary>
+    /// <param name="outer">The declared array type.</param>
+    /// <param name="rank">The CLR array's rank.</param>
+    /// <returns>The element type.</returns>
+    /// <exception cref="ArgumentException">The declared depth is not the CLR rank.</exception>
+    private static TypeNode ResolveLeafType(TypeNode outer, int rank)
+    {
+        TypeNode leaf = outer;
+        int depth = 0;
+        while (leaf.Name == "Array" && leaf.Arguments.Count == 1)
         {
+            depth++;
             leaf = leaf.Arguments[0];
         }
 
-        var builder = new StringBuilder();
-        AppendAxis(builder, value, new int[value.Rank], dimension: 0, leaf);
-        return builder.ToString();
+        if (depth == rank)
+        {
+            return leaf;
+        }
+
+        string suggestion = rank > depth ? "shallower" : "deeper";
+        throw new ArgumentException(
+            $"CLR array rank {rank} does not match ClickHouse type '{outer}' " +
+            $"(nested array depth {depth}). Provide a {suggestion} array or change the type hint.");
     }
 
     private static void AppendAxis(StringBuilder builder, Array value, int[] indices, int dimension, TypeNode leaf)

--- a/ClickHouse.Driver.Tcp/Parameters/TcpParameterFormatter.cs
+++ b/ClickHouse.Driver.Tcp/Parameters/TcpParameterFormatter.cs
@@ -178,7 +178,7 @@ internal static class TcpParameterFormatter
 
             // The server takes either spelling and reports the type as JSON, so both must format.
             case "JSON" or "Json":
-                return value is string json ? json : JsonSerializer.Serialize(value);
+                return (value is string json ? json : JsonSerializer.Serialize(value)).Escape();
 
             // A QBit is a fixed-width vector of its element type, written as an array.
             case "QBit" when value is IEnumerable components && type.Arguments.Count == 2:
@@ -486,12 +486,24 @@ internal static class TcpParameterFormatter
             return quote ? "null" : NullValueString;
         }
 
+        TypeNode jsonAlternative = null;
         foreach (TypeNode alternative in type.Arguments)
         {
+            if (string.Equals(alternative.Name, "JSON", StringComparison.OrdinalIgnoreCase))
+            {
+                jsonAlternative ??= alternative;
+                continue;
+            }
+
             if (ParameterTypeInference.Accepts(alternative, value))
             {
                 return Format(alternative, value, quote);
             }
+        }
+
+        if (jsonAlternative is not null)
+        {
+            return Format(jsonAlternative, value, quote);
         }
 
         throw new ArgumentException(

--- a/ClickHouse.Driver.Tcp/Parameters/TcpParameterFormatter.cs
+++ b/ClickHouse.Driver.Tcp/Parameters/TcpParameterFormatter.cs
@@ -24,11 +24,16 @@ namespace ClickHouse.Driver.Tcp.Parameters;
 /// two must be changed together — see the parity-check entry in the TCP TODO.
 /// </para>
 /// <para>
-/// The one deliberate difference is the outer <see cref="ParameterText.Escape"/> and
+/// The first deliberate difference is the outer <see cref="ParameterText.Escape"/> and
 /// <see cref="ParameterText.QuoteSingle"/> in <see cref="Format"/>. HTTP puts the value in the query string,
 /// where the server reads it directly. The native protocol carries it in the settings list as a custom entry,
 /// which the server first restores as a Field, so the whole value must arrive as a quoted SQL literal — for
 /// every type, not only for strings. An unquoted <c>42</c> for an <c>Int32</c> parameter is rejected.
+/// </para>
+/// <para>
+/// The second is the <c>Interval&lt;Unit&gt;</c> family, which this formatter supports and the HTTP one does
+/// not. The difference is in the type systems, not in the two formatters: the RowBinary tree has no Interval
+/// type, so an HTTP query fails while resolving the name, before any formatter runs.
 /// </para>
 /// </remarks>
 internal static class TcpParameterFormatter
@@ -44,6 +49,16 @@ internal static class TcpParameterFormatter
     private static readonly string[] FloatTypeNames = ["Float32", "Float64", "BFloat16"];
 
     private static readonly string[] DecimalTypeNames = ["Decimal", "Decimal32", "Decimal64", "Decimal128", "Decimal256"];
+
+    /// <summary>
+    /// The <c>Interval&lt;Unit&gt;</c> family, which the server reads as its underlying <c>Int64</c> count. The
+    /// list mirrors the codec registry's; a unit missing from both is reported as an unformattable type.
+    /// </summary>
+    private static readonly string[] IntervalTypeNames =
+    [
+        "IntervalNanosecond", "IntervalMicrosecond", "IntervalMillisecond", "IntervalSecond", "IntervalMinute",
+        "IntervalHour", "IntervalDay", "IntervalWeek", "IntervalMonth", "IntervalQuarter", "IntervalYear",
+    ];
 
     /// <summary>Formats a parameter value for the Query packet's parameter list.</summary>
     /// <param name="value">The parameter value.</param>
@@ -96,7 +111,9 @@ internal static class TcpParameterFormatter
     {
         string name = type.Name;
 
-        if (Array.IndexOf(IntegerTypeNames, name) >= 0 || Array.IndexOf(FloatTypeNames, name) >= 0)
+        if (Array.IndexOf(IntegerTypeNames, name) >= 0
+            || Array.IndexOf(FloatTypeNames, name) >= 0
+            || Array.IndexOf(IntervalTypeNames, name) >= 0)
         {
             return Convert.ToString(value, CultureInfo.InvariantCulture);
         }
@@ -117,7 +134,8 @@ internal static class TcpParameterFormatter
             case "Date" or "Date32":
                 return FormatDate(value, quote);
 
-            case "FixedString" when value is byte[] bytes:
+            // Must precede the arm below, which would otherwise print the CLR type name for a byte array.
+            case "String" or "FixedString" when value is byte[] bytes:
                 return QuoteIfNeeded(Encoding.UTF8.GetString(bytes).Escape(), quote);
 
             case "String" or "FixedString" or "Enum8" or "Enum16" or "IPv4" or "IPv6" or "UUID":

--- a/ClickHouse.Driver.Tcp/Parameters/TcpParameterFormatter.cs
+++ b/ClickHouse.Driver.Tcp/Parameters/TcpParameterFormatter.cs
@@ -119,9 +119,12 @@ internal static class TcpParameterFormatter
             case "Date" or "Date32":
                 return FormatDate(value, quote);
 
-            // Must precede the arm below, which would otherwise print the CLR type name for a byte array.
+            // Must precede the arm below, which would otherwise print the CLR type name for a byte payload.
             case "String" or "FixedString" when value is byte[] bytes:
                 return QuoteIfNeeded(BytesToSqlText(bytes), quote);
+
+            case "String" or "FixedString" when value is ReadOnlyMemory<byte> bytesMemory:
+                return QuoteIfNeeded(BytesToSqlText(bytesMemory.Span), quote);
 
             case "String" or "FixedString" or "Enum8" or "Enum16" or "IPv4" or "IPv6" or "UUID":
                 return QuoteIfNeeded(value.ToString().Escape(), quote);
@@ -197,14 +200,28 @@ internal static class TcpParameterFormatter
     /// <summary>Expands a geo type name into the Tuple/Array shape it stands for.</summary>
     /// <param name="name">The geo type name.</param>
     /// <returns>The parsed structural equivalent.</returns>
-    private static TypeNode GeoShapeOf(string name) => TypeParser.Parse(name switch
+    /// <exception cref="ArgumentException"><paramref name="name"/> is not a geo type.</exception>
+    private static TypeNode GeoShapeOf(string name)
+        => TryGeoShapeOf(name, out TypeNode shape) ? shape : throw new ArgumentException($"'{name}' is not a geo type");
+
+    /// <summary>Expands a geo type name into its shape, reporting whether the name is a geo one at all.</summary>
+    /// <param name="name">The type name, which need not be a geo one.</param>
+    /// <param name="shape">The parsed structural equivalent, or null.</param>
+    /// <returns>True when the name is a geo type.</returns>
+    internal static bool TryGeoShapeOf(string name, out TypeNode shape)
     {
-        "Point" => "Tuple(Float64, Float64)",
-        "Ring" or "LineString" => "Array(Point)",
-        "Polygon" or "MultiLineString" => "Array(Ring)",
-        "MultiPolygon" => "Array(Polygon)",
-        _ => throw new ArgumentException($"'{name}' is not a geo type"),
-    });
+        string structural = name switch
+        {
+            "Point" => "Tuple(Float64, Float64)",
+            "Ring" or "LineString" => "Array(Point)",
+            "Polygon" or "MultiLineString" => "Array(Ring)",
+            "MultiPolygon" => "Array(Polygon)",
+            _ => null,
+        };
+
+        shape = structural is null ? null : TypeParser.Parse(structural);
+        return shape is not null;
+    }
 
     /// <summary>Writes raw bytes as escaped SQL text without changing any of them.</summary>
     /// <param name="bytes">The bytes.</param>
@@ -213,7 +230,7 @@ internal static class TcpParameterFormatter
     /// ClickHouse strings store bytes. Valid UTF-8 remains readable; invalid UTF-8 uses <c>\xHH</c> escapes to
     /// avoid replacement-character corruption.
     /// </remarks>
-    private static string BytesToSqlText(byte[] bytes)
+    private static string BytesToSqlText(ReadOnlySpan<byte> bytes)
     {
         try
         {

--- a/ClickHouse.Driver.Tcp/Parameters/TcpParameterFormatter.cs
+++ b/ClickHouse.Driver.Tcp/Parameters/TcpParameterFormatter.cs
@@ -1,0 +1,404 @@
+using System;
+using System.Collections;
+using System.Globalization;
+using System.Linq;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.Json;
+using ClickHouse.Driver.Tcp.Numerics;
+using ClickHouse.Driver.Tcp.Types;
+using ClickHouse.Driver.Tcp.Types.Codecs;
+
+namespace ClickHouse.Driver.Tcp.Parameters;
+
+/// <summary>
+/// Formats a parameter value as the text the native protocol's parameter list carries.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The inner text is the same SQL representation the HTTP transport sends as <c>param_&lt;name&gt;</c>, so this
+/// mirrors <c>HttpParameterFormatter</c> arm for arm. It cannot call it: the project reference runs from
+/// <c>ClickHouse.Driver</c> to <c>ClickHouse.Driver.Tcp</c>, so a reference back would be circular, and the HTTP
+/// formatter is written against the RowBinary <c>ClickHouseType</c> tree, which this assembly does not have. The
+/// two must be changed together — see the parity-check entry in the TCP TODO.
+/// </para>
+/// <para>
+/// The one deliberate difference is the outer <see cref="ParameterText.Escape"/> and
+/// <see cref="ParameterText.QuoteSingle"/> in <see cref="Format"/>. HTTP puts the value in the query string,
+/// where the server reads it directly. The native protocol carries it in the settings list as a custom entry,
+/// which the server first restores as a Field, so the whole value must arrive as a quoted SQL literal — for
+/// every type, not only for strings. An unquoted <c>42</c> for an <c>Int32</c> parameter is rejected.
+/// </para>
+/// </remarks>
+internal static class TcpParameterFormatter
+{
+    private const string NullValueString = "\\N";
+
+    private static readonly string[] IntegerTypeNames =
+    [
+        "UInt8", "UInt16", "UInt32", "UInt64", "UInt128", "UInt256",
+        "Int8", "Int16", "Int32", "Int64", "Int128", "Int256",
+    ];
+
+    private static readonly string[] FloatTypeNames = ["Float32", "Float64", "BFloat16"];
+
+    private static readonly string[] DecimalTypeNames = ["Decimal", "Decimal32", "Decimal64", "Decimal128", "Decimal256"];
+
+    /// <summary>Formats a parameter value for the Query packet's parameter list.</summary>
+    /// <param name="value">The parameter value.</param>
+    /// <param name="typeName">The resolved ClickHouse type name (e.g. <c>DateTime64(3)</c>).</param>
+    /// <param name="parameterName">The parameter name, for error messages.</param>
+    /// <returns>The wire value: the SQL representation, escaped and quoted for the Field stage.</returns>
+    /// <exception cref="ArgumentException">The value cannot be formatted as the type.</exception>
+    /// <exception cref="FormatException"><paramref name="typeName"/> is malformed.</exception>
+    public static string Format(object value, string typeName, string parameterName)
+        => FormatSqlText(value, typeName, parameterName).Escape().QuoteSingle();
+
+    /// <summary>
+    /// Formats the SQL representation alone, without the native protocol's outer escape and quote. This is the
+    /// exact text the HTTP transport sends, and is the level the two formatters are compared at.
+    /// </summary>
+    /// <param name="value">The parameter value.</param>
+    /// <param name="typeName">The resolved ClickHouse type name.</param>
+    /// <param name="parameterName">The parameter name, for error messages.</param>
+    /// <returns>The SQL representation of the value.</returns>
+    internal static string FormatSqlText(object value, string typeName, string parameterName)
+    {
+        if (value is null or DBNull)
+        {
+            return NullValueString;
+        }
+
+        TypeNode parsed = TypeParser.Parse(typeName);
+        try
+        {
+            return Format(parsed, value, quote: false);
+        }
+        catch (ArgumentException ex) when (ex.GetType() == typeof(ArgumentException))
+        {
+            // Inner arms describe only the leaf type and value they saw. This is the one place that knows the
+            // parameter name and the outer type. Filter to the exact base type so a subclass propagates as
+            // itself, and forward ParamName so it is not lost.
+            throw new ArgumentException(
+                $"Parameter '{parameterName}' (type {parsed}): {ex.Message}",
+                ex.ParamName,
+                ex);
+        }
+    }
+
+    /// <summary>Formats a value as a type, quoting it when it sits inside a composite literal.</summary>
+    /// <param name="type">The parsed type.</param>
+    /// <param name="value">The value.</param>
+    /// <param name="quote">True when the caller is a composite, which needs its string-like elements quoted.</param>
+    /// <returns>The formatted value.</returns>
+    internal static string Format(TypeNode type, object value, bool quote)
+    {
+        string name = type.Name;
+
+        if (Array.IndexOf(IntegerTypeNames, name) >= 0 || Array.IndexOf(FloatTypeNames, name) >= 0)
+        {
+            return Convert.ToString(value, CultureInfo.InvariantCulture);
+        }
+
+        if (Array.IndexOf(DecimalTypeNames, name) >= 0)
+        {
+            return FormatDecimal(value);
+        }
+
+        switch (name)
+        {
+            case "Nothing":
+                return NullValueString;
+
+            case "Bool":
+                return (bool)value ? "true" : "false";
+
+            case "Date" or "Date32":
+                return FormatDate(value, quote);
+
+            case "FixedString" when value is byte[] bytes:
+                return QuoteIfNeeded(Encoding.UTF8.GetString(bytes).Escape(), quote);
+
+            case "String" or "FixedString" or "Enum8" or "Enum16" or "IPv4" or "IPv6" or "UUID":
+                return QuoteIfNeeded(value.ToString().Escape(), quote);
+
+            case "Identifier":
+                // The server substitutes this as a bare SQL identifier and applies its own backtick quoting, so
+                // the value goes through unescaped. Escaping here would corrupt an identifier that contains a
+                // quote or a backslash, and is not needed for safety because the value is never parsed as SQL.
+                return value.ToString();
+
+            case "LowCardinality" when type.Arguments.Count == 1:
+                return Format(type.Arguments[0], value, quote);
+
+            case "DateTime":
+                return QuoteIfNeeded(FormatDateTime(type, value), quote);
+
+            case "DateTime64":
+                return QuoteIfNeeded(FormatDateTime64(type, value), quote);
+
+            case "Time":
+                return value is TimeSpan timeSpan
+                    ? FormatTime(timeSpan)
+                    : FormatTime(Convert.ToInt32(value, CultureInfo.InvariantCulture));
+
+            case "Time64" when value is TimeSpan time64:
+                return FormatTime64(time64, ScaleOf(type, defaultScale: 3));
+
+            case "Nullable" when type.Arguments.Count == 1:
+                return value is null or DBNull
+                    ? quote ? "null" : NullValueString
+                    : Format(type.Arguments[0], value, quote);
+
+            // Must precede the IEnumerable arm. A rank>1 CLR array iterates flattened, so that arm would
+            // serialise [[1,2],[3,4]] as [1,2,3,4].
+            case "Array" when value is Array multidimensional && multidimensional.Rank > 1:
+                return FormatMultidimensional(type, multidimensional);
+
+            case "Array" when value is IEnumerable elements && type.Arguments.Count == 1:
+                return "[" + string.Join(",", elements.Cast<object>().Select(e => Format(type.Arguments[0], e, quote: true))) + "]";
+
+            case "Nested":
+                return FormatNested(type, value);
+
+            case "Tuple":
+                return FormatTuple(type, value);
+
+            case "Map" when value is IDictionary dictionary && type.Arguments.Count == 2:
+                return FormatMap(type, dictionary);
+
+            case "Variant":
+                return FormatVariant(type, value, quote);
+
+            case "JSON":
+                return value is string json ? json : JsonSerializer.Serialize(value);
+
+            default:
+                throw new ArgumentException(
+                    $"Cannot convert value of type '{value.GetType().FullName}' ({value}) to ClickHouse type {type}");
+        }
+    }
+
+    private static string FormatDecimal(object value) => value switch
+    {
+        ClickHouseDecimal chd => chd.ToString(null, CultureInfo.InvariantCulture),
+        string s => ParseDecimalText(s).ToString(null, CultureInfo.InvariantCulture),
+        _ => Convert.ToDecimal(value, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture),
+    };
+
+    /// <summary>
+    /// Reads a decimal from its text, keeping every digit. A <see cref="decimal"/> would cap the value at 29
+    /// digits, which the wider ClickHouse decimals exceed.
+    /// </summary>
+    /// <param name="text">The decimal in invariant form.</param>
+    /// <returns>The parsed value.</returns>
+    /// <exception cref="ArgumentException"><paramref name="text"/> is not a decimal.</exception>
+    private static ClickHouseDecimal ParseDecimalText(string text)
+    {
+        string trimmed = text.Trim();
+        int point = trimmed.IndexOf('.');
+        string digits = point < 0 ? trimmed : trimmed.Remove(point, 1);
+        int scale = point < 0 ? 0 : trimmed.Length - point - 1;
+
+        if (!BigInteger.TryParse(digits, NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out BigInteger mantissa))
+        {
+            throw new ArgumentException($"Cannot convert value '{text}' to a ClickHouse decimal");
+        }
+
+        return new ClickHouseDecimal(mantissa, scale);
+    }
+
+    private static string FormatDate(object value, bool quote)
+    {
+        string text = value switch
+        {
+            DateTimeOffset dto => dto.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+            DateOnly dateOnly => dateOnly.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+            _ => Convert.ToDateTime(value, CultureInfo.InvariantCulture).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+        };
+
+        return QuoteIfNeeded(text, quote);
+    }
+
+    private static string FormatDateTime(TypeNode type, object value)
+    {
+        // A DateTime with no kind is already in the parameter's timezone, so it is sent as it stands. A kinded
+        // value or an offset names an instant, which is moved into that timezone to keep the instant.
+        if (value is DateTime { Kind: DateTimeKind.Unspecified } unspecified)
+        {
+            return unspecified.ToString("s", CultureInfo.InvariantCulture);
+        }
+
+        DateTime local = InTargetTimezone(type, ToOffset(value));
+        return local.ToString("s", CultureInfo.InvariantCulture);
+    }
+
+    private static string FormatDateTime64(TypeNode type, object value)
+    {
+        if (value is DateTime { Kind: DateTimeKind.Unspecified } unspecified)
+        {
+            return unspecified.ToString("yyyy-MM-dd HH:mm:ss.fffffff", CultureInfo.InvariantCulture);
+        }
+
+        DateTime local = InTargetTimezone(type, ToOffset(value));
+        return local.ToString("yyyy-MM-dd HH:mm:ss.fffffff", CultureInfo.InvariantCulture);
+    }
+
+    private static DateTimeOffset ToOffset(object value) => value switch
+    {
+        DateTimeOffset dto => dto,
+        DateTime dt => new DateTimeOffset(dt),
+        _ => throw new ArgumentException(
+            $"Cannot convert value of type '{value.GetType().FullName}' ({value}) to a date and time"),
+    };
+
+    /// <summary>
+    /// Moves an instant into the type's timezone. The timezone defaults to UTC, not to the session timezone,
+    /// which is what the HTTP formatter does.
+    /// </summary>
+    /// <param name="type">The timezone-bearing type.</param>
+    /// <param name="value">The instant.</param>
+    /// <returns>The wall-clock time in the type's timezone.</returns>
+    private static DateTime InTargetTimezone(TypeNode type, DateTimeOffset value)
+    {
+        // The timezone is the last argument: DateTime('UTC') or DateTime64(3, 'UTC').
+        string explicitTimezone = type.Arguments.Count > 0
+            ? DateTimeZones.UnquoteTimezone(type.Arguments[^1])
+            : null;
+
+        // A DateTime64 precision digit is not a timezone.
+        if (explicitTimezone is not null && int.TryParse(explicitTimezone, NumberStyles.None, CultureInfo.InvariantCulture, out _))
+        {
+            explicitTimezone = null;
+        }
+
+        TimeZoneInfo timeZone = DateTimeZones.Resolve(explicitTimezone, serverTimezone: null);
+        return TimeZoneInfo.ConvertTime(value, timeZone).DateTime;
+    }
+
+    private static string FormatMultidimensional(TypeNode type, Array value)
+    {
+        TypeNode leaf = type;
+        for (int rank = 0; rank < value.Rank && leaf.Name == "Array" && leaf.Arguments.Count == 1; rank++)
+        {
+            leaf = leaf.Arguments[0];
+        }
+
+        var builder = new StringBuilder();
+        AppendAxis(builder, value, new int[value.Rank], dimension: 0, leaf);
+        return builder.ToString();
+    }
+
+    private static void AppendAxis(StringBuilder builder, Array value, int[] indices, int dimension, TypeNode leaf)
+    {
+        builder.Append('[');
+        int length = value.GetLength(dimension);
+        int lower = value.GetLowerBound(dimension);
+        for (int i = 0; i < length; i++)
+        {
+            if (i > 0)
+            {
+                builder.Append(',');
+            }
+
+            indices[dimension] = lower + i;
+            if (dimension == value.Rank - 1)
+            {
+                builder.Append(Format(leaf, value.GetValue(indices), quote: true));
+            }
+            else
+            {
+                AppendAxis(builder, value, indices, dimension + 1, leaf);
+            }
+        }
+
+        builder.Append(']');
+    }
+
+    private static string FormatNested(TypeNode type, object value)
+    {
+        // A Nested value is the whole set of rows, so an enumerable is the rows and each row is a tuple of the
+        // declared fields. The result has the same shape as Array(Tuple(...)). A bare tuple is one row.
+        if (value is IEnumerable rows and not ITuple)
+        {
+            return "[" + string.Join(",", rows.Cast<object>().Select(row => FormatTuple(type, row))) + "]";
+        }
+
+        return FormatTuple(type, value);
+    }
+
+    private static string FormatTuple(TypeNode type, object value)
+    {
+        TypeNode[] elementTypes = NamedElementParser.Split(type).Select(element => element.Type).ToArray();
+
+        return value switch
+        {
+            ITuple tuple => "(" + string.Join(",", elementTypes.Select((t, i) => Format(t, tuple[i], quote: true))) + ")",
+            IList list => "(" + string.Join(",", elementTypes.Select((t, i) => Format(t, list[i], quote: true))) + ")",
+            _ => throw new ArgumentException(
+                $"Cannot convert value of type '{value.GetType().FullName}' ({value}) to ClickHouse type {type}"),
+        };
+    }
+
+    private static string FormatMap(TypeNode type, IDictionary value)
+    {
+        var pairs = value.Keys.Cast<object>().Select(key =>
+            Format(type.Arguments[0], key, quote: true) + " : " + Format(type.Arguments[1], value[key], quote: true));
+
+        return "{" + string.Join(",", pairs) + "}";
+    }
+
+    private static string FormatVariant(TypeNode type, object value, bool quote)
+    {
+        if (value is null or DBNull)
+        {
+            return quote ? "null" : NullValueString;
+        }
+
+        foreach (TypeNode alternative in type.Arguments)
+        {
+            if (ParameterTypeInference.Accepts(alternative, value))
+            {
+                return Format(alternative, value, quote);
+            }
+        }
+
+        throw new ArgumentException(
+            $"Cannot convert value of type '{value.GetType().FullName}' ({value}) to ClickHouse type {type}: " +
+            "no alternative of the Variant accepts it");
+    }
+
+    private static string FormatTime(TimeSpan value) => FormatTime((int)Math.Round(value.TotalSeconds));
+
+    private static string FormatTime(int totalSeconds)
+    {
+        int absolute = Math.Abs(totalSeconds);
+        string text = $"{absolute / 3600}:{(absolute % 3600) / 60:D2}:{absolute % 60:D2}";
+        return totalSeconds < 0 ? "-" + text : text;
+    }
+
+    private static string FormatTime64(TimeSpan value, int scale)
+    {
+        decimal totalSeconds = (decimal)value.Ticks / TimeSpan.TicksPerSecond;
+        bool negative = totalSeconds < 0;
+        decimal absolute = Math.Abs(totalSeconds);
+
+        int hours = (int)(absolute / 3600m);
+        decimal remainder = absolute % 3600m;
+        int minutes = (int)(remainder / 60m);
+        decimal seconds = remainder % 60m;
+
+        string secondsText = seconds.ToString("00." + new string('0', scale), CultureInfo.InvariantCulture);
+        string text = $"{hours}:{minutes:D2}:{secondsText}";
+        return negative ? "-" + text : text;
+    }
+
+    private static int ScaleOf(TypeNode type, int defaultScale)
+        => type.Arguments.Count > 0
+            && int.TryParse(type.Arguments[0].Name, NumberStyles.None, CultureInfo.InvariantCulture, out int scale)
+            ? scale
+            : defaultScale;
+
+    private static string QuoteIfNeeded(string value, bool quote) => quote ? value.QuoteSingle() : value;
+}

--- a/ClickHouse.Driver.Tcp/Parameters/TcpParameterFormatter.cs
+++ b/ClickHouse.Driver.Tcp/Parameters/TcpParameterFormatter.cs
@@ -163,7 +163,8 @@ internal static class TcpParameterFormatter
             case "Array" when value is Array multidimensional && multidimensional.Rank > 1:
                 return FormatMultidimensional(type, multidimensional);
 
-            case "Array" when value is IEnumerable elements && type.Arguments.Count == 1:
+            // A string is a sequence of chars, so taking it here would send one element per character.
+            case "Array" when value is not string and IEnumerable elements && type.Arguments.Count == 1:
                 return "[" + string.Join(",", elements.Cast<object>().Select(e => Format(type.Arguments[0], e, quote: true))) + "]";
 
             case "Nested":
@@ -187,7 +188,7 @@ internal static class TcpParameterFormatter
                 return (value is string json ? json : JsonSerializer.Serialize(value)).Escape();
 
             // A QBit is a fixed-width vector of its element type, written as an array.
-            case "QBit" when value is IEnumerable components && type.Arguments.Count == 2:
+            case "QBit" when value is not string and IEnumerable components && type.Arguments.Count == 2:
                 return "[" + string.Join(",", components.Cast<object>().Select(c => Format(type.Arguments[0], c, quote: true))) + "]";
 
             // Geo types format as their underlying tuple/array shapes.
@@ -357,12 +358,17 @@ internal static class TcpParameterFormatter
             ? "A DateTimeOffset names an instant"
             : $"A DateTime with Kind={((DateTime)value).Kind} names an instant";
 
+        // The suggestion keeps the declared scale, which the caller chose.
+        string suggestion = type.Name == "DateTime64"
+            ? $"DateTime64({ScaleOf(type, defaultScale: 3)}, 'UTC')"
+            : $"{type.Name}('UTC')";
+
         throw new ArgumentException(
             $"{valueDescription}, but the type declares no timezone, so the instant cannot be sent without " +
             $"loss. The server reads the value in its session timezone, which moves the instant when that is " +
-            $"not UTC, and reports no error. Declare the timezone in the type — {type.Name}" +
-            $"{(type.Name == "DateTime64" ? "(3, 'UTC')" : "('UTC')")} — or pass a DateTime with " +
-            $"Kind=Unspecified to send a wall-clock time for the server to read in its own timezone.");
+            $"not UTC, and reports no error. Declare the timezone in the type — {suggestion} — or pass a " +
+            $"DateTime with Kind=Unspecified to send a wall-clock time for the server to read in its own " +
+            $"timezone.");
     }
 
     /// <summary>Reads the timezone a date-and-time type declares.</summary>
@@ -461,8 +467,9 @@ internal static class TcpParameterFormatter
 
     private static string FormatNested(TypeNode type, object value)
     {
-        // Nested formats as Array(Tuple(...)); a bare tuple represents one row.
-        if (value is IEnumerable rows and not ITuple)
+        // Nested formats as Array(Tuple(...)); a bare tuple represents one row. A string is a sequence of
+        // chars, so it belongs to neither shape.
+        if (value is IEnumerable rows and not ITuple and not string)
         {
             return "[" + string.Join(",", rows.Cast<object>().Select(row => FormatTuple(type, row))) + "]";
         }

--- a/ClickHouse.Driver.Tcp/Parameters/TcpParameterFormatter.cs
+++ b/ClickHouse.Driver.Tcp/Parameters/TcpParameterFormatter.cs
@@ -36,7 +36,7 @@ internal static class TcpParameterFormatter
         "Int8", "Int16", "Int32", "Int64", "Int128", "Int256",
     ];
 
-    private static readonly string[] FloatTypeNames = ["Float32", "Float64", "BFloat16"];
+    private static readonly string[] FloatTypeNames = ["Float32", "Float64"];
 
     private static readonly string[] DecimalTypeNames = ["Decimal", "Decimal32", "Decimal64", "Decimal128", "Decimal256"];
 
@@ -115,6 +115,9 @@ internal static class TcpParameterFormatter
 
             case "Bool":
                 return (bool)value ? "true" : "false";
+
+            case "BFloat16":
+                return FormatBFloat16(value);
 
             case "Date" or "Date32":
                 return FormatDate(value, quote);
@@ -247,6 +250,17 @@ internal static class TcpParameterFormatter
             return builder.ToString();
         }
     }
+
+    /// <summary>Formats a BFloat16 value, which only a 32-bit float carries.</summary>
+    /// <param name="value">The value.</param>
+    /// <returns>The invariant text of the float.</returns>
+    /// <exception cref="ArgumentException">The value is not a float.</exception>
+    private static string FormatBFloat16(object value) => value is float single
+        ? single.ToString(CultureInfo.InvariantCulture)
+        : throw new ArgumentException(
+            $"Cannot convert value of type '{value.GetType().FullName}' ({value}) to ClickHouse type BFloat16: " +
+            "a BFloat16 holds the top 16 bits of a 32-bit float. The server narrows a wider value with no " +
+            "error, and a value outside the float range arrives as an infinity. Pass a float.");
 
     private static string FormatDecimal(object value) => value switch
     {

--- a/ClickHouse.Driver.Tests/ADO/SqlParameterTypeExtractorTests.cs
+++ b/ClickHouse.Driver.Tests/ADO/SqlParameterTypeExtractorTests.cs
@@ -88,6 +88,30 @@ public class SqlParameterTypeExtractorTests
         Assert.That(hints["e"], Is.EqualTo(expectedType));
     }
 
+    // ClickHouse accepts a backslash-escaped quote in a string literal as well as a doubled one. Treating \'
+    // as the end of the string made everything after it look like SQL, so the real placeholder was skipped
+    // and its type was silently lost.
+    [TestCase(@"SELECT 'it\'s', {p:Int32}", TestName = "ExtractTypeHints_BackslashEscapedQuoteInLiteral_FindsLaterHint")]
+    [TestCase(@"SELECT 'a\'b\'c', {p:Int32}", TestName = "ExtractTypeHints_SeveralBackslashEscapedQuotes_FindsLaterHint")]
+    [TestCase(@"SELECT 'decoy \' {p:Wrong}', {p:Int32}", TestName = "ExtractTypeHints_DecoyPlaceholderAfterEscape_FindsRealHint")]
+    public void ExtractTypeHints_LiteralWithBackslashEscape_StillFindsHintAfterIt(string sql)
+    {
+        var hints = SqlParameterTypeExtractor.ExtractTypeHints(sql);
+
+        Assert.That(hints["p"], Is.EqualTo("Int32"));
+    }
+
+    [Test]
+    public void ExtractTypeHints_BackslashEscapedQuoteInEnum_ReturnsFullType()
+    {
+        var expectedType = @"Enum8('it\'s' = 1, 'hello' = 2)";
+        var sql = $"SELECT {{e:{expectedType}}}";
+
+        var hints = SqlParameterTypeExtractor.ExtractTypeHints(sql);
+
+        Assert.That(hints["e"], Is.EqualTo(expectedType));
+    }
+
     [Test]
     public void ExtractTypeHints_NullString_ReturnsEmptyDictionary()
     {

--- a/ClickHouse.Driver.Tests/ADO/SqlParameterTypeExtractorTests.cs
+++ b/ClickHouse.Driver.Tests/ADO/SqlParameterTypeExtractorTests.cs
@@ -88,30 +88,6 @@ public class SqlParameterTypeExtractorTests
         Assert.That(hints["e"], Is.EqualTo(expectedType));
     }
 
-    // ClickHouse accepts a backslash-escaped quote in a string literal as well as a doubled one. Treating \'
-    // as the end of the string made everything after it look like SQL, so the real placeholder was skipped
-    // and its type was silently lost.
-    [TestCase(@"SELECT 'it\'s', {p:Int32}", TestName = "ExtractTypeHints_BackslashEscapedQuoteInLiteral_FindsLaterHint")]
-    [TestCase(@"SELECT 'a\'b\'c', {p:Int32}", TestName = "ExtractTypeHints_SeveralBackslashEscapedQuotes_FindsLaterHint")]
-    [TestCase(@"SELECT 'decoy \' {p:Wrong}', {p:Int32}", TestName = "ExtractTypeHints_DecoyPlaceholderAfterEscape_FindsRealHint")]
-    public void ExtractTypeHints_LiteralWithBackslashEscape_StillFindsHintAfterIt(string sql)
-    {
-        var hints = SqlParameterTypeExtractor.ExtractTypeHints(sql);
-
-        Assert.That(hints["p"], Is.EqualTo("Int32"));
-    }
-
-    [Test]
-    public void ExtractTypeHints_BackslashEscapedQuoteInEnum_ReturnsFullType()
-    {
-        var expectedType = @"Enum8('it\'s' = 1, 'hello' = 2)";
-        var sql = $"SELECT {{e:{expectedType}}}";
-
-        var hints = SqlParameterTypeExtractor.ExtractTypeHints(sql);
-
-        Assert.That(hints["e"], Is.EqualTo(expectedType));
-    }
-
     [Test]
     public void ExtractTypeHints_NullString_ReturnsEmptyDictionary()
     {


### PR DESCRIPTION
**Stacked on #560** (`tcp/epic-m-connection-pool`) — review that one first; this PR's diff is the parameters only.

TCP epic **N11**: bind values to a parameterized query's `{name:Type}` placeholders. The Query packet has carried a parameter-list field since L4, but the client always sent it empty.

```csharp
await using var client = new ClickHouseTcpClient("Host=localhost");

var options = new ClickHouseTcpQueryOptions
{
    Parameters = new ClickHouseTcpParameterCollection
    {
        { "since", new DateOnly(2026, 1, 1) },
        { "tags",  new[] { "a", "b" } },
    },
};

await foreach (object[] row in client.QueryAsync(
    "SELECT * FROM events WHERE day >= {since:Date} AND tag IN {tags:Array(String)}", options))
{
}
```

No method signature changed — every overload already took an options object, so only four internal `parameters: null` call sites moved. `InsertAsync` inherits `Parameters` from the same record, so `INSERT INTO t SELECT ... WHERE x > {t:Int32}` works with no extra plumbing.

## The wire contract is not what the spec said

This is the part worth reading. Our native-protocol spec note (`ignored-docs/tcp/native-protocol.md`, not in the repo) claimed that *String* parameters must arrive single-quoted. The truth is broader and sharper, and I established it by probing ~60 cases against ClickHouse 26.6.1 on both transports before writing any code.

**Every type must be quoted.** The parameter rides the settings list with `flags = 0x02 (Custom)`, so the server runs `Field::restoreFromDump` on the text *before* the `{name:Type}` substitution ever sees it. An unquoted `42` for an `Int32` parameter fails with `Couldn't restore Field from dump: 42`, exactly as a bare `Alice` does for a `String`.

**The value therefore crosses two unescape stages**, and stage 2 turns out to be the *same* escaped-text reader that HTTP's `param_<name>` feeds — I confirmed that by curling the HTTP endpoint and getting byte-identical results. So the rule is:

```
wire value = QuoteSingle(Escape(T))     where T is the exact text HTTP sends
```

To send the three characters `a\b` the wire carries `'a\\\\b'`. A literal newline must travel as `'a\\nb'`, because stage 2 terminates on a raw newline or tab.

Two server behaviours here are silent rather than diagnosed, and both corrupt data:

- **Doubling a quote does not escape it.** `'a''b'` restores as `a`, no error. Only backslash escaping works.
- **Trailing text after the closing quote is ignored.** `'ab' XYZ` restores as `ab`.

Neither is reachable through this API — the formatter owns the quoting — but they are why the escaping is not negotiable, and why `ParameterText.Escape` is applied twice rather than once. The spec note and the L4 TODO entry are corrected.

## Decisions worth a look

**The formatter is a deliberate duplicate, and that is the uncomfortable part.** Since the inner text must match HTTP byte for byte, the ideal is one implementation. The assembly graph forbids it: `ClickHouse.Driver` already references `ClickHouse.Driver.Tcp`, so a reference back is circular, and `HttpParameterFormatter` is written against the RowBinary `ClickHouseType` tree, which this assembly does not have. Sharing would mean moving `ClickHouseType`, `TypeConverter` and `TypeSettings` into `ClickHouse.Driver.Common` while keeping the net6.0 HTTP build green — an epic, not a PR. So `TcpParameterFormatter` mirrors `HttpParameterFormatter` arm for arm, and **nothing enforces that today**. A CI parity test (one shared case table through both formatters, asserting `tcp == http.Escape().QuoteSingle()`) is filed as TODO **N11a** rather than built here. It is also the precondition for ever collapsing the two.

**Five defects found by comparing against the other two implementations.** I first wrote this port to reproduce two known HTTP bugs on the grounds that parity was the invariant. That was the wrong call — parity with a bug is still a bug — so they are fixed, and I then went looking for more by diffing this formatter's behaviour against the HTTP test corpus and against clickhouse-go's native parameter tests.

They are fixed **on the TCP side only**. This PR touches nothing outside `ClickHouse.Driver.Tcp` and its tests: HTTP is a shipped transport, and changing its behaviour does not belong in a TCP epic PR. An earlier revision of this branch did fix them there too; that is reverted.

Two were inherited HTTP defects. **One of the two has since been fixed on `main` independently**, by #483/#484, so it is no longer a divergence:

- **A `byte[]` bound to a `String` parameter was sent as the literal text `System.Byte[]`.** Only `FixedString` read the bytes. Silent corruption, and reachable in practice since `readStringsAsByteArrays` makes that a plausible round-trip. HTTP now reads the bytes too, and also accepts a `ReadOnlyMemory<byte>`; this branch matches both.
- **`Interval<Unit>` threw.** TCP now sends the underlying `Int64` count, and the server accepts it, so this was purely a missing arm. HTTP could not be fixed the same way regardless: the RowBinary tree has no Interval type at all, so an HTTP query fails while *resolving the name*, before any formatter runs. Adding it is a feature with a read path and a PublicAPI change (there is already a `TODO: following interval implementation` at `Types/BinaryTypeDecoder.cs:136`). This one is still a divergence.

Three more were this port being *behind* HTTP, which the comparison is what surfaced:

- **`{p:Json}` threw** — the arm matched only the uppercase `JSON`, though the server takes either spelling and reports both as `JSON`.
- **`QBit(T, N)` had no arm.**
- **The six geo names had no arm** (`Point`, `Ring`, `LineString`, `Polygon`, `MultiLineString`, `MultiPolygon`). They now format as the shape they stand for, mirroring HTTP, where `PointType : TupleType` and the rest are `ArrayType`.

All eight of those types now have live round-trips.

**Type resolution has two sources:** a non-empty `ClickHouseType` override, then the query `{name:Type}` hint. The scanner ignores comments and string literals. If neither source supplies a type, binding throws with guidance to declare one. CLR inference remains for future client-side `?`/`@` placeholders and for matching `Variant` alternatives, but native `{name:Type}` binding does not call it.

**Deliberately out of scope:** ADO-style `@name` rewriting (this client is not an ADO provider; revisit if a TCP-backed `DbConnection` lands) and the `IParameterFormatter` / `IParameterTypeResolver` hooks (both live in the HTTP assembly and cannot be referenced from here).

**No changelog entry, and no diff outside the TCP projects.** No commit in this epic series has touched `CHANGELOG.md`, since the TCP client is unreleased and `[Experimental]`, and that holds here. Say the word if you want the whole epic summarised there when it lands.

**The divergence list is much shorter than it was, because `main` closed most of it.** An earlier revision of this description counted eight divergences, six of them HTTP defects this port fixed only on its own side. #483/#484 has since fixed the two that silently corrupted data (`byte[]` bound to `String`, and a `byte[]` that is not valid UTF-8) and added `TimeOnly` binding, and the geo and `QBit` arms turned out to exist on HTTP already. What I can still see after this round:

- **`Interval`.** TCP sends the `Int64` count; an HTTP query fails while resolving the name, because the RowBinary tree has no Interval type. Closing it is the feature described above, not a formatter change.
- **A kinded `DateTime`/`DateTimeOffset` against a hint that declares no timezone.** TCP refuses it, HTTP sends it. Deliberate, and argued below under N11d-http.
- **The text a byte payload travels as**, which is a representation difference rather than a behavioural one. HTTP's `EscapeBytes` emits `\xHH` for every byte outside printable ASCII; this formatter tries strict UTF-8 first, so `héllo` stays readable and only genuinely invalid UTF-8 falls back to `\xHH`. The server reads back the same bytes either way, which is the property that matters, but the two do not produce identical text and a naive `tcp == http.Escape().QuoteSingle()` assertion would fail on it.

That last point is the reason the parity check filed as **N11a** still needs building: it has to compare what the server stores, not the text. Nothing enforces any of this today.

**A silent timezone defect, now refused rather than sent.** A bare `{d:DateTime}` hint declares no timezone, so the server reads the wall-clock text in `session_timezone`. The client wrote a kinded `DateTime`/`DateTimeOffset` as UTC, so on a non-UTC session the instant moved — nine hours for `Asia/Tokyo` — with no error. The client now throws instead, naming the value's kind, what the server would have done, and both ways out:

> Parameter 'd' (type DateTime): A DateTimeOffset names an instant, but the type declares no timezone, so the instant cannot be sent without loss. The server reads the value in its session timezone, which moves the instant when that is not UTC, and reports no error. Declare the timezone in the type — DateTime('UTC') — or pass a DateTime with Kind=Unspecified to send a wall-clock time for the server to read in its own timezone.

`Kind=Unspecified` with a bare hint **stays legal**, and that limit is the point. Unspecified is a wall clock with no instant attached, which is exactly what a type with no timezone carries — nothing is lost and the round-trip is faithful. Only a value that *names an instant* is refused, because only then does the client hold information the wire cannot carry.

**Epoch was the first candidate and the evidence killed it.** clickhouse-go sends epoch seconds, which is immune to `session_timezone` — I confirmed that. But it cannot carry the range: the server reads an integer of **four digits or fewer as a year**, so epoch `0`–`9999` (1970-01-01 00:00:00 to 02:46:39 UTC) is rejected with `value 1000 cannot be parsed as Date`, as is any negative epoch for `DateTime`. An encoding with a hole in it is not an encoding. The other candidate — formatting into the session timezone — needs the client to guess server state at format time and go silently wrong when the guess is stale. Refusing beat guessing.

**HTTP keeps the old behaviour, deliberately.** The distinction is not timidity: on HTTP this combination is *correct today for everyone on a UTC server*, which is the default. Throwing there would break working code for the majority to protect the non-UTC minority, and it is a shipped client. TCP is unreleased and `[Experimental]`, so establishing "declare your timezone" costs nobody. Filed as **N11d-http** with three graded options (log a warning / opt-in switch / throw), and a note that the kinded half has no HTTP test at all — that should be written first, because it fails silently today.

## Security

The `Identifier` arm is the only one that emits its value unescaped, so I checked what it can reach. The server substitutes it as a single AST identifier and applies its own backtick quoting, so it cannot break out:

| value for `{c:Identifier}` | result |
|---|---|
| `a) UNION ALL (SELECT 999` | `UNKNOWN_IDENTIFIER`, treated as one name |
| ``a`,`b`` | escaped to ``a\`,\`b``, one name |
| `system.tables` | one name — it cannot even cross a database |

Ordinary values are inert too: `' OR 1=1 --` round-trips as data, covered by a test at both the formatter and the live-server level. An `Identifier` parameter is still a "trusted name" surface in the same sense it is on HTTP — it selects a name, so a caller must not let an untrusted value choose which column is read — but it cannot inject syntax.

## Testing

The full net9.0 TCP suite passes (2,669 tests), including the live-server parameter cases covering every supported parameter type. Coverage on the new files: formatter 99.3%, extractor 98.9%, collection 100%, `MapPairs` 100%, `ParameterText` 100%, inference 95.6%. The one uncovered branch worth naming is a defensive `if (sql[startIndex] != '{')` guard in the extractor that its only call site makes unreachable.

The escaping expectations are hand-derived from the two-stage rule and then confirmed against a real server, so the unit and integration layers check each other rather than restating one belief twice. The character-class cases are the ones I would keep: a carriage return and a NUL need no escape while a newline and a tab do, which is easy to get wrong in either direction.

**The corner cases came from reading the other two implementations' suites rather than from imagination.** I inventoried what `ClickHouse.Driver.Tests` binds as an HTTP parameter and what clickhouse-go binds as a native one, then took everything either had that this did not. The additions a live server can settle:

- `NaN`, `+Infinity`, `-Infinity` — .NET and ClickHouse spell these differently and the server happens to accept both, which only a round-trip shows;
- a `Bool` inside a composite — the server takes `1`/`0` for a scalar `Bool` but rejects them for `Array(Bool)`, so a formatter emitting digits passes the scalar case and fails this one (clickhouse-go hit exactly this, issue #1891);
- the `Date` and `Date32` range ends, a pre-epoch `DateTime64`, and scale 9;
- an `Enum` by number rather than by label; decimals of 30 and 50 digits, past what a CLR `decimal` holds;
- negative and past-24h `Time`/`Time64`; a surrogate pair; a nine-element `ValueTuple` (`TRest` nesting);
- four more `Map` shapes — empty, a key needing escapes, a non-string key, one holding an array.

Non-zero-lower-bound and zero-length array axes are unit tests, being shapes no server round-trip can produce.

**The suite can now gate on server version**, which QBit forced: it reached the matrix and failed on 25.8, which predates the type. `TcpFeature` carries a `[SinceVersion]` per capability and `TcpServerFeatures` maps a version onto the set — the same shape as `Feature` and `ClickHouseFeatureMap` in the HTTP suite, kept as a separate copy because the TCP projects do not reference `ClickHouse.Driver`, which is what keeps the TCP CI job building only the two TCP projects. Whole tests use `[RequiresServerFeature]`; a single case of a `TestCaseSource` guards its `yield`, since a case that is never yielded cannot carry an attribute. The version comes from `CLICKHOUSE_VERSION` rather than from the server, because a case source is enumerated during discovery, before the fixture has started the container. A moving tag resolves to "everything supported", so a real gap fails loudly instead of being skipped in silence. The mapping has its own tests — a wrong answer there does not fail a test, it skips one.

The comparison also found gaps in the **HTTP** suite that I did not fix here, filed as **N11c**: no NaN/Infinity parameter anywhere, no upper-bound dates (only the lower bound is ever tested), no DST-gap or DST-overlap instant, and `Time`/`Time64` commented out of the composite matrix. Each is two tests, and the HTTP half may well find something.

## Third review round

Five findings, plus a sixth that followed from fixing one of them. Four were this branch's to fix, one belongs to #609, and two carried over from earlier rounds are closed by argument rather than by code.

The largest was not really one finding. **The SQL scanner was a port of a pre-#509 version of the HTTP one**, so it re-introduced the bug #511 had already fixed there: the colon search reached past its own brace and took the colon of the next parameter, dropping that parameter's hint. `SELECT 1 AS "col{x}", {p:Int32}` is a query the server answers, and this client could not bind it. That was the reported symptom; the port was also missing backtick and double-quote identifiers, `$tag$` heredocs, `//` comments, nested block comments, and the rule that only `# ` and `#!` open a comment. The scanner is now the current HTTP one, ported whole, and each of those rules is pinned by a case confirmed against 26.6.1 first.

The comment rule cost one existing test, which asserted that a bare `#` opens a comment. The server disagrees: `SELECT {val:Int32} #{val:String}` fails with `Unrecognized token`, while `# ` and `#!` both work. That case is replaced by one pinning the server's rule, mirroring `ExtractTypeHints_BareHash_NotTreatedAsComment` in the HTTP suite. It is the only existing assertion this PR changes.

Three more defects:

- **A `ReadOnlyMemory<byte>` bound to `String` or `FixedString` was sent as the CLR type name.** HTTP reads it. Fixing the formatter exposed a second half, reported once the first fix was pushed: `Accepts` did not recognise a byte payload in one either, so no text `Variant` alternative would take it, and a `JSON` alternative would take it and serialize it as base64. Both halves are fixed.
- **A `byte[]` matched any `Array` alternative by name.** `Variant(Array(String), Array(UInt8))` sent `['65','66']`, which the server stores without complaint as a valid `Array(String)`. The element type decides now.
- **Geo names and `QBit` matched no `Variant` alternative**, though the formatter writes both, so `Variant(Point, String)` refused a value it could have written. They now match the shape the name stands for, which also made the geo shape mapping shared between formatting and matching instead of living only in the formatter.

**`TimeOnly` binding belongs to #609**, which lands the same three hunks. I had written a duplicate and removed it before committing, so this branch carries none and the stack has exactly one.

Two findings are declined:

- **`FormatTime64` can emit `0:00:60`.** Checked against 26.6.1: `CAST('0:00:60' AS Time64(0))` normalizes to `00:01:00`, and the HTTP formatter emits the same text. Non-canonical, not rejected and not corrupting.
- **`Variant` matching enumerates a sequence twice**, once to choose an alternative and once to format. Buffering would add an allocation and a full traversal to the normal path. The contract is now written on `ClickHouseTcpParameter.Value` rather than living only in a review reply.

Every new test here was run against the unfixed code first: 21 unit and 7 integration cases fail without the scanner, byte and geo fixes, and 4 more fail without the `ReadOnlyMemory` matcher.

## Second review round

Six inline comments, all valid against current `HEAD` — none of them outdated. Four defects, plus two of my own tests that passed against the code they were meant to guard:

- **The SQL scanner ignored backslash-escaped quotes.** A quoted literal could appear to end early, hiding a later placeholder and losing its type hint.
- **Variant alternatives were matched on the outer type name alone,** so a `string[]` took the first arm of `Variant(Array(Int32), Array(String))` and every element went out unquoted. Matching now recurses into element, key/value and tuple element types, and checks tuple arity.
- **A Map read back from this client could not be bound again.** The codec surfaces a row as `KeyValuePair[]` so duplicate keys and order survive, and only `IDictionary` was accepted.
- **`byte[]` was decoded as UTF-8,** so `0xFF` became U+FFFD and the server stored `EF BF BD`. Probing showed `\xHH` in the inner text yields the exact byte, so bytes that are not valid UTF-8 now travel that way while valid UTF-8 keeps the readable form.
- **The `InsertAsync` test called `ExecuteAsync`.** A dropped `parameters` argument in either real overload would have passed the whole suite. Both are covered now, through a parameterized target.
- **The one-shot sequence test exercised a fallback that native binding no longer uses.** Native parameters now require an explicit type or SQL hint. Inference remains directly tested for future client-side placeholders.

Since the sharpest finding was "this test passes on the unfixed code", I reverted all four source fixes and re-ran. Fifteen new tests failed, as they should — and **two of mine passed**, so I had repeated the mistake while fixing it. One put the literal after the placeholder, so the scanner never entered a string on the way to the hint; with that corrected it still passed, because an even number of escaped quotes makes the mis-scan open and close the same number of times and land outside a string again. The third attempt showed the difference is not observable through the server at all, so that test is gone and a comment points at the unit tests, which are true negatives. Every new test here has been run against the unfixed code and fails there.

Coverage then flagged that the Variant pair-sequence arm had no test at all, and that a `try/catch (FormatException)` I had added around `NamedElementParser.Split` can never fire — the exception comes from `ElementTypeStrings`, which validates arity. Both fixed; `ParameterTypeInference` 82% → 95%.

## Review outcomes

This is the earlier review pass, before the cross-implementation comparison above. Five defects found and fixed. Four were parity divergences, and one of those was silent:

- **A `byte[]` in a `Variant` became the text `System.Byte[]`.** It matched a string alternative before an array one, and the string arm prints the CLR type. HTTP picks `Array(UInt8)` via `CanWrite`. This was the only silent corruption found — everything else failed loudly.
- **`Time64` rounded away from zero** where HTTP pre-rounds to even, so a midpoint landed one tick high.
- **A decimal given as text** rejected the exponent, thousands-separator and accounting-parentheses forms HTTP accepts.
- **A `Variant` error named a parameter the caller never wrote**, because alternative matching inferred under a placeholder name.
- **The native path inferred untyped parameters and could consume one-shot sequences.** Native binding now requires a declared type, so it never takes that path; inference remains for future client-side placeholders.

Plus the multidimensional-array depth check I found myself before the review landed: the arm peeled the declared nesting only as far as the CLR rank, so a rank-3 array declared `Array(Array(T))` emitted three bracket levels and only the server noticed.

**One trap the client cannot fix, and CI corrected my understanding of it.** A parameter named after a server setting can be applied *as that setting*, because the native protocol carries parameters in the settings list. `limit` and `offset` are the names callers reach for, and the failure is a parse error about a quoted string that names neither the parameter nor the cause.

I first wrote this up as a fixed protocol limitation, on the evidence of my local 26.6.1. The matrix disagreed: **it is version-dependent and already fixed upstream** — 25.8 through 26.6 reject the query, `latest` binds correctly. My local server happened to sit on the broken side, so nothing short of the matrix would have shown it.

The test therefore pins the property that holds on *every* version rather than one version's error: such a name must **never bind to the wrong value**. Either the server rejects the query, or the count is right; a wrong count fails. That is the outcome that would actually hurt, and it is a stronger assertion than the one it replaced. The doc now says "rename the parameter if you support any server in 25.8–26.6" instead of claiming the protocol forbids it. Unaffected on HTTP, which carries the name separately.

The review also confirmed the parts I most wanted checked: the two-stage escaping held against every adversarial input it tried (BEL/BS/FF/VT, an already-quoted value, a 200 000-character value, literal `\x41` and `\N` sequences, emoji), and the `Identifier` arm is contained by the outer escape. It also called the extractor a faithful port, which the third round showed it was not: faithful to the HTTP scanner as it stood before #509, three fixes behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

