### PR TITLE
TCP B9: Add TLS to the native client

### DIFF
--- a/ClickHouse.Driver.Tcp.Tests/Client/ClickHouseTcpClientOptionsTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Client/ClickHouseTcpClientOptionsTests.cs
@@ -133,6 +133,33 @@ public class ClickHouseTcpClientOptionsTests
         Assert.DoesNotThrow(() => options.Validate());
     }
 
+    [TestCase("")]
+    [TestCase("   ")]
+    public void Validate_EmptyTlsCaCertificatePath_ThrowsArgumentException(string path)
+    {
+        var options = new ClickHouseTcpClientOptions
+        {
+            UseTls = true,
+            TlsCaCertificatePath = path,
+        };
+
+        var thrown = Assert.Throws<ArgumentException>(() => options.Validate());
+
+        Assert.That(thrown.ParamName, Is.EqualTo(nameof(ClickHouseTcpClientOptions.TlsCaCertificatePath)));
+    }
+
+    [Test]
+    public void Validate_NullTlsCaCertificatePath_UsesHostTrustAndDoesNotThrow()
+    {
+        var options = new ClickHouseTcpClientOptions
+        {
+            UseTls = true,
+            TlsCaCertificatePath = null,
+        };
+
+        Assert.DoesNotThrow(() => options.Validate());
+    }
+
     [Test]
     public void Validate_TlsWithValidationTurnedOff_DoesNotThrow()
     {

--- a/ClickHouse.Driver.Tcp.Tests/Client/ClickHouseTcpClientOptionsTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Client/ClickHouseTcpClientOptionsTests.cs
@@ -15,8 +15,13 @@ public class ClickHouseTcpClientOptionsTests
         Assert.Multiple(() =>
         {
             Assert.That(options.Host, Is.EqualTo("localhost"));
-            Assert.That(options.Port, Is.EqualTo(9000));
+            Assert.That(options.Port, Is.Null, "the port is derived from UseTls unless set");
             Assert.That(options.Username, Is.EqualTo("default"));
+            Assert.That(options.UseTls, Is.False);
+            Assert.That(options.TlsServerName, Is.Null);
+            Assert.That(options.TlsAllowInvalidCertificates, Is.False);
+            Assert.That(options.TlsCaCertificatePath, Is.Null);
+            Assert.That(options.ConfigureTls, Is.Null);
             Assert.That(options.Password, Is.EqualTo(string.Empty));
             Assert.That(options.Database, Is.EqualTo("default"));
             Assert.That(options.DialTimeout, Is.EqualTo(TimeSpan.FromSeconds(30)));
@@ -79,6 +84,119 @@ public class ClickHouseTcpClientOptionsTests
         var options = new ClickHouseTcpClientOptions { Port = port };
 
         Assert.Throws<ArgumentOutOfRangeException>(() => options.Validate());
+    }
+
+    [Test]
+    public void ResolvedPort_UseTlsAndNoExplicitPort_IsTheSecureNativePort()
+    {
+        var options = new ClickHouseTcpClientOptions { UseTls = true };
+
+        Assert.That(options.ResolvedPort, Is.EqualTo(9440));
+    }
+
+    [Test]
+    public void ResolvedPort_NoTlsAndNoExplicitPort_IsThePlaintextNativePort()
+    {
+        var options = new ClickHouseTcpClientOptions();
+
+        Assert.That(options.ResolvedPort, Is.EqualTo(9000));
+    }
+
+    [TestCase(true)]
+    [TestCase(false)]
+    public void ResolvedPort_ExplicitPort_IsHonouredWhateverTlsSays(bool useTls)
+    {
+        // Deriving the port must never override a caller who named one: TLS on a non-standard port is legitimate.
+        var options = new ClickHouseTcpClientOptions { UseTls = useTls, Port = 9123 };
+
+        Assert.That(options.ResolvedPort, Is.EqualTo(9123));
+    }
+
+    [Test]
+    public void Validate_NullPort_DoesNotThrow()
+    {
+        // Null is a request to derive the port, not a value, so the range check must skip it.
+        Assert.DoesNotThrow(() => new ClickHouseTcpClientOptions { Port = null }.Validate());
+    }
+
+    [Test]
+    public void Validate_TlsWithAPinnedAuthority_DoesNotThrow()
+    {
+        var options = new ClickHouseTcpClientOptions
+        {
+            UseTls = true,
+            TlsServerName = "cert.example",
+            TlsCaCertificatePath = "/etc/ca.pem",
+            ConfigureTls = _ => { },
+        };
+
+        Assert.DoesNotThrow(() => options.Validate());
+    }
+
+    [Test]
+    public void Validate_TlsWithValidationTurnedOff_DoesNotThrow()
+    {
+        var options = new ClickHouseTcpClientOptions
+        {
+            UseTls = true,
+            TlsServerName = "cert.example",
+            TlsAllowInvalidCertificates = true,
+            ConfigureTls = _ => { },
+        };
+
+        Assert.DoesNotThrow(() => options.Validate());
+    }
+
+    [Test]
+    public void Validate_ValidationTurnedOffAndAnAuthorityPinned_ThrowsArgumentException()
+    {
+        // Contradictory: with validation off no certificate is checked, so the authority would be read from disk
+        // and never consulted. Whichever the caller meant, they did not mean both.
+        var options = new ClickHouseTcpClientOptions
+        {
+            UseTls = true,
+            TlsAllowInvalidCertificates = true,
+            TlsCaCertificatePath = "/etc/ca.pem",
+        };
+
+        Assert.Throws<ArgumentException>(() => options.Validate());
+    }
+
+    [Test]
+    public void Validate_EmptyTlsServerNameWithoutUseTls_DoesNotThrow()
+    {
+        // An empty name is what the connection factory ignores, so Validate must not treat it as configured —
+        // otherwise the two disagree about what "set" means.
+        Assert.DoesNotThrow(() => new ClickHouseTcpClientOptions { TlsServerName = string.Empty }.Validate());
+    }
+
+    // Named per case: ToString prints none of the four properties, so without SetName all four report under one
+    // display name and a failure would not say which property regressed.
+    private static readonly TestCaseData[] TlsPropertiesWithoutUseTls =
+    [
+        new TestCaseData(new ClickHouseTcpClientOptions { TlsServerName = "cert.example" })
+            .SetName($"{{m}}({nameof(ClickHouseTcpClientOptions.TlsServerName)})"),
+        new TestCaseData(new ClickHouseTcpClientOptions { TlsAllowInvalidCertificates = true })
+            .SetName($"{{m}}({nameof(ClickHouseTcpClientOptions.TlsAllowInvalidCertificates)})"),
+        new TestCaseData(new ClickHouseTcpClientOptions { TlsCaCertificatePath = "/etc/ca.pem" })
+            .SetName($"{{m}}({nameof(ClickHouseTcpClientOptions.TlsCaCertificatePath)})"),
+        new TestCaseData(new ClickHouseTcpClientOptions { ConfigureTls = _ => { } })
+            .SetName($"{{m}}({nameof(ClickHouseTcpClientOptions.ConfigureTls)})"),
+    ];
+
+    [TestCaseSource(nameof(TlsPropertiesWithoutUseTls))]
+    public void Validate_TlsPropertySetButUseTlsFalse_ThrowsArgumentException(ClickHouseTcpClientOptions options)
+    {
+        // Ignoring the property would leave the caller with a plaintext connection they configured as encrypted.
+        var thrown = Assert.Throws<ArgumentException>(() => options.Validate());
+
+        Assert.That(thrown.Message, Does.Contain(nameof(ClickHouseTcpClientOptions.UseTls)));
+    }
+
+    [Test]
+    public void Validate_UseTlsWithNothingElseSet_DoesNotThrow()
+    {
+        Assert.DoesNotThrow(() => new ClickHouseTcpClientOptions { UseTls = true }.Validate());
     }
 
     [Test]
@@ -308,6 +426,11 @@ public class ClickHouseTcpClientOptionsTests
             Password = "copy-password",
             Database = "copy-db",
             QuotaKey = "copy-quota",
+            UseTls = true,
+            TlsServerName = "copy-sni",
+            TlsAllowInvalidCertificates = true,
+            TlsCaCertificatePath = "copy-ca.pem",
+            ConfigureTls = _ => { },
             CustomSettings = new Dictionary<string, string> { ["max_threads"] = "4" },
             MaxSendBufferBytes = 4096,
             DialTimeout = TimeSpan.FromSeconds(3),
@@ -441,6 +564,20 @@ public class ClickHouseTcpClientOptionsTests
                 text,
                 Does.Contain("example.invalid").And.Contain("9440").And.Contain("alice").And.Contain("analytics"),
                 "the endpoint, user and database stay, so the text is still useful for diagnostics");
+        });
+    }
+
+    [Test]
+    public void ToString_PortLeftToBeDerived_ShowsThePortAConnectionWouldDial()
+    {
+        // Printing "Port = " with nothing after it helps nobody diagnose a connection; the resolved port is the
+        // one that was actually dialled.
+        var text = new ClickHouseTcpClientOptions { Host = "example.invalid", UseTls = true }.ToString();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(text, Does.Contain("9440"));
+            Assert.That(text, Does.Contain($"{nameof(ClickHouseTcpClientOptions.UseTls)} = True"));
         });
     }
 

--- a/ClickHouse.Driver.Tcp.Tests/Client/ClickHouseTcpConnectionStringBuilderTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Client/ClickHouseTcpConnectionStringBuilderTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Data.Common;
 
 namespace ClickHouse.Driver.Tcp.Tests.Client;
 
@@ -360,8 +361,36 @@ public class ClickHouseTcpConnectionStringBuilderTests
         Assert.That(options.UseTls, Is.EqualTo(expected));
     }
 
-    // 'UseTls=' with nothing after it is not covered: DbConnectionStringBuilder drops a key with an empty value
-    // while parsing, so it never reaches the getter and reads as absent, exactly like omitting the key.
+    [TestCase("Host=h;UseTls=")]
+    [TestCase("Host=h;UseTls=   ")]
+    [TestCase("Host=h;UseTls=\"\"")]
+    [TestCase("Host=h;UseTls=\"   \"")]
+    [TestCase("Host=h;UseTls=true;UseTls=")]
+    public void Constructor_UseTlsWithAnEmptyValue_ThrowsRatherThanSelectingPlaintext(string connectionString)
+    {
+        Assert.Throws<ArgumentException>(() => new ClickHouseTcpConnectionStringBuilder(connectionString));
+    }
+
+    [Test]
+    public void ConnectionString_SetThroughBaseTypeWithAnEmptyUseTls_ThrowsRatherThanSelectingPlaintext()
+    {
+        DbConnectionStringBuilder builder = new ClickHouseTcpConnectionStringBuilder();
+
+        Assert.Throws<ArgumentException>(() => builder.ConnectionString = "Host=h;UseTls=");
+    }
+
+    [Test]
+    public void FromConnectionString_EmptyUseTls_ThrowsRatherThanSelectingPlaintext()
+    {
+        Assert.Throws<ArgumentException>(() => ClickHouseTcpClientOptions.FromConnectionString("Host=h;UseTls="));
+    }
+
+    [Test]
+    public void ClickHouseTcpClient_EmptyUseTls_ThrowsAtConstructionRatherThanSelectingPlaintext()
+    {
+        Assert.Throws<ArgumentException>(() => new ClickHouseTcpClient("Host=h;UseTls="));
+    }
+
     [TestCase("yes")]
     [TestCase("on")]
     [TestCase("2")]
@@ -418,6 +447,50 @@ public class ClickHouseTcpConnectionStringBuilderTests
             Assert.That(reparsed.TlsAllowInvalidCertificates, Is.True);
             Assert.That(reparsed.TlsCaCertificatePath, Is.EqualTo("/tmp/rt-ca.pem"));
         });
+    }
+
+    [TestCase("Host=h;UseTls=true;TlsCaCertificatePath=")]
+    [TestCase("Host=h;UseTls=true;TlsCaCertificatePath=   ")]
+    [TestCase("Host=h;UseTls=true;TlsCaCertificatePath=\"\"")]
+    [TestCase("Host=h;UseTls=true;TlsCaCertificatePath=\"   \"")]
+    [TestCase("Host=h;UseTls=true;TlsCaCertificatePath=/tmp/ca.pem;TlsCaCertificatePath=")]
+    public void Constructor_TlsCaCertificatePathWithAnEmptyValue_ThrowsRatherThanUsingHostTrust(string connectionString)
+    {
+        Assert.Throws<ArgumentException>(() => new ClickHouseTcpConnectionStringBuilder(connectionString));
+    }
+
+    [Test]
+    public void TlsCaCertificatePath_SetToNull_RemovesTheKeyAndUsesHostTrust()
+    {
+        var builder = new ClickHouseTcpConnectionStringBuilder
+        {
+            Host = "h",
+            UseTls = true,
+            TlsCaCertificatePath = "/tmp/ca.pem",
+        };
+
+        builder.TlsCaCertificatePath = null;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(builder.TlsCaCertificatePath, Is.Null);
+            Assert.That(builder.ConnectionString, Does.Not.Contain(nameof(builder.TlsCaCertificatePath)).IgnoreCase);
+            Assert.That(builder.ToOptions().TlsCaCertificatePath, Is.Null);
+        });
+    }
+
+    [Test]
+    public void Clear_BuilderHoldingSecurityKeys_RemovesThemWithoutTreatingThemAsEmptyValues()
+    {
+        var builder = new ClickHouseTcpConnectionStringBuilder
+        {
+            Host = "h",
+            UseTls = true,
+            TlsCaCertificatePath = "/tmp/ca.pem",
+        };
+
+        Assert.DoesNotThrow(builder.Clear);
+        Assert.That(builder.ConnectionString, Is.Empty);
     }
 
     [Test]

--- a/ClickHouse.Driver.Tcp.Tests/Client/ClickHouseTcpConnectionStringBuilderTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Client/ClickHouseTcpConnectionStringBuilderTests.cs
@@ -35,11 +35,15 @@ public class ClickHouseTcpConnectionStringBuilderTests
         Assert.Multiple(() =>
         {
             Assert.That(options.Host, Is.EqualTo("only-host"));
-            Assert.That(options.Port, Is.EqualTo(9000));
+            Assert.That(options.Port, Is.Null, "an absent Port key derives the port from UseTls");
             Assert.That(options.Username, Is.EqualTo("default"));
             Assert.That(options.Password, Is.EqualTo(string.Empty));
             Assert.That(options.Database, Is.EqualTo("default"));
             Assert.That(options.DialTimeout, Is.EqualTo(TimeSpan.FromSeconds(30)));
+            Assert.That(options.UseTls, Is.False);
+            Assert.That(options.TlsServerName, Is.Null);
+            Assert.That(options.TlsAllowInvalidCertificates, Is.False);
+            Assert.That(options.TlsCaCertificatePath, Is.Null);
         });
     }
 
@@ -152,6 +156,28 @@ public class ClickHouseTcpConnectionStringBuilderTests
             Assert.That(builder.MaxSendBufferBytes, Is.EqualTo(2048));
             Assert.That(builder.DialTimeout, Is.EqualTo(TimeSpan.FromSeconds(7)));
             Assert.That(builder.ReadTimeout, Is.EqualTo(TimeSpan.FromSeconds(45)));
+        });
+    }
+
+    [Test]
+    public void TypedTlsSetters_ReadBackOnSameInstance_ReturnValuesNotDefaults()
+    {
+        // The boolean setters store a boxed bool, which is a different getter arm from the string a parsed
+        // connection string leaves behind. Both have to read back, as they already must for the numeric keys.
+        var builder = new ClickHouseTcpConnectionStringBuilder
+        {
+            UseTls = true,
+            TlsAllowInvalidCertificates = true,
+            TlsServerName = "sni.example",
+            TlsCaCertificatePath = "/etc/ca.pem",
+        };
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(builder.UseTls, Is.True);
+            Assert.That(builder.TlsAllowInvalidCertificates, Is.True);
+            Assert.That(builder.TlsServerName, Is.EqualTo("sni.example"));
+            Assert.That(builder.TlsCaCertificatePath, Is.EqualTo("/etc/ca.pem"));
         });
     }
 
@@ -280,6 +306,131 @@ public class ClickHouseTcpConnectionStringBuilderTests
             Assert.That(reparsed.Port, Is.EqualTo(9001));
             Assert.That(reparsed.Username, Is.EqualTo("u"));
             Assert.That(reparsed.Database, Is.EqualTo("d"));
+        });
+    }
+
+    [Test]
+    public void ToOptions_TlsKeys_ParsesEachValue()
+    {
+        var builder = new ClickHouseTcpConnectionStringBuilder(
+            "Host=db.example;UseTls=true;TlsServerName=cert.example;TlsAllowInvalidCertificates=true;TlsCaCertificatePath=/etc/ca.pem");
+
+        var options = builder.ToOptions();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(options.UseTls, Is.True);
+            Assert.That(options.TlsServerName, Is.EqualTo("cert.example"));
+            Assert.That(options.TlsAllowInvalidCertificates, Is.True);
+            Assert.That(options.TlsCaCertificatePath, Is.EqualTo("/etc/ca.pem"));
+        });
+    }
+
+    [Test]
+    public void ToOptions_UseTlsWithNoPortKey_ResolvesToTheSecureNativePort()
+    {
+        var options = ClickHouseTcpClientOptions.FromConnectionString("Host=db.example;UseTls=true");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(options.Port, Is.Null, "no key was given, so nothing is stored");
+            Assert.That(options.ResolvedPort, Is.EqualTo(9440));
+        });
+    }
+
+    [Test]
+    public void ToOptions_UseTlsWithAnExplicitPort_KeepsThatPort()
+    {
+        // A server may serve secure native connections on a non-standard port; an explicit key always wins.
+        var options = ClickHouseTcpClientOptions.FromConnectionString("Host=db.example;UseTls=true;Port=9000");
+
+        Assert.That(options.ResolvedPort, Is.EqualTo(9000));
+    }
+
+    [TestCase("true", true)]
+    [TestCase("True", true)]
+    [TestCase("TRUE", true)]
+    [TestCase("1", true)]
+    [TestCase("false", false)]
+    [TestCase("0", false)]
+    public void UseTls_RecognizedBooleanSpelling_Parses(string value, bool expected)
+    {
+        var options = ClickHouseTcpClientOptions.FromConnectionString($"Host=h;UseTls={value}");
+
+        Assert.That(options.UseTls, Is.EqualTo(expected));
+    }
+
+    // 'UseTls=' with nothing after it is not covered: DbConnectionStringBuilder drops a key with an empty value
+    // while parsing, so it never reaches the getter and reads as absent, exactly like omitting the key.
+    [TestCase("yes")]
+    [TestCase("on")]
+    [TestCase("2")]
+    public void UseTls_UnrecognizedValue_ThrowsRatherThanReadingAsFalse(string value)
+    {
+        // Falling back to the default here would hand back a plaintext connection the caller believes is
+        // encrypted, so an unparseable value must be loud.
+        var builder = new ClickHouseTcpConnectionStringBuilder($"Host=h;UseTls={value}");
+
+        Assert.Throws<ArgumentException>(() => builder.ToOptions());
+    }
+
+    [Test]
+    public void TlsAllowInvalidCertificates_UnrecognizedValue_ThrowsRatherThanReadingAsFalse()
+    {
+        var builder = new ClickHouseTcpConnectionStringBuilder("Host=h;UseTls=true;TlsAllowInvalidCertificates=maybe");
+
+        Assert.Throws<ArgumentException>(() => builder.ToOptions());
+    }
+
+    [TestCase(1, true)]
+    [TestCase(0, false)]
+    [TestCase(true, true)]
+    [TestCase(false, false)]
+    public void UseTls_SetThroughTheUntypedIndexer_ReadsAsTheValueGiven(object value, bool expected)
+    {
+        // The untyped indexer is a supported path on this class, and the base converts whatever it is handed to a
+        // string — so an int or a bool set this way must still read as the boolean it means, never fall back to
+        // false, which would connect in the clear while the caller believes otherwise.
+        var builder = new ClickHouseTcpConnectionStringBuilder { Host = "h" };
+        builder["UseTls"] = value;
+
+        Assert.That(builder.ToOptions().UseTls, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void TlsSetters_RoundTripThroughConnectionString()
+    {
+        var builder = new ClickHouseTcpConnectionStringBuilder
+        {
+            Host = "rt-host",
+            UseTls = true,
+            TlsServerName = "rt-sni",
+            TlsAllowInvalidCertificates = true,
+            TlsCaCertificatePath = "/tmp/rt-ca.pem",
+        };
+
+        var reparsed = new ClickHouseTcpConnectionStringBuilder(builder.ConnectionString).ToOptions();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(reparsed.UseTls, Is.True);
+            Assert.That(reparsed.TlsServerName, Is.EqualTo("rt-sni"));
+            Assert.That(reparsed.TlsAllowInvalidCertificates, Is.True);
+            Assert.That(reparsed.TlsCaCertificatePath, Is.EqualTo("/tmp/rt-ca.pem"));
+        });
+    }
+
+    [Test]
+    public void Port_SetToNull_RemovesTheKeySoThePortIsDerivedAgain()
+    {
+        var builder = new ClickHouseTcpConnectionStringBuilder { Host = "h", Port = 9001, UseTls = true };
+
+        builder.Port = null;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(builder.Port, Is.Null);
+            Assert.That(builder.ToOptions().ResolvedPort, Is.EqualTo(9440));
         });
     }
 }

--- a/ClickHouse.Driver.Tcp.Tests/Client/ConnectionPoolTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Client/ConnectionPoolTests.cs
@@ -1242,6 +1242,27 @@ public class ConnectionPoolTests
     }
 
     [Test]
+    public async Task DisposeAsync_DisposesTheFactoryAfterEveryConnectionIsClosed()
+    {
+        // The factory owns what outlives a single connection — the TLS certificate authorities — so the pool has to
+        // release it, and only once nothing can still be handshaking against it.
+        var factory = new FakeConnectionFactory();
+        var pool = new ConnectionPool(Options(maxPoolSize: 3), factory, new ControlledTimeProvider());
+        await ReturnConcurrentLeasesAsync(pool, 3);
+
+        await pool.DisposeAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(factory.Disposed, Is.True);
+            Assert.That(
+                factory.Created.Select(c => c.State),
+                Is.All.EqualTo(TcpConnectionState.Terminated),
+                "the connections are closed before the factory goes, not after");
+        });
+    }
+
+    [Test]
     public async Task DisposeAsync_CalledTwice_IsNoOp()
     {
         var pool = new ConnectionPool(Options(), new FakeConnectionFactory(), new ControlledTimeProvider());

--- a/ClickHouse.Driver.Tcp.Tests/Client/ConnectionPoolTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Client/ConnectionPoolTests.cs
@@ -1247,6 +1247,9 @@ public class ConnectionPoolTests
         // The factory owns what outlives a single connection — the TLS certificate authorities — so the pool has to
         // release it, and only once nothing can still be handshaking against it.
         var factory = new FakeConnectionFactory();
+        bool everyConnectionWasClosed = false;
+        factory.OnDispose = () => everyConnectionWasClosed = factory.Created
+            .All(c => c.State == TcpConnectionState.Terminated);
         var pool = new ConnectionPool(Options(maxPoolSize: 3), factory, new ControlledTimeProvider());
         await ReturnConcurrentLeasesAsync(pool, 3);
 
@@ -1255,58 +1258,130 @@ public class ConnectionPoolTests
         Assert.Multiple(() =>
         {
             Assert.That(factory.Disposed, Is.True);
+            Assert.That(factory.DisposeCount, Is.EqualTo(1));
             Assert.That(
-                factory.Created.Select(c => c.State),
-                Is.All.EqualTo(TcpConnectionState.Terminated),
+                everyConnectionWasClosed,
+                Is.True,
                 "the connections are closed before the factory goes, not after");
         });
     }
 
     [Test]
-    public async Task DisposeAsync_ADialStillRunningPastTheDrainDeadline_LeavesTheFactoryUndisposed()
+    public async Task DisposeAsync_DeferredFactoryDisposalThrows_DoesNotReplaceTheDialFailure()
     {
-        // The dial is the one caller disposal cannot reach: it holds a permit but is not in `leased`, so the abort
-        // after the drain deadline does not see it. Disposing the factory anyway would free the TLS certificate
-        // authorities under a live handshake, which surfaces as a cryptographic error from inside the platform.
-        // Holding every permit is the only proof that no dial is running, so a drain that timed out must not.
-        var gate = new TaskCompletionSource();
-        var factory = new FakeConnectionFactory { BeforeCreate = _ => gate.Task };
+        var dialFailure = new InvalidOperationException("dial failed");
+        FakeConnectionFactory factory = GatedDialFactory(out SemaphoreSlim dialing, out TaskCompletionSource finishDial);
+        factory.FailNextWith = dialFailure;
+        factory.OnDispose = () => throw new InvalidOperationException("factory disposal failed");
         var pool = new ConnectionPool(
             Options(maxPoolSize: 1, poolTimeout: TimeSpan.FromMilliseconds(150)),
             factory,
             new ControlledTimeProvider());
 
-        // Started and left running: BeforeCreate never completes, so this dial ignores the shutdown token the way a
-        // slow ConfigureTls callback or an uncancellable name resolution would.
-        Task<IConnectionLease> stuck = pool.RentAsync(CancellationToken.None).AsTask();
-        await Task.Delay(50);
+        Task<IConnectionLease> stuck = Task.Run(async () => await pool.RentAsync(None));
+        Assert.That(await dialing.WaitAsync(TimeSpan.FromSeconds(30)), Is.True, "the dial should be in the factory");
+        await pool.DisposeAsync();
+
+        finishDial.SetResult();
+        InvalidOperationException thrown = Assert.ThrowsAsync<InvalidOperationException>(async () => await stuck);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(thrown, Is.SameAs(dialFailure), "factory disposal must not replace the dial's own result");
+            Assert.That(factory.DisposeCount, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public async Task DisposeAsync_ADialStillRunningPastTheDrainDeadline_DisposesTheFactoryWhenTheDialFinishes()
+    {
+        // The dial is the one caller disposal cannot reach: it holds a permit but is not in `leased`, so the abort
+        // after the drain deadline does not see it. Disposing the factory anyway would free the TLS certificate
+        // authorities under a live handshake. It still has to be disposed once that handshake leaves the factory.
+        FakeConnectionFactory factory = GatedDialFactory(out SemaphoreSlim dialing, out TaskCompletionSource finishDial);
+        var pool = new ConnectionPool(
+            Options(maxPoolSize: 1, poolTimeout: TimeSpan.FromMilliseconds(150)),
+            factory,
+            new ControlledTimeProvider());
+
+        Task<IConnectionLease> stuck = Task.Run(async () => await pool.RentAsync(None));
+        Assert.That(await dialing.WaitAsync(TimeSpan.FromSeconds(30)), Is.True, "the dial should be in the factory");
 
         await pool.DisposeAsync();
 
         Assert.That(
             factory.Disposed,
             Is.False,
-            "the drain timed out, so a dial may still be inside the factory and its certificates must survive");
+            "the certificates must survive while the dial is still using them");
 
-        // Release the dial so the test leaves nothing running.
-        gate.SetResult();
-        try
+        finishDial.SetResult();
+        Assert.ThrowsAsync<ObjectDisposedException>(async () => await stuck);
+
+        Assert.Multiple(() =>
         {
-            await (await stuck).DisposeAsync();
-        }
-        catch (Exception e) when (e is ObjectDisposedException or OperationCanceledException)
+            Assert.That(factory.Disposed, Is.True, "the last dial out performs the deferred disposal");
+            Assert.That(factory.DisposeCount, Is.EqualTo(1));
+            Assert.That(factory.Created[0].State, Is.EqualTo(TcpConnectionState.Terminated));
+        });
+    }
+
+    [Test]
+    public async Task DisposeAsync_TwoDialsOutliveTheDrain_DisposesTheFactoryOnlyAfterBothFinish()
+    {
+        var dialing = new SemaphoreSlim(0);
+        var finishFirst = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var finishSecond = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource[] finishes = [finishFirst, finishSecond];
+        int dialIndex = -1;
+        var factory = new FakeConnectionFactory
         {
-            // Either is a correct outcome for a checkout that raced disposal; which one is not this test's subject.
-        }
+            IgnoresCancellation = true,
+            BeforeCreate = async _ =>
+            {
+                int index = Interlocked.Increment(ref dialIndex);
+                dialing.Release();
+                await finishes[index].Task;
+            },
+        };
+        var pool = new ConnectionPool(
+            Options(maxPoolSize: 2, poolTimeout: TimeSpan.FromMilliseconds(150)),
+            factory,
+            new ControlledTimeProvider());
+
+        Task<IConnectionLease> first = Task.Run(async () => await pool.RentAsync(None));
+        Assert.That(await dialing.WaitAsync(TimeSpan.FromSeconds(30)), Is.True, "the first dial should be active");
+        Task<IConnectionLease> second = Task.Run(async () => await pool.RentAsync(None));
+        Assert.That(await dialing.WaitAsync(TimeSpan.FromSeconds(30)), Is.True, "the second dial should be active");
+
+        await pool.DisposeAsync();
+        Assert.That(factory.Disposed, Is.False, "both dials still retain the factory");
+
+        finishFirst.SetResult();
+        Assert.ThrowsAsync<ObjectDisposedException>(async () => await first);
+        Assert.Multiple(() =>
+        {
+            Assert.That(factory.Disposed, Is.False, "the second dial still retains the factory");
+            Assert.That(factory.DisposeCount, Is.Zero);
+        });
+
+        finishSecond.SetResult();
+        Assert.ThrowsAsync<ObjectDisposedException>(async () => await second);
+        Assert.Multiple(() =>
+        {
+            Assert.That(factory.Disposed, Is.True, "the last dial out performs the deferred disposal");
+            Assert.That(factory.DisposeCount, Is.EqualTo(1));
+        });
     }
 
     [Test]
     public async Task DisposeAsync_CalledTwice_IsNoOp()
     {
-        var pool = new ConnectionPool(Options(), new FakeConnectionFactory(), new ControlledTimeProvider());
+        var factory = new FakeConnectionFactory();
+        var pool = new ConnectionPool(Options(), factory, new ControlledTimeProvider());
         await pool.DisposeAsync();
 
         Assert.DoesNotThrowAsync(async () => await pool.DisposeAsync());
+        Assert.That(factory.DisposeCount, Is.EqualTo(1));
     }
 
     [Test]
@@ -1346,6 +1421,47 @@ public class ConnectionPoolTests
     }
 
     [Test]
+    public async Task RentAsync_DisposedAfterTheLastPreDialCheck_DoesNotEnterTheFactory()
+    {
+        var clock = new ControlledTimeProvider();
+        var factory = new FakeConnectionFactory();
+        await using var pool = new ConnectionPool(
+            Options(
+                maxPoolSize: 1,
+                maxConnectionLifetime: TimeSpan.FromMinutes(1),
+                idleTimeout: TimeSpan.Zero),
+            factory,
+            clock);
+
+        await using (await pool.RentAsync(None))
+        {
+        }
+
+        clock.Advance(TimeSpan.FromMinutes(2));
+        int createAttempts = 0;
+        factory.BeforeCreate = _ =>
+        {
+            Interlocked.Increment(ref createAttempts);
+            return Task.CompletedTask;
+        };
+
+        Task disposing = null;
+        clock.OnNextTimestamp = () => disposing = pool.DisposeAsync().AsTask();
+
+        Assert.ThrowsAsync<ObjectDisposedException>(async () => await pool.RentAsync(None));
+        Assert.That(clock.OnNextTimestamp, Is.Null, "the checkout must have reached the post-check clock seam");
+        Assert.That(disposing, Is.Not.Null, "the clock seam must have started disposal");
+        await disposing;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(createAttempts, Is.Zero, "the raced checkout must not enter the factory");
+            Assert.That(factory.CreateCount, Is.EqualTo(1), "only the connection opened before disposal exists");
+            Assert.That(factory.DisposeCount, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
     public void RentAsync_PreCancelledToken_ThrowsWithoutOpeningAConnection()
     {
         var factory = new FakeConnectionFactory();
@@ -1374,14 +1490,13 @@ public class ConnectionPoolTests
     }
 
     [Test]
-    public async Task DisposeAsync_WithALeaseNeverReturned_GivesUpAfterPoolTimeout()
+    public async Task DisposeAsync_WithALeaseHeldPastPoolTimeout_DisposesTheFactoryBeforeTheLeaseReturns()
     {
         var factory = new FakeConnectionFactory();
         var pool = new ConnectionPool(
             Options(maxPoolSize: 1, poolTimeout: TimeSpan.FromMilliseconds(150)), factory, new ControlledTimeProvider());
 
-        // Rented and deliberately never disposed: the caller abandoned the operation.
-        await pool.RentAsync(None);
+        IConnectionLease held = await pool.RentAsync(None);
 
         var elapsed = Stopwatch.StartNew();
         await pool.DisposeAsync();
@@ -1395,7 +1510,15 @@ public class ConnectionPoolTests
             // transport is aborted rather than fully torn down, because the operation may still hold buffers.
             Assert.That(factory.Created[0].State, Is.EqualTo(TcpConnectionState.Terminated));
             Assert.That(factory.Created[0].IsReusable, Is.False);
+            Assert.That(factory.Disposed, Is.True, "an established connection no longer uses the factory");
+            Assert.That(factory.DisposeCount, Is.EqualTo(1));
         });
+
+        Assert.DoesNotThrowAsync(async () => await held.DisposeAsync());
+        Assert.That(
+            factory.DisposeCount,
+            Is.EqualTo(1),
+            "returning the timed-out lease cannot dispose the factory twice");
     }
 
     [Test]

--- a/ClickHouse.Driver.Tcp.Tests/Client/ConnectionPoolTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Client/ConnectionPoolTests.cs
@@ -1263,6 +1263,44 @@ public class ConnectionPoolTests
     }
 
     [Test]
+    public async Task DisposeAsync_ADialStillRunningPastTheDrainDeadline_LeavesTheFactoryUndisposed()
+    {
+        // The dial is the one caller disposal cannot reach: it holds a permit but is not in `leased`, so the abort
+        // after the drain deadline does not see it. Disposing the factory anyway would free the TLS certificate
+        // authorities under a live handshake, which surfaces as a cryptographic error from inside the platform.
+        // Holding every permit is the only proof that no dial is running, so a drain that timed out must not.
+        var gate = new TaskCompletionSource();
+        var factory = new FakeConnectionFactory { BeforeCreate = _ => gate.Task };
+        var pool = new ConnectionPool(
+            Options(maxPoolSize: 1, poolTimeout: TimeSpan.FromMilliseconds(150)),
+            factory,
+            new ControlledTimeProvider());
+
+        // Started and left running: BeforeCreate never completes, so this dial ignores the shutdown token the way a
+        // slow ConfigureTls callback or an uncancellable name resolution would.
+        Task<IConnectionLease> stuck = pool.RentAsync(CancellationToken.None).AsTask();
+        await Task.Delay(50);
+
+        await pool.DisposeAsync();
+
+        Assert.That(
+            factory.Disposed,
+            Is.False,
+            "the drain timed out, so a dial may still be inside the factory and its certificates must survive");
+
+        // Release the dial so the test leaves nothing running.
+        gate.SetResult();
+        try
+        {
+            await (await stuck).DisposeAsync();
+        }
+        catch (Exception e) when (e is ObjectDisposedException or OperationCanceledException)
+        {
+            // Either is a correct outcome for a checkout that raced disposal; which one is not this test's subject.
+        }
+    }
+
+    [Test]
     public async Task DisposeAsync_CalledTwice_IsNoOp()
     {
         var pool = new ConnectionPool(Options(), new FakeConnectionFactory(), new ControlledTimeProvider());

--- a/ClickHouse.Driver.Tcp.Tests/Client/TcpConnectionFactoryTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Client/TcpConnectionFactoryTests.cs
@@ -1,7 +1,10 @@
 using System;
 using System.Diagnostics;
+using System.IO;
 using System.Net;
+using System.Net.Security;
 using System.Net.Sockets;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 using ClickHouse.Driver.Tcp.Client;
@@ -17,6 +20,13 @@ namespace ClickHouse.Driver.Tcp.Tests.Client;
 [TestFixture]
 public class TcpConnectionFactoryTests
 {
+    // The name the test server's certificate carries. Not the loopback address the factory dials, so the tests
+    // also cover TlsServerName being what the certificate is matched against.
+    private const string CertificateName = "clickhouse.factory.test.invalid";
+
+    [OneTimeTearDown]
+    public void DeleteTemporaryCertificateFiles() => TestCertificates.DeleteTemporaryFiles();
+
     [Test]
     public async Task CreateAsync_ServerAcceptsButNeverCompletesTheHandshake_ThrowsTimeoutNamingDialTimeout()
     {
@@ -210,5 +220,135 @@ public class TcpConnectionFactoryTests
         {
             listener.Stop();
         }
+    }
+
+    [Test]
+    public void Constructor_TlsCaCertificatePathThatDoesNotExist_Throws()
+    {
+        // The file is read once here rather than per connect, which is also what makes a typo in the path fail
+        // where the caller can act on it instead of on whichever operation happens to dial first.
+        var options = new ClickHouseTcpClientOptions
+        {
+            Host = "127.0.0.1",
+            UseTls = true,
+            TlsCaCertificatePath = Path.Combine(Path.GetTempPath(), $"absent-ca-{Guid.NewGuid():N}.pem"),
+        };
+
+        Assert.Throws<FileNotFoundException>(() => new TcpConnectionFactory(options));
+    }
+
+    [Test]
+    public void ClickHouseTcpClient_TlsCaCertificatePathThatDoesNotExist_ThrowsAtConstruction()
+    {
+        // The client builds its pool, and so its factory, eagerly. This is the caller-facing half of the test
+        // above: nothing defers the failure to the first query.
+        var options = new ClickHouseTcpClientOptions
+        {
+            Host = "127.0.0.1",
+            UseTls = true,
+            TlsCaCertificatePath = Path.Combine(Path.GetTempPath(), $"absent-ca-{Guid.NewGuid():N}.pem"),
+        };
+
+        Assert.Throws<FileNotFoundException>(() => new ClickHouseTcpClient(options));
+    }
+
+    [Test]
+    public void Constructor_NoTls_DoesNotThrow()
+    {
+        // A plaintext factory must not touch any TLS machinery, so constructing one reads no certificate file.
+        Assert.DoesNotThrow(() => new TcpConnectionFactory(new ClickHouseTcpClientOptions { Host = "127.0.0.1" }));
+    }
+
+    [Test]
+    public async Task CreateAsync_UseTlsAgainstATlsServer_HandshakesInsideTheTunnel()
+    {
+        // The only test that covers the whole wiring — options.UseTls to BuildTlsParameters to the SslStream the
+        // native handshake then runs inside. Invert the UseTls test in the factory and every other test still
+        // passes, because the rest either build TlsParameters by hand or need a Cloud service.
+        using X509Certificate2 authority = TestCertificates.CreateAuthority();
+        using X509Certificate2 serverCertificate = TestCertificates.IssueServerCertificate(authority, CertificateName);
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        Task server = RunTlsClickHouseServerAsync(listener, serverCertificate);
+
+        try
+        {
+            var factory = new TcpConnectionFactory(new ClickHouseTcpClientOptions
+            {
+                Host = "127.0.0.1",
+                Port = ((IPEndPoint)listener.LocalEndpoint).Port,
+                UseTls = true,
+
+                // The certificate names CertificateName, not the loopback address Host carries.
+                TlsServerName = CertificateName,
+                TlsCaCertificatePath = TestCertificates.WritePemFile(authority),
+                DialTimeout = TimeSpan.FromSeconds(30),
+            });
+
+            using ClickHouseTcpConnection connection = await factory.CreateAsync(CancellationToken.None);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+                Assert.That(connection.Server.ServerName, Is.EqualTo("ClickHouse"));
+                Assert.That(connection.Server.Timezone, Is.EqualTo("UTC"), "the Hello was decoded from inside the tunnel, not guessed");
+            });
+        }
+        finally
+        {
+            await server.ContinueWith(static _ => { }, TaskScheduler.Default);
+            listener.Stop();
+        }
+    }
+
+    [Test]
+    public async Task CreateAsync_TlsServerButUseTlsLeftOff_DoesNotReachReady()
+    {
+        // The negative half: a plaintext client against a TLS port must fail rather than appear to work. Proves
+        // the previous test passes because TLS was negotiated, not because the server would take anything.
+        using X509Certificate2 authority = TestCertificates.CreateAuthority();
+        using X509Certificate2 serverCertificate = TestCertificates.IssueServerCertificate(authority, CertificateName);
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        Task server = RunTlsClickHouseServerAsync(listener, serverCertificate);
+
+        try
+        {
+            var factory = new TcpConnectionFactory(new ClickHouseTcpClientOptions
+            {
+                Host = "127.0.0.1",
+                Port = ((IPEndPoint)listener.LocalEndpoint).Port,
+                DialTimeout = TimeSpan.FromSeconds(10),
+            });
+
+            Assert.CatchAsync(async () => await factory.CreateAsync(CancellationToken.None));
+        }
+        finally
+        {
+            await server.ContinueWith(static _ => { }, TaskScheduler.Default);
+            listener.Stop();
+        }
+    }
+
+    // A ClickHouse server just complete enough to finish a handshake, wrapped in TLS: read the ClientHello, reply
+    // with a server Hello, then absorb the Addendum the client sends next.
+    private static async Task RunTlsClickHouseServerAsync(TcpListener listener, X509Certificate2 certificate)
+    {
+        using TcpClient accepted = await listener.AcceptTcpClientAsync();
+        using var ssl = new SslStream(accepted.GetStream(), leaveInnerStreamOpen: false);
+        await ssl.AuthenticateAsServerAsync(new SslServerAuthenticationOptions { ServerCertificate = certificate });
+
+        var buffer = new byte[1024];
+        int clientHello = await ssl.ReadAsync(buffer);
+        Assert.That(clientHello, Is.GreaterThan(0), "the client must send its Hello inside the tunnel");
+
+        byte[] hello = await FakeConnectionFactory.ServerHelloBytesAsync(CancellationToken.None);
+        await ssl.WriteAsync(hello);
+        await ssl.FlushAsync();
+
+        // The client writes its Addendum after reading Hello; read it so the client is never blocked on a full
+        // send buffer, and so this task ends rather than being torn down mid-write. A short read is fine here —
+        // nothing inspects the bytes.
+        _ = await ssl.ReadAsync(buffer);
     }
 }

--- a/ClickHouse.Driver.Tcp.Tests/Client/TcpConnectionFactoryTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Client/TcpConnectionFactoryTests.cs
@@ -253,6 +253,23 @@ public class TcpConnectionFactoryTests
     }
 
     [Test]
+    public void ClickHouseTcpClient_TlsCaCertificatePathHoldingOnlyAnIntermediate_ThrowsAtConstruction()
+    {
+        using X509Certificate2 root = TestCertificates.CreateAuthority();
+        using X509Certificate2 intermediate = TestCertificates.CreateIntermediate(root);
+        var options = new ClickHouseTcpClientOptions
+        {
+            Host = "127.0.0.1",
+            UseTls = true,
+            TlsCaCertificatePath = TestCertificates.WritePemFile(intermediate),
+        };
+
+        var thrown = Assert.Throws<ArgumentException>(() => new ClickHouseTcpClient(options));
+
+        Assert.That(thrown.Message, Does.Contain("root certificate"));
+    }
+
+    [Test]
     public void Constructor_NoTls_DoesNotThrow()
     {
         // A plaintext factory must not touch any TLS machinery, so constructing one reads no certificate file.

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpConnectionIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpConnectionIntegrationTests.cs
@@ -68,6 +68,7 @@ public class ClickHouseTcpConnectionIntegrationTests
                 TcpServerFixture.Host,
                 1,
                 new ClientHandshakeParameters { Username = "default" },
+                tls: null,
                 None));
     }
 }

--- a/ClickHouse.Driver.Tcp.Tests/Integration/TcpServerFixture.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/TcpServerFixture.cs
@@ -83,6 +83,7 @@ public sealed class TcpServerFixture
                 Username = username ?? Username,
                 Password = password ?? Password,
             },
+            tls: null,
             cancellationToken);
 
     /// <summary>Builds client options pointed at the test server, optionally overriding the credentials.</summary>

--- a/ClickHouse.Driver.Tcp.Tests/Protocol/ClickHouseTcpConnectionTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Protocol/ClickHouseTcpConnectionTests.cs
@@ -207,12 +207,12 @@ public class ClickHouseTcpConnectionTests
     [Test]
     public void ConnectAsync_NullHost_ThrowsArgumentNull()
         => Assert.ThrowsAsync<ArgumentNullException>(async () =>
-            await ClickHouseTcpConnection.ConnectAsync(null, 9000, Handshake, None));
+            await ClickHouseTcpConnection.ConnectAsync(null, 9000, Handshake, tls: null, None));
 
     [Test]
     public void ConnectAsync_NullHandshake_ThrowsArgumentNull()
         => Assert.ThrowsAsync<ArgumentNullException>(async () =>
-            await ClickHouseTcpConnection.ConnectAsync("localhost", 9000, null, None));
+            await ClickHouseTcpConnection.ConnectAsync("localhost", 9000, null, tls: null, None));
 
     // IsReusable is what the pool asks before every checkout. A live server cannot be made to produce the cases
     // that matter — a stream left out of step, a connection already terminated — so they are scripted here.

--- a/ClickHouse.Driver.Tcp.Tests/Protocol/TlsParametersTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Protocol/TlsParametersTests.cs
@@ -1,9 +1,11 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Security.Authentication;
+using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading;
@@ -72,8 +74,8 @@ public class TlsParametersTests
     [Test]
     public void WrapAsync_AuthorityTrustedButCertificateNamesAnotherHost_ThrowsAuthenticationException()
     {
-        // The custom-root path re-takes the trust decision only. Naming a private authority says who to trust,
-        // not that the server's identity stopped mattering, so a name mismatch must still fail.
+        // Pinning decides who to trust, not whether the server's identity still matters, so the host-name match
+        // must still fail the handshake.
         using X509Certificate2 authority = TestCertificates.CreateAuthority();
         using X509Certificate2 server = TestCertificates.IssueServerCertificate(authority, ServerName);
 
@@ -106,9 +108,9 @@ public class TlsParametersTests
     [Test]
     public void WrapAsync_CertificateUnderTheAuthorityButNotValidForServerAuthentication_ThrowsAuthenticationException()
     {
-        // The rebuild replaces the platform's chain check, so it has to keep the platform's requirement that the
-        // certificate is valid for server authentication. Without that, a private authority which also issues
-        // client certificates lets any holder of one impersonate the server for a name it covers.
+        // A private authority which also issues client certificates must not let the holder of one impersonate the
+        // server for a name it covers. The handshake applies the serverAuth requirement itself, so this passes even
+        // with the policy's ApplicationPolicy removed; it is here to pin the outcome against a change to either.
         using X509Certificate2 authority = TestCertificates.CreateAuthority();
         using X509Certificate2 server = TestCertificates.IssueServerCertificate(authority, ServerName, CertificatePurpose.ClientAuthentication);
 
@@ -124,8 +126,8 @@ public class TlsParametersTests
     [Test]
     public async Task WrapAsync_LeafUnderAnIntermediateWithOnlyTheRootPinned_CompletesHandshake()
     {
-        // The rebuild starts from an empty store, so a chain that does not end at the pinned root in one hop can
-        // only be completed from the intermediates the server sent. Delete the ExtraStore loop and this fails.
+        // Pinning starts trust from an empty store, so a chain that does not reach the pinned root in one hop
+        // is completed only from the intermediates the server sent alongside its leaf.
         using X509Certificate2 root = TestCertificates.CreateAuthority();
         using X509Certificate2 intermediate = TestCertificates.CreateIntermediate(root);
         using X509Certificate2 server = TestCertificates.IssueServerCertificate(intermediate, ServerName);
@@ -176,11 +178,11 @@ public class TlsParametersTests
     }
 
     [Test]
-    public async Task WrapAsync_ConfigureHookAsksForRevocationChecking_TheCustomRootRebuildUsesIt()
+    public async Task WrapAsync_ConfigureHookEditsThePinnedChainPolicy_TheHandshakeUsesTheEdit()
     {
-        // The rebuild must not hardcode revocation off, or a caller who turned it on gets nothing and a revoked
-        // certificate is accepted. Neither test certificate names a revocation list, so a rebuild that honours
-        // the request cannot determine revocation status and refuses; one that ignores it accepts.
+        // Pinning is expressed as a chain policy so the hook can adjust it and have the adjustment take effect.
+        // Revocation checking is the case with an observable outcome: neither test certificate names a revocation
+        // list, so a handshake that honours the request cannot establish revocation status and refuses.
         using X509Certificate2 authority = TestCertificates.CreateAuthority();
         using X509Certificate2 server = TestCertificates.IssueServerCertificate(authority, ServerName);
         string caPath = TestCertificates.WritePemFile(authority);
@@ -189,13 +191,13 @@ public class TlsParametersTests
         {
             TargetHost = ServerName,
             CaCertificates = TlsParameters.LoadCaCertificates(caPath),
-            Configure = options => options.CertificateRevocationCheckMode = X509RevocationMode.Online,
+            Configure = options => options.CertificateChainPolicy.RevocationMode = X509RevocationMode.Online,
         };
 
         Assert.ThrowsAsync<AuthenticationException>(async () => await RoundTripThroughTlsAsync(server, honoured));
 
         // The same chain, with the default of no revocation checking, is accepted — so the refusal above is the
-        // revocation mode taking effect and not something else wrong with the certificate.
+        // hook's edit taking effect and not something else wrong with the certificate.
         var byDefault = new TlsParameters
         {
             TargetHost = ServerName,
@@ -203,6 +205,34 @@ public class TlsParametersTests
         };
 
         Assert.That(await RoundTripThroughTlsAsync(server, byDefault), Is.EqualTo(Payload));
+    }
+
+    [Test]
+    public void WrapAsync_PinnedAuthority_ExposesThePolicyToTheHookRatherThanHidingItInACallback()
+    {
+        // What the hook is handed has to be the policy the handshake will use, or an edit to it is silently lost.
+        using X509Certificate2 authority = TestCertificates.CreateAuthority();
+        using X509Certificate2 server = TestCertificates.IssueServerCertificate(authority, ServerName);
+        X509ChainPolicy observed = null;
+
+        var tls = new TlsParameters
+        {
+            TargetHost = ServerName,
+            CaCertificates = TlsParameters.LoadCaCertificates(TestCertificates.WritePemFile(authority)),
+            Configure = options => observed = options.CertificateChainPolicy,
+        };
+
+        Assert.That(async () => await RoundTripThroughTlsAsync(server, tls), Throws.Nothing);
+        Assert.Multiple(() =>
+        {
+            Assert.That(observed, Is.Not.Null);
+            Assert.That(observed.TrustMode, Is.EqualTo(X509ChainTrustMode.CustomRootTrust));
+            Assert.That(observed.CustomTrustStore, Has.Count.EqualTo(1));
+            Assert.That(
+                observed.ApplicationPolicy.Cast<Oid>().Select(oid => oid.Value),
+                Does.Contain("1.3.6.1.5.5.7.3.1"),
+                "serverAuth is named on the policy rather than left to the handshake applying it");
+        });
     }
 
     [Test]
@@ -284,9 +314,11 @@ public class TlsParametersTests
             await encrypted.WriteAsync(Payload);
             await encrypted.FlushAsync();
 
+            // ReadExactly, not Read: a stream may return a short read whenever it likes, which would leave the
+            // payload comparison below to fail on fragmentation rather than on anything this test is about.
             var received = new byte[Payload.Length];
-            int read = await encrypted.ReadAsync(received);
-            return received.AsSpan(0, read).ToArray();
+            await encrypted.ReadExactlyAsync(received);
+            return received;
         }
         finally
         {
@@ -315,9 +347,11 @@ public class TlsParametersTests
 
         await ssl.AuthenticateAsServerAsync(options);
 
-        var buffer = new byte[64];
-        int read = await ssl.ReadAsync(buffer);
-        await ssl.WriteAsync(buffer.AsMemory(0, read));
+        // This server echoes one known payload, so it can wait for all of it rather than echo a short read back
+        // and leave the client comparing fewer bytes than it sent.
+        var buffer = new byte[Payload.Length];
+        await ssl.ReadExactlyAsync(buffer);
+        await ssl.WriteAsync(buffer);
         await ssl.FlushAsync();
     }
 

--- a/ClickHouse.Driver.Tcp.Tests/Protocol/TlsParametersTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Protocol/TlsParametersTests.cs
@@ -1,0 +1,366 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Protocol;
+using ClickHouse.Driver.Tcp.Tests.Utilities;
+
+namespace ClickHouse.Driver.Tcp.Tests.Protocol;
+
+/// <summary>
+/// TLS is a transport concern the native protocol never sees, so these run against a bare TLS echo server rather
+/// than a ClickHouse server: what needs proving is which server certificates the client accepts and which it
+/// refuses, not what it sends once the tunnel is up. A real ClickHouse server over TLS is covered by the Cloud
+/// tests, which cannot reach these cases — no cloud service will present a self-signed certificate, one from a
+/// private authority, or one issued for the wrong purpose on request.
+/// </summary>
+[TestFixture]
+public class TlsParametersTests
+{
+    private const string ServerName = "clickhouse.test.invalid";
+
+    private static readonly byte[] Payload = Encoding.UTF8.GetBytes("ping");
+
+    [OneTimeTearDown]
+    public void DeleteTemporaryCertificateFiles() => TestCertificates.DeleteTemporaryFiles();
+
+    [Test]
+    public async Task WrapAsync_CertificateIssuedByTheConfiguredAuthority_CompletesHandshake()
+    {
+        using X509Certificate2 authority = TestCertificates.CreateAuthority();
+        using X509Certificate2 server = TestCertificates.IssueServerCertificate(authority, ServerName);
+
+        var tls = new TlsParameters
+        {
+            TargetHost = ServerName,
+            CaCertificates = TlsParameters.LoadCaCertificates(TestCertificates.WritePemFile(authority)),
+        };
+
+        byte[] echoed = await RoundTripThroughTlsAsync(server, tls);
+
+        Assert.That(echoed, Is.EqualTo(Payload));
+    }
+
+    [Test]
+    public void WrapAsync_SelfSignedCertificateAndValidationLeftOn_ThrowsAuthenticationException()
+    {
+        using X509Certificate2 server = TestCertificates.CreateSelfSignedServerCertificate(ServerName);
+
+        var tls = new TlsParameters { TargetHost = ServerName };
+
+        Assert.ThrowsAsync<AuthenticationException>(async () => await RoundTripThroughTlsAsync(server, tls));
+    }
+
+    [Test]
+    public async Task WrapAsync_SelfSignedCertificateAndValidationTurnedOff_CompletesHandshake()
+    {
+        using X509Certificate2 server = TestCertificates.CreateSelfSignedServerCertificate(ServerName);
+
+        var tls = new TlsParameters { TargetHost = ServerName, AllowInvalidCertificates = true };
+
+        byte[] echoed = await RoundTripThroughTlsAsync(server, tls);
+
+        Assert.That(echoed, Is.EqualTo(Payload));
+    }
+
+    [Test]
+    public void WrapAsync_AuthorityTrustedButCertificateNamesAnotherHost_ThrowsAuthenticationException()
+    {
+        // The custom-root path re-takes the trust decision only. Naming a private authority says who to trust,
+        // not that the server's identity stopped mattering, so a name mismatch must still fail.
+        using X509Certificate2 authority = TestCertificates.CreateAuthority();
+        using X509Certificate2 server = TestCertificates.IssueServerCertificate(authority, ServerName);
+
+        var tls = new TlsParameters
+        {
+            TargetHost = "someone.else.invalid",
+            CaCertificates = TlsParameters.LoadCaCertificates(TestCertificates.WritePemFile(authority)),
+        };
+
+        Assert.ThrowsAsync<AuthenticationException>(async () => await RoundTripThroughTlsAsync(server, tls));
+    }
+
+    [Test]
+    public void WrapAsync_CertificateFromAnUnrelatedAuthority_ThrowsAuthenticationException()
+    {
+        // Trusting one private authority must not trust every private authority.
+        using X509Certificate2 trusted = TestCertificates.CreateAuthority();
+        using X509Certificate2 other = TestCertificates.CreateAuthority();
+        using X509Certificate2 server = TestCertificates.IssueServerCertificate(other, ServerName);
+
+        var tls = new TlsParameters
+        {
+            TargetHost = ServerName,
+            CaCertificates = TlsParameters.LoadCaCertificates(TestCertificates.WritePemFile(trusted)),
+        };
+
+        Assert.ThrowsAsync<AuthenticationException>(async () => await RoundTripThroughTlsAsync(server, tls));
+    }
+
+    [Test]
+    public void WrapAsync_CertificateUnderTheAuthorityButNotValidForServerAuthentication_ThrowsAuthenticationException()
+    {
+        // The rebuild replaces the platform's chain check, so it has to keep the platform's requirement that the
+        // certificate is valid for server authentication. Without that, a private authority which also issues
+        // client certificates lets any holder of one impersonate the server for a name it covers.
+        using X509Certificate2 authority = TestCertificates.CreateAuthority();
+        using X509Certificate2 server = TestCertificates.IssueServerCertificate(authority, ServerName, CertificatePurpose.ClientAuthentication);
+
+        var tls = new TlsParameters
+        {
+            TargetHost = ServerName,
+            CaCertificates = TlsParameters.LoadCaCertificates(TestCertificates.WritePemFile(authority)),
+        };
+
+        Assert.ThrowsAsync<AuthenticationException>(async () => await RoundTripThroughTlsAsync(server, tls));
+    }
+
+    [Test]
+    public async Task WrapAsync_LeafUnderAnIntermediateWithOnlyTheRootPinned_CompletesHandshake()
+    {
+        // The rebuild starts from an empty store, so a chain that does not end at the pinned root in one hop can
+        // only be completed from the intermediates the server sent. Delete the ExtraStore loop and this fails.
+        using X509Certificate2 root = TestCertificates.CreateAuthority();
+        using X509Certificate2 intermediate = TestCertificates.CreateIntermediate(root);
+        using X509Certificate2 server = TestCertificates.IssueServerCertificate(intermediate, ServerName);
+
+        var tls = new TlsParameters
+        {
+            TargetHost = ServerName,
+            CaCertificates = TlsParameters.LoadCaCertificates(TestCertificates.WritePemFile(root)),
+        };
+
+        byte[] echoed = await RoundTripThroughTlsAsync(server, tls, intermediate);
+
+        Assert.That(echoed, Is.EqualTo(Payload));
+    }
+
+    [Test]
+    public void WrapAsync_ConfigureHookRejects_OverridesTheDeclarativeSettings()
+    {
+        // The hook is documented as applied last, so it must be able to override even AllowInvalidCertificates.
+        using X509Certificate2 server = TestCertificates.CreateSelfSignedServerCertificate(ServerName);
+
+        var tls = new TlsParameters
+        {
+            TargetHost = ServerName,
+            AllowInvalidCertificates = true,
+            Configure = options => options.RemoteCertificateValidationCallback = (_, _, _, _) => false,
+        };
+
+        Assert.ThrowsAsync<AuthenticationException>(async () => await RoundTripThroughTlsAsync(server, tls));
+    }
+
+    [Test]
+    public async Task WrapAsync_ConfigureHook_SeesTheTargetHostAlreadySet()
+    {
+        using X509Certificate2 server = TestCertificates.CreateSelfSignedServerCertificate(ServerName);
+        string observed = null;
+
+        var tls = new TlsParameters
+        {
+            TargetHost = ServerName,
+            AllowInvalidCertificates = true,
+            Configure = options => observed = options.TargetHost,
+        };
+
+        await RoundTripThroughTlsAsync(server, tls);
+
+        Assert.That(observed, Is.EqualTo(ServerName));
+    }
+
+    [Test]
+    public async Task WrapAsync_ConfigureHookAsksForRevocationChecking_TheCustomRootRebuildUsesIt()
+    {
+        // The rebuild must not hardcode revocation off, or a caller who turned it on gets nothing and a revoked
+        // certificate is accepted. Neither test certificate names a revocation list, so a rebuild that honours
+        // the request cannot determine revocation status and refuses; one that ignores it accepts.
+        using X509Certificate2 authority = TestCertificates.CreateAuthority();
+        using X509Certificate2 server = TestCertificates.IssueServerCertificate(authority, ServerName);
+        string caPath = TestCertificates.WritePemFile(authority);
+
+        var honoured = new TlsParameters
+        {
+            TargetHost = ServerName,
+            CaCertificates = TlsParameters.LoadCaCertificates(caPath),
+            Configure = options => options.CertificateRevocationCheckMode = X509RevocationMode.Online,
+        };
+
+        Assert.ThrowsAsync<AuthenticationException>(async () => await RoundTripThroughTlsAsync(server, honoured));
+
+        // The same chain, with the default of no revocation checking, is accepted — so the refusal above is the
+        // revocation mode taking effect and not something else wrong with the certificate.
+        var byDefault = new TlsParameters
+        {
+            TargetHost = ServerName,
+            CaCertificates = TlsParameters.LoadCaCertificates(caPath),
+        };
+
+        Assert.That(await RoundTripThroughTlsAsync(server, byDefault), Is.EqualTo(Payload));
+    }
+
+    [Test]
+    public async Task WrapAsync_HandshakeFails_DisposesTheInnerStream()
+    {
+        // WrapAsync takes ownership of the inner stream the moment it wraps it. If it did not close it on the
+        // failure path, every rejected certificate would leak the transport it was negotiating over.
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+
+        // Accept and drop, so the TLS handshake fails before any certificate is exchanged.
+        Task server = Task.Run(async () =>
+        {
+            using TcpClient accepted = await listener.AcceptTcpClientAsync();
+            accepted.Close();
+        });
+
+        using var socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
+        await socket.ConnectAsync(IPAddress.Loopback, ((IPEndPoint)listener.LocalEndpoint).Port);
+        var inner = new DisposeTrackingStream(new NetworkStream(socket, ownsSocket: false));
+
+        var tls = new TlsParameters { TargetHost = ServerName, AllowInvalidCertificates = true };
+
+        Assert.That(async () => await tls.WrapAsync(inner, CancellationToken.None), Throws.Exception);
+        Assert.That(inner.Disposed, Is.True);
+
+        await server;
+    }
+
+    [Test]
+    public void LoadCaCertificates_FileHoldingNoCertificate_ThrowsArgumentException()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"tcp-tls-empty-{Guid.NewGuid():N}.pem");
+        File.WriteAllText(path, "not a certificate\n");
+        TestCertificates.TrackForCleanUp(path);
+
+        Assert.Throws<ArgumentException>(() => TlsParameters.LoadCaCertificates(path));
+    }
+
+    [Test]
+    public void LoadCaCertificates_MissingFile_Throws()
+    {
+        // Reading happens once at client construction, so a typo in the path must surface there.
+        string path = Path.Combine(Path.GetTempPath(), $"tcp-tls-absent-{Guid.NewGuid():N}.pem");
+
+        Assert.Throws<FileNotFoundException>(() => TlsParameters.LoadCaCertificates(path));
+    }
+
+    [Test]
+    public void LoadCaCertificates_PemFileHoldingTwoCertificates_LoadsBoth()
+    {
+        // A CA bundle commonly carries a root and the intermediate that signs for it.
+        using X509Certificate2 root = TestCertificates.CreateAuthority();
+        using X509Certificate2 intermediate = TestCertificates.CreateIntermediate(root);
+
+        X509Certificate2Collection loaded = TlsParameters.LoadCaCertificates(TestCertificates.WritePemFile(root, intermediate));
+
+        Assert.That(loaded, Has.Count.EqualTo(2));
+    }
+
+    // Runs one TLS exchange against a throwaway echo server presenting the given certificate, and returns what
+    // came back. Throws whatever the client's handshake threw.
+    private static async Task<byte[]> RoundTripThroughTlsAsync(
+        X509Certificate2 serverCertificate,
+        TlsParameters tls,
+        X509Certificate2 intermediate = null)
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        Task server = RunTlsEchoServerAsync(listener, serverCertificate, intermediate);
+
+        try
+        {
+            using var socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
+            await socket.ConnectAsync(IPAddress.Loopback, ((IPEndPoint)listener.LocalEndpoint).Port);
+
+            // WrapAsync owns the NetworkStream from here, and disposing the returned stream closes both.
+            using Stream encrypted = await tls.WrapAsync(new NetworkStream(socket, ownsSocket: false), CancellationToken.None);
+            await encrypted.WriteAsync(Payload);
+            await encrypted.FlushAsync();
+
+            var received = new byte[Payload.Length];
+            int read = await encrypted.ReadAsync(received);
+            return received.AsSpan(0, read).ToArray();
+        }
+        finally
+        {
+            // The server side fails too when the client rejects the certificate; that is expected, not a failure
+            // of the test, so its exception is swallowed rather than masking the client's.
+            await server.ContinueWith(static _ => { }, TaskScheduler.Default);
+        }
+    }
+
+    private static async Task RunTlsEchoServerAsync(TcpListener listener, X509Certificate2 certificate, X509Certificate2 intermediate)
+    {
+        using TcpClient accepted = await listener.AcceptTcpClientAsync();
+        using var ssl = new SslStream(accepted.GetStream(), leaveInnerStreamOpen: false);
+
+        var options = new SslServerAuthenticationOptions();
+        if (intermediate is null)
+        {
+            options.ServerCertificate = certificate;
+        }
+        else
+        {
+            // Sending the intermediate alongside the leaf is what lets a client that pins only the root complete
+            // the chain, and is how a real server is configured.
+            options.ServerCertificateContext = SslStreamCertificateContext.Create(certificate, [intermediate]);
+        }
+
+        await ssl.AuthenticateAsServerAsync(options);
+
+        var buffer = new byte[64];
+        int read = await ssl.ReadAsync(buffer);
+        await ssl.WriteAsync(buffer.AsMemory(0, read));
+        await ssl.FlushAsync();
+    }
+
+    // Reports whether the stream it wraps was disposed, which is how the ownership contract is observed.
+    private sealed class DisposeTrackingStream(Stream inner) : Stream
+    {
+        internal bool Disposed { get; private set; }
+
+        public override bool CanRead => inner.CanRead;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => inner.CanWrite;
+
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush() => inner.Flush();
+
+        public override int Read(byte[] buffer, int offset, int count) => inner.Read(buffer, offset, count);
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+            => inner.ReadAsync(buffer, cancellationToken);
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => inner.Write(buffer, offset, count);
+
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+            => inner.WriteAsync(buffer, cancellationToken);
+
+        protected override void Dispose(bool disposing)
+        {
+            Disposed = true;
+            inner.Dispose();
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Protocol/TlsParametersTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Protocol/TlsParametersTests.cs
@@ -263,6 +263,52 @@ public class TlsParametersTests
     }
 
     [Test]
+    public void WrapAsync_AfterDispose_RefusesInsteadOfFallingBackToTheHostTrustStore()
+    {
+        // The pinned-roots branch tests for a non-empty collection, so roots that were disposed and emptied would
+        // skip it and leave the handshake validating against the host trust store instead. This certificate is
+        // from a private authority, so that fall-through happens to fail here too — but against a publicly
+        // trusted certificate, which is exactly what pinning a private authority is meant to exclude, it would
+        // succeed. Hence a refusal rather than a fall-through.
+        using X509Certificate2 authority = TestCertificates.CreateAuthority();
+        using X509Certificate2 server = TestCertificates.IssueServerCertificate(authority, ServerName);
+
+        var tls = new TlsParameters
+        {
+            TargetHost = ServerName,
+            CaCertificates = TlsParameters.LoadCaCertificates(TestCertificates.WritePemFile(authority)),
+        };
+
+        tls.Dispose();
+
+        Assert.ThrowsAsync<ObjectDisposedException>(async () => await RoundTripThroughTlsAsync(server, tls));
+    }
+
+    [Test]
+    public void Dispose_CalledTwice_IsANoOp()
+    {
+        using X509Certificate2 authority = TestCertificates.CreateAuthority();
+        var tls = new TlsParameters
+        {
+            TargetHost = ServerName,
+            CaCertificates = TlsParameters.LoadCaCertificates(TestCertificates.WritePemFile(authority)),
+        };
+
+        tls.Dispose();
+
+        // Disposing an X509Certificate2 twice is harmless, but the second pass must not depend on that.
+        Assert.DoesNotThrow(tls.Dispose);
+    }
+
+    [Test]
+    public void Dispose_PlaintextParametersWithNoAuthorities_IsANoOp()
+    {
+        var tls = new TlsParameters { TargetHost = ServerName, AllowInvalidCertificates = true };
+
+        Assert.DoesNotThrow(tls.Dispose);
+    }
+
+    [Test]
     public void LoadCaCertificates_FileHoldingNoCertificate_ThrowsArgumentException()
     {
         string path = Path.Combine(Path.GetTempPath(), $"tcp-tls-empty-{Guid.NewGuid():N}.pem");

--- a/ClickHouse.Driver.Tcp.Tests/Protocol/TlsParametersTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Protocol/TlsParametersTests.cs
@@ -144,6 +144,33 @@ public class TlsParametersTests
     }
 
     [Test]
+    public async Task WrapAsync_RootAndIntermediateInBundleWithServerSendingOnlyLeaf_CompletesHandshake()
+    {
+        // Self-issued certificates in the configured bundle are trust anchors. The intermediate belongs in
+        // ExtraStore, where it can complete a chain even when the server sends only its leaf certificate.
+        using X509Certificate2 root = TestCertificates.CreateAuthority();
+        using X509Certificate2 intermediate = TestCertificates.CreateIntermediate(root);
+        using X509Certificate2 server = TestCertificates.IssueServerCertificate(intermediate, ServerName);
+        X509ChainPolicy observed = null;
+
+        var tls = new TlsParameters
+        {
+            TargetHost = ServerName,
+            CaCertificates = TlsParameters.LoadCaCertificates(TestCertificates.WritePemFile(root, intermediate)),
+            Configure = options => observed = options.CertificateChainPolicy,
+        };
+
+        byte[] echoed = await RoundTripThroughTlsAsync(server, tls);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(echoed, Is.EqualTo(Payload));
+            Assert.That(observed?.CustomTrustStore, Has.Count.EqualTo(1));
+            Assert.That(observed?.ExtraStore, Has.Count.EqualTo(1));
+        });
+    }
+
+    [Test]
     public void WrapAsync_ConfigureHookRejects_OverridesTheDeclarativeSettings()
     {
         // The hook is documented as applied last, so it must be able to override even AllowInvalidCertificates.
@@ -208,12 +235,10 @@ public class TlsParametersTests
     }
 
     [Test]
-    public void WrapAsync_ConfigureHookSetsTheTopLevelRevocationMode_TheHandshakeStillHonoursIt()
+    public async Task WrapAsync_PinnedPolicyAndHookSetsOnlyTopLevelRevocationMode_ThePolicyRemainsAuthoritative()
     {
-        // The trap this covers: the platform reads CertificateRevocationCheckMode only when it builds the chain
-        // policy itself. Pinning supplies one, so setting the obvious top-level property was silently ignored and
-        // a revoked certificate would have been accepted. Neither test certificate names a revocation list, so a
-        // handshake that honours the request cannot establish revocation status and refuses.
+        // A supplied CertificateChainPolicy supersedes CertificateRevocationCheckMode in .NET. The hook is applied
+        // last, so the driver must not translate the top-level value into the policy after the hook returns.
         using X509Certificate2 authority = TestCertificates.CreateAuthority();
         using X509Certificate2 server = TestCertificates.IssueServerCertificate(authority, ServerName);
 
@@ -224,13 +249,38 @@ public class TlsParametersTests
             Configure = options => options.CertificateRevocationCheckMode = X509RevocationMode.Online,
         };
 
-        Assert.ThrowsAsync<AuthenticationException>(async () => await RoundTripThroughTlsAsync(server, tls));
+        Assert.That(await RoundTripThroughTlsAsync(server, tls), Is.EqualTo(Payload));
     }
 
-    // Both revocation modes reject a certificate that names no revocation list, so the handshake outcome cannot say
-    // which value was applied. The policy object can: the hook captures the instance, and normalization mutates that
-    // same instance, so reading it afterwards shows the value the handshake was given.
-    [TestCase(X509RevocationMode.NoCheck, X509RevocationMode.Online, TestName = "{m}(nested left default, top-level carried in)")]
+    [Test]
+    public async Task WrapAsync_NoSuppliedPolicyAndHookSetsTopLevelRevocationMode_TheGeneratedPolicyUsesIt()
+    {
+        // Without a supplied CertificateChainPolicy, .NET carries CertificateRevocationCheckMode into the policy
+        // it builds. The callback accepts the private certificate but observes that generated policy directly.
+        using X509Certificate2 server = TestCertificates.CreateSelfSignedServerCertificate(ServerName);
+        X509RevocationMode? observed = null;
+
+        var tls = new TlsParameters
+        {
+            TargetHost = ServerName,
+            Configure = options =>
+            {
+                options.CertificateRevocationCheckMode = X509RevocationMode.Online;
+                options.RemoteCertificateValidationCallback = (_, _, chain, _) =>
+                {
+                    observed = chain?.ChainPolicy.RevocationMode;
+                    return true;
+                };
+            },
+        };
+
+        Assert.That(await RoundTripThroughTlsAsync(server, tls), Is.EqualTo(Payload));
+        Assert.That(observed, Is.EqualTo(X509RevocationMode.Online));
+    }
+
+    // The policy object records the authoritative value even when the handshake fails because the test certificates
+    // carry no revocation information.
+    [TestCase(X509RevocationMode.NoCheck, X509RevocationMode.NoCheck, TestName = "{m}(nested NoCheck remains authoritative)")]
     [TestCase(X509RevocationMode.Offline, X509RevocationMode.Offline, TestName = "{m}(nested set explicitly, nested kept)")]
     public async Task WrapAsync_HookSetsRevocationOnBothForms_ThePolicyEndsUpWithTheRightValue(
         X509RevocationMode nested,
@@ -258,7 +308,7 @@ public class TlsParametersTests
         }
         catch (AuthenticationException)
         {
-            // Expected either way: neither certificate names a revocation list. The value is the subject here.
+            // Offline cannot establish revocation status for these certificates. The policy value is the subject.
         }
 
         Assert.That(captured?.RevocationMode, Is.EqualTo(expected));
@@ -322,11 +372,8 @@ public class TlsParametersTests
     [Test]
     public void WrapAsync_AfterDispose_RefusesInsteadOfFallingBackToTheHostTrustStore()
     {
-        // The pinned-roots branch tests for a non-empty collection, so roots that were disposed and emptied would
-        // skip it and leave the handshake validating against the host trust store instead. This certificate is
-        // from a private authority, so that fall-through happens to fail here too — but against a publicly
-        // trusted certificate, which is exactly what pinning a private authority is meant to exclude, it would
-        // succeed. Hence a refusal rather than a fall-through.
+        // Disposing releases the configured authorities' native handles. A later handshake must be refused before
+        // it can try to build a policy from those disposed certificates.
         using X509Certificate2 authority = TestCertificates.CreateAuthority();
         using X509Certificate2 server = TestCertificates.IssueServerCertificate(authority, ServerName);
 
@@ -382,6 +429,18 @@ public class TlsParametersTests
         string path = Path.Combine(Path.GetTempPath(), $"tcp-tls-absent-{Guid.NewGuid():N}.pem");
 
         Assert.Throws<FileNotFoundException>(() => TlsParameters.LoadCaCertificates(path));
+    }
+
+    [Test]
+    public void LoadCaCertificates_PemFileHoldingOnlyAnIntermediate_ThrowsArgumentException()
+    {
+        using X509Certificate2 root = TestCertificates.CreateAuthority();
+        using X509Certificate2 intermediate = TestCertificates.CreateIntermediate(root);
+        string path = TestCertificates.WritePemFile(intermediate);
+
+        var thrown = Assert.Throws<ArgumentException>(() => TlsParameters.LoadCaCertificates(path));
+
+        Assert.That(thrown.Message, Does.Contain("root certificate"));
     }
 
     [Test]

--- a/ClickHouse.Driver.Tcp.Tests/Protocol/TlsParametersTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Protocol/TlsParametersTests.cs
@@ -208,6 +208,63 @@ public class TlsParametersTests
     }
 
     [Test]
+    public void WrapAsync_ConfigureHookSetsTheTopLevelRevocationMode_TheHandshakeStillHonoursIt()
+    {
+        // The trap this covers: the platform reads CertificateRevocationCheckMode only when it builds the chain
+        // policy itself. Pinning supplies one, so setting the obvious top-level property was silently ignored and
+        // a revoked certificate would have been accepted. Neither test certificate names a revocation list, so a
+        // handshake that honours the request cannot establish revocation status and refuses.
+        using X509Certificate2 authority = TestCertificates.CreateAuthority();
+        using X509Certificate2 server = TestCertificates.IssueServerCertificate(authority, ServerName);
+
+        var tls = new TlsParameters
+        {
+            TargetHost = ServerName,
+            CaCertificates = TlsParameters.LoadCaCertificates(TestCertificates.WritePemFile(authority)),
+            Configure = options => options.CertificateRevocationCheckMode = X509RevocationMode.Online,
+        };
+
+        Assert.ThrowsAsync<AuthenticationException>(async () => await RoundTripThroughTlsAsync(server, tls));
+    }
+
+    // Both revocation modes reject a certificate that names no revocation list, so the handshake outcome cannot say
+    // which value was applied. The policy object can: the hook captures the instance, and normalization mutates that
+    // same instance, so reading it afterwards shows the value the handshake was given.
+    [TestCase(X509RevocationMode.NoCheck, X509RevocationMode.Online, TestName = "{m}(nested left default, top-level carried in)")]
+    [TestCase(X509RevocationMode.Offline, X509RevocationMode.Offline, TestName = "{m}(nested set explicitly, nested kept)")]
+    public async Task WrapAsync_HookSetsRevocationOnBothForms_ThePolicyEndsUpWithTheRightValue(
+        X509RevocationMode nested,
+        X509RevocationMode expected)
+    {
+        using X509Certificate2 authority = TestCertificates.CreateAuthority();
+        using X509Certificate2 server = TestCertificates.IssueServerCertificate(authority, ServerName);
+        X509ChainPolicy captured = null;
+
+        var tls = new TlsParameters
+        {
+            TargetHost = ServerName,
+            CaCertificates = TlsParameters.LoadCaCertificates(TestCertificates.WritePemFile(authority)),
+            Configure = options =>
+            {
+                captured = options.CertificateChainPolicy;
+                options.CertificateRevocationCheckMode = X509RevocationMode.Online;
+                options.CertificateChainPolicy.RevocationMode = nested;
+            },
+        };
+
+        try
+        {
+            await RoundTripThroughTlsAsync(server, tls);
+        }
+        catch (AuthenticationException)
+        {
+            // Expected either way: neither certificate names a revocation list. The value is the subject here.
+        }
+
+        Assert.That(captured?.RevocationMode, Is.EqualTo(expected));
+    }
+
+    [Test]
     public void WrapAsync_PinnedAuthority_ExposesThePolicyToTheHookRatherThanHidingItInACallback()
     {
         // What the hook is handed has to be the policy the handshake will use, or an edit to it is silently lost.

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/PoolTestDoubles.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/PoolTestDoubles.cs
@@ -71,6 +71,7 @@ internal sealed class FakeConnectionFactory : IConnectionFactory
 {
     private readonly List<ClickHouseTcpConnection> created = [];
     private readonly object gate = new();
+    private int disposeCount;
 
     /// <summary>Set to make the next create fail with this exception instead of returning a connection.</summary>
     public Exception FailNextWith { get; set; }
@@ -101,11 +102,21 @@ internal sealed class FakeConnectionFactory : IConnectionFactory
     /// </summary>
     public bool IgnoresCancellation { get; set; }
 
+    /// <summary>Runs when the pool disposes the factory. Null for none.</summary>
+    public Action OnDispose { get; set; }
+
     /// <summary>Whether the pool disposed this factory during its teardown.</summary>
-    public bool Disposed { get; private set; }
+    public bool Disposed => DisposeCount != 0;
+
+    /// <summary>How many times the pool disposed this factory.</summary>
+    public int DisposeCount => Volatile.Read(ref disposeCount);
 
     /// <summary>Records the call. This double holds nothing to release; the real factory holds TLS certificates.</summary>
-    public void Dispose() => Disposed = true;
+    public void Dispose()
+    {
+        Interlocked.Increment(ref disposeCount);
+        OnDispose?.Invoke();
+    }
 
     /// <summary>How many connections have been opened.</summary>
     public int CreateCount

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/PoolTestDoubles.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/PoolTestDoubles.cs
@@ -101,6 +101,12 @@ internal sealed class FakeConnectionFactory : IConnectionFactory
     /// </summary>
     public bool IgnoresCancellation { get; set; }
 
+    /// <summary>Whether the pool disposed this factory during its teardown.</summary>
+    public bool Disposed { get; private set; }
+
+    /// <summary>Records the call. This double holds nothing to release; the real factory holds TLS certificates.</summary>
+    public void Dispose() => Disposed = true;
+
     /// <summary>How many connections have been opened.</summary>
     public int CreateCount
     {

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/TestCertificates.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/TestCertificates.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+
+namespace ClickHouse.Driver.Tcp.Tests.Utilities;
+
+/// <summary>
+/// Builds throwaway certificate chains for the TLS tests: a private authority, optional intermediates, and server
+/// certificates issued under them. Shared so a test of the transport and a test of the client wiring present the
+/// same certificates to the same validation code.
+/// </summary>
+/// <remarks>
+/// One clock reading for the whole process, and an authority whose validity window strictly contains the leaf's.
+/// Reading the clock per certificate lets a leaf issued a second later ask for a <c>notAfter</c> past its issuer's,
+/// which <see cref="CertificateRequest.Create(X509Certificate2, DateTimeOffset, DateTimeOffset, byte[])"/> rejects.
+/// </remarks>
+internal static class TestCertificates
+{
+    // id-kp-serverAuth and id-kp-clientAuth.
+    private const string ServerAuthenticationOid = "1.3.6.1.5.5.7.3.1";
+    private const string ClientAuthenticationOid = "1.3.6.1.5.5.7.3.2";
+
+    private static readonly DateTimeOffset Now = DateTimeOffset.UtcNow;
+    private static readonly DateTimeOffset AuthorityNotBefore = Now.AddDays(-3);
+    private static readonly DateTimeOffset AuthorityNotAfter = Now.AddDays(3);
+    private static readonly DateTimeOffset LeafNotBefore = Now.AddDays(-1);
+    private static readonly DateTimeOffset LeafNotAfter = Now.AddDays(1);
+
+    private static readonly ConcurrentBag<string> WrittenFiles = [];
+
+    /// <summary>A self-signed certificate authority, able to sign both certificates and other authorities.</summary>
+    /// <returns>The authority, with its private key.</returns>
+    internal static X509Certificate2 CreateAuthority()
+    {
+        using RSA key = RSA.Create(2048);
+        var request = new CertificateRequest($"CN=ClickHouse TCP test CA {Guid.NewGuid():N}", key, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        request.CertificateExtensions.Add(new X509BasicConstraintsExtension(certificateAuthority: true, hasPathLengthConstraint: false, pathLengthConstraint: 0, critical: true));
+        request.CertificateExtensions.Add(new X509KeyUsageExtension(X509KeyUsageFlags.KeyCertSign | X509KeyUsageFlags.DigitalSignature, critical: true));
+        return request.CreateSelfSigned(AuthorityNotBefore, AuthorityNotAfter);
+    }
+
+    /// <summary>An intermediate authority signed by <paramref name="root"/>, for testing chains longer than one hop.</summary>
+    /// <param name="root">The authority that signs it.</param>
+    /// <returns>The intermediate, with its private key.</returns>
+    internal static X509Certificate2 CreateIntermediate(X509Certificate2 root)
+    {
+        using RSA key = RSA.Create(2048);
+        var request = new CertificateRequest($"CN=ClickHouse TCP test intermediate {Guid.NewGuid():N}", key, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        request.CertificateExtensions.Add(new X509BasicConstraintsExtension(certificateAuthority: true, hasPathLengthConstraint: false, pathLengthConstraint: 0, critical: true));
+        request.CertificateExtensions.Add(new X509KeyUsageExtension(X509KeyUsageFlags.KeyCertSign | X509KeyUsageFlags.DigitalSignature, critical: true));
+
+        // Between the root's window and the leaf's, so both containments hold.
+        using X509Certificate2 issued = request.Create(root, AuthorityNotBefore.AddDays(1), AuthorityNotAfter.AddDays(-1), Guid.NewGuid().ToByteArray());
+        return issued.CopyWithPrivateKey(key);
+    }
+
+    /// <summary>A server certificate issued by <paramref name="issuer"/> and usable by an <c>SslStream</c> server.</summary>
+    /// <param name="issuer">The authority that signs it.</param>
+    /// <param name="dnsName">The name to put in the subject alternative name.</param>
+    /// <param name="purpose">Which extended key usage to declare.</param>
+    /// <returns>The certificate, with a private key every platform accepts.</returns>
+    internal static X509Certificate2 IssueServerCertificate(X509Certificate2 issuer, string dnsName, CertificatePurpose purpose = CertificatePurpose.ServerAuthentication)
+    {
+        using RSA key = RSA.Create(2048);
+        CertificateRequest request = ServerCertificateRequest(key, dnsName, purpose);
+        using X509Certificate2 issued = request.Create(issuer, LeafNotBefore, LeafNotAfter, Guid.NewGuid().ToByteArray());
+        using X509Certificate2 withKey = issued.CopyWithPrivateKey(key);
+        return MakeUsableAsServerCertificate(withKey);
+    }
+
+    /// <summary>A self-signed server certificate, which no authority vouches for.</summary>
+    /// <param name="dnsName">The name to put in the subject alternative name.</param>
+    /// <returns>The certificate, with a private key every platform accepts.</returns>
+    internal static X509Certificate2 CreateSelfSignedServerCertificate(string dnsName)
+    {
+        using RSA key = RSA.Create(2048);
+        using X509Certificate2 created = ServerCertificateRequest(key, dnsName, CertificatePurpose.ServerAuthentication)
+            .CreateSelfSigned(LeafNotBefore, LeafNotAfter);
+        return MakeUsableAsServerCertificate(created);
+    }
+
+    /// <summary>Writes certificates to a temporary PEM file, as a certificate-authority option expects one.</summary>
+    /// <param name="certificates">The certificates to write, in order.</param>
+    /// <returns>The path written.</returns>
+    internal static string WritePemFile(params X509Certificate2[] certificates)
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"tcp-tls-ca-{Guid.NewGuid():N}.pem");
+        var pem = new StringBuilder();
+        foreach (X509Certificate2 certificate in certificates)
+        {
+            pem.AppendLine(certificate.ExportCertificatePem());
+        }
+
+        File.WriteAllText(path, pem.ToString());
+        WrittenFiles.Add(path);
+        return path;
+    }
+
+    /// <summary>Records a path this class did not write, so a fixture's teardown removes it too.</summary>
+    /// <param name="path">The file to delete on cleanup.</param>
+    internal static void TrackForCleanUp(string path) => WrittenFiles.Add(path);
+
+    /// <summary>Deletes every temporary file written so far. Call from a fixture's one-time teardown.</summary>
+    internal static void DeleteTemporaryFiles()
+    {
+        while (WrittenFiles.TryTake(out string path))
+        {
+            try
+            {
+                File.Delete(path);
+            }
+            catch (IOException)
+            {
+                // A leftover temp file is not worth failing a run over.
+            }
+        }
+    }
+
+    private static CertificateRequest ServerCertificateRequest(RSA key, string dnsName, CertificatePurpose purpose)
+    {
+        var request = new CertificateRequest($"CN={dnsName}", key, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        request.CertificateExtensions.Add(new X509BasicConstraintsExtension(certificateAuthority: false, hasPathLengthConstraint: false, pathLengthConstraint: 0, critical: true));
+
+        string oid = purpose == CertificatePurpose.ServerAuthentication ? ServerAuthenticationOid : ClientAuthenticationOid;
+        request.CertificateExtensions.Add(new X509EnhancedKeyUsageExtension([new Oid(oid)], critical: false));
+
+        // Modern TLS stacks match the name against the SAN, never the subject alone.
+        var alternativeNames = new SubjectAlternativeNameBuilder();
+        alternativeNames.AddDnsName(dnsName);
+        request.CertificateExtensions.Add(alternativeNames.Build());
+        return request;
+    }
+
+    // A certificate built in memory carries an ephemeral key, which SslStream refuses to serve with on Windows.
+    // Round-tripping through PKCS#12 gives it a key handle every platform accepts.
+    private static X509Certificate2 MakeUsableAsServerCertificate(X509Certificate2 certificate)
+    {
+        byte[] exported = certificate.Export(X509ContentType.Pfx);
+#if NET9_0_OR_GREATER
+        return X509CertificateLoader.LoadPkcs12(exported, password: null);
+#else
+        return new X509Certificate2(exported);
+#endif
+    }
+}
+
+/// <summary>Which extended key usage a test certificate declares.</summary>
+internal enum CertificatePurpose
+{
+    /// <summary>Valid for authenticating a server, which is what a TLS client requires.</summary>
+    ServerAuthentication,
+
+    /// <summary>Valid for authenticating a client only, so a TLS client must refuse it.</summary>
+    ClientAuthentication,
+}

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClientOptions.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClientOptions.cs
@@ -119,6 +119,13 @@ public sealed record ClickHouseTcpClientOptions
     /// <c>RemoteCertificateValidationCallback</c> drops the check configured above, and clearing
     /// <c>TargetHost</c> stops the server name being matched at all while chain validation still appears to run.
     /// </para>
+    /// <para>
+    /// With <see cref="TlsCaCertificatePath"/> set, a <c>CertificateChainPolicy</c> is already in place, and the
+    /// hook receives it and may edit it. Revocation checking can be asked for either way — on
+    /// <c>CertificateRevocationCheckMode</c> or on the policy's own <c>RevocationMode</c> — because a value set on
+    /// the former is carried into the latter, which is the only one the handshake reads once a policy exists. A
+    /// value set directly on the policy takes precedence.
+    /// </para>
     /// </remarks>
     public Action<SslClientAuthenticationOptions> ConfigureTls { get; init; }
 

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClientOptions.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClientOptions.cs
@@ -89,8 +89,9 @@ public sealed record ClickHouseTcpClientOptions
 
     /// <summary>
     /// Path to a PEM file of certificate authorities to validate the server against, instead of the host's trust
-    /// store. Null, the default, uses the host's trust store. The file may hold several certificates; the host
-    /// name is still matched either way.
+    /// store. Null, the default, uses the host's trust store. The file must contain at least one self-issued root;
+    /// it may also contain intermediate certificates needed to build the server's chain. The host name is still
+    /// matched either way.
     /// </summary>
     /// <remarks>
     /// <para>
@@ -100,7 +101,9 @@ public sealed record ClickHouseTcpClientOptions
     /// </para>
     /// <para>
     /// The file is read once, when the client is constructed, so a missing or malformed file fails there rather
-    /// than on the first connection. Cannot be combined with <see cref="TlsAllowInvalidCertificates"/>.
+    /// than on the first connection. Self-issued certificates are the trust anchors; other certificates in the
+    /// file are available only to build a chain to one of those anchors. Cannot be combined with
+    /// <see cref="TlsAllowInvalidCertificates"/>.
     /// </para>
     /// </remarks>
     public string TlsCaCertificatePath { get; init; }
@@ -121,10 +124,8 @@ public sealed record ClickHouseTcpClientOptions
     /// </para>
     /// <para>
     /// With <see cref="TlsCaCertificatePath"/> set, a <c>CertificateChainPolicy</c> is already in place, and the
-    /// hook receives it and may edit it. Revocation checking can be asked for either way — on
-    /// <c>CertificateRevocationCheckMode</c> or on the policy's own <c>RevocationMode</c> — because a value set on
-    /// the former is carried into the latter, which is the only one the handshake reads once a policy exists. A
-    /// value set directly on the policy takes precedence.
+    /// hook receives it and may edit it. In that case .NET ignores <c>CertificateRevocationCheckMode</c>; configure
+    /// revocation through the policy's own <c>RevocationMode</c> property instead.
     /// </para>
     /// </remarks>
     public Action<SslClientAuthenticationOptions> ConfigureTls { get; init; }
@@ -311,16 +312,21 @@ public sealed record ClickHouseTcpClientOptions
             throw new ArgumentOutOfRangeException(nameof(Port), port, "Port must be between 1 and 65535.");
         }
 
-        // The emptiness tests match what the connection factory treats as set, so a value it would ignore is not
-        // rejected here (and one it would honour is never let through).
+        if (TlsCaCertificatePath is not null && string.IsNullOrWhiteSpace(TlsCaCertificatePath))
+        {
+            throw new ArgumentException(
+                $"{nameof(TlsCaCertificatePath)} must be null or a non-empty path.",
+                nameof(TlsCaCertificatePath));
+        }
+
         RequireTlsFor(!string.IsNullOrEmpty(TlsServerName), nameof(TlsServerName));
         RequireTlsFor(TlsAllowInvalidCertificates, nameof(TlsAllowInvalidCertificates));
-        RequireTlsFor(!string.IsNullOrEmpty(TlsCaCertificatePath), nameof(TlsCaCertificatePath));
+        RequireTlsFor(TlsCaCertificatePath is not null, nameof(TlsCaCertificatePath));
         RequireTlsFor(ConfigureTls is not null, nameof(ConfigureTls));
 
         // Contradictory: with validation off no certificate is checked against anything, so the authority would
         // be read from disk and never consulted. Refusing beats a precedence rule nobody reads.
-        if (TlsAllowInvalidCertificates && !string.IsNullOrEmpty(TlsCaCertificatePath))
+        if (TlsAllowInvalidCertificates && TlsCaCertificatePath is not null)
         {
             throw new ArgumentException(
                 $"{nameof(TlsAllowInvalidCertificates)} and {nameof(TlsCaCertificatePath)} cannot both be set: with certificate validation off the authority is never consulted.",

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClientOptions.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClientOptions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Net.Security;
 using ClickHouse.Driver.Tcp.Protocol;
 
 namespace ClickHouse.Driver.Tcp;
@@ -10,15 +11,17 @@ namespace ClickHouse.Driver.Tcp;
 /// <see cref="FromConnectionString"/>, or derive a variant of an existing instance with a <c>with</c> expression.
 /// </summary>
 /// <remarks>
-/// Being a record, two instances compare equal when every property does. <see cref="CustomSettings"/> is compared
-/// by reference, not by content, because the declared type is an interface with no value-equality contract: two
-/// options that hold equal-but-distinct dictionaries are <b>not</b> equal. Do not use these options as a cache or
-/// pool key; use a purpose-built key type.
+/// Being a record, two instances compare equal when every property does. <see cref="CustomSettings"/> and
+/// <see cref="ConfigureTls"/> are compared by reference, not by content: the first is an interface with no
+/// value-equality contract, the second a delegate. Two options that hold equal-but-distinct dictionaries, or
+/// equivalent-but-distinct lambdas, are <b>not</b> equal. Do not use these options as a cache or pool key; use a
+/// purpose-built key type.
 /// </remarks>
 public sealed record ClickHouseTcpClientOptions
 {
     internal const string DefaultHost = "localhost";
     internal const int DefaultPort = 9000;
+    internal const int DefaultTlsPort = 9440;
     internal const string DefaultUsername = "default";
     internal const string DefaultDatabase = "default";
     internal const int DefaultMaxSendBufferBytes = Format.BlockWriter.DefaultFlushThresholdBytes;
@@ -34,18 +37,90 @@ public sealed record ClickHouseTcpClientOptions
     /// <summary>The server host name or address. Defaults to <c>localhost</c>.</summary>
     public string Host { get; init; } = DefaultHost;
 
-    /// <summary>The server's native-protocol port. Defaults to <c>9000</c>.</summary>
-    public int Port { get; init; } = DefaultPort;
+    /// <summary>
+    /// The server's native-protocol port. Null, the default, derives the port from <see cref="UseTls"/>:
+    /// <c>9440</c> for the secure native port, <c>9000</c> for the plaintext one. An explicit value is always
+    /// used as given, so a server on a non-standard port needs no other change.
+    /// </summary>
+    public int? Port { get; init; }
+
+    /// <summary>The port a connection actually dials: <see cref="Port"/> when set, otherwise derived from <see cref="UseTls"/>.</summary>
+    internal int ResolvedPort => Port ?? (UseTls ? DefaultTlsPort : DefaultPort);
 
     /// <summary>The user to authenticate as. Defaults to <c>default</c>.</summary>
     public string Username { get; init; } = DefaultUsername;
 
     /// <summary>
-    /// The password, sent to the server in plaintext during the handshake. This client's native-protocol
-    /// transport is not encrypted, so the password (and all data) travels in the clear — use it only over a
-    /// trusted network. Defaults to empty.
+    /// The password, sent to the server in plaintext during the handshake. Without <see cref="UseTls"/> the
+    /// native-protocol transport is not encrypted, so the password (and all data) travels in the clear — over an
+    /// untrusted network, enable TLS. Defaults to empty.
     /// </summary>
     public string Password { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Whether to encrypt the transport with TLS, negotiated before the handshake. Defaults to false. The
+    /// protocol bytes are identical either way, so this changes nothing above the transport — but the handshake
+    /// carries <see cref="Password"/> in plaintext, so TLS is the only thing protecting credentials in transit.
+    /// </summary>
+    /// <remarks>
+    /// The server must be listening for secure native connections (<c>tcp_port_secure</c>, conventionally 9440);
+    /// TLS is not negotiated in-band, so pointing a TLS client at a plaintext port fails the TLS handshake rather
+    /// than falling back. With <see cref="Port"/> left null the correct port is chosen for you.
+    /// </remarks>
+    public bool UseTls { get; init; }
+
+    /// <summary>
+    /// The host name to present as SNI and to match the server certificate against. Null, the default, uses
+    /// <see cref="Host"/>. Set it when <see cref="Host"/> is an address or an internal alias that the certificate
+    /// does not name.
+    /// </summary>
+    public string TlsServerName { get; init; }
+
+    /// <summary>
+    /// Whether to accept a server certificate that fails validation — an expired or self-signed certificate, or
+    /// one naming another host. Defaults to false, and should stay false outside development.
+    /// </summary>
+    /// <remarks>
+    /// This stops the client from making sure the peer is the server it asked for. An attacker who can intercept
+    /// the connection can then present any certificate and read the handshake password. To trust a private
+    /// certificate authority and keep that check, use <see cref="TlsCaCertificatePath"/>.
+    /// </remarks>
+    public bool TlsAllowInvalidCertificates { get; init; }
+
+    /// <summary>
+    /// Path to a PEM file of certificate authorities to validate the server against, instead of the host's trust
+    /// store. Null, the default, uses the host's trust store. The file may hold several certificates; the host
+    /// name is still matched either way.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Instead of, not as well as: the server must chain to one of these authorities, and a certificate the
+    /// host's trust store would accept on its own is refused. That is the point of naming an authority — an
+    /// additive check would still take a certificate mis-issued by any public authority.
+    /// </para>
+    /// <para>
+    /// The file is read once, when the client is constructed, so a missing or malformed file fails there rather
+    /// than on the first connection. Cannot be combined with <see cref="TlsAllowInvalidCertificates"/>.
+    /// </para>
+    /// </remarks>
+    public string TlsCaCertificatePath { get; init; }
+
+    /// <summary>
+    /// A hook to adjust the TLS client options before the handshake, applied last and so able to override
+    /// everything the properties above set. Null, the default, leaves them as configured.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the escape hatch for anything the declarative properties do not cover — client certificates, a
+    /// protocol-version floor, cipher suites, a bespoke validation callback. It runs once per connection.
+    /// </para>
+    /// <para>
+    /// Because it runs last it can also weaken the transport, and in two ways that are easy to miss: replacing
+    /// <c>RemoteCertificateValidationCallback</c> drops the check configured above, and clearing
+    /// <c>TargetHost</c> stops the server name being matched at all while chain validation still appears to run.
+    /// </para>
+    /// </remarks>
+    public Action<SslClientAuthenticationOptions> ConfigureTls { get; init; }
 
     /// <summary>The default database for queries. Defaults to <c>default</c>.</summary>
     public string Database { get; init; } = DefaultDatabase;
@@ -223,9 +298,26 @@ public sealed record ClickHouseTcpClientOptions
             throw new ArgumentException("Database must not be null or empty.", nameof(Database));
         }
 
-        if (Port is < 1 or > 65535)
+        // Only when set. Null is not a value here but a request to derive the port, which cannot be out of range.
+        if (Port is { } port && port is < 1 or > 65535)
         {
-            throw new ArgumentOutOfRangeException(nameof(Port), Port, "Port must be between 1 and 65535.");
+            throw new ArgumentOutOfRangeException(nameof(Port), port, "Port must be between 1 and 65535.");
+        }
+
+        // The emptiness tests match what the connection factory treats as set, so a value it would ignore is not
+        // rejected here (and one it would honour is never let through).
+        RequireTlsFor(!string.IsNullOrEmpty(TlsServerName), nameof(TlsServerName));
+        RequireTlsFor(TlsAllowInvalidCertificates, nameof(TlsAllowInvalidCertificates));
+        RequireTlsFor(!string.IsNullOrEmpty(TlsCaCertificatePath), nameof(TlsCaCertificatePath));
+        RequireTlsFor(ConfigureTls is not null, nameof(ConfigureTls));
+
+        // Contradictory: with validation off no certificate is checked against anything, so the authority would
+        // be read from disk and never consulted. Refusing beats a precedence rule nobody reads.
+        if (TlsAllowInvalidCertificates && !string.IsNullOrEmpty(TlsCaCertificatePath))
+        {
+            throw new ArgumentException(
+                $"{nameof(TlsAllowInvalidCertificates)} and {nameof(TlsCaCertificatePath)} cannot both be set: with certificate validation off the authority is never consulted.",
+                nameof(TlsCaCertificatePath));
         }
 
         RequireUsableTimeout(DialTimeout, nameof(DialTimeout));
@@ -295,6 +387,21 @@ public sealed record ClickHouseTcpClientOptions
     }
 
     /// <summary>
+    /// Rejects a TLS property configured on a client that does not use TLS. Such a property has no effect, and
+    /// silently ignoring it would let a connection meant to be encrypted run in the clear — the exact mistake a
+    /// forgotten <see cref="UseTls"/> makes, with a configured certificate authority as the evidence.
+    /// </summary>
+    /// <param name="isSet">Whether the property carries a value.</param>
+    /// <param name="name">The property's name, for the exception.</param>
+    private void RequireTlsFor(bool isSet, string name)
+    {
+        if (isSet && !UseTls)
+        {
+            throw new ArgumentException($"{name} is set but {nameof(UseTls)} is false, so the connection would not be encrypted. Set {nameof(UseTls)} to true, or remove {name}.", name);
+        }
+    }
+
+    /// <summary>
     /// Rejects a deadline that cannot be armed. The timer APIs these feed (<c>CancelAfter</c>,
     /// <c>SemaphoreSlim.WaitAsync</c>) take a millisecond count as an <see cref="int"/>, so a span beyond about
     /// 24.85 days would throw from inside every operation instead of at construction.
@@ -328,8 +435,9 @@ public sealed record ClickHouseTcpClientOptions
     /// <remarks>
     /// A record's generated <c>ToString</c> prints every property, which would put the plaintext password into any
     /// log line that formats these options. This override names the safe properties explicitly instead, so a secret
-    /// added later is left out until someone chooses to include it.
+    /// added later is left out until someone chooses to include it. The port shown is the resolved one, which is
+    /// what a connection dials.
     /// </remarks>
     public override string ToString()
-        => $"{nameof(ClickHouseTcpClientOptions)} {{ Host = {Host}, Port = {Port}, Username = {Username}, Database = {Database} }}";
+        => $"{nameof(ClickHouseTcpClientOptions)} {{ Host = {Host}, Port = {ResolvedPort}, Username = {Username}, Database = {Database}, UseTls = {UseTls} }}";
 }

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpConnectionStringBuilder.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpConnectionStringBuilder.cs
@@ -29,6 +29,37 @@ public sealed class ClickHouseTcpConnectionStringBuilder : DbConnectionStringBui
         ConnectionString = connectionString;
     }
 
+    /// <inheritdoc/>
+    public override object this[string keyword]
+    {
+        get => base[keyword];
+        set
+        {
+            if (IsRequiredSecurityValue(keyword)
+                && (value is null || (value is string text && string.IsNullOrWhiteSpace(text))))
+            {
+                throw EmptySecurityValue(keyword);
+            }
+
+            base[keyword] = value;
+        }
+    }
+
+    /// <inheritdoc/>
+    public override bool Remove(string keyword)
+    {
+        // DbConnectionStringBuilder represents an unquoted empty value by calling Remove rather than retaining
+        // the key. Intercept that virtual call so UseTls= cannot disappear and become the plaintext default, and
+        // an empty CA path cannot disappear and silently switch to the host trust store. This also reaches a
+        // ConnectionString setter invoked through a DbConnectionStringBuilder reference.
+        if (IsRequiredSecurityValue(keyword))
+        {
+            throw EmptySecurityValue(keyword);
+        }
+
+        return base.Remove(keyword);
+    }
+
     /// <summary>The server host name or address. Defaults to <c>localhost</c>.</summary>
     public string Host
     {
@@ -111,10 +142,26 @@ public sealed class ClickHouseTcpConnectionStringBuilder : DbConnectionStringBui
     }
 
     /// <summary>Path to a PEM file of certificate authorities to validate the server against. Absent uses the host's trust store.</summary>
+    /// <remarks>
+    /// At least one self-issued root is required. Other certificates in the file are used only to build a chain
+    /// to one of those roots.
+    /// </remarks>
     public string TlsCaCertificatePath
     {
         get => GetStringOrDefault("TlsCaCertificatePath", null);
-        set => this["TlsCaCertificatePath"] = value;
+        set
+        {
+            if (value is null)
+            {
+                // Null on the typed property deliberately means "use the host trust store". Call the base
+                // implementation directly so it is not confused with an empty value erased by the parser.
+                base.Remove("TlsCaCertificatePath");
+            }
+            else
+            {
+                this["TlsCaCertificatePath"] = value;
+            }
+        }
     }
 
     /// <summary>The connect-plus-handshake deadline, in seconds. Defaults to 30.</summary>
@@ -323,6 +370,19 @@ public sealed class ClickHouseTcpConnectionStringBuilder : DbConnectionStringBui
                 $"Connection-string key '{name}' has value '{value}', which is not a boolean. Use true, false, 1, or 0."),
         };
     }
+
+    private static bool IsRequiredSecurityValue(string keyword)
+        => string.Equals(keyword, "UseTls", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(keyword, "TlsCaCertificatePath", StringComparison.OrdinalIgnoreCase);
+
+    private static ArgumentException EmptySecurityValue(string keyword)
+        => string.Equals(keyword, "UseTls", StringComparison.OrdinalIgnoreCase)
+            ? new ArgumentException(
+                $"Connection-string key '{keyword}' must be true, false, 1, or 0; an empty value could silently select a plaintext connection.",
+                keyword)
+            : new ArgumentException(
+                $"Connection-string key '{keyword}' must name a PEM certificate file; omit it from the connection string to use the host trust store.",
+                keyword);
 
     // An enum value read back is normally the name a connection string carried (the typed setter stores a name
     // too); a boxed enum arrives only through the untyped indexer. Names are matched case-insensitively, as

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpConnectionStringBuilder.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpConnectionStringBuilder.cs
@@ -36,11 +36,24 @@ public sealed class ClickHouseTcpConnectionStringBuilder : DbConnectionStringBui
         set => this["Host"] = value;
     }
 
-    /// <summary>The server's native-protocol port. Defaults to <c>9000</c>.</summary>
-    public int Port
+    /// <summary>
+    /// The server's native-protocol port. Absent, the default, derives it from <see cref="UseTls"/> —
+    /// <c>9440</c> with TLS, <c>9000</c> without. Setting null removes the key.
+    /// </summary>
+    public int? Port
     {
-        get => GetIntOrDefault("Port", ClickHouseTcpClientOptions.DefaultPort);
-        set => this["Port"] = value;
+        get => GetIntOrNull("Port");
+        set
+        {
+            if (value is { } port)
+            {
+                this["Port"] = port;
+            }
+            else
+            {
+                Remove("Port");
+            }
+        }
     }
 
     /// <summary>The user to authenticate as. Defaults to <c>default</c>.</summary>
@@ -69,6 +82,39 @@ public sealed class ClickHouseTcpConnectionStringBuilder : DbConnectionStringBui
     {
         get => GetStringOrDefault("QuotaKey", string.Empty);
         set => this["QuotaKey"] = value;
+    }
+
+    /// <summary>Whether to encrypt the transport with TLS. Defaults to false.</summary>
+    /// <exception cref="ArgumentException">The stored value is not a boolean.</exception>
+    public bool UseTls
+    {
+        get => GetBoolOrDefault("UseTls", false);
+        set => this["UseTls"] = value;
+    }
+
+    /// <summary>The host name to match the server certificate against. Absent, the default, uses <see cref="Host"/>.</summary>
+    public string TlsServerName
+    {
+        get => GetStringOrDefault("TlsServerName", null);
+        set => this["TlsServerName"] = value;
+    }
+
+    /// <summary>
+    /// Whether to accept a server certificate that fails validation. Defaults to false; setting it true removes
+    /// the protection TLS provides against an intercepted connection, so keep it to development.
+    /// </summary>
+    /// <exception cref="ArgumentException">The stored value is not a boolean.</exception>
+    public bool TlsAllowInvalidCertificates
+    {
+        get => GetBoolOrDefault("TlsAllowInvalidCertificates", false);
+        set => this["TlsAllowInvalidCertificates"] = value;
+    }
+
+    /// <summary>Path to a PEM file of certificate authorities to validate the server against. Absent uses the host's trust store.</summary>
+    public string TlsCaCertificatePath
+    {
+        get => GetStringOrDefault("TlsCaCertificatePath", null);
+        set => this["TlsCaCertificatePath"] = value;
     }
 
     /// <summary>The connect-plus-handshake deadline, in seconds. Defaults to 30.</summary>
@@ -190,6 +236,10 @@ public sealed class ClickHouseTcpConnectionStringBuilder : DbConnectionStringBui
             Password = Password,
             Database = Database,
             QuotaKey = QuotaKey,
+            UseTls = UseTls,
+            TlsServerName = TlsServerName,
+            TlsAllowInvalidCertificates = TlsAllowInvalidCertificates,
+            TlsCaCertificatePath = TlsCaCertificatePath,
             DialTimeout = DialTimeout,
             ReadTimeout = ReadTimeout,
             MaxSendBufferBytes = MaxSendBufferBytes,
@@ -229,6 +279,48 @@ public sealed class ClickHouseTcpConnectionStringBuilder : DbConnectionStringBui
             int i => i,
             string s when int.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out int result) => result,
             _ => @default,
+        };
+    }
+
+    // The nullable form, for a key whose absence means "derive it" rather than "use the default".
+    private int? GetIntOrNull(string name)
+    {
+        if (!TryGetValue(name, out object value))
+        {
+            return null;
+        }
+
+        return value switch
+        {
+            int i => i,
+            string s when int.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out int result) => result,
+            _ => null,
+        };
+    }
+
+    // Unlike the numeric getters, an unreadable value throws rather than falling back. These keys decide whether
+    // the transport is encrypted and how far its certificate is checked, so 'UseTls=yes' reading as false would
+    // hand the caller a plaintext connection they believe is secure. '1' and '0' are accepted alongside the names
+    // bool.TryParse takes, matching how boolean settings are written elsewhere in ClickHouse.
+    //
+    // The base indexer converts whatever it is given to a string, so a value set programmatically arrives here as
+    // one too and the bool arm is only reached through this class's own typed setter. The final arm is therefore
+    // defensive rather than reachable; it throws because that is the safe direction for these keys.
+    private bool GetBoolOrDefault(string name, bool @default)
+    {
+        if (!TryGetValue(name, out object value))
+        {
+            return @default;
+        }
+
+        return value switch
+        {
+            bool b => b,
+            string s when bool.TryParse(s, out bool parsed) => parsed,
+            string s when s == "1" => true,
+            string s when s == "0" => false,
+            _ => throw new ArgumentException(
+                $"Connection-string key '{name}' has value '{value}', which is not a boolean. Use true, false, 1, or 0."),
         };
     }
 

--- a/ClickHouse.Driver.Tcp/Client/ConnectionPool.cs
+++ b/ClickHouse.Driver.Tcp/Client/ConnectionPool.cs
@@ -253,6 +253,7 @@ internal sealed class ConnectionPool : IConnectionSource
         // same reason a checkout is: an operation that never releases its connection, such as an `await foreach`
         // whose enumerator is never disposed, must not turn disposal into a hang.
         using var drainDeadline = new CancellationTokenSource(options.PoolTimeout);
+        bool drained = true;
         try
         {
             for (int i = 0; i < options.MaxPoolSize; i++)
@@ -262,6 +263,7 @@ internal sealed class ConnectionPool : IConnectionSource
         }
         catch (OperationCanceledException)
         {
+            drained = false;
             // The drain deadline elapsed: at least one operation did not give its connection back. Abort what is
             // still out, since nothing else can. The pool holds the only other reference to it, and the caller has
             // evidently lost theirs. Aborting closes the transport only, which frees an operation parked on a read
@@ -276,9 +278,19 @@ internal sealed class ConnectionPool : IConnectionSource
             }
         }
 
-        // Last, once every connection is closed or aborted: the factory owns what outlives a single connection,
-        // today the TLS certificate authorities, and a handshake still reading them would be using freed handles.
-        factory.Dispose();
+        // Only when the drain finished. Holding every permit is the proof that no dial is running: a checkout keeps
+        // its permit across its dial, and a new one cannot start, so nothing can still be inside the factory. The
+        // factory owns what outlives a single connection — today the TLS certificate authorities — and a handshake
+        // reading those while they are freed fails with a cryptographic error out of the depths of the platform.
+        //
+        // A dial that ignores the shutdown token for longer than PoolTimeout is the case that misses the deadline:
+        // it is not in `leased`, so the abort above does not reach it either. Its certificates are then left to the
+        // finalizer, which is where they were before this call existed. Releasing handles promptly is worth having,
+        // but not at the price of freeing them under a live handshake.
+        if (drained)
+        {
+            factory.Dispose();
+        }
 
         // Neither the semaphore nor the shutdown source is disposed, for the same reason. Neither holds an
         // unmanaged resource here: the semaphore's AvailableWaitHandle is never touched, and the source has no

--- a/ClickHouse.Driver.Tcp/Client/ConnectionPool.cs
+++ b/ClickHouse.Driver.Tcp/Client/ConnectionPool.cs
@@ -276,6 +276,10 @@ internal sealed class ConnectionPool : IConnectionSource
             }
         }
 
+        // Last, once every connection is closed or aborted: the factory owns what outlives a single connection,
+        // today the TLS certificate authorities, and a handshake still reading them would be using freed handles.
+        factory.Dispose();
+
         // Neither the semaphore nor the shutdown source is disposed, for the same reason. Neither holds an
         // unmanaged resource here: the semaphore's AvailableWaitHandle is never touched, and the source has no
         // timer, because nothing calls CancelAfter on it. Disposing either would instead fault work still winding

--- a/ClickHouse.Driver.Tcp/Client/ConnectionPool.cs
+++ b/ClickHouse.Driver.Tcp/Client/ConnectionPool.cs
@@ -84,6 +84,14 @@ internal sealed class ConnectionPool : IConnectionSource
     // MaxPoolSize while they are in the air. Guarded by `gate`.
     private int pending;
 
+    // Factory use has a lifetime of its own. A dial starts before it has a connection the pool can put in a set,
+    // so a drain that times out cannot tell it apart from an established lease by counting permits alone. The
+    // counter keeps the factory alive for those dials; once teardown requests disposal, the last one out releases
+    // it. Guarded by `gate`.
+    private int activeDials;
+    private bool factoryDisposalRequested;
+    private bool factoryDisposed;
+
     private int disposed;
 
     // 1 while a top-up is running. Only one at a time, or two sweeps race to fill the same gap.
@@ -253,7 +261,6 @@ internal sealed class ConnectionPool : IConnectionSource
         // same reason a checkout is: an operation that never releases its connection, such as an `await foreach`
         // whose enumerator is never disposed, must not turn disposal into a hang.
         using var drainDeadline = new CancellationTokenSource(options.PoolTimeout);
-        bool drained = true;
         try
         {
             for (int i = 0; i < options.MaxPoolSize; i++)
@@ -263,7 +270,6 @@ internal sealed class ConnectionPool : IConnectionSource
         }
         catch (OperationCanceledException)
         {
-            drained = false;
             // The drain deadline elapsed: at least one operation did not give its connection back. Abort what is
             // still out, since nothing else can. The pool holds the only other reference to it, and the caller has
             // evidently lost theirs. Aborting closes the transport only, which frees an operation parked on a read
@@ -278,19 +284,10 @@ internal sealed class ConnectionPool : IConnectionSource
             }
         }
 
-        // Only when the drain finished. Holding every permit is the proof that no dial is running: a checkout keeps
-        // its permit across its dial, and a new one cannot start, so nothing can still be inside the factory. The
-        // factory owns what outlives a single connection — today the TLS certificate authorities — and a handshake
-        // reading those while they are freed fails with a cryptographic error out of the depths of the platform.
-        //
-        // A dial that ignores the shutdown token for longer than PoolTimeout is the case that misses the deadline:
-        // it is not in `leased`, so the abort above does not reach it either. Its certificates are then left to the
-        // finalizer, which is where they were before this call existed. Releasing handles promptly is worth having,
-        // but not at the price of freeing them under a live handshake.
-        if (drained)
-        {
-            factory.Dispose();
-        }
+        // The factory owns what outlives a single connection — today the TLS certificate authorities. Established
+        // connections no longer read it, so a timed-out lease does not delay this release. A dial that ignored the
+        // shutdown token does: it is counted separately and the last such dial performs the release as it leaves.
+        RequestFactoryDisposal();
 
         // Neither the semaphore nor the shutdown source is disposed, for the same reason. Neither holds an
         // unmanaged resource here: the semaphore's AvailableWaitHandle is never touched, and the source has no
@@ -490,8 +487,7 @@ internal sealed class ConnectionPool : IConnectionSource
                 bool pooled = false;
                 try
                 {
-                    ClickHouseTcpConnection opened = await factory
-                        .CreateAsync(shutdown.Token).ConfigureAwait(false);
+                    ClickHouseTcpConnection opened = await CreateConnectionAsync(shutdown.Token).ConfigureAwait(false);
                     var connection = new PooledConnection(opened, time);
 
                     lock (gate)
@@ -599,11 +595,82 @@ internal sealed class ConnectionPool : IConnectionSource
         using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, shutdown.Token);
         try
         {
-            return await factory.CreateAsync(linked.Token).ConfigureAwait(false);
+            return await CreateConnectionAsync(linked.Token).ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (shutdown.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
         {
             throw new ObjectDisposedException(ClientTypeName);
+        }
+    }
+
+    /// <summary>Uses the factory for one dial, keeping it alive until that dial has left the factory.</summary>
+    private async ValueTask<ClickHouseTcpConnection> CreateConnectionAsync(CancellationToken cancellationToken)
+    {
+        lock (gate)
+        {
+            // A dial is either counted before disposal starts or refused after it. This closes the earlier window
+            // between RentAsync's last check and entering the factory.
+            ThrowIfDisposed();
+
+            activeDials++;
+        }
+
+        try
+        {
+            return await factory.CreateAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            ReleaseFactoryUse();
+        }
+    }
+
+    /// <summary>Requests one-time factory disposal, immediately unless a dial is still using it.</summary>
+    private void RequestFactoryDisposal()
+    {
+        bool disposeFactory;
+        lock (gate)
+        {
+            factoryDisposalRequested = true;
+            disposeFactory = activeDials == 0 && !factoryDisposed;
+            if (disposeFactory)
+            {
+                factoryDisposed = true;
+            }
+        }
+
+        if (disposeFactory)
+        {
+            factory.Dispose();
+        }
+    }
+
+    /// <summary>Ends one dial and performs a deferred factory disposal when this was the last one.</summary>
+    private void ReleaseFactoryUse()
+    {
+        bool disposeFactory;
+        lock (gate)
+        {
+            activeDials--;
+            disposeFactory = activeDials == 0 && factoryDisposalRequested && !factoryDisposed;
+            if (disposeFactory)
+            {
+                factoryDisposed = true;
+            }
+        }
+
+        if (!disposeFactory)
+        {
+            return;
+        }
+
+        try
+        {
+            factory.Dispose();
+        }
+        catch (Exception e) when (e is not OutOfMemoryException and not StackOverflowException)
+        {
+            // This runs in a dial's finally block. A teardown failure must not replace that dial's result.
         }
     }
 

--- a/ClickHouse.Driver.Tcp/Client/IConnectionFactory.cs
+++ b/ClickHouse.Driver.Tcp/Client/IConnectionFactory.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 using ClickHouse.Driver.Tcp.Protocol;
@@ -10,7 +11,12 @@ namespace ClickHouse.Driver.Tcp.Client;
 /// operation. A seam rather than a direct call so the pool's own behaviour — queueing, reuse, retirement — can
 /// be exercised over connections that need no server.
 /// </summary>
-internal interface IConnectionFactory
+/// <remarks>
+/// Disposable because a factory may hold resources for the client's whole life — the TLS certificate authorities
+/// are the case that exists today. The pool disposes it at the very end of its teardown, once no connection can
+/// still be handshaking against them.
+/// </remarks>
+internal interface IConnectionFactory : IDisposable
 {
     /// <summary>Opens a connection and returns it Ready. On failure nothing is left open.</summary>
     /// <param name="cancellationToken">A token to observe while connecting.</param>
@@ -59,6 +65,26 @@ internal sealed class TcpConnectionFactory : IConnectionFactory
         }
     }
 
+    /// <summary>
+    /// Releases the certificate authorities loaded for TLS, which hold native key handles. Safe to call more than
+    /// once, and a no-op for a plaintext client, which loaded none.
+    /// </summary>
+    public void Dispose()
+    {
+        if (tls?.CaCertificates is not { } certificates)
+        {
+            return;
+        }
+
+        foreach (X509Certificate2 certificate in certificates)
+        {
+            certificate.Dispose();
+        }
+
+        // Emptied so a second call finds nothing to dispose rather than disposing the same handles again.
+        certificates.Clear();
+    }
+
     /// <summary>The TLS configuration these options describe, or null when the client connects in the clear.</summary>
     /// <param name="options">The client's validated options.</param>
     /// <returns>The parameters a connect uses to wrap its socket, or null.</returns>
@@ -70,7 +96,9 @@ internal sealed class TcpConnectionFactory : IConnectionFactory
                 // names something else (an internal alias, or a Host given as an address).
                 TargetHost = string.IsNullOrEmpty(options.TlsServerName) ? options.Host : options.TlsServerName,
                 AllowInvalidCertificates = options.TlsAllowInvalidCertificates,
-                CaCertificates = options.TlsCaCertificatePath is null
+                // IsNullOrEmpty, matching Validate: an empty path is not a configured authority there, so reading
+                // it as one here would fail construction for a client that validation just accepted.
+                CaCertificates = string.IsNullOrEmpty(options.TlsCaCertificatePath)
                     ? null
                     : TlsParameters.LoadCaCertificates(options.TlsCaCertificatePath),
                 Configure = options.ConfigureTls,

--- a/ClickHouse.Driver.Tcp/Client/IConnectionFactory.cs
+++ b/ClickHouse.Driver.Tcp/Client/IConnectionFactory.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 using ClickHouse.Driver.Tcp.Protocol;
@@ -66,24 +65,10 @@ internal sealed class TcpConnectionFactory : IConnectionFactory
     }
 
     /// <summary>
-    /// Releases the certificate authorities loaded for TLS, which hold native key handles. Safe to call more than
-    /// once, and a no-op for a plaintext client, which loaded none.
+    /// Releases the TLS configuration this factory built, and with it the certificate authorities it loaded. Safe
+    /// to call more than once, and a no-op for a plaintext client, which built none.
     /// </summary>
-    public void Dispose()
-    {
-        if (tls?.CaCertificates is not { } certificates)
-        {
-            return;
-        }
-
-        foreach (X509Certificate2 certificate in certificates)
-        {
-            certificate.Dispose();
-        }
-
-        // Emptied so a second call finds nothing to dispose rather than disposing the same handles again.
-        certificates.Clear();
-    }
+    public void Dispose() => tls?.Dispose();
 
     /// <summary>The TLS configuration these options describe, or null when the client connects in the clear.</summary>
     /// <param name="options">The client's validated options.</param>

--- a/ClickHouse.Driver.Tcp/Client/IConnectionFactory.cs
+++ b/ClickHouse.Driver.Tcp/Client/IConnectionFactory.cs
@@ -25,12 +25,18 @@ internal interface IConnectionFactory
 internal sealed class TcpConnectionFactory : IConnectionFactory
 {
     private readonly ClickHouseTcpClientOptions options;
+    private readonly TlsParameters tls;
 
-    /// <summary>Initializes the factory over the client's validated options.</summary>
-    /// <param name="options">The endpoint, credentials, and dial timeout to open connections with.</param>
+    /// <summary>
+    /// Initializes the factory over the client's validated options, resolving the TLS configuration once. A
+    /// certificate authority file is read here, so a missing or malformed one fails at client construction
+    /// rather than on every connect.
+    /// </summary>
+    /// <param name="options">The endpoint, credentials, TLS configuration, and dial timeout to open connections with.</param>
     internal TcpConnectionFactory(ClickHouseTcpClientOptions options)
     {
         this.options = options;
+        tls = BuildTlsParameters(options);
     }
 
     /// <inheritdoc/>
@@ -41,14 +47,33 @@ internal sealed class TcpConnectionFactory : IConnectionFactory
         try
         {
             return await ClickHouseTcpConnection.ConnectAsync(
-                options.Host, options.Port, options.ToHandshakeParameters(), linked.Token).ConfigureAwait(false);
+                options.Host, options.ResolvedPort, options.ToHandshakeParameters(), tls, linked.Token).ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested && linked.IsCancellationRequested)
         {
             // The linked token, not the caller's, fired: the dial deadline elapsed. Surface it as a timeout so a
-            // hung connect is distinguishable from a caller cancellation.
+            // hung connect is distinguishable from a caller cancellation. The deadline covers the TLS handshake
+            // too, which is one more round trip a wedged server can stall on.
             throw new TimeoutException(
-                $"Connecting to {options.Host}:{options.Port} timed out after {options.DialTimeout.TotalSeconds:0.###}s (DialTimeout).");
+                $"Connecting to {options.Host}:{options.ResolvedPort} timed out after {options.DialTimeout.TotalSeconds:0.###}s (DialTimeout).");
         }
     }
+
+    /// <summary>The TLS configuration these options describe, or null when the client connects in the clear.</summary>
+    /// <param name="options">The client's validated options.</param>
+    /// <returns>The parameters a connect uses to wrap its socket, or null.</returns>
+    private static TlsParameters BuildTlsParameters(ClickHouseTcpClientOptions options)
+        => options.UseTls
+            ? new TlsParameters
+            {
+                // The certificate names the server, which is Host unless the caller says the certificate
+                // names something else (an internal alias, or a Host given as an address).
+                TargetHost = string.IsNullOrEmpty(options.TlsServerName) ? options.Host : options.TlsServerName,
+                AllowInvalidCertificates = options.TlsAllowInvalidCertificates,
+                CaCertificates = options.TlsCaCertificatePath is null
+                    ? null
+                    : TlsParameters.LoadCaCertificates(options.TlsCaCertificatePath),
+                Configure = options.ConfigureTls,
+            }
+            : null;
 }

--- a/ClickHouse.Driver.Tcp/Client/IConnectionFactory.cs
+++ b/ClickHouse.Driver.Tcp/Client/IConnectionFactory.cs
@@ -81,9 +81,7 @@ internal sealed class TcpConnectionFactory : IConnectionFactory
                 // names something else (an internal alias, or a Host given as an address).
                 TargetHost = string.IsNullOrEmpty(options.TlsServerName) ? options.Host : options.TlsServerName,
                 AllowInvalidCertificates = options.TlsAllowInvalidCertificates,
-                // IsNullOrEmpty, matching Validate: an empty path is not a configured authority there, so reading
-                // it as one here would fail construction for a client that validation just accepted.
-                CaCertificates = string.IsNullOrEmpty(options.TlsCaCertificatePath)
+                CaCertificates = options.TlsCaCertificatePath is null
                     ? null
                     : TlsParameters.LoadCaCertificates(options.TlsCaCertificatePath),
                 Configure = options.ConfigureTls,

--- a/ClickHouse.Driver.Tcp/Protocol/ClickHouseTcpConnection.cs
+++ b/ClickHouse.Driver.Tcp/Protocol/ClickHouseTcpConnection.cs
@@ -214,7 +214,7 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
         {
             await socket.ConnectAsync(host, port, cancellationToken).ConfigureAwait(false);
 
-            // TLS is negotiated here, before a single protocol byte is written: the ClientHello that follows
+            // TLS is negotiated here, before a single protocol byte is written: the native client Hello that follows
             // carries the password in plaintext, so it must already be inside the encrypted stream.
             transport = new NetworkStream(socket, ownsSocket: false);
             if (tls is not null)

--- a/ClickHouse.Driver.Tcp/Protocol/ClickHouseTcpConnection.cs
+++ b/ClickHouse.Driver.Tcp/Protocol/ClickHouseTcpConnection.cs
@@ -93,6 +93,14 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
     /// position no longer matches the server's.
     ///
     /// <para>
+    /// Under TLS the poll is one step further from the truth, in both directions. Decrypted bytes held inside the
+    /// <c>SslStream</c> are invisible to it, because a TLS record is read whole while a caller may ask for less;
+    /// and a record that carries no application data, such as a late session ticket, makes the socket readable and
+    /// so discards a healthy connection. Neither has been seen against ClickHouse, and both fail safe — the first
+    /// is caught by the next read being out of step, the second only costs a reconnect.
+    /// </para>
+    ///
+    /// <para>
     /// This detects only a peer that closed in an orderly way. A connection dropped without a FIN, by a partition or a
     /// machine that lost power, still looks alive here, and the operation sent over it stalls until TCP itself gives
     /// up, which on Linux takes about fifteen minutes. That is inherent to a client-side check, so the pool does not
@@ -158,9 +166,10 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
     public NegotiatedProtocol Protocol => server.Negotiated;
 
     /// <summary>
-    /// Opens a connection: dials the socket, runs the handshake, and returns a connection in the Ready state.
-    /// The socket is configured with <c>TCP_NODELAY</c> so message-boundary flushes leave promptly. On any
-    /// failure the socket is closed and the exception propagates; no half-open connection is returned.
+    /// Opens a connection: dials the socket, negotiates TLS when asked, runs the handshake, and returns a
+    /// connection in the Ready state. The socket is configured with <c>TCP_NODELAY</c> so message-boundary
+    /// flushes leave promptly. On any failure the socket is closed and the exception propagates; no half-open
+    /// connection is returned.
     ///
     /// <para>
     /// A connect <i>timeout</i> is the caller's responsibility: the OS-level TCP connect can hang far longer
@@ -169,12 +178,14 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
     /// </para>
     /// </summary>
     /// <param name="host">The server host name or address.</param>
-    /// <param name="port">The server's native-protocol port (typically 9000).</param>
+    /// <param name="port">The server's native-protocol port (typically 9000, or 9440 with TLS).</param>
     /// <param name="handshake">The client-supplied handshake values (identity and credentials).</param>
+    /// <param name="tls">How to negotiate TLS before the handshake, or null to run in the clear.</param>
     /// <param name="cancellationToken">A token to observe for cancellation (and to bound the connect).</param>
     /// <returns>A connected, handshaken connection ready to accept a request.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="host"/> or <paramref name="handshake"/> is null.</exception>
     /// <exception cref="SocketException">The socket could not connect to the server.</exception>
+    /// <exception cref="System.Security.Authentication.AuthenticationException">The TLS handshake failed (certificate rejected, or the port is not a TLS port).</exception>
     /// <exception cref="ClickHouseServerException">The server rejected the handshake (e.g. authentication failure).</exception>
     /// <exception cref="ClickHouseProtocolException">The server's handshake reply was neither Hello nor Exception.</exception>
     /// <exception cref="OperationCanceledException"><paramref name="cancellationToken"/> was cancelled.</exception>
@@ -182,6 +193,7 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
         string host,
         int port,
         ClientHandshakeParameters handshake,
+        TlsParameters tls,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(host);
@@ -197,9 +209,18 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
         }
 
         var socket = new Socket(SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };
+        Stream transport;
         try
         {
             await socket.ConnectAsync(host, port, cancellationToken).ConfigureAwait(false);
+
+            // TLS is negotiated here, before a single protocol byte is written: the ClientHello that follows
+            // carries the password in plaintext, so it must already be inside the encrypted stream.
+            transport = new NetworkStream(socket, ownsSocket: false);
+            if (tls is not null)
+            {
+                transport = await tls.WrapAsync(transport, cancellationToken).ConfigureAwait(false);
+            }
         }
         catch
         {
@@ -209,7 +230,7 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
 
         // HandshakeAsync terminates the connection (closing this socket) on any failure, so a throw here needs
         // no extra cleanup.
-        var connection = new ClickHouseTcpConnection(new NetworkStream(socket, ownsSocket: false), socket);
+        var connection = new ClickHouseTcpConnection(transport, socket);
         await connection.HandshakeAsync(handshake, cancellationToken).ConfigureAwait(false);
         return connection;
     }
@@ -967,6 +988,8 @@ internal sealed class ClickHouseTcpConnection : IDisposable, IAsyncDisposable
         try
         {
             // NetworkStream does not own the socket, so close the socket first to abort pending network I/O.
+            // Under TLS the stream is an SslStream over that NetworkStream; neither does I/O when disposed, so
+            // disposing them after the socket is closed is safe and the ordering still holds.
             socket?.Dispose();
         }
         finally

--- a/ClickHouse.Driver.Tcp/Protocol/TlsParameters.cs
+++ b/ClickHouse.Driver.Tcp/Protocol/TlsParameters.cs
@@ -47,17 +47,35 @@ internal sealed class TlsParameters : IDisposable
     /// </summary>
     /// <param name="path">Path to a PEM file holding one or more certificates.</param>
     /// <returns>The certificates in the file.</returns>
-    /// <exception cref="ArgumentException">The file holds no certificate.</exception>
+    /// <exception cref="ArgumentException">The file holds no certificate, or holds no self-issued root.</exception>
     internal static X509Certificate2Collection LoadCaCertificates(string path)
     {
         var certificates = new X509Certificate2Collection();
-        certificates.ImportFromPemFile(path);
-        if (certificates.Count == 0)
+        try
         {
-            throw new ArgumentException($"The certificate authority file '{path}' contains no PEM certificate.", nameof(path));
-        }
+            certificates.ImportFromPemFile(path);
+            if (certificates.Count == 0)
+            {
+                throw new ArgumentException($"The certificate authority file '{path}' contains no PEM certificate.", nameof(path));
+            }
 
-        return certificates;
+            foreach (X509Certificate2 certificate in certificates)
+            {
+                if (IsSelfIssued(certificate))
+                {
+                    return certificates;
+                }
+            }
+
+            throw new ArgumentException(
+                $"The certificate authority file '{path}' contains no self-issued root certificate.",
+                nameof(path));
+        }
+        catch
+        {
+            DisposeCertificates(certificates);
+            throw;
+        }
     }
 
     /// <summary>
@@ -70,9 +88,8 @@ internal sealed class TlsParameters : IDisposable
     /// <returns>The encrypted stream.</returns>
     internal async ValueTask<Stream> WrapAsync(Stream inner, CancellationToken cancellationToken)
     {
-        // Refused rather than continued: the pinned authorities are gone once this is disposed, and the branch
-        // below that selects them tests for a non-empty collection. Carrying on would fall through to the host
-        // trust store, quietly turning exclusive pinning into whatever the machine happens to trust.
+        // Refused rather than continued: the pinned authorities are gone once this is disposed. Carrying on could
+        // otherwise negotiate with certificates whose native resources were already released.
         ObjectDisposedException.ThrowIf(disposed, this);
 
         var ssl = new SslStream(inner, leaveInnerStreamOpen: false);
@@ -89,9 +106,9 @@ internal sealed class TlsParameters : IDisposable
                 authentication.RemoteCertificateValidationCallback = static (_, _, _, _) => true;
 #pragma warning restore CA5359
             }
-            else if (CaCertificates is { Count: > 0 } roots)
+            else if (CaCertificates is { } authorities)
             {
-                authentication.CertificateChainPolicy = PinnedRootPolicy(roots);
+                authentication.CertificateChainPolicy = PinnedRootPolicy(authorities);
             }
 
             // Last, so a caller can override any of the above. The pinned roots are expressed as a chain policy
@@ -99,8 +116,6 @@ internal sealed class TlsParameters : IDisposable
             // the verification time, the revocation mode, the flags — and every change takes effect, because this
             // is the policy the handshake builds the chain with.
             Configure?.Invoke(authentication);
-
-            NormalizeRevocationMode(authentication);
 
             await ssl.AuthenticateAsClientAsync(authentication, cancellationToken).ConfigureAwait(false);
             return ssl;
@@ -110,27 +125,6 @@ internal sealed class TlsParameters : IDisposable
             // Built with leaveInnerStreamOpen false, so this closes the inner stream as well.
             ssl.Dispose();
             throw;
-        }
-    }
-
-    /// <summary>
-    /// Carries a revocation mode set on the options into the chain policy, which is the only place the handshake
-    /// reads it from once a policy is present.
-    /// </summary>
-    /// <remarks>
-    /// The platform copies <c>CertificateRevocationCheckMode</c> into the chain policy it builds, but only when it
-    /// builds one. Once a policy is supplied — which pinning does — the top-level property is ignored, so
-    /// <c>ConfigureTls</c> setting the obvious property would silently do nothing and a revoked certificate would
-    /// be accepted. Both values start at <c>NoCheck</c>, so a change to either is visible; a nested edit wins,
-    /// because a caller who reached into the policy meant that policy.
-    /// </remarks>
-    /// <param name="authentication">The options about to be handed to the handshake.</param>
-    private static void NormalizeRevocationMode(SslClientAuthenticationOptions authentication)
-    {
-        if (authentication.CertificateChainPolicy is { RevocationMode: X509RevocationMode.NoCheck } policy
-            && authentication.CertificateRevocationCheckMode != X509RevocationMode.NoCheck)
-        {
-            policy.RevocationMode = authentication.CertificateRevocationCheckMode;
         }
     }
 
@@ -146,7 +140,7 @@ internal sealed class TlsParameters : IDisposable
             return;
         }
 
-        // Set first, so a use racing this disposal is refused rather than handed certificates being freed.
+        // Mark disposed before releasing the certificates so any later use is refused.
         disposed = true;
 
         if (CaCertificates is not { } certificates)
@@ -154,13 +148,10 @@ internal sealed class TlsParameters : IDisposable
             return;
         }
 
-        foreach (X509Certificate2 certificate in certificates)
-        {
-            certificate.Dispose();
-        }
+        DisposeCertificates(certificates);
 
-        // The collection is deliberately left populated. Clearing it would make the pinned-roots branch in
-        // WrapAsync see an empty set and skip, which is the fall-through to host trust the flag above prevents.
+        // The collection is deliberately left populated so a concurrent use cannot observe a different policy;
+        // the disposed flag above makes every later use fail before it reaches the certificates.
     }
 
     /// <summary>
@@ -168,13 +159,13 @@ internal sealed class TlsParameters : IDisposable
     /// the chain with this policy, so the host-name match it always applies is unaffected.
     /// </summary>
     /// <remarks>
-    /// Pinning replaces the host's trust store rather than adding to it: the server must chain to one of these
-    /// authorities, and a certificate the host would accept on its own is refused. An additive check would still
-    /// take a certificate mis-issued by any public authority, which is what pinning a private root prevents.
+    /// Pinning replaces the host's trust store rather than adding to it: the server must chain to one of the
+    /// self-issued roots. Other certificates in the bundle are available only as intermediates while building
+    /// that chain. A certificate the host would accept on its own is refused.
     /// </remarks>
-    /// <param name="roots">The certificate authorities to trust.</param>
+    /// <param name="authorities">The root and intermediate certificate authorities to use.</param>
     /// <returns>The policy to hand the handshake.</returns>
-    private static X509ChainPolicy PinnedRootPolicy(X509Certificate2Collection roots)
+    private static X509ChainPolicy PinnedRootPolicy(X509Certificate2Collection authorities)
     {
         var policy = new X509ChainPolicy
         {
@@ -185,7 +176,22 @@ internal sealed class TlsParameters : IDisposable
             RevocationMode = X509RevocationMode.NoCheck,
         };
 
-        policy.CustomTrustStore.AddRange(roots);
+        foreach (X509Certificate2 certificate in authorities)
+        {
+            if (IsSelfIssued(certificate))
+            {
+                policy.CustomTrustStore.Add(certificate);
+            }
+            else
+            {
+                policy.ExtraStore.Add(certificate);
+            }
+        }
+
+        if (policy.CustomTrustStore.Count == 0)
+        {
+            throw new InvalidOperationException("The configured certificate authorities contain no self-issued root certificate.");
+        }
 
         // A server certificate must not exclude server authentication, so that a private authority which also
         // issues client certificates cannot let the holder of one impersonate a host its name covers. The
@@ -193,5 +199,18 @@ internal sealed class TlsParameters : IDisposable
         // policy a caller can read and does not leave it resting on that behaviour.
         policy.ApplicationPolicy.Add(ServerAuthentication);
         return policy;
+    }
+
+    // Match the classification used by .NET's OpenSSL and Apple chain PALs: a self-issued certificate is a
+    // configured trust anchor, while every other certificate is only available to build the chain.
+    private static bool IsSelfIssued(X509Certificate2 certificate)
+        => certificate.SubjectName.RawData.AsSpan().SequenceEqual(certificate.IssuerName.RawData);
+
+    private static void DisposeCertificates(X509Certificate2Collection certificates)
+    {
+        foreach (X509Certificate2 certificate in certificates)
+        {
+            certificate.Dispose();
+        }
     }
 }

--- a/ClickHouse.Driver.Tcp/Protocol/TlsParameters.cs
+++ b/ClickHouse.Driver.Tcp/Protocol/TlsParameters.cs
@@ -80,15 +80,13 @@ internal sealed class TlsParameters
             }
             else if (CaCertificates is { Count: > 0 } roots)
             {
-                // The revocation mode is read when the callback runs, not now, so a hook that asks for revocation
-                // checking still gets it — the rebuild would otherwise re-decide with revocation off and accept a
-                // certificate the platform had just refused as revoked.
-                authentication.RemoteCertificateValidationCallback =
-                    (_, certificate, chain, errors) => ValidateAgainstCustomRoots(
-                        roots, certificate, chain, errors, authentication.CertificateRevocationCheckMode);
+                authentication.CertificateChainPolicy = PinnedRootPolicy(roots);
             }
 
-            // Last, so a caller can override any of the above.
+            // Last, so a caller can override any of the above. The pinned roots are expressed as a chain policy
+            // rather than a validation callback partly for this: the hook receives that policy and can adjust it —
+            // the verification time, the revocation mode, the flags — and every change takes effect, because this
+            // is the policy the handshake builds the chain with.
             Configure?.Invoke(authentication);
 
             await ssl.AuthenticateAsClientAsync(authentication, cancellationToken).ConfigureAwait(false);
@@ -103,62 +101,34 @@ internal sealed class TlsParameters
     }
 
     /// <summary>
-    /// Replaces the platform's trust decision with one taken against a private set of roots, leaving every other
-    /// check alone. A name mismatch or a missing certificate still fails: naming a root says who to trust, not
-    /// that identity stops mattering.
+    /// The chain policy that pins the server to a private set of certificate authorities. The handshake builds
+    /// the chain with this policy, so the host-name match it always applies is unaffected.
     /// </summary>
     /// <remarks>
-    /// The rebuild runs even when the platform was satisfied. Naming a certificate authority means the server
-    /// must chain to <i>that</i> authority — accepting whatever the host's trust store already believes would
-    /// make the option additive, so a certificate mis-issued by any public authority would still be taken, which
-    /// is the attack pinning a private root exists to stop.
+    /// Pinning replaces the host's trust store rather than adding to it: the server must chain to one of these
+    /// authorities, and a certificate the host would accept on its own is refused. An additive check would still
+    /// take a certificate mis-issued by any public authority, which is what pinning a private root prevents.
     /// </remarks>
     /// <param name="roots">The certificate authorities to trust.</param>
-    /// <param name="certificate">The server certificate the platform validated.</param>
-    /// <param name="chain">The chain the platform built, whose intermediates the rebuild reuses.</param>
-    /// <param name="errors">The platform's verdict.</param>
-    /// <param name="revocationMode">The revocation checking the TLS options ask for.</param>
-    /// <returns>Whether to accept the certificate.</returns>
-    private static bool ValidateAgainstCustomRoots(
-        X509Certificate2Collection roots,
-        X509Certificate certificate,
-        X509Chain chain,
-        SslPolicyErrors errors,
-        X509RevocationMode revocationMode)
+    /// <returns>The policy to hand the handshake.</returns>
+    private static X509ChainPolicy PinnedRootPolicy(X509Certificate2Collection roots)
     {
-        // Only the trust decision is ours to re-take; anything else the platform flagged stands.
-        if ((errors & ~SslPolicyErrors.RemoteCertificateChainErrors) != SslPolicyErrors.None)
+        var policy = new X509ChainPolicy
         {
-            return false;
-        }
+            TrustMode = X509ChainTrustMode.CustomRootTrust,
 
-        // The runtime always hands the callback an X509Certificate2. Refuse rather than guess if that changes:
-        // a chain cannot be rebuilt from the base type without an API that is obsolete on the newer targets.
-        if (certificate is not X509Certificate2 leaf)
-        {
-            return false;
-        }
+            // The SslStream default. Named here because this policy replaces the one the handshake would have
+            // built, so anything left out is not inherited - it is simply absent.
+            RevocationMode = X509RevocationMode.NoCheck,
+        };
 
-        using var rebuilt = new X509Chain();
-        rebuilt.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
-        rebuilt.ChainPolicy.CustomTrustStore.AddRange(roots);
-        rebuilt.ChainPolicy.RevocationMode = revocationMode;
+        policy.CustomTrustStore.AddRange(roots);
 
-        // The platform requires the certificate to be valid for server authentication. This rebuild replaces the
-        // platform's check, so it must apply the same requirement: without it, any certificate under the named
-        // authority whose name covers this host is accepted, including one issued to a client.
-        rebuilt.ChainPolicy.ApplicationPolicy.Add(ServerAuthentication);
-
-        // Intermediates the server sent live in the platform's chain; without them a path to a custom root
-        // that is not the direct issuer cannot be completed.
-        if (chain is not null)
-        {
-            foreach (X509ChainElement element in chain.ChainElements)
-            {
-                rebuilt.ChainPolicy.ExtraStore.Add(element.Certificate);
-            }
-        }
-
-        return rebuilt.Build(leaf);
+        // A server certificate must say it is for server authentication, so that a private authority which also
+        // issues client certificates cannot let the holder of one impersonate a host its name covers. The
+        // handshake applies this requirement to a client-side chain anyway; naming it keeps the requirement in the
+        // policy a caller can read and does not leave it resting on that behaviour.
+        policy.ApplicationPolicy.Add(ServerAuthentication);
+        return policy;
     }
 }

--- a/ClickHouse.Driver.Tcp/Protocol/TlsParameters.cs
+++ b/ClickHouse.Driver.Tcp/Protocol/TlsParameters.cs
@@ -18,10 +18,12 @@ namespace ClickHouse.Driver.Tcp.Protocol;
 /// encrypted or not. TLS keeps the ClientHello private, and that message carries the password as plaintext.
 /// </para>
 /// </summary>
-internal sealed class TlsParameters
+internal sealed class TlsParameters : IDisposable
 {
     // id-kp-serverAuth: the purpose a certificate must declare to authenticate a server.
     private static readonly Oid ServerAuthentication = new("1.3.6.1.5.5.7.3.1");
+
+    private bool disposed;
 
     /// <summary>The host name presented as SNI and matched against the server certificate.</summary>
     required public string TargetHost { get; init; }
@@ -64,6 +66,11 @@ internal sealed class TlsParameters
     /// <returns>The encrypted stream.</returns>
     internal async ValueTask<Stream> WrapAsync(Stream inner, CancellationToken cancellationToken)
     {
+        // Refused rather than continued: the pinned authorities are gone once this is disposed, and the branch
+        // below that selects them tests for a non-empty collection. Carrying on would fall through to the host
+        // trust store, quietly turning exclusive pinning into whatever the machine happens to trust.
+        ObjectDisposedException.ThrowIf(disposed, this);
+
         var ssl = new SslStream(inner, leaveInnerStreamOpen: false);
         try
         {
@@ -98,6 +105,35 @@ internal sealed class TlsParameters
             ssl.Dispose();
             throw;
         }
+    }
+
+    /// <summary>
+    /// Releases the loaded certificate authorities, which hold native key handles. Idempotent, and a no-op when
+    /// none were loaded. The owner calls this once nothing can still be handshaking: <see cref="WrapAsync"/>
+    /// refuses afterwards rather than negotiating without them.
+    /// </summary>
+    public void Dispose()
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        // Set first, so a use racing this disposal is refused rather than handed certificates being freed.
+        disposed = true;
+
+        if (CaCertificates is not { } certificates)
+        {
+            return;
+        }
+
+        foreach (X509Certificate2 certificate in certificates)
+        {
+            certificate.Dispose();
+        }
+
+        // The collection is deliberately left populated. Clearing it would make the pinned-roots branch in
+        // WrapAsync see an empty set and skip, which is the fall-through to host trust the flag above prevents.
     }
 
     /// <summary>

--- a/ClickHouse.Driver.Tcp/Protocol/TlsParameters.cs
+++ b/ClickHouse.Driver.Tcp/Protocol/TlsParameters.cs
@@ -15,12 +15,16 @@ namespace ClickHouse.Driver.Tcp.Protocol;
 ///
 /// <para>
 /// TLS is below the protocol, so nothing above the transport changes: the native protocol sends the same bytes
-/// encrypted or not. TLS keeps the ClientHello private, and that message carries the password as plaintext.
+/// encrypted or not. What TLS keeps private is the native protocol's client Hello packet, which carries the
+/// password as plaintext. (That packet is named ClientHello in the protocol spec; it is not the TLS ClientHello,
+/// which is part of the visible handshake below it and carries no credentials.)
 /// </para>
 /// </summary>
 internal sealed class TlsParameters : IDisposable
 {
-    // id-kp-serverAuth: the purpose a certificate must declare to authenticate a server.
+    // id-kp-serverAuth: the extended key usage a certificate must permit to authenticate a server. A certificate
+    // carrying no such extension is unrestricted and satisfies this (RFC 5280 4.2.1.12); it constrains the
+    // extension when present rather than requiring it.
     private static readonly Oid ServerAuthentication = new("1.3.6.1.5.5.7.3.1");
 
     private bool disposed;
@@ -96,6 +100,8 @@ internal sealed class TlsParameters : IDisposable
             // is the policy the handshake builds the chain with.
             Configure?.Invoke(authentication);
 
+            NormalizeRevocationMode(authentication);
+
             await ssl.AuthenticateAsClientAsync(authentication, cancellationToken).ConfigureAwait(false);
             return ssl;
         }
@@ -104,6 +110,27 @@ internal sealed class TlsParameters : IDisposable
             // Built with leaveInnerStreamOpen false, so this closes the inner stream as well.
             ssl.Dispose();
             throw;
+        }
+    }
+
+    /// <summary>
+    /// Carries a revocation mode set on the options into the chain policy, which is the only place the handshake
+    /// reads it from once a policy is present.
+    /// </summary>
+    /// <remarks>
+    /// The platform copies <c>CertificateRevocationCheckMode</c> into the chain policy it builds, but only when it
+    /// builds one. Once a policy is supplied — which pinning does — the top-level property is ignored, so
+    /// <c>ConfigureTls</c> setting the obvious property would silently do nothing and a revoked certificate would
+    /// be accepted. Both values start at <c>NoCheck</c>, so a change to either is visible; a nested edit wins,
+    /// because a caller who reached into the policy meant that policy.
+    /// </remarks>
+    /// <param name="authentication">The options about to be handed to the handshake.</param>
+    private static void NormalizeRevocationMode(SslClientAuthenticationOptions authentication)
+    {
+        if (authentication.CertificateChainPolicy is { RevocationMode: X509RevocationMode.NoCheck } policy
+            && authentication.CertificateRevocationCheckMode != X509RevocationMode.NoCheck)
+        {
+            policy.RevocationMode = authentication.CertificateRevocationCheckMode;
         }
     }
 
@@ -160,7 +187,7 @@ internal sealed class TlsParameters : IDisposable
 
         policy.CustomTrustStore.AddRange(roots);
 
-        // A server certificate must say it is for server authentication, so that a private authority which also
+        // A server certificate must not exclude server authentication, so that a private authority which also
         // issues client certificates cannot let the holder of one impersonate a host its name covers. The
         // handshake applies this requirement to a client-side chain anyway; naming it keeps the requirement in the
         // policy a caller can read and does not leave it resting on that behaviour.

--- a/ClickHouse.Driver.Tcp/Protocol/TlsParameters.cs
+++ b/ClickHouse.Driver.Tcp/Protocol/TlsParameters.cs
@@ -1,0 +1,164 @@
+using System;
+using System.IO;
+using System.Net.Security;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ClickHouse.Driver.Tcp.Protocol;
+
+/// <summary>
+/// How a connection negotiates TLS: the name to authenticate the server as, and how to validate the certificate
+/// chain it presents. The connection layer builds this from client options once; a connect uses it to wrap its
+/// socket before the handshake writes a byte.
+///
+/// <para>
+/// TLS is below the protocol, so nothing above the transport changes: the native protocol sends the same bytes
+/// encrypted or not. TLS keeps the ClientHello private, and that message carries the password as plaintext.
+/// </para>
+/// </summary>
+internal sealed class TlsParameters
+{
+    // id-kp-serverAuth: the purpose a certificate must declare to authenticate a server.
+    private static readonly Oid ServerAuthentication = new("1.3.6.1.5.5.7.3.1");
+
+    /// <summary>The host name presented as SNI and matched against the server certificate.</summary>
+    required public string TargetHost { get; init; }
+
+    /// <summary>Whether to accept a certificate that fails validation. Development only — see the option that sets it.</summary>
+    public bool AllowInvalidCertificates { get; init; }
+
+    /// <summary>Certificate authorities to validate against instead of the host's trust store, or null to use the host's.</summary>
+    public X509Certificate2Collection CaCertificates { get; init; }
+
+    /// <summary>A hook applied to the TLS options last, able to override everything else here. Null for none.</summary>
+    public Action<SslClientAuthenticationOptions> Configure { get; init; }
+
+    /// <summary>
+    /// Loads a PEM file of certificate authorities. Called once per client so a bad path fails at construction
+    /// rather than on every connect.
+    /// </summary>
+    /// <param name="path">Path to a PEM file holding one or more certificates.</param>
+    /// <returns>The certificates in the file.</returns>
+    /// <exception cref="ArgumentException">The file holds no certificate.</exception>
+    internal static X509Certificate2Collection LoadCaCertificates(string path)
+    {
+        var certificates = new X509Certificate2Collection();
+        certificates.ImportFromPemFile(path);
+        if (certificates.Count == 0)
+        {
+            throw new ArgumentException($"The certificate authority file '{path}' contains no PEM certificate.", nameof(path));
+        }
+
+        return certificates;
+    }
+
+    /// <summary>
+    /// Wraps a transport stream in TLS and completes the handshake. The wrapper owns <paramref name="inner"/>
+    /// from the moment it is built, either way: on success disposing the returned stream disposes both, and on
+    /// failure both are disposed here before the exception propagates.
+    /// </summary>
+    /// <param name="inner">The plaintext transport stream to encrypt.</param>
+    /// <param name="cancellationToken">A token to observe while handshaking.</param>
+    /// <returns>The encrypted stream.</returns>
+    internal async ValueTask<Stream> WrapAsync(Stream inner, CancellationToken cancellationToken)
+    {
+        var ssl = new SslStream(inner, leaveInnerStreamOpen: false);
+        try
+        {
+            var authentication = new SslClientAuthenticationOptions { TargetHost = TargetHost };
+
+            if (AllowInvalidCertificates)
+            {
+                // CA5359 is exactly what this option asks for, and the property that sets it documents the cost.
+                // The analyzer cannot tell an opt-in development switch from an accident, so the suppression is
+                // kept to this one statement rather than the file.
+#pragma warning disable CA5359 // Do Not Disable Certificate Validation
+                authentication.RemoteCertificateValidationCallback = static (_, _, _, _) => true;
+#pragma warning restore CA5359
+            }
+            else if (CaCertificates is { Count: > 0 } roots)
+            {
+                // The revocation mode is read when the callback runs, not now, so a hook that asks for revocation
+                // checking still gets it — the rebuild would otherwise re-decide with revocation off and accept a
+                // certificate the platform had just refused as revoked.
+                authentication.RemoteCertificateValidationCallback =
+                    (_, certificate, chain, errors) => ValidateAgainstCustomRoots(
+                        roots, certificate, chain, errors, authentication.CertificateRevocationCheckMode);
+            }
+
+            // Last, so a caller can override any of the above.
+            Configure?.Invoke(authentication);
+
+            await ssl.AuthenticateAsClientAsync(authentication, cancellationToken).ConfigureAwait(false);
+            return ssl;
+        }
+        catch
+        {
+            // Built with leaveInnerStreamOpen false, so this closes the inner stream as well.
+            ssl.Dispose();
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Replaces the platform's trust decision with one taken against a private set of roots, leaving every other
+    /// check alone. A name mismatch or a missing certificate still fails: naming a root says who to trust, not
+    /// that identity stops mattering.
+    /// </summary>
+    /// <remarks>
+    /// The rebuild runs even when the platform was satisfied. Naming a certificate authority means the server
+    /// must chain to <i>that</i> authority — accepting whatever the host's trust store already believes would
+    /// make the option additive, so a certificate mis-issued by any public authority would still be taken, which
+    /// is the attack pinning a private root exists to stop.
+    /// </remarks>
+    /// <param name="roots">The certificate authorities to trust.</param>
+    /// <param name="certificate">The server certificate the platform validated.</param>
+    /// <param name="chain">The chain the platform built, whose intermediates the rebuild reuses.</param>
+    /// <param name="errors">The platform's verdict.</param>
+    /// <param name="revocationMode">The revocation checking the TLS options ask for.</param>
+    /// <returns>Whether to accept the certificate.</returns>
+    private static bool ValidateAgainstCustomRoots(
+        X509Certificate2Collection roots,
+        X509Certificate certificate,
+        X509Chain chain,
+        SslPolicyErrors errors,
+        X509RevocationMode revocationMode)
+    {
+        // Only the trust decision is ours to re-take; anything else the platform flagged stands.
+        if ((errors & ~SslPolicyErrors.RemoteCertificateChainErrors) != SslPolicyErrors.None)
+        {
+            return false;
+        }
+
+        // The runtime always hands the callback an X509Certificate2. Refuse rather than guess if that changes:
+        // a chain cannot be rebuilt from the base type without an API that is obsolete on the newer targets.
+        if (certificate is not X509Certificate2 leaf)
+        {
+            return false;
+        }
+
+        using var rebuilt = new X509Chain();
+        rebuilt.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
+        rebuilt.ChainPolicy.CustomTrustStore.AddRange(roots);
+        rebuilt.ChainPolicy.RevocationMode = revocationMode;
+
+        // The platform requires the certificate to be valid for server authentication. This rebuild replaces the
+        // platform's check, so it must apply the same requirement: without it, any certificate under the named
+        // authority whose name covers this host is accepted, including one issued to a client.
+        rebuilt.ChainPolicy.ApplicationPolicy.Add(ServerAuthentication);
+
+        // Intermediates the server sent live in the platform's chain; without them a path to a custom root
+        // that is not the direct issuer cannot be completed.
+        if (chain is not null)
+        {
+            foreach (X509ChainElement element in chain.ChainElements)
+            {
+                rebuilt.ChainPolicy.ExtraStore.Add(element.Certificate);
+            }
+        }
+
+        return rebuilt.Build(leaf);
+    }
+}


### PR DESCRIPTION
Stacked on #562 (`tcp/epic-j5-json`). Review that one first — this diff is only the TLS work.

Closes epic story **B9**: the TLS transport and its option surface. The Cloud test wiring that used to
live here is split out into #611, stacked directly on this branch.

## What this does

`ClickHouseTcpConnection.ConnectAsync` takes a `TlsParameters` (null = plaintext) and wraps the `NetworkStream` in an `SslStream` between the socket connect and the protocol handshake. TLS sits below the protocol, so nothing above the transport changes — the native protocol sends the same bytes either way. What it buys is that the ClientHello, which carries the password as plaintext, is already inside the tunnel.

Options are flat on `ClickHouseTcpClientOptions`, each with a matching connection-string key:

| Option | Connection-string key | Meaning |
|---|---|---|
| `UseTls` | `UseTls` | Encrypt the transport |
| `TlsServerName` | `TlsServerName` | SNI and certificate name; defaults to `Host` |
| `TlsAllowInvalidCertificates` | `TlsAllowInvalidCertificates` | Development skip-verify |
| `TlsCaCertificatePath` | `TlsCaCertificatePath` | PEM authority file to validate against |
| `ConfigureTls` | — (code only) | `Action<SslClientAuthenticationOptions>` escape hatch, applied last |

```csharp
await using var client = new ClickHouseTcpClient("Host=abc.clickhouse.cloud;UseTls=true;Password=…");
```

## Decisions worth a reviewer's attention

**`Port` is now `int?`.** `ResolvedPort` derives 9440 with TLS and 9000 without; an explicit value always wins, so TLS on a non-standard port needs no other change. This is a source-breaking change to a public property — acceptable because `ClickHouse.Driver.Tcp` is `IsPackable=false`, has no `PublicAPI/*.txt` baseline yet (Epic R1), and is gated behind the experimental diagnostic.

**A pinned authority replaces the host trust store rather than adding to it.** A certificate the host would accept on its own is refused unless it also chains to the named authority. An additive check would still take a certificate mis-issued by any public authority, which is the attack pinning exists to stop. The rebuild also keeps the two checks the platform would have made — the `serverAuth` EKU, and the revocation mode the TLS options carry — because it *replaces* the platform's check rather than supplementing it.

**Three guards against silently connecting in the clear.** `Validate()` refuses any `Tls*` property set while `UseTls` is false (a forgotten `UseTls` with a configured CA is exactly the mistake worth catching), refuses `TlsAllowInvalidCertificates` together with `TlsCaCertificatePath` as contradictory, and the connection-string boolean getter throws on a value it cannot read instead of falling back to false — `UseTls=yes` reading as false would hand back a plaintext connection the caller believes is secure.

**mTLS is not implemented.** Client certificates are reachable only through `ConfigureTls`. A declarative surface is filed as its own story: it also interacts with the handshake credential fields and with how the server maps a certificate subject to a user.

## Testing

`TlsParametersTests` drives real TLS handshakes against an in-process `SslStream` server, covering what no cloud service can be asked to present: a self-signed certificate, one from a private authority, one for the wrong purpose, and a chain through an intermediate. `TcpConnectionFactoryTests` covers the wiring `UseTls` → `BuildTlsParameters` → `ConnectAsync` against a TLS listener that speaks the server Hello, plus the negative that a plaintext client fails there — without that test nothing on the standard CI matrix would touch the wiring.

Each fix was mutation-checked: dropping the EKU, hardcoding `NoCheck`, dropping the `ExtraStore` loop, and inverting the `UseTls` test each fail exactly their own test.

Verified end-to-end against a ClickHouse container with `tcp_port_secure` and a self-signed certificate — pinned-CA accept, wrong-CA reject, no-CA reject (`UntrustedRoot`), skip-verify accept — and the session-reuse test confirmed load-bearing by forcing the pool to retire between operations.

Full suite: 2801 passed, 0 failed on net9.0. Coverage on the new `TlsParameters.cs` is 96.4%; the only uncovered lines are a documented unreachable defensive guard.

No CHANGELOG/RELEASENOTES entry. This is a deliberate **stack-level exception**, not an oversight: neither file mentions `ClickHouse.Driver.Tcp` at all today, the assembly is `IsPackable=false` and gated behind an experimental diagnostic, and an earlier commit on this stack (`07c59bd4`) explicitly removed an entry to keep these PRs to the TCP projects. Epic R3 adds the entries as one piece when the client ships. Raised in review and **confirmed as the intended behaviour** for this stack, so it is settled rather than outstanding. R3 is scoped to sweep every epic, not just the last one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
