### PR TITLE
Fix the broken main build: read TryGetEnumOrdinal out of the typed column slot

### DIFF
--- a/ClickHouse.Driver/ADO/Readers/ClickHouseDataReader.cs
+++ b/ClickHouse.Driver/ADO/Readers/ClickHouseDataReader.cs
@@ -167,7 +167,18 @@ public class ClickHouseDataReader : DbDataReader, IEnumerator<IDataReader>, IEnu
     /// </returns>
     public bool TryGetEnumOrdinal(int ordinal, out int value)
     {
-        if (CurrentRow[ordinal] is string label &&
+        // Takes the label straight from the slot instead of through GetValue: the ordinal is the raw wire value, so
+        // a configured IReadValueConverter must not run here — it rewrites the label, which would then resolve to a
+        // different ordinal or to none at all. An enum column decodes into its own FrameworkType (string), so these
+        // are the only two slot kinds it can get; a NULL cell leaves HasValue false and falls through to false.
+        var label = Slot(ordinal) switch
+        {
+            ValueSlot<string> stringSlot => stringSlot.Value,
+            NullableSlot<string> nullableSlot when nullableSlot.HasValue => nullableSlot.Value,
+            _ => null,
+        };
+
+        if (label is not null &&
             GetEffectiveClickHouseType(ordinal) is EnumType enumType &&
             enumType.TryLookup(label, out value))
         {


### PR DESCRIPTION
## Problem

`main` does not compile, on every target framework:

```
ClickHouse.Driver/ADO/Readers/ClickHouseDataReader.cs(170,13):
error CS0103: The name 'CurrentRow' does not exist in the current context
```

Everything downstream of the library fails as a result — Tests, Integration, Examples, Benchmark and CodeQL all went red at 1e5971cf. The last green commit is 8152c6cf.

## Cause

A semantic merge conflict between two pull requests that never saw each other:

- **#445** added `TryGetEnumOrdinal`, which reads the current row through `CurrentRow[ordinal]`.
- **#499** replaced that boxed `object[]` row buffer with the `ColumnSlot[]` typed slots, and was branched before #445 landed, so `CurrentRow` went away while the new caller stayed.

The two changes touch different regions of the same file, so git merged both without a conflict. Nothing was mis-rebased — a textually clean merge simply is not a compiling one, and no CI run ever built the combination before it reached `main`.

## Fix

Read the enum label from the slot. An enum column decodes into its own `FrameworkType` (`string`), so it gets `ValueSlot<string>` when it is not nullable and `NullableSlot<string>` when it is; those are the only two slot kinds it can get. A NULL cell leaves `HasValue` false and returns `false`, as before.

Going through the slot rather than `GetValue` also keeps the ordinal converter-independent, which is what the accessor documents: an `IReadValueConverter` rewrites the label, and resolving the rewritten label would yield a different ordinal or none at all.

## Verification

Builds that were failing before this change and pass now: `ClickHouse.Driver` + `ClickHouse.Driver.Tests` on net9.0, and `ClickHouse.Driver.Benchmark`, `ClickHouse.Driver.IntegrationTests` and `examples` on net10.0.

Test results are from CI on this pull request, all 18 checks green — net6.0/net9.0/net10.0, ClickHouse 25.8/26.3/26.5/26.6/26.7/latest, Examples, Integration, Cloud, macOS, Windows, Code Coverage. The net9.0 regression job reports **10781 passed, 0 failed**.

I could not complete the suite locally, for a reason unrelated to this change: issue #567 (an empty tuple type makes the type parser build a self-referential node) crashes the test host with an uncatchable stack overflow once a `Tuple()` column exists anywhere on the server, which is true of my local instance and not of CI's fresh one. Local runs abort at roughly 2600 of ~11000 tests, so any local pass count on this branch is a partial result and I am not citing one. CI is the signal here.

The behavior this touches is already covered by the tests #445 shipped — `TryGetEnumOrdinal_*` in `DataReaderTests` (Enum8/Enum16, negative ordinals, ordinals past the Enum8 range, `Nullable(Enum8)` with a value, a NULL `Nullable(Enum8)`, and non-enum String/Int columns) and the two converter-independence cases in `ReadValueConverterTests`. No new tests: those already pin every branch of this method, they simply could not run while the build was broken.

No changelog fragment: `TryGetEnumOrdinal` and the slot rewrite are already described by #445 and #499, and this repairs their combination without changing what either promised. The `changelog.d` gate passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)