### PR TITLE
TCP J5: Add JSON support (String serialization)

### DIFF
--- a/ClickHouse.Driver.Tcp.Tests/Client/ClickHouseTcpClientSettingsTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Client/ClickHouseTcpClientSettingsTests.cs
@@ -7,33 +7,41 @@ namespace ClickHouse.Driver.Tcp.Tests.Client;
 public class ClickHouseTcpClientSettingsTests
 {
     private const string FlattenedSetting = "output_format_native_use_flattened_dynamic_and_json_serialization";
+    private const string JsonAsStringSetting = "output_format_native_write_json_as_string";
 
-    [Test]
-    public void MergeSettings_NoSettings_InjectsFlattenedSerializationByDefault()
+    // The client injects both serialization settings so a caller never has to know about them: the flattened one
+    // for Dynamic, the text one for JSON. Each is overridable at either level — turning one off is how a caller
+    // asks for an encoding this client does not decode, so the override has to reach the server rather than being
+    // silently forced back on.
+    [TestCase(FlattenedSetting)]
+    [TestCase(JsonAsStringSetting)]
+    public void MergeSettings_NoSettings_InjectsTheSerializationSettingByDefault(string setting)
     {
         var merged = ClickHouseTcpClient.MergeSettings(clientSettings: null, perQuerySettings: null);
 
-        Assert.That(merged[FlattenedSetting], Is.EqualTo("1"));
+        Assert.That(merged[setting], Is.EqualTo("1"));
     }
 
-    [Test]
-    public void MergeSettings_CallerSetsFlattened_CallerValueWins()
+    [TestCase(FlattenedSetting)]
+    [TestCase(JsonAsStringSetting)]
+    public void MergeSettings_PerQuerySetsTheSerializationSetting_CallerValueWins(string setting)
     {
-        var perQuery = new Dictionary<string, string> { [FlattenedSetting] = "0" };
+        var perQuery = new Dictionary<string, string> { [setting] = "0" };
 
         var merged = ClickHouseTcpClient.MergeSettings(clientSettings: null, perQuery);
 
-        Assert.That(merged[FlattenedSetting], Is.EqualTo("0"));
+        Assert.That(merged[setting], Is.EqualTo("0"));
     }
 
-    [Test]
-    public void MergeSettings_ClientSetsFlattened_ClientValueNotOverwritten()
+    [TestCase(FlattenedSetting)]
+    [TestCase(JsonAsStringSetting)]
+    public void MergeSettings_ClientSetsTheSerializationSetting_ClientValueNotOverwritten(string setting)
     {
-        var client = new Dictionary<string, string> { [FlattenedSetting] = "0" };
+        var client = new Dictionary<string, string> { [setting] = "0" };
 
         var merged = ClickHouseTcpClient.MergeSettings(client, perQuerySettings: null);
 
-        Assert.That(merged[FlattenedSetting], Is.EqualTo("0"));
+        Assert.That(merged[setting], Is.EqualTo("0"));
     }
 
     [Test]

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpClientIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpClientIntegrationTests.cs
@@ -467,6 +467,36 @@ public class ClickHouseTcpClientIntegrationTests
     }
 
     [Test]
+    public async Task QueryAsync_JsonColumn_DecodesAsTextWithoutCallerSettingJsonAsString()
+    {
+        await using var client = TcpServerFixture.CreateClient();
+
+        // The caller sets no serialization setting at all — the client injects
+        // output_format_native_write_json_as_string, so the column arrives as its JSON text. Without that injection
+        // the server would send a per-path encoding and the codec would reject the version. (The experimental-type
+        // flag is obsolete on every server this suite supports, so the query needs no settings whatsoever.)
+        var rows = await client.QueryAsync("SELECT CAST('{\"a\":1}', 'JSON') AS j").ToListAsync();
+
+        Assert.That(rows, Has.Count.EqualTo(1));
+        Assert.That(rows[0][0], Is.EqualTo("{\"a\":1}"));
+    }
+
+    // Registering the JSON codec also makes it reachable as a Dynamic runtime type, where the JSON version word is
+    // nested inside the Dynamic state prefix (after the type-name list) rather than heading the column. Only the
+    // read direction can be exercised: DynamicTypeInference maps a CLR string to String, not JSON, so a JSON value
+    // cannot be written into a Dynamic ergonomically.
+    [Test]
+    public async Task QueryAsync_DynamicColumnHoldingJson_DecodesTheNestedJsonText()
+    {
+        await using var client = TcpServerFixture.CreateClient();
+
+        var rows = await client.QueryAsync("SELECT CAST(CAST('{\"b\":2,\"a\":1}', 'JSON'), 'Dynamic') AS d").ToListAsync();
+
+        Assert.That(rows, Has.Count.EqualTo(1));
+        Assert.That(rows[0][0], Is.EqualTo("{\"a\":1,\"b\":2}"));
+    }
+
+    [Test]
     public async Task PingAsync_LiveServer_Completes()
     {
         await using var client = TcpServerFixture.CreateClient();

--- a/ClickHouse.Driver.Tcp.Tests/Types/JsonStringColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/JsonStringColumnCodecTests.cs
@@ -1,0 +1,292 @@
+using System;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Protocol;
+using ClickHouse.Driver.Tcp.Tests.Utilities;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Tests.Types;
+
+[TestFixture]
+public class JsonStringColumnCodecTests
+{
+    private const string Json = "JSON";
+
+    // Three JSON values as their compact text. Verified against a ClickHouse 26.6 SELECT ... FORMAT Native with
+    // output_format_native_write_json_as_string = 1.
+    private static readonly byte[] DocumentedBytes =
+    {
+        0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // state prefix: serialization version = 1 (String)
+        0x07, 0x7B, 0x22, 0x61, 0x22, 0x3A, 0x31, 0x7D, // len = 7,  {"a":1}
+        0x02, 0x7B, 0x7D,                               // len = 2,  {}
+        0x0A, 0x7B, 0x22, 0x62, 0x22, 0x3A, 0x22, 0x68, // len = 10, {"b":"hi"}
+        0x69, 0x22, 0x7D,
+    };
+
+    private static readonly string[] DocumentedValues = { "{\"a\":1}", "{}", "{\"b\":\"hi\"}" };
+
+    private static IColumnCodec Resolve(string type) => ColumnCodecRegistry.Default.Resolve(type, default);
+
+    [Test]
+    public async Task WriteStatePrefixAndColumn_DocumentedExample_ProducesTheDocumentedBytes()
+    {
+        IColumnCodec codec = Resolve(Json);
+        var column = new ArrayColumn<string>("j", Json, DocumentedValues);
+
+        byte[] bytes = await CodecTestHarness.WriteAsync(w =>
+        {
+            codec.WriteStatePrefix(w, column);
+            codec.WriteColumn(w, column);
+        });
+
+        CollectionAssert.AreEqual(DocumentedBytes, bytes);
+    }
+
+    [Test]
+    public async Task ReadColumn_DocumentedBytes_ReconstructsTheJsonText()
+    {
+        IColumnCodec codec = Resolve(Json);
+
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(DocumentedBytes);
+        await codec.ReadStatePrefixAsync(reader, CodecTestHarness.None);
+        using IColumn column = await codec.ReadColumnAsync(reader, "j", Json, 3, CodecTestHarness.None);
+
+        Assert.That(column.RowCount, Is.EqualTo(3));
+        Assert.That(column.GetValue(0), Is.EqualTo("{\"a\":1}"));
+        Assert.That(column.GetValue(1), Is.EqualTo("{}"));
+        Assert.That(column.GetValue(2), Is.EqualTo("{\"b\":\"hi\"}"));
+    }
+
+    // The version heads the prefix precisely so a client that implements one encoding can detect the others rather
+    // than mis-read them. 0 = V1, 2 = V2, 3 = FLATTENED, 4 = V3 — all per-path encodings. Which one a server sends
+    // when the text setting is off depends on the negotiated revision: at this client's 54460 it is 0, because V2
+    // needs 54473.
+    [TestCase(0UL)]
+    [TestCase(2UL)]
+    [TestCase(3UL)]
+    [TestCase(4UL)]
+    public async Task ReadStatePrefix_APerPathVersion_ThrowsNamingTheSettingThatSelectsText(ulong version)
+    {
+        IColumnCodec codec = Resolve(Json);
+        byte[] bytes = await CodecTestHarness.WriteAsync(w => w.WriteUInt64(version));
+
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(bytes);
+        var exception = Assert.ThrowsAsync<ClickHouseProtocolException>(
+            async () => await codec.ReadStatePrefixAsync(reader, CodecTestHarness.None));
+
+        Assert.That(exception.Message, Does.Contain($"version {version}"));
+        Assert.That(exception.Message, Does.Contain("output_format_native_write_json_as_string=1"));
+    }
+
+    // Every JSON spelling is the same String column on the wire — the typed paths, the max_dynamic_* hints and the
+    // SKIP clauses only tell the server how to store the parsed value. The quoted regex is the form most likely to
+    // break a naive parse: it holds a comma and a parenthesis that must not split the argument list.
+    [TestCase("JSON")]
+    [TestCase("JSON(a UInt32, b String)")]
+    [TestCase("JSON(max_dynamic_paths=8)")]
+    [TestCase("JSON(max_dynamic_types=4, max_dynamic_paths=8)")]
+    [TestCase("JSON(a Array(UInt32))")]
+    [TestCase("JSON(`b.c` String)")]
+    [TestCase("JSON(SKIP z)")]
+    [TestCase("JSON(a UInt32, SKIP REGEXP '^tmp(x,y)')")]
+    public void Resolve_AnyJsonTypeString_ResolvesToTheTextCodecKeepingTheTypeName(string type)
+    {
+        IColumnCodec codec = Resolve(type);
+
+        Assert.That(codec.ElementType, Is.EqualTo(typeof(string)));
+        Assert.That(codec.TypeName, Is.EqualTo(type));
+    }
+
+    [Test]
+    public void CanWrite_StringColumn_ReturnsTrue()
+    {
+        IColumnCodec codec = Resolve(Json);
+
+        Assert.That(codec.CanWrite(new ArrayColumn<string>("j", Json, DocumentedValues)), Is.True);
+    }
+
+    [Test]
+    public void CanWrite_NonStringColumn_ReturnsFalse()
+    {
+        IColumnCodec codec = Resolve(Json);
+
+        Assert.That(codec.CanWrite(PrimitiveColumn<uint>.FromValues("j", Json, new uint[] { 1 })), Is.False);
+    }
+
+    // Unlike every other codec's placeholder, this one is real input: see the Nullable(JSON) test below.
+    [Test]
+    public void NullPlaceholder_IsTheEmptyJsonObject()
+    {
+        IColumnCodec codec = Resolve(Json);
+
+        Assert.That(codec.NullPlaceholder, Is.EqualTo("{}"));
+        Assert.That(codec.NullPlaceholderAs(typeof(string)), Is.EqualTo("{}"));
+    }
+
+    [Test]
+    public void NullPlaceholderAs_UnsupportedWriteType_Throws()
+    {
+        IColumnCodec codec = Resolve(Json);
+
+        Assert.Throws<NotSupportedException>(() => codec.NullPlaceholderAs(typeof(int)));
+    }
+
+    // A JSON value is parsed by the server rather than stored verbatim, and a Nullable column's values stream is
+    // parsed at every position — the null ones included. So the placeholder standing in for a NULL row has to be
+    // parseable JSON: the empty string a String column would write is rejected as INCORRECT_DATA. Verified against
+    // a ClickHouse 26.6 SELECT ... FORMAT Native, which writes "{}" in that position too.
+    [Test]
+    public async Task WriteStatePrefixAndColumn_NullableJson_WritesAnEmptyObjectWhereTheRowIsNull()
+    {
+        IColumnCodec codec = Resolve("Nullable(JSON)");
+        var column = new ArrayColumn<string>("j", "Nullable(JSON)", new[] { "{\"a\":1}", null });
+
+        byte[] bytes = await CodecTestHarness.WriteAsync(w =>
+        {
+            codec.WriteStatePrefix(w, column);
+            codec.WriteColumn(w, column);
+        });
+
+        CollectionAssert.AreEqual(
+            new byte[]
+            {
+                0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // the JSON version, ahead of the null map
+                0x00, 0x01,                                     // null map: row 0 present, row 1 NULL
+                0x07, 0x7B, 0x22, 0x61, 0x22, 0x3A, 0x31, 0x7D, // row 0: {"a":1}
+                0x02, 0x7B, 0x7D,                               // row 1: the "{}" placeholder
+            },
+            bytes);
+    }
+
+    // JSON carries a state prefix, so it must not be treated as a flat leaf inner (ISpanWritableCodec) by a
+    // concatenating composite: the version belongs on the wire once, ahead of the array's own offsets. Writing it
+    // per row — or not at all — desynchronizes the block instead of failing cleanly. Verified against a
+    // ClickHouse 26.6 SELECT ... FORMAT Native.
+    [Test]
+    public async Task WriteStatePrefixAndColumn_ArrayOfJson_WritesTheVersionOnceAheadOfTheOffsets()
+    {
+        IColumnCodec codec = Resolve("Array(JSON)");
+        var column = new ArrayColumn<string[]>("j", "Array(JSON)", new[]
+        {
+            new[] { "{\"a\":1}", "{\"b\":\"hi\"}" },
+            Array.Empty<string>(),
+        });
+
+        byte[] bytes = await CodecTestHarness.WriteAsync(w =>
+        {
+            codec.WriteStatePrefix(w, column);
+            codec.WriteColumn(w, column);
+        });
+
+        CollectionAssert.AreEqual(
+            new byte[]
+            {
+                0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // the JSON version, once, before the offsets
+                0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // offsets[0] = 2
+                0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // offsets[1] = 2 (second row empty)
+                0x07, 0x7B, 0x22, 0x61, 0x22, 0x3A, 0x31, 0x7D, // {"a":1}
+                0x0A, 0x7B, 0x22, 0x62, 0x22, 0x3A, 0x22, 0x68, // {"b":"hi"}
+                0x69, 0x22, 0x7D,
+            },
+            bytes);
+    }
+
+    // A slice starting past row 0 is what every insert above DefaultMaxRowsPerBlock writes, and a start of 0 proves
+    // nothing about it — see AGENTS.local.md. The version is written once for the slice, not once per row, and only
+    // the slice's own rows follow it. Covers the ergonomic column; the dense read-back is the next test.
+    [Test]
+    public async Task WriteStatePrefixAndColumn_SliceAfterEarlierRows_WritesTheVersionOnceAndOnlyTheSliceRows()
+    {
+        IColumnCodec codec = Resolve(Json);
+        var column = new ArrayColumn<string>("j", Json, new[] { "{}", "{\"a\":1}", "{\"b\":\"hi\"}", "{\"c\":2}" });
+
+        byte[] bytes = await CodecTestHarness.WriteAsync(w =>
+        {
+            codec.WriteStatePrefix(w, column, 1, 2);
+            codec.WriteColumn(w, column, 1, 2);
+        });
+
+        CollectionAssert.AreEqual(
+            new byte[]
+            {
+                0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // the version, once for the slice
+                0x07, 0x7B, 0x22, 0x61, 0x22, 0x3A, 0x31, 0x7D, // row 1: {"a":1}
+                0x0A, 0x7B, 0x22, 0x62, 0x22, 0x3A, 0x22, 0x68, // row 2: {"b":"hi"}
+                0x69, 0x22, 0x7D,                               // rows 0 and 3 are outside the slice
+            },
+            bytes);
+    }
+
+    // The same slice taken from the dense read-back column, which is a different write source (a StringColumn's
+    // blob plus offsets) from the ergonomic string[] above and computes the slice its own way.
+    [Test]
+    public async Task WriteStatePrefixAndColumn_DenseColumnSliceAfterEarlierRows_WritesOnlyTheSliceRows()
+    {
+        IColumnCodec codec = Resolve(Json);
+
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(DocumentedBytes);
+        await codec.ReadStatePrefixAsync(reader, CodecTestHarness.None);
+        using IColumn dense = await codec.ReadColumnAsync(reader, "j", Json, 3, CodecTestHarness.None);
+
+        byte[] bytes = await CodecTestHarness.WriteAsync(w =>
+        {
+            codec.WriteStatePrefix(w, dense, 1, 2);
+            codec.WriteColumn(w, dense, 1, 2);
+        });
+
+        CollectionAssert.AreEqual(
+            new byte[]
+            {
+                0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // the version
+                0x02, 0x7B, 0x7D,                               // row 1: {}
+                0x0A, 0x7B, 0x22, 0x62, 0x22, 0x3A, 0x22, 0x68, // row 2: {"b":"hi"}
+                0x69, 0x22, 0x7D,                               // row 0 is outside the slice
+            },
+            bytes);
+    }
+
+    // Slicing an Array(JSON) is where a dropped rebase shows: the wire offsets are cumulative from the start of the
+    // block, so a slice must restart them at 0 rather than carry the whole column's running total. Row 0 holds one
+    // element, so an unrebased write would emit 3 and 3 here instead of 2 and 2 and mis-frame every row.
+    [Test]
+    public async Task WriteStatePrefixAndColumn_ArrayOfJsonSlice_RebasesTheOffsetsToTheSliceStart()
+    {
+        IColumnCodec codec = Resolve("Array(JSON)");
+        var column = new ArrayColumn<string[]>("j", "Array(JSON)", new[]
+        {
+            new[] { "{\"a\":1}" },
+            new[] { "{\"b\":\"hi\"}", "{\"c\":2}" },
+            Array.Empty<string>(),
+        });
+
+        byte[] bytes = await CodecTestHarness.WriteAsync(w =>
+        {
+            codec.WriteStatePrefix(w, column, 1, 2);
+            codec.WriteColumn(w, column, 1, 2);
+        });
+
+        CollectionAssert.AreEqual(
+            new byte[]
+            {
+                0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // the JSON version, once, before the offsets
+                0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // offsets[0] = 2, rebased (not 3)
+                0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // offsets[1] = 2 (third row empty)
+                0x0A, 0x7B, 0x22, 0x62, 0x22, 0x3A, 0x22, 0x68, // {"b":"hi"}
+                0x69, 0x22, 0x7D,
+                0x07, 0x7B, 0x22, 0x63, 0x22, 0x3A, 0x32, 0x7D, // {"c":2}
+            },
+            bytes);
+    }
+
+    // A zero-row block carries no state prefix at all (the block layer skips the prefix phase), so the codec is
+    // asked only for an empty column.
+    [Test]
+    public async Task ReadColumnAsync_ZeroRows_ReturnsAnEmptyColumn()
+    {
+        IColumnCodec codec = Resolve(Json);
+
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(Array.Empty<byte>());
+        using IColumn column = await codec.ReadColumnAsync(reader, "j", Json, 0, CodecTestHarness.None);
+
+        Assert.That(column.RowCount, Is.Zero);
+    }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
@@ -1168,6 +1168,126 @@ public sealed class InsertRoundTripCase
                 new (object, string)[] { (null, "d") },
             }),
             DynamicSettings);
+
+        // JSON in its String serialization: each value is its compact JSON text, so the column is an
+        // IColumn<string>. The server parses the text on insert and re-serializes it on read, so a case whose
+        // values are not already canonical reads back normalized — see the normalization case below. These values
+        // are canonical (keys ordinally sorted, no whitespace, no JSON null), so insert equals read-back.
+        yield return JsonTexts("{}", "{\"a\":1}", "{\"a\":1,\"b\":\"hi\"}", "{\"n\":{\"deep\":[1,2,3]}}");
+
+        // Every value empty: the whole column carries no path at all.
+        yield return JsonTexts("{}", "{}");
+
+        // Typed paths are declared in the type string and always materialize, so a value omitting one reads back
+        // with that path at its type's default ("" for String) rather than absent — hence the separate expected
+        // builder. The undeclared path rides along as a dynamic path.
+        yield return new InsertRoundTripCase(
+            "JSON(a UInt32, b String) [typed paths default when absent]",
+            "JSON(a UInt32, b String)",
+            name => new ArrayColumn<string>(name, "JSON(a UInt32, b String)", new[]
+            {
+                "{\"a\":1,\"x\":\"p\"}",
+                "{\"a\":2,\"b\":\"q\"}",
+            }),
+            name => new ArrayColumn<string>(name, "JSON(a UInt32, b String)", new[]
+            {
+                "{\"a\":1,\"b\":\"\",\"x\":\"p\"}",
+                "{\"a\":2,\"b\":\"q\"}",
+            }),
+            JsonSettings);
+
+        // The server parses a JSON value rather than storing the text, so what comes back is its own rendering:
+        // keys ordinally sorted (so "A" precedes "a"), whitespace dropped, numbers re-rendered canonically
+        // (1.0 -> 1, 1e3 -> 1000, -0 -> 0), a dotted key read as nesting, and a JSON null or an empty object
+        // contributing no path at all. Nothing about that is the client's doing, but a client that mangled the text
+        // would show up here.
+        yield return new InsertRoundTripCase(
+            "JSON [server normalizes the text]",
+            "JSON",
+            name => new ArrayColumn<string>(name, "JSON", new[]
+            {
+                "{  \"b\" : 1 ,  \"a\" : 2 }",
+                "{\"a\":1.0,\"b\":1e3,\"c\":-0}",
+                "{\"a\":null,\"b\":{}}",
+                "{\"a.b\":1}",
+                "{\"a\":\"x\",\"A\":\"y\"}",
+            }),
+            name => new ArrayColumn<string>(name, "JSON", new[]
+            {
+                "{\"a\":2,\"b\":1}",
+                "{\"a\":1,\"b\":1000,\"c\":0}",
+                "{}",
+                "{\"a\":{\"b\":1}}",
+                "{\"A\":\"y\",\"a\":\"x\"}",
+            }),
+            JsonSettings);
+
+        // Nullable(JSON): unlike Array/Tuple/Map/Variant, the server does accept it. A NULL row still occupies the
+        // values stream, and those bytes are parsed like any other, so the placeholder written there must be
+        // parseable JSON ("{}") — an empty string is rejected outright. The all-null case is the one that proves it,
+        // since it is placeholder and nothing else.
+        yield return NullableJsonTexts("{\"a\":1}", null, "{}", "{\"b\":\"hi\"}", null);
+        yield return NullableJsonTexts(null, null);
+
+        // Array(JSON): JSON carries a state prefix, so the array has to emit the version once ahead of its offsets
+        // rather than treat JSON as a flat leaf. Empty rows and an all-empty column ride along.
+        yield return Arrays("JSON", JsonSettings, new[] { "{\"a\":1}", "{}" }, Array.Empty<string>(), new[] { "{\"b\":\"hi\"}" });
+
+        // Tuple(JSON, String): each element is its own child column, so the JSON version is written from the
+        // element the tuple projects.
+        yield return Same(
+            "Tuple(JSON, String)",
+            "Tuple(JSON, String)",
+            name => new TupleColumn<string, string>(name, "Tuple(JSON, String)", new (string, string)[]
+            {
+                ("{\"a\":1}", "x"),
+                ("{}", string.Empty),
+            }),
+            JsonSettings);
+
+        // Map(String, JSON): the JSON value stream's version prefix has to travel through the map's shape object,
+        // the same path LowCardinality's dictionary prefix takes.
+        yield return Maps<string, string>(
+            "String",
+            "JSON",
+            JsonSettings,
+            Pairs<string, string>(("a", "{\"a\":1}"), ("b", "{}")),
+            Array.Empty<KeyValuePair<string, string>>(),
+            Pairs<string, string>(("c", "{\"b\":\"hi\"}")));
+
+        // Variant(JSON, UInt64): JSON as a variant alternative. Variant is the trickiest prefix carrier — it writes
+        // every alternative's prefix from that alternative's own row slice, zero-length ones included — so this is
+        // where a JSON version word is most easily lost or duplicated. The alternatives arrive canonicalized and
+        // "JSON" sorts before "UInt64", so JSON is discriminator 0. UInt64 is chosen as the second alternative on
+        // purpose: pairing JSON with String would make the two indistinguishable to the ergonomic write path, which
+        // picks an alternative by runtime CLR type and would send every string to the JSON arm.
+        yield return Same(
+            "Variant(JSON, UInt64)",
+            "Variant(JSON, UInt64)",
+            name => new ArrayColumn<object>(name, "Variant(JSON, UInt64)", new object[]
+            {
+                "{\"a\":1}", 42UL, null, "{}", 0UL,
+            }),
+            MergeSettings(VariantSettings, JsonSettings));
+
+        // Nested(a JSON, b String): a JSON field inside a Nested column.
+        yield return Same(
+            "Nested(a JSON, b String)",
+            "Nested(a JSON, b String)",
+            name => new NestedColumn(
+                name,
+                "Nested(a JSON, b String)",
+                new[] { "a", "b" },
+                new IColumn[]
+                {
+                    new ArrayColumn<string>(name, "JSON", new[] { "{\"a\":1}", "{}", "{\"b\":\"hi\"}" }),
+                    new ArrayColumn<string>(name, "String", new[] { "a", "b", "c" }),
+                },
+                new[] { 0, 2, 2, 3 },
+                rowCount: 3,
+                pooledOffsets: false,
+                ownsFields: false),
+            MergeSettings(NestedSettings, JsonSettings));
     }
 
     // Merges two settings dictionaries into one (later entries win) for cases needing both flags.
@@ -1267,6 +1387,14 @@ public sealed class InsertRoundTripCase
 
     private static InsertRoundTripCase NullableStrings(params string[] values)
         => Same($"Nullable(String) [{values.Length} rows]", "Nullable(String)", name => new ArrayColumn<string>(name, "Nullable(String)", values));
+
+    // JSON is inserted and read back as its compact text, so the column is an ArrayColumn<string> like String's.
+    // Values must already be canonical for insert to equal read-back; see the normalization case.
+    private static InsertRoundTripCase JsonTexts(params string[] values)
+        => Same($"JSON [{values.Length} rows]", "JSON", name => new ArrayColumn<string>(name, "JSON", values), JsonSettings);
+
+    private static InsertRoundTripCase NullableJsonTexts(params string[] values)
+        => Same($"Nullable(JSON) [{values.Length} rows]", "Nullable(JSON)", name => new ArrayColumn<string>(name, "Nullable(JSON)", values), JsonSettings);
 
     private static InsertRoundTripCase NullableIps(string innerType, params string[] values)
     {
@@ -1396,5 +1524,17 @@ public sealed class InsertRoundTripCase
     {
         ["allow_experimental_dynamic_type"] = "1",
         ["output_format_native_use_flattened_dynamic_and_json_serialization"] = "1",
+    };
+
+    /// <summary>
+    /// Enables the experimental <c>JSON</c> type and selects the String serialization the client reads (without it
+    /// the server would emit one of the per-path encodings, which the client rejects). The insert direction needs no
+    /// setting — the server reads whichever version the client's state prefix declares. <c>ClickHouseTcpClient</c>
+    /// injects the output setting itself; these cases drive a connection directly, so they pass it explicitly.
+    /// </summary>
+    private static readonly IReadOnlyDictionary<string, string> JsonSettings = new Dictionary<string, string>(StringComparer.Ordinal)
+    {
+        ["allow_experimental_json_type"] = "1",
+        ["output_format_native_write_json_as_string"] = "1",
     };
 }

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClient.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClient.cs
@@ -38,8 +38,8 @@ namespace ClickHouse.Driver.Tcp;
 [Experimental("CHTCP0001")]
 public sealed class ClickHouseTcpClient : IClickHouseTcpClient
 {
-    // Reading and writing Dynamic (and later JSON) requires the flattened native serialization; the client
-    // enables it on every operation so callers never have to know about it. A caller-supplied value wins.
+    // Reading and writing Dynamic requires the flattened native serialization; the client enables it on every
+    // operation so callers never have to know about it. A caller-supplied value wins.
     private const string FlattenedSerializationSetting = "output_format_native_use_flattened_dynamic_and_json_serialization";
 
     // How many rows QueryAsync<T> materializes at once. A whole block would otherwise be alive together, and a
@@ -51,6 +51,12 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
     // per column, which did not register even on a two-column row of fixed-width values, while the cost of too
     // large a window is the promotion this is here to avoid, against a gen0 budget that varies by host and GC mode.
     private const int MaterializationWindowRows = 256;
+
+    // Reading JSON requires the server to send it as text rather than one column per path, which is the only
+    // encoding this client decodes. Enabled on every operation for the same reason, and likewise overridable.
+    // Writes need no setting: the client always writes the String version and the server reads whichever the
+    // prefix declares.
+    private const string JsonAsStringSetting = "output_format_native_write_json_as_string";
 
     private static readonly ClickHouseTcpInsertOptions DefaultInsertOptions = new();
 
@@ -449,8 +455,8 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
 
     /// <summary>
     /// Merges the settings for one operation: the client-level custom settings, overlaid by the per-query
-    /// settings, with the flattened-serialization setting injected unless a caller already set it at either
-    /// level.
+    /// settings, with the flattened-serialization and JSON-as-string settings injected unless a caller already set
+    /// them at either level.
     /// </summary>
     /// <param name="clientSettings">The client-level custom settings, or null for none.</param>
     /// <param name="perQuerySettings">The per-query settings that override the client-level ones, or null for none.</param>
@@ -492,6 +498,11 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
         if (!merged.ContainsKey(FlattenedSerializationSetting))
         {
             merged[FlattenedSerializationSetting] = "1";
+        }
+
+        if (!merged.ContainsKey(JsonAsStringSetting))
+        {
+            merged[JsonAsStringSetting] = "1";
         }
 
         return merged;

--- a/ClickHouse.Driver.Tcp/Types/Codecs/JsonStringColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/JsonStringColumnCodec.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Protocol;
+
+namespace ClickHouse.Driver.Tcp.Types.Codecs;
+
+/// <summary>
+/// A codec for the ClickHouse <c>JSON</c> column in its String serialization (version 1) — every value is its
+/// compact JSON text, so the column is a <see cref="StringColumnCodec"/> body behind a version marker. The type
+/// string is irrelevant to this layout: <c>JSON</c>, <c>JSON(a UInt32)</c> and <c>JSON(max_dynamic_paths=8)</c>
+/// all arrive as the same String column.
+///
+/// <para>
+/// The wire layout per non-empty block is a <c>UInt64</c> version (1) — the <em>state prefix</em> — then a
+/// standard String column of <c>num_rows</c> values. So under a composite the version precedes the composite's
+/// own framing: <c>Array(JSON)</c> is the version, then the array offsets, then the texts.
+/// </para>
+///
+/// <para>
+/// The two directions are not symmetric in what they need. Reading requires the query setting
+/// <c>output_format_native_write_json_as_string = 1</c> (the client sets it by default), because the server
+/// otherwise emits one of the per-path binary encodings, which this codec rejects. Writing needs no setting at
+/// all: the server reads whichever version the prefix declares, so a written version 1 makes it parse the text
+/// into the real paths server-side — including into the typed paths a <c>JSON(a UInt32)</c> column declares.
+/// </para>
+///
+/// <para>
+/// Because a value is parsed rather than stored verbatim, the server normalizes what comes back: keys are sorted
+/// ordinally, whitespace is dropped, numbers are re-rendered canonically, and a JSON <c>null</c> or an empty
+/// object contributes no path at all. Text in is therefore not always text out.
+/// </para>
+/// </summary>
+internal sealed class JsonStringColumnCodec : IColumnCodec
+{
+    /// <summary>
+    /// The serialization version that heads a <c>JSON</c>/<c>Object</c> column's state prefix in the String
+    /// layout — the only layout this client reads or writes. The others (<c>0</c> = V1, <c>2</c> = V2, <c>3</c> =
+    /// FLATTENED, <c>4</c> = V3) split the column into one sub-column per JSON path.
+    /// </summary>
+    private const ulong StringVersion = 1;
+
+    private JsonStringColumnCodec(string typeName) => TypeName = typeName;
+
+    /// <inheritdoc/>
+    public string TypeName { get; }
+
+    /// <inheritdoc/>
+    public Type ElementType => typeof(string);
+
+    /// <summary>
+    /// The JSON text an empty object serializes to. Unlike every other codec's placeholder, this one reaches the
+    /// server as real input: a <c>Nullable(JSON)</c> column's values stream is parsed at every position, the null
+    /// ones included, so the empty string a String column would use is rejected as unparseable JSON.
+    /// </summary>
+    public object NullPlaceholder => "{}";
+
+    /// <summary>Builds a <c>JSON</c> codec.</summary>
+    /// <param name="node">The parsed <c>JSON</c> node. Its arguments — typed paths, <c>max_dynamic_paths=N</c>, <c>SKIP</c> hints — do not affect the String layout and are kept only in the type name.</param>
+    /// <returns>The codec.</returns>
+    public static JsonStringColumnCodec Create(TypeNode node) => new(node.ToString());
+
+    /// <inheritdoc/>
+    public async ValueTask ReadStatePrefixAsync(ClickHouseBinaryReader reader, CancellationToken cancellationToken)
+    {
+        ulong version = await reader.ReadUInt64Async(cancellationToken).ConfigureAwait(false);
+        if (version != StringVersion)
+        {
+            throw new ClickHouseProtocolException(
+                $"JSON column '{TypeName}' uses serialization version {version}; this client supports only the String version {StringVersion}. " +
+                "Enable it with the query setting output_format_native_write_json_as_string=1.");
+        }
+    }
+
+    /// <inheritdoc/>
+    public ValueTask<IColumn> ReadColumnAsync(ClickHouseBinaryReader reader, string columnName, string columnType, int rowCount, CancellationToken cancellationToken)
+        => StringColumnCodec.Instance.ReadColumnAsync(reader, columnName, columnType, rowCount, cancellationToken);
+
+    /// <inheritdoc/>
+    public bool CanWrite(IColumn column) => StringColumnCodec.Instance.CanWrite(column);
+
+    /// <inheritdoc/>
+    // The prefix is a fixed version marker, independent of the data; the column/slice is unused.
+    public void WriteStatePrefix(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
+        => writer.WriteUInt64(StringVersion);
+
+    /// <inheritdoc/>
+    public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
+        => StringColumnCodec.Instance.WriteColumn(writer, column, start, length);
+}

--- a/ClickHouse.Driver.Tcp/Types/ColumnCodecRegistry.cs
+++ b/ClickHouse.Driver.Tcp/Types/ColumnCodecRegistry.cs
@@ -162,6 +162,11 @@ internal sealed class ColumnCodecRegistry
         // the registry and context. NULL rides a discriminator, so it is never wrapped in Nullable.
         AddFactory("Dynamic", static (TypeNode node, in ResolveContext context, ColumnCodecRegistry registry) => DynamicColumnCodec.Create(node, context, registry));
 
+        // JSON is read and written in its String serialization: a version marker, then the values as compact JSON
+        // text. The type string's arguments (typed paths, max_dynamic_paths, SKIP hints) do not change that layout,
+        // so every JSON spelling resolves to the same codec and the arguments ride along in the type name only.
+        AddFactory("JSON", static (TypeNode node, in ResolveContext _, ColumnCodecRegistry _) => JsonStringColumnCodec.Create(node));
+
         return new ColumnCodecRegistry(byName);
     }
 }

--- a/ClickHouse.Driver.Tcp/Types/IColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/IColumnCodec.cs
@@ -86,10 +86,16 @@ internal interface IColumnCodec
 
     /// <summary>
     /// A value of <see cref="ElementType"/> to encode where a row has no value of its own — the placeholder
-    /// written at the null positions of a <c>Nullable(T)</c> column's values stream. The server ignores those
-    /// bytes, but the codec must still be handed a value it accepts, so this is the type's canonical zero/epoch
-    /// (e.g. <c>0</c>, <c>1970-01-01</c>, <c>0.0.0.0</c>, the empty string) rather than the CLR default, which a
-    /// range-checked type would reject. A codec whose values cannot be written throws when this is read.
+    /// written at the null positions of a <c>Nullable(T)</c> column's values stream. The codec must be handed a
+    /// value it accepts, so this is the type's canonical zero/epoch (e.g. <c>0</c>, <c>1970-01-01</c>,
+    /// <c>0.0.0.0</c>, the empty string) rather than the CLR default, which a range-checked type would reject.
+    /// A codec whose values cannot be written throws when this is read.
+    ///
+    /// <para>
+    /// The server discards these bytes for most types, but not for one whose values it <em>parses</em> rather than
+    /// copies: a <c>Nullable(JSON)</c> values stream is parsed at every position, so an unparseable placeholder is
+    /// rejected outright. The placeholder must therefore be valid input for the type, not merely well-formed bytes.
+    /// </para>
     /// </summary>
     object NullPlaceholder { get; }
 


### PR DESCRIPTION
Adds the ClickHouse `JSON` column type over the native protocol, stacked on #561 (query parameters).

`JSON` has several wire encodings. This reads and writes **only the String serialization (wire version 1)**: a `UInt64` version word, then a plain String column whose values are compact JSON text. So `JsonStringColumnCodec` is that version marker in front of `StringColumnCodec`, and a JSON column surfaces as `IColumn<string>`. Any other version (`0` = V1, `2` = V2, `3` = FLATTENED, `4` = V3 — the per-path encodings) is rejected as a protocol error that names the setting to enable.

The per-path encoding (Tier 2) is deliberately **not** here. It splits the column into one sub-column per JSON path, and the path set lives in the *per-block* prefix and follows the data: one `JSON(a UInt32, b String)` column was seen to report dynamic path `x` in block 1 and `y` in block 2. A JSON column therefore has no stable schema across a result set, which is a real question for the borrowed-column API rather than a wire question. Tracked as J6 in the TODO, with the byte layout already written up.

## What's here
- **Read + write** of top-level `JSON`. The unit-test byte fixtures are real 26.6 server captures.
- **Every type-string spelling** resolves to the same codec — `JSON`, `JSON(a UInt32, b String)`, `JSON(max_dynamic_paths=8)`, ``JSON(`b.c` String)``, `JSON(SKIP z)`, `JSON(a UInt32, SKIP REGEXP '^tmp(x,y)')`. The arguments are deliberately **not** validated: the String tier ignores all of them, so a rejection would only break on a server that adds a new hint form. `TypeParser` already handled every form, so nothing changed there.
- **The client injects `output_format_native_write_json_as_string = 1`** next to the existing flattened flag, so a caller never has to know about it; a caller-supplied value still wins. Turning it off is how you would ask for an encoding this client cannot decode, so the override has to reach the server.
- **Composition, both directions**: `Nullable(JSON)`, `Array(JSON)`, `Tuple(JSON, String)`, `Map(String, JSON)`, `Nested(a JSON, b String)`, `Variant(JSON, UInt64)`. Registering the codec also makes JSON reachable as a `Dynamic` runtime type, where the version word nests inside the `Dynamic` prefix after the type-name list.

## Three points the wire behavior forced
- **The two directions are asymmetric.** Reading needs the setting above, because the server otherwise sends a per-path encoding. Writing needs **no** setting at all — there is no `input_format_native_*` counterpart, because the server reads whichever version the prefix declares and parses the text into the real paths, typed paths included. Verified by hand-building a Native block and POSTing it.
- **`NullPlaceholder` is `"{}"`, not the empty string.** `Nullable(JSON)` is a legal type, and the server *parses* a JSON value instead of copying it, so it parses the placeholder at a NULL position too. An empty string is refused as `INCORRECT_DATA`. This is the first type whose placeholder is not inert, so `IColumnCodec` no longer promises that the server discards those bytes. The server writes `{}` there itself.
- **The codec must not implement `ISpanWritableCodec<string>`**, although it delegates to `StringColumnCodec`, which does. That interface means "no state prefix", and a concatenating composite uses it to drive the inner codec one row at a time. The version word would be dropped — and only on the ergonomic path, since the dense branch ignores the interface — which desynchronizes `Array(JSON)`. A test fails if anyone adds the interface.

## Testing
- **Codec unit tests** (24): documented bytes from a server capture, version-not-1 rejection for all four per-path versions, the eight type-string forms, `CanWrite`, the `{}` placeholder, `Nullable(JSON)` bytes (version ahead of the null map), `Array(JSON)` bytes (version once, ahead of the offsets), zero rows, and per `AGENTS.local.md` three `start > 0` slice tests — the ergonomic column, the dense read-back, and an `Array(JSON)` whose offsets must rebase to the slice start rather than carry the column's running total.
- **Integration round-trip cases** (11), which fan out through five fixtures — round-trip, dense re-insert, one-row-per-block slicing, POCO read, POCO write. A JSON column maps to a `string` POCO property with no registration work.
- One case pins **the server's own normalization**, so text in is not assumed to be text out: keys sorted ordinally, whitespace dropped, numbers re-rendered (`1e3` → `1000`), a dotted key read as nesting, a JSON `null` or an empty object contributing no path, and a declared typed path defaulting when the value omits it.
- Full suite green: **2598 tests**. `JsonStringColumnCodec` fully covered.

## Notes / deferred
- **`Variant(JSON, String)` is ambiguous on the ergonomic write path.** Both alternatives surface CLR `string`, and that path picks an alternative by runtime CLR type, so every string takes the first-listed arm (`JSON` sorts first) and a non-JSON string is refused server-side. Reading works, and the dense `VariantColumn` source is unaffected because it carries explicit discriminators. Same root cause as the outer-type-name matching gap in the N11 table; logged in the TODO as needing a semantic decision. The corpus covers `Variant(JSON, UInt64)`, whose alternatives are CLR-distinguishable.
- **`Dynamic` holding JSON is read-only.** `DynamicTypeInference` maps a CLR string to `String`, not `JSON`, so that shape cannot be written ergonomically. Covered by a read test.
- `LowCardinality(JSON)` needs nothing: the server rejects the type.
- No CHANGELOG entry — the TCP client is `[Experimental]` and this branch keeps TCP work out of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
