### PR TITLE
TCP K: geo aliases, Geometry, SimpleAggregateFunction and AggregateFunction

### DIFF
--- a/ClickHouse.Driver.Tcp.Tests/Integration/GeometryIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/GeometryIntegrationTests.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Format;
+using ClickHouse.Driver.Tcp.Protocol;
+using ClickHouse.Driver.Tcp.Tests.Utilities;
+using ClickHouse.Driver.Tcp.Types;
+using ClickHouse.Driver.Tcp.Types.Codecs;
+
+namespace ClickHouse.Driver.Tcp.Tests.Integration;
+
+/// <summary>
+/// Pins the <c>Geometry</c> discriminator order against the server. The column header carries only the alias, so
+/// the client expands it to a six-alternative <c>Variant</c> from a constant of its own; nothing on the wire
+/// carries that ordering, and a caller of the dense column depends on it to mean what they intend.
+///
+/// <para>
+/// A round trip cannot check that constant, because the client applies it to the write and to the read. If two
+/// alternatives are transposed, the write picks the wrong discriminator and the read of that discriminator picks
+/// the same wrong alternative back, so the value returns intact while the server holds it under the other type.
+/// Transposing <c>Point</c> or <c>MultiPolygon</c> is still caught: the wrong alternative has a different layout,
+/// so the bytes stop parsing. The other four are two structurally identical pairs (<c>Ring</c> with
+/// <c>LineString</c>, <c>Polygon</c> with <c>MultiLineString</c>) whose blocks are byte-identical, so nothing
+/// objects. Their CLR types are identical too, so knowing a value's type does not name its alternative either.
+/// </para>
+///
+/// <para>
+/// Only the server breaks that symmetry, and it has to be asked what it calls a given row. Asking what it calls
+/// discriminator <c>i</c> answers from its own list and never consults the client's. So one row is written against
+/// each discriminator, and the server's name for that row is compared with the client's name for it.
+/// </para>
+/// </summary>
+[TestFixture]
+[Category("Integration")]
+[RequiresServerFeature(TcpFeature.Geometry)]
+public class GeometryIntegrationTests
+{
+    private static readonly CancellationToken None = CancellationToken.None;
+    private static readonly (double, double)[] Square = { (0d, 0d), (2d, 0d), (2d, 2d), (0d, 0d) };
+
+    [Test]
+    public async Task InsertAsync_OneRowPerDiscriminator_TheServerNamesEachOneWhatTheClientCallsIt()
+    {
+        var codec = (VariantColumnCodec)ColumnCodecRegistry.Default.Resolve("Geometry", ResolveContext.ForWrite);
+        IReadOnlyList<string> clientOrder = codec.AlternativeTypeNames;
+
+        await using var connection = await TcpServerFixture.ConnectAsync(None);
+        string table = UniqueTableName();
+        try
+        {
+            await ExecuteAsync(connection, $"CREATE TABLE {table} (id UInt8, value Geometry) ENGINE = Memory");
+
+            // Row i selects discriminator i and carries a value of the shape the client's alternative i expects, so
+            // the server's name for row i is directly comparable with clientOrder[i].
+            var alternatives = new IColumn[clientOrder.Count];
+            var discriminators = new byte[clientOrder.Count];
+            var ids = new byte[clientOrder.Count];
+            for (int i = 0; i < clientOrder.Count; i++)
+            {
+                alternatives[i] = SampleFor(clientOrder[i]);
+                discriminators[i] = (byte)i;
+                ids[i] = (byte)i;
+            }
+
+            using var value = new VariantColumn("value", "Geometry", discriminators, alternatives, clientOrder.Count, pooledDiscriminators: false, ownsColumns: false);
+            var id = PrimitiveColumn<byte>.FromValues("id", "UInt8", ids);
+            await connection.InsertAsync($"INSERT INTO {table} (id, value) VALUES", new IColumn[] { id, value }, cancellationToken: None);
+
+            // toString, because variantType returns an Enum8 and this client surfaces an enum as its raw ordinal —
+            // which is the very numbering under test, so reading it back would prove nothing.
+            var served = new List<string>();
+            await foreach (Block block in connection.QueryAsync($"SELECT toString(variantType(value)) FROM {table} ORDER BY id", cancellationToken: None))
+            {
+                for (int row = 0; row < block.RowCount; row++)
+                {
+                    served.Add((string)block[0].GetValue(row));
+                }
+            }
+
+            Assert.That(served, Is.EqualTo(clientOrder), "the client's alternative order must be the server's");
+        }
+        finally
+        {
+            await ExecuteAsync(connection, $"DROP TABLE IF EXISTS {table}");
+        }
+    }
+
+    // A one-row column of the shape the named geo alias surfaces as.
+    private static IColumn SampleFor(string alias) => alias switch
+    {
+        "Point" => new ArrayColumn<(double, double)>("value", alias, new[] { (1.5d, -2.5d) }),
+        "Ring" or "LineString" => new ArrayColumn<(double, double)[]>("value", alias, new[] { Square }),
+        "Polygon" or "MultiLineString" => new ArrayColumn<(double, double)[][]>("value", alias, new[] { new[] { Square } }),
+        "MultiPolygon" => new ArrayColumn<(double, double)[][][]>("value", alias, new[] { new[] { new[] { Square } } }),
+        _ => throw new ArgumentException($"Geometry gained an alternative this test does not know: '{alias}'.", nameof(alias)),
+    };
+
+    private static string UniqueTableName() => $"tcp_geometry_test_{Guid.NewGuid():N}";
+
+    private static async Task ExecuteAsync(ClickHouseTcpConnection connection, string sql)
+    {
+        await foreach (Block block in connection.QueryAsync(sql, cancellationToken: None))
+        {
+            _ = block;
+        }
+    }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Integration/PocoWriteIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/PocoWriteIntegrationTests.cs
@@ -44,6 +44,17 @@ public class PocoWriteIntegrationTests
             IColumn insert = testCase.BuildInsertColumn("value");
             string sql = $"INSERT INTO {table} (value) VALUES";
 
+            // Four of Geometry's six alternatives are two structurally identical pairs, so a gathered row of either
+            // shape surfaces a CLR type that names no single alternative and no value-level test can separate them.
+            if (testCase.ClickHouseType == "Geometry")
+            {
+                ArgumentException ambiguous = Assert.ThrowsAsync<ArgumentException>(
+                    async () => await InsertColumnAsRowsAsync(client, sql, insertOptions, insert, ElementTypeOf(insert)));
+
+                Assert.That(ambiguous.Message, Does.Contain("does not say which of them is meant"));
+                return;
+            }
+
             // Nested and composites containing it require a specialized column shape that row gathering cannot build.
             if (testCase.ClickHouseType.Contains("Nested(", StringComparison.Ordinal))
             {

--- a/ClickHouse.Driver.Tcp.Tests/Types/ColumnCodecRegistryTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/ColumnCodecRegistryTests.cs
@@ -32,11 +32,86 @@ public class ColumnCodecRegistryTests
         Assert.That(codec.TypeName, Is.EqualTo("DateTime('UTC')"));
     }
 
+    // A parseable type the registry has no factory for. Deliberately not a real ClickHouse type: every real one this
+    // stood for has since been implemented, and the fallback itself is what the test is about.
     [Test]
     public void Resolve_UnsupportedButWellFormedType_ThrowsNotSupported()
-        => Assert.Throws<NotSupportedException>(() => ColumnCodecRegistry.Default.Resolve("Point", default));
+        => Assert.Throws<NotSupportedException>(() => ColumnCodecRegistry.Default.Resolve("NotAType(UInt8)", default));
 
     [Test]
     public void Resolve_MalformedType_ThrowsFormat()
         => Assert.Throws<FormatException>(() => ColumnCodecRegistry.Default.Resolve(string.Empty, default));
+
+    // The geo aliases name structures the client already encodes. The round-trip corpus proves the values; what
+    // only a resolution test reaches is that the alias survives as the codec's own name — a codec reporting
+    // "Tuple(Float64, Float64)" would still round-trip, and would still misname the type in every diagnostic.
+    [TestCase("Point", typeof((double, double)))]
+    [TestCase("Ring", typeof((double, double)[]))]
+    [TestCase("LineString", typeof((double, double)[]))]
+    [TestCase("Polygon", typeof((double, double)[][]))]
+    [TestCase("MultiLineString", typeof((double, double)[][]))]
+    [TestCase("MultiPolygon", typeof((double, double)[][][]))]
+    public void Resolve_GeoAlias_KeepsTheAliasNameAndSurfacesTheStructuralType(string type, Type elementType)
+    {
+        IColumnCodec codec = ColumnCodecRegistry.Default.Resolve(type, default);
+        Assert.Multiple(() =>
+        {
+            Assert.That(codec.TypeName, Is.EqualTo(type));
+            Assert.That(codec.ElementType, Is.EqualTo(elementType));
+        });
+    }
+
+    // Geometry expands to a Variant the header never spells out. The client applies its own alternative order to
+    // the write and to the read, so no round trip can see a transposition of Ring with LineString or Polygon with
+    // MultiLineString: the same wrong order on both sides returns the value intact, and each pair is
+    // byte-identical so the server never objects. GeometryIntegrationTests pins the order by asking the server.
+    [Test]
+    public void Resolve_Geometry_KeepsTheAliasNameAndSurfacesTheVariantType()
+    {
+        IColumnCodec codec = ColumnCodecRegistry.Default.Resolve("Geometry", default);
+        Assert.Multiple(() =>
+        {
+            Assert.That(codec.TypeName, Is.EqualTo("Geometry"));
+            Assert.That(codec.ElementType, Is.EqualTo(typeof(object)));
+        });
+    }
+
+
+    // SimpleAggregateFunction encodes as its inner type, so it must resolve to the inner codec *itself* rather than
+    // to a renaming wrapper — which the corpus cannot tell apart, since a wrapper would round-trip identically.
+    // The aliased inner additionally pins that the inner goes back through the registry: a resolver that only
+    // handled plain type names would fail there and nowhere else. The composite inners pin that the whole parsed
+    // node reaches the registry with its own arguments, not just its name — including when the function itself is
+    // parameterized, which parses as a node with arguments of its own and must not be read as a second inner type.
+    [TestCase("SimpleAggregateFunction(sum, UInt64)", "UInt64")]
+    [TestCase("SimpleAggregateFunction(anyLast, Point)", "Point")]
+    [TestCase("SimpleAggregateFunction(groupArrayArray, Array(UInt64))", "Array(UInt64)")]
+    [TestCase("SimpleAggregateFunction(maxMap, Map(String, UInt64))", "Map(String, UInt64)")]
+    [TestCase("SimpleAggregateFunction(groupArrayLastArray(10), Array(String))", "Array(String)")]
+    public void Resolve_SimpleAggregateFunction_ResolvesToTheInnerTypesCodec(string type, string innerTypeName)
+    {
+        IColumnCodec codec = ColumnCodecRegistry.Default.Resolve(type, default);
+        Assert.That(codec.TypeName, Is.EqualTo(innerTypeName));
+    }
+
+    [TestCase("SimpleAggregateFunction(sum)")]
+    [TestCase("SimpleAggregateFunction(sum, UInt64, UInt8)")]
+    public void Resolve_SimpleAggregateFunctionWithoutExactlyOneInnerType_ThrowsFormat(string type)
+        => Assert.Throws<FormatException>(() => ColumnCodecRegistry.Default.Resolve(type, default));
+
+    // AggregateFunction holds the function's own intermediate state, which no generic codec decodes. The hint has to
+    // be a query that actually runs: the combinator attaches to the bare name, and a parameterized function keeps its
+    // parameters in their own list ahead of the column. "quantiles(0.5, 0.9)Merge" is not a function, and a bare
+    // "quantilesMerge(column)" is rejected by the server for wanting its parameters — verified on 26.6.
+    [TestCase("AggregateFunction(sum, UInt64)", "sumMerge(column)")]
+    [TestCase("AggregateFunction(quantiles(0.5, 0.9), UInt64)", "quantilesMerge(0.5, 0.9)(column)")]
+    public void Resolve_AggregateFunction_ThrowsSuggestingAMergeQueryThatRuns(string type, string expectedHint)
+    {
+        var exception = Assert.Throws<NotSupportedException>(() => ColumnCodecRegistry.Default.Resolve(type, default));
+        Assert.That(exception.Message, Does.Contain(expectedHint));
+    }
+
+    [Test]
+    public void Resolve_AggregateFunctionNamingNoFunction_ThrowsFormat()
+        => Assert.Throws<FormatException>(() => ColumnCodecRegistry.Default.Resolve("AggregateFunction()", default));
 }

--- a/ClickHouse.Driver.Tcp.Tests/Types/NullableColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/NullableColumnCodecTests.cs
@@ -317,7 +317,7 @@ public class NullableColumnCodecTests
 
     [Test]
     public void Resolve_UnsupportedInner_ThrowsNotSupported()
-        => Assert.Throws<NotSupportedException>(() => Resolve("Nullable(Point)"));
+        => Assert.Throws<NotSupportedException>(() => Resolve("Nullable(NotAType)"));
 
     [Test]
     public void Resolve_Nullable_StampsFullTypeName()

--- a/ClickHouse.Driver.Tcp.Tests/Types/VariantColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/VariantColumnCodecTests.cs
@@ -126,6 +126,25 @@ public class VariantColumnCodecTests
         Assert.ThrowsAsync<ArgumentException>(async () => await CodecTestHarness.WriteAsync(w => codec.WriteColumn(w, column)));
     }
 
+    // The refusal lists what the variant does take, so it must include a type a collision settles: IPv4 and IPv6
+    // both surface IPAddress, and Variant(IPv4, IPv6, String) does write an address of either family. Listing only
+    // the alternatives that own their CLR type outright would report IPAddress as unsupported.
+    [Test]
+    public void WriteColumn_ValueWithNoMatchingAlternative_NamesTheTypesACollisionSettles()
+    {
+        const string type = "Variant(IPv4, IPv6, String)";
+        IColumnCodec codec = Resolve(type);
+        var column = new ArrayColumn<object>("v", type, new object[] { 3.14 });
+
+        ArgumentException refusal = Assert.ThrowsAsync<ArgumentException>(
+            async () => await CodecTestHarness.WriteAsync(w => codec.WriteColumn(w, column)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(refusal.Message, Does.Contain(typeof(IPAddress).ToString()));
+            Assert.That(refusal.Message, Does.Contain(typeof(string).ToString()));
+        });
+    }
+
     // Several alternatives can share a CLR element type even though the server forbids duplicate alternative types
     // — they only have to surface the same one. JSON and String are both string; Int64, DateTime64 and Time64 are
     // all long; Geometry collides twice over (Ring/LineString, Polygon/MultiLineString). No alternative claims

--- a/ClickHouse.Driver.Tcp.Tests/Types/VariantColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/VariantColumnCodecTests.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Net;
 using System.Threading.Tasks;
 using ClickHouse.Driver.Tcp.Protocol;
 using ClickHouse.Driver.Tcp.Tests.Utilities;
@@ -122,6 +124,83 @@ public class VariantColumnCodecTests
         var column = new ArrayColumn<object>("v", StringUInt64, new object[] { 3.14 }); // double matches neither String nor UInt64
 
         Assert.ThrowsAsync<ArgumentException>(async () => await CodecTestHarness.WriteAsync(w => codec.WriteColumn(w, column)));
+    }
+
+    // Several alternatives can share a CLR element type even though the server forbids duplicate alternative types
+    // — they only have to surface the same one. JSON and String are both string; Int64, DateTime64 and Time64 are
+    // all long; Geometry collides twice over (Ring/LineString, Polygon/MultiLineString). No alternative claims
+    // such a value, and picking one would store it as the wrong type with no error. The message names the
+    // alternatives it could not choose between, and prescribes nothing: there is no way for a caller to say which
+    // one is meant.
+    [TestCaseSource(nameof(AmbiguousAlternativeCases))]
+    public void WriteColumn_ValueWhoseClrTypeSeveralAlternativesShare_ThrowsNamingThem(string type, object ambiguous, string[] expectedNames)
+    {
+        IColumnCodec codec = Resolve(type);
+        var column = new ArrayColumn<object>("v", type, new[] { ambiguous });
+
+        ArgumentException refusal = Assert.ThrowsAsync<ArgumentException>(
+            async () => await CodecTestHarness.WriteAsync(w => codec.WriteColumn(w, column)));
+        Assert.Multiple(() =>
+        {
+            foreach (string name in expectedNames)
+            {
+                Assert.That(refusal.Message, Does.Contain($"'{name}'"));
+            }
+
+            Assert.That(refusal.Message, Does.Not.Contain("VariantColumn"));
+        });
+    }
+
+    // A collision the value itself settles: IPv4 and IPv6 both surface IPAddress, but an address carries its
+    // family, so exactly one alternative claims it and the write goes through. This is the only one of the four
+    // collision families a value-level test can resolve — a string says nothing about JSON versus String, a long
+    // nothing about Int64 versus DateTime64, and a Ring nothing about LineString.
+    [TestCase("127.0.0.1", 0, TestName = "An IPv4 address goes to the IPv4 alternative")]
+    [TestCase("::1", 1, TestName = "An IPv6 address goes to the IPv6 alternative")]
+    public async Task WriteColumn_IpValueWhoseFamilyNamesOneAlternative_WritesThatDiscriminator(string address, byte expectedDiscriminator)
+    {
+        const string Type = "Variant(IPv4, IPv6, String)";
+        IColumnCodec codec = Resolve(Type);
+        var column = new ArrayColumn<object>("v", Type, new object[] { IPAddress.Parse(address) });
+
+        byte[] bytes = await CodecTestHarness.WriteAsync(w => codec.WriteColumn(w, column));
+        Assert.That(bytes[0], Is.EqualTo(expectedDiscriminator));
+    }
+
+    // The refusal above is per value, not per column: an IColumn<object> says nothing about the runtime types it
+    // holds, so refusing the whole column would also reject every unambiguous value in it. A string is unambiguous
+    // in Variant(IPv4, IPv6, String) and a UInt64 is in Variant(JSON, String, UInt64), and both still write.
+    [TestCaseSource(nameof(UnambiguousAlternativeCases))]
+    public async Task WriteColumn_ValueWhoseClrTypeOneAlternativeHas_WritesEvenWhenOthersCollide(string type, object unambiguous)
+    {
+        IColumnCodec codec = Resolve(type);
+        var column = new ArrayColumn<object>("v", type, new[] { unambiguous });
+
+        byte[] bytes = await CodecTestHarness.WriteAsync(w => codec.WriteColumn(w, column));
+        Assert.That(bytes, Is.Not.Empty);
+    }
+
+    private static IEnumerable<TestCaseData> AmbiguousAlternativeCases()
+    {
+        yield return new TestCaseData("Variant(JSON, String, UInt64)", (object)"{}", new[] { "JSON", "String" })
+            .SetName("JSON and String are both string");
+
+        // Three, not two. Striking a colliding type from the map must not free the key for the next alternative to
+        // claim: an odd-sized collision group would then resolve to its last member and write every such value as
+        // that alternative. All three of these surface the raw long the wire carries.
+        yield return new TestCaseData("Variant(DateTime64(3), Int64, Time64(3))", (object)5L, new[] { "DateTime64(3)", "Int64", "Time64(3)" })
+            .SetName("Int64, DateTime64 and Time64 are all long");
+
+        // The structural pairs inside Geometry, which no value-level test can separate.
+        yield return new TestCaseData("Geometry", (object)new[] { (0d, 0d), (1d, 1d) }, new[] { "LineString", "Ring" })
+            .SetName("LineString and Ring are both Array(Point)");
+    }
+
+    private static IEnumerable<TestCaseData> UnambiguousAlternativeCases()
+    {
+        yield return new TestCaseData("Variant(IPv4, IPv6, String)", (object)"abc").SetName("String beside the colliding IP pair");
+        yield return new TestCaseData("Variant(JSON, String, UInt64)", (object)7UL).SetName("UInt64 beside the colliding text pair");
+        yield return new TestCaseData("Variant(DateTime64(3), Int64, String, Time64(3))", (object)"abc").SetName("String beside the colliding long trio");
     }
 
     [Test]

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
@@ -911,6 +911,24 @@ public sealed class InsertRoundTripCase
             name => new ArrayColumn<object>(name, "Variant(Bool, Int32, String)", new object[] { true, 42, "x", null, false, -1 }),
             VariantSettings);
 
+        // Two alternatives surfacing one CLR type, settled by the value. IPv4 and IPv6 are both IPAddress, so the
+        // runtime type alone picks neither; the address family does, and the server's own view of which
+        // alternative each row took is what the read-back compares. A String rides along to keep the rest of the
+        // resolution honest: it collides with nothing and must still take its own discriminator.
+        yield return Same(
+            "Variant(IPv4, IPv6, String)",
+            "Variant(IPv4, IPv6, String)",
+            name => new ArrayColumn<object>(name, "Variant(IPv4, IPv6, String)", new object[]
+            {
+                IPAddress.Parse("10.0.0.1"),
+                IPAddress.Parse("2001:db8::1"),
+                "not an address",
+                null,
+                IPAddress.Parse("0.0.0.0"),
+                IPAddress.Parse("::"),
+            }),
+            VariantSettings);
+
         // A composite alternative: an Array as one of the variant types. A row selecting it carries the inner
         // element array (ulong[]); the other rows carry a String or NULL.
         yield return Same(
@@ -1289,6 +1307,146 @@ public sealed class InsertRoundTripCase
                 pooledOffsets: false,
                 ownsFields: false),
             MergeSettings(NestedSettings, JsonSettings));
+
+        // The geo aliases name structures already covered above — Point is Tuple(Float64, Float64) and the rest
+        // are arrays over it — so what these cases prove is not the layout but that the alias resolves to it: the
+        // server puts "Point"/"Ring"/… in the column header, and the client has to accept that name in both
+        // directions. Like Array and Tuple, they take no Nullable case: Nullable(Point) needs
+        // enable_nullable_tuple_type and the server rejects a Nullable array outright.
+        // Supplied as a flat column of tuples rather than a dense TupleColumn: that column's convenience
+        // constructor derives its children's types by re-parsing its own type name, which an alias is not. The
+        // dense shape is still covered — the read comes back as one, and the dense-readback case re-inserts it.
+        yield return Same(
+            "Point",
+            "Point",
+            name => new ArrayColumn<(double, double)>(name, "Point", new[] { (0d, 0d), (1.5d, -2.5d), (double.MinValue, double.MaxValue) }));
+
+        // Ring and LineString share a structure and differ only in name, so each needs its own case — a
+        // registration that mapped one of them to the wrong codec would still pass the other's.
+        yield return Same(
+            "Ring",
+            "Ring",
+            name => new ArrayColumn<(double, double)[]>(name, "Ring", new[]
+            {
+                new[] { (0d, 0d), (1d, 0d), (1d, 1d), (0d, 0d) },
+                Array.Empty<(double, double)>(),
+            }));
+
+        yield return Same(
+            "LineString",
+            "LineString",
+            name => new ArrayColumn<(double, double)[]>(name, "LineString", new[]
+            {
+                new[] { (0d, 0d), (1.5d, 2.5d) },
+                Array.Empty<(double, double)>(),
+            }));
+
+        // Polygon and MultiLineString likewise share a structure (an array of the array-of-Point aliases) and
+        // differ only in which alias sits underneath.
+        yield return Same(
+            "Polygon",
+            "Polygon",
+            name => new ArrayColumn<(double, double)[][]>(name, "Polygon", new[]
+            {
+                new[] { new[] { (0d, 0d), (2d, 0d), (2d, 2d), (0d, 0d) }, new[] { (0.5d, 0.5d), (1d, 0.5d), (1d, 1d), (0.5d, 0.5d) } },
+                Array.Empty<(double, double)[]>(),
+            }));
+
+        yield return Same(
+            "MultiLineString",
+            "MultiLineString",
+            name => new ArrayColumn<(double, double)[][]>(name, "MultiLineString", new[]
+            {
+                new[] { new[] { (0d, 0d), (1d, 1d) }, new[] { (2d, 2d), (3d, 3d) } },
+                Array.Empty<(double, double)[]>(),
+            }));
+
+        yield return Same(
+            "MultiPolygon",
+            "MultiPolygon",
+            name => new ArrayColumn<(double, double)[][][]>(name, "MultiPolygon", new[]
+            {
+                new[] { new[] { new[] { (0d, 0d), (2d, 0d), (2d, 2d), (0d, 0d) } } },
+                Array.Empty<(double, double)[][]>(),
+            }));
+
+        // The alias inside a composite: the registry has to reach it while resolving a child node, not only as a
+        // whole column type.
+        yield return Arrays("Point", new[] { (0d, 0d), (1d, 2d) }, Array.Empty<(double, double)>());
+
+        // No Nullable(Point) case, though the server accepts the type behind enable_nullable_tuple_type and this
+        // client reads it correctly. Writing it hits a pre-existing defect that has nothing to do with geo:
+        // NullableColumnCodec forwards the *outer* column to the inner's state-prefix phase, and TupleColumnCodec
+        // builds its write state there, so it is handed a column of (double, double)? where it needs
+        // (double, double). Any Nullable(Tuple(...)) fails the same way. Tracked as an I6 residual.
+
+        // Geometry is a Variant over the six aliases, and the column header carries only "Geometry", so the client
+        // expands it and picks the discriminator order itself. A row against each of the six discriminators, plus a
+        // NULL on 255, catches an order that disagrees with the server for Point and MultiPolygon, whose layouts
+        // are unique. It cannot catch a transposition within the two structurally identical pairs: the block is
+        // byte-identical, and the read applies the same order the write used, so the value survives either way.
+        // GeometryIntegrationTests asks the server for its own name for each row instead.
+        // The insert source is the dense column: a gathered row of one of those pairs would name neither
+        // alternative, so only explicit discriminators can express this column.
+        if (TcpServerFeatures.Has(TcpFeature.Geometry))
+        {
+            yield return Same("Geometry", "Geometry", name => BuildGeometryColumn(name));
+        }
+
+        // SimpleAggregateFunction(func, T) encodes as a bare T — the function only tells the server how to merge
+        // rows — so these cases prove the alias is transparent, including when T is itself composite or nullable
+        // and when the function carries parameters.
+        // A Memory table stores the column as declared, so the round-trip never merges and the value is what was
+        // written.
+        yield return Same(
+            "SimpleAggregateFunction(sum, UInt64)",
+            "SimpleAggregateFunction(sum, UInt64)",
+            name => PrimitiveColumn<ulong>.FromValues(name, "SimpleAggregateFunction(sum, UInt64)", new ulong[] { 0, 1, ulong.MaxValue }));
+
+        yield return Same(
+            "SimpleAggregateFunction(anyLast, Nullable(String))",
+            "SimpleAggregateFunction(anyLast, Nullable(String))",
+            name => new ArrayColumn<string>(name, "SimpleAggregateFunction(anyLast, Nullable(String))", new[] { "a", null, string.Empty }));
+
+        yield return Same(
+            "SimpleAggregateFunction(groupArrayArray, Array(UInt64))",
+            "SimpleAggregateFunction(groupArrayArray, Array(UInt64))",
+            name => new ArrayColumn<ulong[]>(name, "SimpleAggregateFunction(groupArrayArray, Array(UInt64))", new[]
+            {
+                new ulong[] { 1, 2, 3 },
+                Array.Empty<ulong>(),
+            }));
+
+        // A parameterized function keeps its parameters in the type name, on the wire as well as in the DDL. It
+        // parses as one node carrying its own arguments, so the type still has exactly two arguments and the
+        // parameters are never mistaken for a second inner type.
+        yield return Same(
+            "SimpleAggregateFunction(groupArrayLastArray(10), Array(String))",
+            "SimpleAggregateFunction(groupArrayLastArray(10), Array(String))",
+            name => new ArrayColumn<string[]>(name, "SimpleAggregateFunction(groupArrayLastArray(10), Array(String))", new[]
+            {
+                new[] { "x", string.Empty },
+                Array.Empty<string>(),
+            }));
+    }
+
+    // One row per Geometry alternative, in declared discriminator order, plus a NULL. Each alternative column holds
+    // only the rows that selected it — one each here — so every child is a single-row column.
+    private static IColumn BuildGeometryColumn(string name)
+    {
+        var square = new[] { (0d, 0d), (2d, 0d), (2d, 2d), (0d, 0d) };
+        IColumn[] alternatives =
+        {
+            new ArrayColumn<(double, double)[]>(name, "LineString", new[] { new[] { (0d, 0d), (1d, 1d) } }),
+            new ArrayColumn<(double, double)[][]>(name, "MultiLineString", new[] { new[] { new[] { (2d, 2d), (3d, 3d) } } }),
+            new ArrayColumn<(double, double)[][][]>(name, "MultiPolygon", new[] { new[] { new[] { square } } }),
+            new ArrayColumn<(double, double)>(name, "Point", new[] { (1.5d, -2.5d) }),
+            new ArrayColumn<(double, double)[][]>(name, "Polygon", new[] { new[] { square } }),
+            new ArrayColumn<(double, double)[]>(name, "Ring", new[] { square }),
+        };
+
+        var discriminators = new byte[] { 0, 1, 2, 3, 4, 5, IVariantColumn.NullDiscriminator };
+        return new VariantColumn(name, "Geometry", discriminators, alternatives, rowCount: discriminators.Length, pooledDiscriminators: false, ownsColumns: false);
     }
 
     // Merges two settings dictionaries into one (later entries win) for cases needing both flags.

--- a/ClickHouse.Driver.Tcp/Types/Codecs/AggregateFunctionColumnCodecs.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/AggregateFunctionColumnCodecs.cs
@@ -1,0 +1,65 @@
+using System;
+
+namespace ClickHouse.Driver.Tcp.Types.Codecs;
+
+/// <summary>
+/// The two aggregate-state type families, which the wire treats very differently.
+/// <c>SimpleAggregateFunction(func, T)</c> is a plain <c>T</c> — the functions it admits are the ones whose
+/// state <em>is</em> the value — so it resolves to <c>T</c>'s codec. <c>AggregateFunction(func, ...)</c> is the
+/// opposite: its body is the function's own intermediate state, encoded by that function alone, so there is
+/// nothing generic to decode and the client refuses it by name.
+/// </summary>
+internal static class AggregateFunctionColumnCodecs
+{
+    /// <summary>
+    /// Resolves <c>SimpleAggregateFunction(func, T)</c> to <c>T</c>'s codec. The function name affects only how
+    /// the server merges rows, never their encoding, so the alias adds no bytes and needs no codec of its own.
+    /// The inner type is resolved recursively, so a composite or aliased <c>T</c> works like any other.
+    /// </summary>
+    /// <param name="node">The parsed node; its arguments are the function name and the inner type.</param>
+    /// <param name="context">The resolution context, forwarded to the inner codec's factory.</param>
+    /// <param name="registry">The registry used to resolve the inner type's codec.</param>
+    /// <returns>The inner type's codec.</returns>
+    /// <exception cref="FormatException">The type has other than two arguments.</exception>
+    public static IColumnCodec CreateSimple(TypeNode node, in ResolveContext context, ColumnCodecRegistry registry)
+    {
+        // Always exactly two: the function and one value type. A parameterized function
+        // ("groupArrayLastArray(10)", which the server does accept) parses as a single node with its own
+        // arguments, so it does not widen this list — and the server rejects a second value type outright.
+        if (node.Arguments.Count != 2)
+        {
+            throw new FormatException($"SimpleAggregateFunction type '{node}' must have a function name and exactly one inner type argument.");
+        }
+
+        return registry.ResolveNode(node.Arguments[1], in context);
+    }
+
+    /// <summary>
+    /// Refuses <c>AggregateFunction(func, ...)</c>, naming the function and the query that reads it. The column
+    /// holds serialized intermediate states, not values: the encoding belongs to the aggregate function rather
+    /// than to the Native format, so no client-side decode is possible for the family as a whole. Merging the
+    /// state server-side turns the column into an ordinary typed one this client does read.
+    /// </summary>
+    /// <param name="node">The parsed node; its first argument names the function.</param>
+    /// <returns>Never returns.</returns>
+    /// <exception cref="FormatException">The type names no function.</exception>
+    /// <exception cref="NotSupportedException">Otherwise always — the refusal this method exists for.</exception>
+    public static IColumnCodec RefuseAggregateFunction(TypeNode node)
+    {
+        if (node.Arguments.Count == 0)
+        {
+            throw new FormatException($"AggregateFunction type '{node}' must name an aggregate function.");
+        }
+
+        // A parameterized function ("quantiles(0.5, 0.9)") parses as a node of its own: the Merge combinator
+        // attaches to the bare name, and the parameters move to their own list ahead of the column —
+        // quantilesMerge(0.5, 0.9)(column). Suggesting the bare form there hands back a query the server rejects.
+        TypeNode function = node.Arguments[0];
+        string parameters = function.Arguments.Count > 0 ? $"({string.Join(", ", function.Arguments)})" : string.Empty;
+
+        throw new NotSupportedException(
+            $"Column type '{node}' holds the intermediate states of the '{function.Name}' aggregate function, whose encoding is the " +
+            $"function's own; this client cannot decode it. Merge the state in the query instead — " +
+            $"'SELECT {function.Name}Merge{parameters}(column) ...' — which returns an ordinary column.");
+    }
+}

--- a/ClickHouse.Driver.Tcp/Types/Codecs/ArrayColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/ArrayColumnCodec.cs
@@ -25,9 +25,12 @@ internal static class ArrayColumnCodec
     /// <param name="node">The parsed <c>Array</c> type node; its single argument is the inner type.</param>
     /// <param name="context">The resolution context, forwarded to the inner codec's factory.</param>
     /// <param name="registry">The registry used to resolve the inner type's codec.</param>
+    /// <param name="typeName">The name to report as the codec's <see cref="IColumnCodec.TypeName"/>, or null to use
+    /// <paramref name="node"/>'s own. An alias whose structure is an array (<c>Ring</c>, <c>Polygon</c>) passes its
+    /// own name so diagnostics name the type the server sent rather than the structure it stands for.</param>
     /// <returns>The codec, closed over the inner codec's element type.</returns>
     /// <exception cref="FormatException">The type has other than one argument.</exception>
-    public static IColumnCodec Create(TypeNode node, in ResolveContext context, ColumnCodecRegistry registry)
+    public static IColumnCodec Create(TypeNode node, in ResolveContext context, ColumnCodecRegistry registry, string typeName = null)
     {
         if (node.Arguments.Count != 1)
         {
@@ -35,7 +38,7 @@ internal static class ArrayColumnCodec
         }
 
         IColumnCodec inner = registry.ResolveNode(node.Arguments[0], in context);
-        return Factories.GetOrAdd(inner.ElementType, BuildFactory)(node.ToString(), inner);
+        return Factories.GetOrAdd(inner.ElementType, BuildFactory)(typeName ?? node.ToString(), inner);
     }
 
     // Closes ArrayColumnCodec<T> over elementType once — via a generic helper invoked reflectively — and returns a

--- a/ClickHouse.Driver.Tcp/Types/Codecs/GeoColumnCodecs.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/GeoColumnCodecs.cs
@@ -1,0 +1,65 @@
+namespace ClickHouse.Driver.Tcp.Types.Codecs;
+
+/// <summary>
+/// The geo type aliases. Each names a structure the client already encodes, so none needs a codec of its own —
+/// only a registration that resolves its structure and keeps its own name:
+///
+/// <list type="table">
+/// <item><term><c>Point</c></term><description><c>Tuple(Float64, Float64)</c> → <c>(double, double)</c></description></item>
+/// <item><term><c>Ring</c>, <c>LineString</c></term><description><c>Array(Point)</c> → <c>(double, double)[]</c></description></item>
+/// <item><term><c>Polygon</c>, <c>MultiLineString</c></term><description><c>Array(Ring)</c> / <c>Array(LineString)</c> → <c>(double, double)[][]</c></description></item>
+/// <item><term><c>MultiPolygon</c></term><description><c>Array(Polygon)</c> → <c>(double, double)[][][]</c></description></item>
+/// <item><term><c>Geometry</c></term><description>a <c>Variant</c> over the six above</description></item>
+/// </list>
+///
+/// <para>
+/// The bytes are the structure's, but the *name* on the wire is always the alias: a column header says
+/// <c>Point</c>, never <c>Tuple(Float64, Float64)</c>. So the client expands the alias itself, and reports the
+/// alias back as the codec's type name. That is also structurally what the HTTP driver surfaces, though that one
+/// builds <c>System.Tuple</c> where this builds <c>ValueTuple</c>.
+/// </para>
+///
+/// <para>
+/// <c>Ring</c>/<c>LineString</c> and <c>Polygon</c>/<c>MultiLineString</c> are distinct types to the server and
+/// identical to this client beyond their names. Inside <c>Geometry</c> that makes a value of either shared shape
+/// ambiguous, so it can only be written from the dense column, whose discriminators name the alternative; a
+/// <c>Point</c> or <c>MultiPolygon</c> is unique and still writes from an ergonomic one.
+/// </para>
+/// </summary>
+internal static class GeoColumnCodecs
+{
+    // Each alias in the server's own terms, parsed once. The nested aliases name each other rather than spelling
+    // out the whole structure, so the codec a Polygon resolves to holds a Ring codec that reports itself as "Ring".
+    private static readonly TypeNode PointStructure = TypeParser.Parse("Tuple(Float64, Float64)");
+    private static readonly TypeNode RingStructure = TypeParser.Parse("Array(Point)");
+    private static readonly TypeNode LineStringStructure = TypeParser.Parse("Array(Point)");
+    private static readonly TypeNode PolygonStructure = TypeParser.Parse("Array(Ring)");
+    private static readonly TypeNode MultiLineStringStructure = TypeParser.Parse("Array(LineString)");
+    private static readonly TypeNode MultiPolygonStructure = TypeParser.Parse("Array(Polygon)");
+
+    // The order is the discriminator order the server sends: the canonical name-sorted one, confirmed against
+    // variantType's Enum8 ('LineString' = 0 … 'Ring' = 5) and pinned by GeometryIntegrationTests.
+    private static readonly TypeNode GeometryStructure =
+        TypeParser.Parse("Variant(LineString, MultiLineString, MultiPolygon, Point, Polygon, Ring)");
+
+    public static IColumnCodec CreatePoint(in ResolveContext context, ColumnCodecRegistry registry)
+        => TupleColumnCodec.Create(PointStructure, in context, registry, "Point");
+
+    public static IColumnCodec CreateRing(in ResolveContext context, ColumnCodecRegistry registry)
+        => ArrayColumnCodec.Create(RingStructure, in context, registry, "Ring");
+
+    public static IColumnCodec CreateLineString(in ResolveContext context, ColumnCodecRegistry registry)
+        => ArrayColumnCodec.Create(LineStringStructure, in context, registry, "LineString");
+
+    public static IColumnCodec CreatePolygon(in ResolveContext context, ColumnCodecRegistry registry)
+        => ArrayColumnCodec.Create(PolygonStructure, in context, registry, "Polygon");
+
+    public static IColumnCodec CreateMultiLineString(in ResolveContext context, ColumnCodecRegistry registry)
+        => ArrayColumnCodec.Create(MultiLineStringStructure, in context, registry, "MultiLineString");
+
+    public static IColumnCodec CreateMultiPolygon(in ResolveContext context, ColumnCodecRegistry registry)
+        => ArrayColumnCodec.Create(MultiPolygonStructure, in context, registry, "MultiPolygon");
+
+    public static IColumnCodec CreateGeometry(in ResolveContext context, ColumnCodecRegistry registry)
+        => VariantColumnCodec.Create(GeometryStructure, in context, registry, "Geometry");
+}

--- a/ClickHouse.Driver.Tcp/Types/Codecs/IpColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/IpColumnCodec.cs
@@ -39,6 +39,11 @@ internal sealed class IPv4ColumnCodec : IColumnCodec
         => writeType == typeof(IPAddress) ? WireEquality.Projected<IPAddress, uint>(ToWireValue) : null;
 
     /// <inheritdoc/>
+    // The address family is the whole of the IPv4/IPv6 tie-break: an IPv4 address is this alternative's, and the
+    // IPv6 codec declines it so that exactly one claims.
+    public bool ClaimsValue(object value) => value is IPAddress address && address.AddressFamily == AddressFamily.InterNetwork;
+
+    /// <inheritdoc/>
     public ValueTask<IColumn> ReadColumnAsync(ClickHouseBinaryReader reader, string columnName, string columnType, int rowCount, CancellationToken cancellationToken)
         => ArrayColumn<IPAddress>.ReadAsync(reader, columnName, columnType, rowCount, checked(rowCount * Size), Fill, cancellationToken);
 
@@ -106,6 +111,12 @@ internal sealed class IPv6ColumnCodec : IColumnCodec
 
     /// <inheritdoc/>
     public object NullPlaceholder => IPAddress.IPv6Any;
+
+    /// <inheritdoc/>
+    // Declines an IPv4 address even though the writer below maps one into 16 bytes: beside an IPv4 alternative
+    // that address means IPv4, and claiming it too would leave the tie unresolved. A standalone IPv6 column, and
+    // an IPv6 alternative with no IPv4 sibling, never reach here and still accept it.
+    public bool ClaimsValue(object value) => value is IPAddress address && address.AddressFamily == AddressFamily.InterNetworkV6;
 
     /// <inheritdoc/>
     public ValueTask<IColumn> ReadColumnAsync(ClickHouseBinaryReader reader, string columnName, string columnType, int rowCount, CancellationToken cancellationToken)

--- a/ClickHouse.Driver.Tcp/Types/Codecs/TupleColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/TupleColumnCodec.cs
@@ -131,10 +131,13 @@ internal sealed class TupleColumnCodec : IColumnCodec
     /// <param name="node">The parsed <c>Tuple</c> node; its arguments are the element types (each optionally name-prefixed).</param>
     /// <param name="context">The resolution context, forwarded to each element codec's factory.</param>
     /// <param name="registry">The registry used to resolve the element codecs.</param>
+    /// <param name="typeName">The name to report as the codec's <see cref="IColumnCodec.TypeName"/>, or null to use
+    /// <paramref name="node"/>'s own. An alias whose structure is a tuple (<c>Point</c>) passes its own name so
+    /// diagnostics name the type the server sent rather than the structure it stands for.</param>
     /// <returns>The codec: <see cref="EmptyTupleColumnCodec"/> for <c>Tuple()</c>, otherwise this per-element one.</returns>
     /// <exception cref="FormatException">The type names no elements and has no argument list either.</exception>
     /// <exception cref="NotSupportedException">The tuple has more elements than this client supports.</exception>
-    public static IColumnCodec Create(TypeNode node, in ResolveContext context, ColumnCodecRegistry registry)
+    public static IColumnCodec Create(TypeNode node, in ResolveContext context, ColumnCodecRegistry registry, string typeName = null)
     {
         if (node.Arguments.Count == 0)
         {
@@ -166,7 +169,7 @@ internal sealed class TupleColumnCodec : IColumnCodec
             anyNamed |= elements[i].Name is not null;
         }
 
-        return new TupleColumnCodec(node.ToString(), childCodecs, anyNamed ? names : null);
+        return new TupleColumnCodec(typeName ?? node.ToString(), childCodecs, anyNamed ? names : null);
     }
 
     /// <inheritdoc/>

--- a/ClickHouse.Driver.Tcp/Types/Codecs/VariantColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/VariantColumnCodec.cs
@@ -67,6 +67,7 @@ internal sealed class VariantColumnCodec : IColumnCodec
     private readonly IColumnCodec[] children;
     private readonly Func<string, string, object[], int, IColumn>[] childFlatBuilders;
     private readonly Dictionary<Type, int> discriminatorByClrType;
+    private readonly Dictionary<Type, int[]> collidingDiscriminatorsByClrType;
     private readonly bool allChildrenWritable;
 
     private VariantColumnCodec(string typeName, IColumnCodec[] children)
@@ -84,20 +85,51 @@ internal sealed class VariantColumnCodec : IColumnCodec
         // here — not a codec's extra convenience write types (e.g. DateTime alongside DateTimeOffset): the
         // per-alternative bucket is materialized as that exact element type (BuildFlatColumn<ElementType>), so a
         // convenience-typed value would fail the bucket cast. Rejecting it up front with a clear "no alternative"
-        // error beats a deep InvalidCastException. If two alternatives claimed the same CLR type the lower
-        // discriminator would win (the server forbids duplicate alternative types, so this is only a tie-break).
-        discriminatorByClrType = new Dictionary<Type, int>();
+        // error beats a deep InvalidCastException.
+        //
+        // Several alternatives can share a CLR type even though the server forbids duplicate alternative *types*:
+        // they only have to surface the same one. Ring and LineString are both Array(Point), so both surface as
+        // (double, double)[], as do Polygon and MultiLineString — which makes four of Geometry's six collide.
+        // IPv4 and IPv6 both surface IPAddress, JSON and String both surface string, and Int64, DateTime64 and
+        // Time64 all surface long. A colliding type is struck from the map and its alternatives are collected
+        // instead, for DiscriminatorFor to settle per value; it never tie-breaks to the lower discriminator. The
+        // rest of the map is unaffected: a string written into Variant(IPv4, IPv6, String) is unambiguous and
+        // resolves in one lookup.
+        var byClrType = new Dictionary<Type, List<int>>();
         bool writable = true;
         for (int i = 0; i < typeCount; i++)
         {
+            Type elementType = children[i].ElementType;
             childFlatBuilders[i] = (Func<string, string, object[], int, IColumn>)builderTemplate
-                .MakeGenericMethod(children[i].ElementType)
+                .MakeGenericMethod(elementType)
                 .CreateDelegate(typeof(Func<string, string, object[], int, IColumn>));
 
-            discriminatorByClrType.TryAdd(children[i].ElementType, i);
+            if (!byClrType.TryGetValue(elementType, out List<int> sharing))
+            {
+                sharing = new List<int>(1);
+                byClrType[elementType] = sharing;
+            }
 
-            // Reject variants with unwritable alternatives before writing.
-            writable &= children[i].CanWriteElementType(children[i].ElementType);
+            sharing.Add(i);
+
+            // A Variant over a non-writable alternative (e.g. Nothing) is rejected up front rather than mid-write.
+            writable &= children[i].CanWriteElementType(elementType);
+        }
+
+        // Split once, so the write path pays nothing for a collision it does not have: a type owned by a single
+        // alternative resolves in one dictionary hit and never touches the candidate list.
+        discriminatorByClrType = new Dictionary<Type, int>(byClrType.Count);
+        collidingDiscriminatorsByClrType = new Dictionary<Type, int[]>();
+        foreach (KeyValuePair<Type, List<int>> entry in byClrType)
+        {
+            if (entry.Value.Count == 1)
+            {
+                discriminatorByClrType[entry.Key] = entry.Value[0];
+            }
+            else
+            {
+                collidingDiscriminatorsByClrType[entry.Key] = entry.Value.ToArray();
+            }
         }
 
         allChildrenWritable = writable;
@@ -105,6 +137,14 @@ internal sealed class VariantColumnCodec : IColumnCodec
 
     /// <inheritdoc/>
     public string TypeName { get; }
+
+    /// <summary>
+    /// The alternatives' ClickHouse type names, in discriminator order — alternative <c>i</c> is what discriminator
+    /// <c>i</c> selects. For a spelled-out <c>Variant(...)</c> this only restates the type string, but for an alias
+    /// the client expands itself (<c>Geometry</c>) it is the whole of the client's claim about the ordering, which
+    /// nothing on the wire carries and which callers of the dense column depend on to mean what they intend.
+    /// </summary>
+    internal IReadOnlyList<string> AlternativeTypeNames => Array.ConvertAll(children, child => child.TypeName);
 
     /// <inheritdoc/>
     public Type ElementType => typeof(object);
@@ -118,10 +158,13 @@ internal sealed class VariantColumnCodec : IColumnCodec
     /// <param name="node">The parsed <c>Variant</c> node; its arguments are the alternative types in discriminator order.</param>
     /// <param name="context">The resolution context, forwarded to each alternative codec's factory.</param>
     /// <param name="registry">The registry used to resolve the alternative codecs.</param>
+    /// <param name="typeName">The name to report as the codec's <see cref="IColumnCodec.TypeName"/>, or null to use
+    /// <paramref name="node"/>'s own. An alias whose structure is a variant (<c>Geometry</c>) passes its own name so
+    /// diagnostics name the type the server sent rather than the structure it stands for.</param>
     /// <returns>The codec.</returns>
     /// <exception cref="FormatException">The variant has no alternatives, or an alternative is <c>Nullable</c>.</exception>
     /// <exception cref="NotSupportedException">The variant has more alternatives than the BASIC layout can address.</exception>
-    public static VariantColumnCodec Create(TypeNode node, in ResolveContext context, ColumnCodecRegistry registry)
+    public static VariantColumnCodec Create(TypeNode node, in ResolveContext context, ColumnCodecRegistry registry, string typeName = null)
     {
         if (node.Arguments.Count == 0)
         {
@@ -156,7 +199,7 @@ internal sealed class VariantColumnCodec : IColumnCodec
             childCodecs[i] = registry.ResolveNode(argument, in context);
         }
 
-        return new VariantColumnCodec(node.ToString(), childCodecs);
+        return new VariantColumnCodec(typeName ?? node.ToString(), childCodecs);
     }
 
     /// <inheritdoc/>
@@ -221,6 +264,11 @@ internal sealed class VariantColumnCodec : IColumnCodec
     // that checked, and the first thing the writer does is put the discriminators on the wire — so a bad value
     // would desync the block mid-stream rather than fail cleanly. Anything else writable arrives as IColumn<object>
     // and goes down the scattered path, which validates as it goes.
+    //
+    // Whether a *value* names an alternative is not answerable here: an IColumn<object> says nothing about the
+    // runtime types it holds, so a Variant with colliding alternatives is still accepted at this gate and refuses
+    // the individual value later, in DiscriminatorFor. Refusing the whole column here instead would also reject
+    // every unambiguous value it holds.
     public bool CanWriteElementType(Type elementType) => allChildrenWritable && elementType == ElementType;
 
     /// <inheritdoc/>
@@ -414,7 +462,7 @@ internal sealed class VariantColumnCodec : IColumnCodec
                     continue;
                 }
 
-                int discriminator = DiscriminatorFor(value.GetType());
+                int discriminator = DiscriminatorFor(value);
                 discriminators[row] = (byte)discriminator;
                 buckets[discriminator][filled[discriminator]++] = value;
             }
@@ -491,17 +539,60 @@ internal sealed class VariantColumnCodec : IColumnCodec
         };
     }
 
-    // Resolves the discriminator for a value's runtime CLR type, or throws if no alternative accepts it.
-    private int DiscriminatorFor(Type clrType)
+    // Resolves the discriminator for a value, or throws if no alternative takes it — or if more than one does.
+    // Reached from BeginWrite, so either refusal happens before a byte is on the wire.
+    private int DiscriminatorFor(object value)
     {
+        Type clrType = value.GetType();
         if (discriminatorByClrType.TryGetValue(clrType, out int discriminator))
         {
             return discriminator;
         }
 
+        if (collidingDiscriminatorsByClrType.TryGetValue(clrType, out int[] candidates))
+        {
+            return SettleCollision(value, clrType, candidates);
+        }
+
         throw new ArgumentException(
             $"Variant '{TypeName}' has no alternative for a value of CLR type '{clrType}'. Supported CLR types: {string.Join(", ", discriminatorByClrType.Keys)}.");
     }
+
+    // Several alternatives surface this CLR type, so the type alone does not name one and the value is asked
+    // instead. Exactly one claimant resolves it; anything else is refused rather than tie-broken, because picking
+    // would store the value as the wrong type in silence — a Ring written as a LineString.
+    private int SettleCollision(object value, Type clrType, int[] candidates)
+    {
+        int claimed = -1;
+        for (int i = 0; i < candidates.Length; i++)
+        {
+            if (!children[candidates[i]].ClaimsValue(value))
+            {
+                continue;
+            }
+
+            if (claimed >= 0)
+            {
+                throw new ArgumentException(
+                    $"Variant '{TypeName}' cannot place a value of CLR type '{clrType}': the alternatives {NameCandidates(candidates)} all " +
+                    "surface that type, and the value does not say which of them is meant.");
+            }
+
+            claimed = candidates[i];
+        }
+
+        if (claimed < 0)
+        {
+            throw new ArgumentException(
+                $"Variant '{TypeName}' cannot place a value of CLR type '{clrType}': it surfaces the type of the alternatives " +
+                $"{NameCandidates(candidates)}, but matches none of them.");
+        }
+
+        return claimed;
+    }
+
+    private string NameCandidates(int[] candidates)
+        => string.Join(", ", Array.ConvertAll(candidates, candidate => $"'{children[candidate].TypeName}'"));
 
     // The write scratch of one slice, shared across the prefix and body phases. ChildColumns holds one column per
     // alternative — borrowed from the dense column, or projected out of the boxed values — with the slice of it that

--- a/ClickHouse.Driver.Tcp/Types/Codecs/VariantColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/VariantColumnCodec.cs
@@ -555,7 +555,25 @@ internal sealed class VariantColumnCodec : IColumnCodec
         }
 
         throw new ArgumentException(
-            $"Variant '{TypeName}' has no alternative for a value of CLR type '{clrType}'. Supported CLR types: {string.Join(", ", discriminatorByClrType.Keys)}.");
+            $"Variant '{TypeName}' has no alternative for a value of CLR type '{clrType}'. Supported CLR types: {SupportedClrTypes()}.");
+    }
+
+    // Every alternative's element type, in discriminator order and without repeats. A type several alternatives
+    // share is supported as well — settled per value in SettleCollision — so listing only the unambiguous map
+    // would call an IPAddress unsupported in Variant(IPv4, IPv6, String).
+    private string SupportedClrTypes()
+    {
+        var seen = new HashSet<Type>();
+        var names = new List<string>(children.Length);
+        foreach (IColumnCodec child in children)
+        {
+            if (seen.Add(child.ElementType))
+            {
+                names.Add(child.ElementType.ToString());
+            }
+        }
+
+        return string.Join(", ", names);
     }
 
     // Several alternatives surface this CLR type, so the type alone does not name one and the value is asked

--- a/ClickHouse.Driver.Tcp/Types/ColumnCodecRegistry.cs
+++ b/ClickHouse.Driver.Tcp/Types/ColumnCodecRegistry.cs
@@ -167,6 +167,26 @@ internal sealed class ColumnCodecRegistry
         // so every JSON spelling resolves to the same codec and the arguments ride along in the type name only.
         AddFactory("JSON", static (TypeNode node, in ResolveContext _, ColumnCodecRegistry _) => JsonStringColumnCodec.Create(node));
 
+        // The geo aliases name structures the codecs above already encode — Point is a two-element Float64 tuple and
+        // the rest are arrays over it. The server puts the alias in the column header, so each resolves its structure
+        // and keeps its own name. Ring and LineString share a structure, as do Polygon and MultiLineString.
+        AddFactory("Point", static (TypeNode _, in ResolveContext context, ColumnCodecRegistry registry) => GeoColumnCodecs.CreatePoint(in context, registry));
+        AddFactory("Ring", static (TypeNode _, in ResolveContext context, ColumnCodecRegistry registry) => GeoColumnCodecs.CreateRing(in context, registry));
+        AddFactory("LineString", static (TypeNode _, in ResolveContext context, ColumnCodecRegistry registry) => GeoColumnCodecs.CreateLineString(in context, registry));
+        AddFactory("Polygon", static (TypeNode _, in ResolveContext context, ColumnCodecRegistry registry) => GeoColumnCodecs.CreatePolygon(in context, registry));
+        AddFactory("MultiLineString", static (TypeNode _, in ResolveContext context, ColumnCodecRegistry registry) => GeoColumnCodecs.CreateMultiLineString(in context, registry));
+        AddFactory("MultiPolygon", static (TypeNode _, in ResolveContext context, ColumnCodecRegistry registry) => GeoColumnCodecs.CreateMultiPolygon(in context, registry));
+
+        // Geometry is an alias too, but to a Variant over the six above rather than to a nested array. The header
+        // carries only "Geometry", so the client expands it itself, in the server's name-sorted discriminator order.
+        AddFactory("Geometry", static (TypeNode _, in ResolveContext context, ColumnCodecRegistry registry) => GeoColumnCodecs.CreateGeometry(in context, registry));
+
+        // SimpleAggregateFunction(func, T) encodes as a bare T, so it resolves to T's codec and the function name
+        // rides in the type string only. AggregateFunction is unrelated in every way but its name: its body is the
+        // function's own intermediate state, so it is refused with the query that reads it.
+        AddFactory("SimpleAggregateFunction", static (TypeNode node, in ResolveContext context, ColumnCodecRegistry registry) => AggregateFunctionColumnCodecs.CreateSimple(node, in context, registry));
+        AddFactory("AggregateFunction", static (TypeNode node, in ResolveContext _, ColumnCodecRegistry _) => AggregateFunctionColumnCodecs.RefuseAggregateFunction(node));
+
         return new ColumnCodecRegistry(byName);
     }
 }

--- a/ClickHouse.Driver.Tcp/Types/IColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/IColumnCodec.cs
@@ -97,6 +97,30 @@ internal interface IColumnCodec
     }
 
     /// <summary>
+    /// Whether <paramref name="value"/> belongs to this type rather than to a sibling that surfaces the same CLR
+    /// element type. Asked only to break a tie between <c>Variant</c> alternatives that collide on
+    /// <see cref="ElementType"/>, and only for a value whose type already reached this codec, so it is never on
+    /// the path of an unambiguous write.
+    ///
+    /// <para>
+    /// Exactly one alternative must claim the value for the tie to resolve; zero or several is a refusal. The
+    /// default therefore claims everything, which is the safe answer for a codec with no value-level test: it can
+    /// never win a tie on its own, so a genuine ambiguity (<c>Variant(JSON, String)</c> given a string) stays a
+    /// refusal rather than becoming a silent pick.
+    /// </para>
+    ///
+    /// <para>
+    /// This is narrower than <see cref="CanWrite"/>: a codec may decline a value here that its writer would
+    /// otherwise accept, because the question is which alternative the value <em>means</em>, not which one could
+    /// store it. <c>IPv6</c> writes an IPv4 address by mapping it, but declines it beside an <c>IPv4</c>
+    /// alternative that is the better home for it.
+    /// </para>
+    /// </summary>
+    /// <param name="value">The non-null value being placed, of this codec's element type.</param>
+    /// <returns>Whether this codec claims the value.</returns>
+    bool ClaimsValue(object value) => true;
+
+    /// <summary>
     /// An <see cref="IEqualityComparer{T}"/> of <paramref name="writeType"/> that holds two values equal exactly
     /// when this codec encodes them to the same bytes, or <see langword="null"/> when the codec offers none.
     ///


### PR DESCRIPTION
Four families of type name the server puts in a column header that the client had no factory for. Each one failed the whole query with `ClickHouse type '...' is not supported by this client yet`.

## Geo aliases

`Point` is `Tuple(Float64, Float64)`; `Ring` and `LineString` are `Array(Point)`; `Polygon` and `MultiLineString` are arrays over those; `MultiPolygon` is `Array(Polygon)`. None needs a codec — only a registration that resolves the structure. They surface the structural CLR value (`(double, double)` up to `(double, double)[][][]`), which is what the TCP parameter formatter already accepted for these names and structurally what the HTTP driver surfaces.

The name on the wire is always the alias — a header says `Point`, never `Tuple(Float64, Float64)` — so `ArrayColumnCodec.Create`, `TupleColumnCodec.Create` and `VariantColumnCodec.Create` take an optional type name and report the alias. The aliases are defined in terms of each other, mirroring the HTTP driver's class hierarchy, so a `Polygon`'s inner codec calls itself `Ring`.

`Ring`/`LineString` and `Polygon`/`MultiLineString` are structurally identical, so each has its own round-trip case: a registration pointing one at the other's codec would still pass the other's case.

## Geometry, and Variant collisions

`Geometry` is an alias to `Variant(LineString, MultiLineString, MultiPolygon, Point, Polygon, Ring)` — the server's canonical name-sorted order, which nothing on the wire carries.

Several alternatives can surface one CLR type, so the runtime type alone does not always name one. `VariantColumnCodec` previously resolved this with a `Dictionary.TryAdd` tie-break, silently writing a `Ring` as a `LineString`. It now asks the value.

**Where the value settles the collision, it does.** `IColumnCodec.ClaimsValue` is a new default interface member, so 22 of 24 codecs are untouched. It is narrower than `CanWrite`: not "could you store this" but "is this value yours". `IPv4` and `IPv6` override it on `AddressFamily`, and `Variant(IPv4, IPv6, String)` now writes an address of either family. IPv6 declines an IPv4 address even though its writer maps one, because beside an IPv4 alternative that address means IPv4; a standalone `IPv6` column, or an `IPv6` alternative with no `IPv4` sibling, resolves by type and never reaches the hook.

**Where nothing settles it, the write is refused.** Exactly one claimant resolves a collision; zero or several is a refusal. That rule is what makes the hook safe — first-match-wins (what the HTTP driver's `VariantType` does) would have silently picked `JSON` for a string in `Variant(JSON, String)`, reintroducing the bug. The default claims everything, so a codec with no value-level test can never win a tie on its own. Refused: `JSON` vs `String`, `Int64` vs `DateTime64` vs `Time64` (all three surface the raw `long`), and the two `Geometry` pairs.

The refusal message names the alternatives it could not choose between and prescribes nothing. It used to say "supply a dense `VariantColumn`", which is `internal` and unreachable from outside the assembly — a remedy pointing at a door that is not open. A public way to name an alternative explicitly is filed as K6.

**The refusal is per value, not per column.** An `IColumn<object>` says nothing about the runtime types it holds, so refusing the whole column would also reject every unambiguous value in it. A `string` in `Variant(IPv4, IPv6, String)` and a `ulong` in `Variant(JSON, String, UInt64)` must keep working, and they do. This also settles the `Variant(JSON, String)` ambiguity left open by J5.

The unambiguous lookup stays a single dictionary hit; candidates are walked only on a miss, so a collision costs only the columns that have one.

## Aggregate states

`SimpleAggregateFunction(func, T)` encodes as a bare `T`, so it resolves to `T`'s codec itself rather than a renaming wrapper, which would cost a virtual call per operation for a cosmetic type name. The inner goes back through the registry, so a composite, nullable, parameterized or itself-aliased `T` all work.

`AggregateFunction` is refused with a merge query that actually runs. The combinator attaches to the bare function name and a parameterized function keeps its parameters ahead of the column, so `AggregateFunction(quantiles(0.5, 0.9), UInt64)` suggests `quantilesMerge(0.5, 0.9)(column)` — not `quantiles(0.5, 0.9)Merge(column)`, which is not a function, and not a bare `quantilesMerge(column)`, which the server rejects for wanting its parameters.

## Testing

Round-trip corpus cases for every alias, for `Variant(IPv4, IPv6, String)`, and for four `SimpleAggregateFunction` shapes (scalar, nullable, composite, parameterized function). Codec unit tests for the resolution surface and the refusal paths only, per the test-layering rules.

The three-way collision case (`Variant(DateTime64(3), Int64, Time64(3))`) is mutation-checked: without the fix it writes discriminator 2, storing an `Int64` as a `Time64`. So is the IP tie-break — reverting either override fails the unit test and both corpus round-trips, because a misplaced IPv4 reads back as `::ffff:10.0.0.1`.

`GeometryIntegrationTests` pins the discriminator order against the server. No round trip can: the client applies its own order to the write and to the read, so a transposition cancels out, and for the two structurally identical pairs the block is byte-identical as well. Nor is it enough to write discriminator *i* and ask the server what it calls *i* — that answers from the server's own list. The expectation is read out of the codec and compared with the server's name for the row written at each position; **mutation-checked** by transposing `Ring` and `LineString`, which the first version of the test did not catch.

Coverage on the new files is 100%; the touched composites are 91–96%.

`Geometry` is gated on `TcpFeature.Geometry` — on the 25.8 CI floor the server resolves it to `String` at DDL time, so an ungated case would silently exercise a `String` column there. Verified by enumerating the corpus at `CLICKHOUSE_VERSION=25.8`: the Geometry cases disappear, the geo aliases stay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
