### PR TITLE
TCP O: sessions — one pinned connection for temporary tables and SET

### DIFF
--- a/ClickHouse.Driver.Tcp.Tests/Client/PinnedConnectionSourceTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Client/PinnedConnectionSourceTests.cs
@@ -1,0 +1,331 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Client;
+using ClickHouse.Driver.Tcp.Protocol;
+using ClickHouse.Driver.Tcp.Tests.Utilities;
+
+namespace ClickHouse.Driver.Tcp.Tests.Client;
+
+// What a session looks like from underneath, in the cases a live session cannot show. A real server proves the
+// effects — state carried, state kept private, connection not pooled afterwards — but not the order the disposal
+// does them in, nor what happens when the session is disposed with an operation still running, which needs an
+// operation held open at an exact moment.
+[TestFixture]
+public class PinnedConnectionSourceTests
+{
+    private static readonly CancellationToken None = CancellationToken.None;
+
+    /// <summary>
+    /// Stands in for the pool: hands over one connection and records what came back, so a test can ask whether the
+    /// lease was returned, how often, and in what state the connection was by then.
+    /// </summary>
+    private sealed class RecordingLease : IConnectionLease
+    {
+        private int returns;
+        private TcpConnectionState? stateOnReturn;
+
+        private RecordingLease(ClickHouseTcpConnection connection) => Connection = connection;
+
+        public ClickHouseTcpConnection Connection { get; }
+
+        /// <summary>
+        /// How many times the lease was returned. More than once would over-release the pool's permit. Counted
+        /// with an interlocked increment, so two concurrent returns register as two rather than racing to one and
+        /// leaving the very failure this exists to catch invisible.
+        /// </summary>
+        public int Returns => Volatile.Read(ref returns);
+
+        /// <summary>The connection's state when the lease came back, or null while it has not.</summary>
+        public TcpConnectionState? StateOnReturn => stateOnReturn;
+
+        internal static async ValueTask<RecordingLease> CreateAsync()
+            => new(await FakeConnectionFactory.CreateReadyAsync().ConfigureAwait(false));
+
+        public ValueTask DisposeAsync()
+        {
+            Interlocked.Increment(ref returns);
+            stateOnReturn = Connection.State;
+            return default;
+        }
+    }
+
+    [Test]
+    public async Task RentAsync_TwoOperationsInARow_BothGetTheSamePinnedConnection()
+    {
+        RecordingLease lease = await RecordingLease.CreateAsync();
+        var source = new PinnedConnectionSource(lease);
+
+        IConnectionLease first = await source.RentAsync(None);
+        ClickHouseTcpConnection connection = first.Connection;
+        await first.DisposeAsync();
+
+        IConnectionLease second = await source.RentAsync(None);
+        try
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(second.Connection, Is.SameAs(connection));
+                Assert.That(lease.Returns, Is.Zero, "the underlying lease stays held between operations");
+            });
+        }
+        finally
+        {
+            await second.DisposeAsync();
+            await source.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task DisposeAsync_WithNoOperationRunning_TerminatesTheConnectionBeforeReturningTheLease()
+    {
+        RecordingLease lease = await RecordingLease.CreateAsync();
+        var source = new PinnedConnectionSource(lease);
+
+        await source.DisposeAsync();
+
+        // The order is what keeps a session's state out of the pool: the pool decides a returned connection's fate
+        // from its state, so a connection still Ready when the lease comes back is one the pool keeps.
+        Assert.Multiple(() =>
+        {
+            Assert.That(lease.Returns, Is.EqualTo(1));
+            Assert.That(lease.StateOnReturn, Is.EqualTo(TcpConnectionState.Terminated));
+        });
+    }
+
+    [Test]
+    public async Task DisposeAsync_WhileAnOperationIsRunning_AbortsAtOnceAndReturnsWhenTheOperationEnds()
+    {
+        RecordingLease lease = await RecordingLease.CreateAsync();
+        var source = new PinnedConnectionSource(lease);
+        IConnectionLease operation = await source.RentAsync(None);
+
+        await source.DisposeAsync();
+
+        // The connection is unusable immediately, so nothing can be started over it, but the lease is held back:
+        // returning it would let the pool close a connection whose buffers the operation is still reading into.
+        Assert.Multiple(() =>
+        {
+            Assert.That(lease.Connection.State, Is.EqualTo(TcpConnectionState.Terminated));
+            Assert.That(lease.Returns, Is.Zero);
+        });
+
+        await operation.DisposeAsync();
+
+        Assert.That(lease.Returns, Is.EqualTo(1), "the operation completes the return as it unwinds");
+    }
+
+    [Test]
+    public async Task DisposeAsync_CalledTwice_ReturnsTheLeaseOnce()
+    {
+        RecordingLease lease = await RecordingLease.CreateAsync();
+        var source = new PinnedConnectionSource(lease);
+
+        await source.DisposeAsync();
+        await source.DisposeAsync();
+
+        // A second return releases a permit the source does not hold, which lets the pool run one operation past
+        // MaxPoolSize for the rest of its life.
+        Assert.That(lease.Returns, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task DisposeAsync_AfterAnOperationEndedFollowingDisposal_DoesNotReturnTheLeaseAgain()
+    {
+        RecordingLease lease = await RecordingLease.CreateAsync();
+        var source = new PinnedConnectionSource(lease);
+        IConnectionLease operation = await source.RentAsync(None);
+
+        await source.DisposeAsync();
+        await operation.DisposeAsync();
+        await source.DisposeAsync();
+
+        Assert.That(lease.Returns, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task DisposeAsync_OperationLeaseDisposedTwice_ReturnsTheLeaseOnce()
+    {
+        RecordingLease lease = await RecordingLease.CreateAsync();
+        var source = new PinnedConnectionSource(lease);
+        IConnectionLease operation = await source.RentAsync(None);
+
+        await source.DisposeAsync();
+        await operation.DisposeAsync();
+        await operation.DisposeAsync();
+
+        Assert.That(lease.Returns, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task RentAsync_WhileAnotherOperationHoldsTheConnection_Throws()
+    {
+        RecordingLease lease = await RecordingLease.CreateAsync();
+        var source = new PinnedConnectionSource(lease);
+        IConnectionLease operation = await source.RentAsync(None);
+
+        try
+        {
+            Assert.That(async () => await source.RentAsync(None), Throws.InvalidOperationException);
+        }
+        finally
+        {
+            await operation.DisposeAsync();
+            await source.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task RentAsync_AfterDisposal_ThrowsObjectDisposed()
+    {
+        RecordingLease lease = await RecordingLease.CreateAsync();
+        var source = new PinnedConnectionSource(lease);
+        await source.DisposeAsync();
+
+        Assert.That(async () => await source.RentAsync(None), Throws.TypeOf<ObjectDisposedException>());
+    }
+
+    [Test]
+    public async Task RentAsync_AfterAnOperationLostTheConnection_ThrowsAndSaysTheSessionIsOver()
+    {
+        RecordingLease lease = await RecordingLease.CreateAsync();
+        var source = new PinnedConnectionSource(lease);
+
+        IConnectionLease operation = await source.RentAsync(None);
+        operation.Connection.Terminate();
+        await operation.DisposeAsync();
+
+        try
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(source.IsOpen, Is.False);
+                Assert.That(
+                    async () => await source.RentAsync(None),
+                    Throws.InvalidOperationException.With.Message.Contains("Open a new session"));
+            });
+        }
+        finally
+        {
+            await source.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task IsOpen_AfterTheConnectionDiesBetweenOperations_TurnsFalseWithoutAnOperationToNoticeIt()
+    {
+        // What testing the connection before each operation buys, and the one case release cannot cover: at
+        // release nothing has had time to go wrong yet. Here the connection is lost while the session sits idle —
+        // a proxy or the server dropping one nobody is using — so only a later look finds it.
+        RecordingLease lease = await RecordingLease.CreateAsync();
+        var source = new PinnedConnectionSource(lease);
+
+        IConnectionLease operation = await source.RentAsync(None);
+        await operation.DisposeAsync();
+        Assert.That(source.IsOpen, Is.True, "the operation left the connection fine");
+
+        // Stands in for the peer going away between operations: the session did nothing, and the connection is
+        // gone all the same.
+        lease.Connection.AbortTransport();
+
+        try
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(source.IsOpen, Is.False);
+                Assert.That(
+                    async () => await source.RentAsync(None),
+                    Throws.InvalidOperationException.With.Message.Contains("Open a new session"));
+            });
+        }
+        finally
+        {
+            await source.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task RentAsync_WhenTheConnectionIsOutOfStepWithTheServer_RefusesItThoughItLooksReady()
+    {
+        // Bytes nobody read leave the reader out of step, which is what an abandoned result leaves behind. The
+        // state is still Ready, so a check on the state alone would run the next operation over a stream whose
+        // position is wrong and read another response's bytes as its own; only the reusability test sees it.
+        var lease = await TrailingBytesLease.CreateAsync();
+        var source = new PinnedConnectionSource(lease);
+
+        try
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(lease.Connection.State, Is.EqualTo(TcpConnectionState.Ready));
+                Assert.That(source.IsOpen, Is.False);
+                Assert.That(
+                    async () => await source.RentAsync(None),
+                    Throws.InvalidOperationException.With.Message.Contains("Open a new session"));
+            });
+        }
+        finally
+        {
+            await source.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task IsOpen_BeforeAndAfterDisposal_ReportsWhetherOperationsCanStillRun()
+    {
+        RecordingLease lease = await RecordingLease.CreateAsync();
+        var source = new PinnedConnectionSource(lease);
+
+        Assert.That(source.IsOpen, Is.True);
+
+        IConnectionLease operation = await source.RentAsync(None);
+        Assert.That(source.IsOpen, Is.True, "a session running an operation is still open");
+
+        await operation.DisposeAsync();
+        await source.DisposeAsync();
+
+        Assert.That(source.IsOpen, Is.False);
+    }
+
+    [Test]
+    public async Task DisposeAsync_RacedAgainstAnEndingOperationAndAnotherDisposal_ReturnsTheLeaseExactlyOnce()
+    {
+        // Over-releasing is the failure that does not announce itself: a second return hands the pool a permit the
+        // source never held, and the pool then runs one operation past MaxPoolSize for good. A session has one
+        // owner by contract, so this is not the supported use — it is the proof that misuse cannot corrupt the
+        // pool the session shares with everyone else.
+        for (int attempt = 0; attempt < 200; attempt++)
+        {
+            RecordingLease lease = await RecordingLease.CreateAsync();
+            var source = new PinnedConnectionSource(lease);
+            IConnectionLease operation = await source.RentAsync(None);
+
+            await Task.WhenAll(
+                Task.Run(async () => await source.DisposeAsync()),
+                Task.Run(async () => await operation.DisposeAsync()),
+                Task.Run(async () => await source.DisposeAsync()));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(lease.Returns, Is.EqualTo(1), $"attempt {attempt}");
+                Assert.That(lease.StateOnReturn, Is.EqualTo(TcpConnectionState.Terminated), $"attempt {attempt}");
+            });
+        }
+    }
+
+    /// <summary>
+    /// A lease over a connection whose "server" said more than the handshake called for. Nothing read those bytes,
+    /// so the connection is Ready but out of step — the state an abandoned result leaves, reproduced without one.
+    /// </summary>
+    private sealed class TrailingBytesLease : IConnectionLease
+    {
+        private TrailingBytesLease(ClickHouseTcpConnection connection) => Connection = connection;
+
+        public ClickHouseTcpConnection Connection { get; }
+
+        internal static async ValueTask<TrailingBytesLease> CreateAsync()
+            => new(await FakeConnectionFactory.CreateReadyAsync(trailing: [0x09]).ConfigureAwait(false));
+
+        public ValueTask DisposeAsync() => default;
+    }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Client/PinnedConnectionSourceTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Client/PinnedConnectionSourceTests.cs
@@ -7,18 +7,14 @@ using ClickHouse.Driver.Tcp.Tests.Utilities;
 
 namespace ClickHouse.Driver.Tcp.Tests.Client;
 
-// What a session looks like from underneath, in the cases a live session cannot show. A real server proves the
-// effects — state carried, state kept private, connection not pooled afterwards — but not the order the disposal
-// does them in, nor what happens when the session is disposed with an operation still running, which needs an
-// operation held open at an exact moment.
+// Tests lease-return ordering and disposal races with explicitly controlled operation lifetimes.
 [TestFixture]
 public class PinnedConnectionSourceTests
 {
     private static readonly CancellationToken None = CancellationToken.None;
 
     /// <summary>
-    /// Stands in for the pool: hands over one connection and records what came back, so a test can ask whether the
-    /// lease was returned, how often, and in what state the connection was by then.
+    /// Records lease returns and the connection state at return without a pool.
     /// </summary>
     private sealed class RecordingLease : IConnectionLease
     {
@@ -30,13 +26,11 @@ public class PinnedConnectionSourceTests
         public ClickHouseTcpConnection Connection { get; }
 
         /// <summary>
-        /// How many times the lease was returned. More than once would over-release the pool's permit. Counted
-        /// with an interlocked increment, so two concurrent returns register as two rather than racing to one and
-        /// leaving the very failure this exists to catch invisible.
+        /// Return count, incremented atomically so concurrent duplicate returns cannot go undetected.
         /// </summary>
         public int Returns => Volatile.Read(ref returns);
 
-        /// <summary>The connection's state when the lease came back, or null while it has not.</summary>
+        /// <summary>Connection state at lease return, or null before return.</summary>
         public TcpConnectionState? StateOnReturn => stateOnReturn;
 
         internal static async ValueTask<RecordingLease> CreateAsync()
@@ -84,8 +78,7 @@ public class PinnedConnectionSourceTests
 
         await source.DisposeAsync();
 
-        // The order is what keeps a session's state out of the pool: the pool decides a returned connection's fate
-        // from its state, so a connection still Ready when the lease comes back is one the pool keeps.
+        // Terminate before returning the lease so the pool cannot reuse session state.
         Assert.Multiple(() =>
         {
             Assert.That(lease.Returns, Is.EqualTo(1));
@@ -102,8 +95,7 @@ public class PinnedConnectionSourceTests
 
         await source.DisposeAsync();
 
-        // The connection is unusable immediately, so nothing can be started over it, but the lease is held back:
-        // returning it would let the pool close a connection whose buffers the operation is still reading into.
+        // Abort immediately, but defer lease return until the operation stops using the connection's buffers.
         Assert.Multiple(() =>
         {
             Assert.That(lease.Connection.State, Is.EqualTo(TcpConnectionState.Terminated));
@@ -124,8 +116,7 @@ public class PinnedConnectionSourceTests
         await source.DisposeAsync();
         await source.DisposeAsync();
 
-        // A second return releases a permit the source does not hold, which lets the pool run one operation past
-        // MaxPoolSize for the rest of its life.
+        // Duplicate returns over-release the pool permit, violating MaxPoolSize.
         Assert.That(lease.Returns, Is.EqualTo(1));
     }
 
@@ -214,9 +205,7 @@ public class PinnedConnectionSourceTests
     [Test]
     public async Task IsOpen_AfterTheConnectionDiesBetweenOperations_TurnsFalseWithoutAnOperationToNoticeIt()
     {
-        // What testing the connection before each operation buys, and the one case release cannot cover: at
-        // release nothing has had time to go wrong yet. Here the connection is lost while the session sits idle —
-        // a proxy or the server dropping one nobody is using — so only a later look finds it.
+        // Idle connection loss must be detected on access, not only when an operation releases its lease.
         RecordingLease lease = await RecordingLease.CreateAsync();
         var source = new PinnedConnectionSource(lease);
 
@@ -224,8 +213,7 @@ public class PinnedConnectionSourceTests
         await operation.DisposeAsync();
         Assert.That(source.IsOpen, Is.True, "the operation left the connection fine");
 
-        // Stands in for the peer going away between operations: the session did nothing, and the connection is
-        // gone all the same.
+        // Simulate transport loss between operations.
         lease.Connection.AbortTransport();
 
         try
@@ -247,9 +235,7 @@ public class PinnedConnectionSourceTests
     [Test]
     public async Task RentAsync_WhenTheConnectionIsOutOfStepWithTheServer_RefusesItThoughItLooksReady()
     {
-        // Bytes nobody read leave the reader out of step, which is what an abandoned result leaves behind. The
-        // state is still Ready, so a check on the state alone would run the next operation over a stream whose
-        // position is wrong and read another response's bytes as its own; only the reusability test sees it.
+        // Unread bytes make a Ready connection non-reusable; checking its state alone is insufficient.
         var lease = await TrailingBytesLease.CreateAsync();
         var source = new PinnedConnectionSource(lease);
 
@@ -290,10 +276,7 @@ public class PinnedConnectionSourceTests
     [Test]
     public async Task DisposeAsync_RacedAgainstAnEndingOperationAndAnotherDisposal_ReturnsTheLeaseExactlyOnce()
     {
-        // Over-releasing is the failure that does not announce itself: a second return hands the pool a permit the
-        // source never held, and the pool then runs one operation past MaxPoolSize for good. A session has one
-        // owner by contract, so this is not the supported use — it is the proof that misuse cannot corrupt the
-        // pool the session shares with everyone else.
+        // Concurrent disposal violates single-owner usage but must not over-release the shared pool's permit.
         for (int attempt = 0; attempt < 200; attempt++)
         {
             RecordingLease lease = await RecordingLease.CreateAsync();
@@ -314,8 +297,7 @@ public class PinnedConnectionSourceTests
     }
 
     /// <summary>
-    /// A lease over a connection whose "server" said more than the handshake called for. Nothing read those bytes,
-    /// so the connection is Ready but out of step — the state an abandoned result leaves, reproduced without one.
+    /// Provides a Ready but non-reusable connection with unread bytes after the fake handshake.
     /// </summary>
     private sealed class TrailingBytesLease : IConnectionLease
     {

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpSessionIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpSessionIntegrationTests.cs
@@ -1,0 +1,406 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Format;
+using ClickHouse.Driver.Tcp.Protocol;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Tests.Integration;
+
+// A session is only worth having if the server agrees that it is one connection, so everything that defines one —
+// state carried between operations, state kept out of everyone else's, and the connection closed rather than pooled
+// afterwards — is asserted against a real server. A temporary table is the marker throughout: the server scopes it
+// to the connection that made it, so its visibility says which connection ran a query without the client having to
+// claim anything about its own pool.
+[TestFixture]
+[Category("Integration")]
+public class ClickHouseTcpSessionIntegrationTests
+{
+    private static readonly CancellationToken None = CancellationToken.None;
+
+    private static string UniqueTableName() => $"tcp_session_test_{Guid.NewGuid():N}";
+
+    private sealed class ValueRow
+    {
+        public ulong Value { get; set; }
+    }
+
+    /// <summary>
+    /// A client whose pool is one connection wide, so a session leaves nothing behind it: whatever the client does
+    /// next must use the very connection the session gave back, which is what makes "was it pooled?" observable.
+    /// </summary>
+    private static ClickHouseTcpClient SingleConnectionClient()
+        => new(TcpServerFixture.Options() with { MaxPoolSize = 1, PoolTimeout = TimeSpan.FromSeconds(10) });
+
+    private static async Task<ulong> ScalarAsync(IClickHouseTcpOperations operations, string sql)
+    {
+        List<ulong> values = [];
+        await foreach (ValueRow row in operations.QueryAsync<ValueRow>(sql, cancellationToken: None))
+        {
+            values.Add(row.Value);
+        }
+
+        return values.Single();
+    }
+
+    [Test]
+    public async Task ExecuteAsync_TemporaryTableCreatedInASession_IsStillThereForTheNextOperation()
+    {
+        await using ClickHouseTcpClient client = TcpServerFixture.CreateClient();
+        await using IClickHouseTcpSession session = await client.OpenSessionAsync(None);
+        string table = UniqueTableName();
+
+        await session.ExecuteAsync($"CREATE TEMPORARY TABLE {table} (value UInt64)", cancellationToken: None);
+        await session.ExecuteAsync($"INSERT INTO {table} SELECT number FROM system.numbers LIMIT 5", cancellationToken: None);
+
+        Assert.That(await ScalarAsync(session, $"SELECT sum(value) AS value FROM {table}"), Is.EqualTo(10UL));
+    }
+
+    [Test]
+    public async Task ExecuteAsync_SetInASession_AppliesToTheNextOperation()
+    {
+        await using ClickHouseTcpClient client = TcpServerFixture.CreateClient();
+        await using IClickHouseTcpSession session = await client.OpenSessionAsync(None);
+
+        // Read back from system.settings rather than the value we sent: that view reports what the server holds for
+        // this connection, so it answers whether the SET survived rather than whether it parsed.
+        await session.ExecuteAsync("SET max_threads = 3", cancellationToken: None);
+
+        ulong threads = await ScalarAsync(
+            session,
+            "SELECT toUInt64(value) AS value FROM system.settings WHERE name = 'max_threads'");
+        Assert.That(threads, Is.EqualTo(3UL));
+    }
+
+    [Test]
+    public async Task OpenSessionAsync_TemporaryTableInASession_IsInvisibleToTheClientItCameFrom()
+    {
+        await using ClickHouseTcpClient client = TcpServerFixture.CreateClient();
+        await using IClickHouseTcpSession session = await client.OpenSessionAsync(None);
+        string table = UniqueTableName();
+
+        await session.ExecuteAsync($"CREATE TEMPORARY TABLE {table} (value UInt64)", cancellationToken: None);
+
+        // The session holds its connection, so the client is served from the rest of the pool and sees no such
+        // table. This is the pinning itself: without it the client could land on the session's connection.
+        Assert.That(
+            async () => await client.ExecuteAsync($"SELECT * FROM {table}", cancellationToken: None),
+            Throws.TypeOf<ClickHouseServerException>());
+    }
+
+    [Test]
+    public async Task OpenSessionAsync_TwoSessionsAtOnce_EachHasItsOwnTemporaryTable()
+    {
+        await using ClickHouseTcpClient client = TcpServerFixture.CreateClient();
+        await using IClickHouseTcpSession first = await client.OpenSessionAsync(None);
+        await using IClickHouseTcpSession second = await client.OpenSessionAsync(None);
+
+        // One name, two sessions: the creates can only both succeed if each landed on its own connection, and the
+        // reads then say which rows each session's table holds.
+        string table = UniqueTableName();
+        await first.ExecuteAsync($"CREATE TEMPORARY TABLE {table} (value UInt64)", cancellationToken: None);
+        await second.ExecuteAsync($"CREATE TEMPORARY TABLE {table} (value UInt64)", cancellationToken: None);
+        await first.ExecuteAsync($"INSERT INTO {table} VALUES (1)", cancellationToken: None);
+        await second.ExecuteAsync($"INSERT INTO {table} VALUES (2)", cancellationToken: None);
+
+        Assert.Multiple(async () =>
+        {
+            Assert.That(await ScalarAsync(first, $"SELECT sum(value) AS value FROM {table}"), Is.EqualTo(1UL));
+            Assert.That(await ScalarAsync(second, $"SELECT sum(value) AS value FROM {table}"), Is.EqualTo(2UL));
+        });
+    }
+
+    [Test]
+    public async Task DisposeAsync_AfterASession_TheConnectionIsClosedRatherThanPooled()
+    {
+        await using ClickHouseTcpClient client = SingleConnectionClient();
+        string table = UniqueTableName();
+
+        IClickHouseTcpSession session = await client.OpenSessionAsync(None);
+        await session.ExecuteAsync($"CREATE TEMPORARY TABLE {table} (value UInt64)", cancellationToken: None);
+        await session.DisposeAsync();
+
+        // The pool is one wide, so this query runs on whatever the session gave back. A pooled connection would
+        // still have the temporary table on it; a closed one is replaced by a dial to a server that never saw it.
+        Assert.That(
+            async () => await client.ExecuteAsync($"SELECT * FROM {table}", cancellationToken: None),
+            Throws.TypeOf<ClickHouseServerException>());
+    }
+
+    [Test]
+    public async Task DisposeAsync_AfterASession_TheSlotGoesBackToThePool()
+    {
+        await using ClickHouseTcpClient client = SingleConnectionClient();
+
+        IClickHouseTcpSession session = await client.OpenSessionAsync(None);
+        await session.PingAsync(None);
+        await session.DisposeAsync();
+
+        // The only slot the pool has. Had disposal closed the connection without returning the lease, this would
+        // wait out PoolTimeout and fail instead.
+        Assert.That(await ScalarAsync(client, "SELECT toUInt64(1) AS value"), Is.EqualTo(1UL));
+    }
+
+    [Test]
+    public async Task DisposeAsync_WithAStreamNobodyAdvancesOrDisposes_DoesNotGetTheSlotBack()
+    {
+        // The caveat on the abort path, pinned rather than left to be discovered. Aborting the transport frees an
+        // operation parked on the socket; an enumerator the caller stopped advancing is parked at its yield
+        // instead, so nothing resumes it, nothing disposes its lease, and the slot stays out. Disposal still
+        // returns promptly and reports nothing — it cannot return the lease itself without letting the pool
+        // terminate a connection a live operation may still be reading into.
+        await using ClickHouseTcpClient client = new(TcpServerFixture.Options() with
+        {
+            MaxPoolSize = 1,
+            PoolTimeout = TimeSpan.FromSeconds(1),
+        });
+
+        IClickHouseTcpSession session = await client.OpenSessionAsync(None);
+        IAsyncEnumerator<Block> abandoned = session
+            .StreamAsync("SELECT number FROM system.numbers LIMIT 100000", cancellationToken: None)
+            .GetAsyncEnumerator(None);
+        Assert.That(await abandoned.MoveNextAsync(), Is.True);
+
+        await session.DisposeAsync();
+
+        Assert.That(
+            async () => await client.ExecuteAsync("SELECT 1", cancellationToken: None),
+            Throws.TypeOf<TimeoutException>(),
+            "the pool's only slot is still held by the enumerator nobody disposed");
+    }
+
+    [Test]
+    public async Task OpenSessionAsync_WhenThePoolIsFull_TimesOutRatherThanWaitingForever()
+    {
+        await using ClickHouseTcpClient client = new(TcpServerFixture.Options() with
+        {
+            MaxPoolSize = 1,
+            PoolTimeout = TimeSpan.FromSeconds(1),
+        });
+
+        await using IClickHouseTcpSession holder = await client.OpenSessionAsync(None);
+
+        // A session competes for a connection like any other operation, and holds one for its whole life, so the
+        // pool being one wide is the pool being full.
+        Assert.That(async () => await client.OpenSessionAsync(None), Throws.TypeOf<TimeoutException>());
+    }
+
+    [Test]
+    public async Task ExecuteAsync_AfterTheClientIsDisposed_ReportsTheSessionAsOverRatherThanTheConnection()
+    {
+        // Disposing the client first is the wrong order — its drain aborts the session's connection — and the
+        // session learns of it only when asked. Because it is asked before each operation, and not merely after
+        // the last one, this reports a finished session rather than letting the connection's own internal
+        // "terminated and cannot be reused" reach the caller.
+        ClickHouseTcpClient client = new(TcpServerFixture.Options() with
+        {
+            MaxPoolSize = 1,
+            PoolTimeout = TimeSpan.FromSeconds(1),
+        });
+
+        IClickHouseTcpSession session = await client.OpenSessionAsync(None);
+        await session.PingAsync(None);
+        await client.DisposeAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(session.IsOpen, Is.False);
+            Assert.That(
+                async () => await session.ExecuteAsync("SELECT 1", cancellationToken: None),
+                Throws.InvalidOperationException.With.Message.Contains("Open a new session"));
+        });
+    }
+
+    [Test]
+    public async Task ExecuteAsync_AfterTheSessionIsDisposed_ThrowsObjectDisposed()
+    {
+        await using ClickHouseTcpClient client = TcpServerFixture.CreateClient();
+
+        IClickHouseTcpSession session = await client.OpenSessionAsync(None);
+        await session.DisposeAsync();
+
+        Assert.That(
+            async () => await session.ExecuteAsync("SELECT 1", cancellationToken: None),
+            Throws.TypeOf<ObjectDisposedException>());
+    }
+
+    [Test]
+    public async Task ExecuteAsync_WhileAStreamIsStillOpen_IsRefusedRatherThanInterleaved()
+    {
+        await using ClickHouseTcpClient client = TcpServerFixture.CreateClient();
+        await using IClickHouseTcpSession session = await client.OpenSessionAsync(None);
+
+        // The enumerator holds the connection between blocks, which is exactly when a second operation would write
+        // its Query packet into the middle of this result.
+        IAsyncEnumerator<Block> stream = session
+            .StreamAsync("SELECT number FROM system.numbers LIMIT 100000", cancellationToken: None)
+            .GetAsyncEnumerator(None);
+        try
+        {
+            Assert.That(await stream.MoveNextAsync(), Is.True);
+
+            // Parked between blocks the connection is mid-response and so not reusable, which is the trap in
+            // testing it for liveness before each operation: a test that ran now would read "not reusable" and
+            // condemn a session that is working perfectly.
+            Assert.That(session.IsOpen, Is.True);
+
+            // The connection refuses a second operation too, so the message is what says the session caught this
+            // first — and the session's message is the one that mentions the enumerator still holding it.
+            Assert.That(
+                async () => await session.ExecuteAsync("SELECT 1", cancellationToken: None),
+                Throws.InvalidOperationException.With.Message.Contains("The session is already running an operation"));
+        }
+        finally
+        {
+            await stream.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task IsOpen_AfterAStreamIsAbandonedPartWay_IsFalseAndFurtherOperationsSayWhy()
+    {
+        await using ClickHouseTcpClient client = TcpServerFixture.CreateClient();
+        await using IClickHouseTcpSession session = await client.OpenSessionAsync(None);
+
+        // Stopping mid-result leaves the rest of it coming, so the connection cannot carry anything else and is
+        // closed. On the client that costs a redial; on a session it is the end of the session, because the state
+        // the session existed for went with the connection.
+        await foreach (Block block in session.StreamAsync("SELECT number FROM system.numbers LIMIT 100000", cancellationToken: None))
+        {
+            _ = block.RowCount;
+            break;
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(session.IsOpen, Is.False);
+            Assert.That(
+                async () => await session.ExecuteAsync("SELECT 1", cancellationToken: None),
+                Throws.TypeOf<InvalidOperationException>().With.Message.Contains("Open a new session"));
+        });
+    }
+
+    [Test]
+    public async Task IsOpen_AfterAQueryTheServerRejects_StaysTrue()
+    {
+        await using ClickHouseTcpClient client = TcpServerFixture.CreateClient();
+        await using IClickHouseTcpSession session = await client.OpenSessionAsync(None);
+        string table = UniqueTableName();
+
+        await session.ExecuteAsync($"CREATE TEMPORARY TABLE {table} (value UInt64)", cancellationToken: None);
+        Assert.That(
+            async () => await session.ExecuteAsync("SELECT * FROM no_such_table_here", cancellationToken: None),
+            Throws.TypeOf<ClickHouseServerException>());
+
+        // An error the server raised over a connection it still owns costs nothing but the query: the session's
+        // temporary table is still there, so the session is still worth keeping.
+        Assert.Multiple(async () =>
+        {
+            Assert.That(session.IsOpen, Is.True);
+            Assert.That(await ScalarAsync(session, $"SELECT count() AS value FROM {table}"), Is.EqualTo(0UL));
+        });
+    }
+
+    [Test]
+    public async Task InsertAsync_IntoASessionTemporaryTable_RoundTripsThroughTheSameConnection()
+    {
+        await using ClickHouseTcpClient client = TcpServerFixture.CreateClient();
+        await using IClickHouseTcpSession session = await client.OpenSessionAsync(None);
+        string table = UniqueTableName();
+
+        await session.ExecuteAsync($"CREATE TEMPORARY TABLE {table} (value UInt64)", cancellationToken: None);
+        IColumn[] columns = [PrimitiveColumn<ulong>.FromValues("value", "UInt64", [7UL, 11UL])];
+        await session.InsertAsync($"INSERT INTO {table} (value) VALUES", columns, cancellationToken: None);
+
+        Assert.That(await ScalarAsync(session, $"SELECT sum(value) AS value FROM {table}"), Is.EqualTo(18UL));
+    }
+
+    [Test]
+    public async Task OpenSessionAsync_WhileASessionIsOpen_TheClientKeepsWorking()
+    {
+        await using ClickHouseTcpClient client = TcpServerFixture.CreateClient();
+        await using IClickHouseTcpSession session = await client.OpenSessionAsync(None);
+
+        // The session owns one connection; the pool serves the client from the others, including concurrently with
+        // the session's own operation.
+        Task<ulong> onTheSession = ScalarAsync(session, "SELECT toUInt64(sleep(0.5) + 1) AS value");
+        ulong[] onTheClient = await Task.WhenAll(Enumerable.Range(0, 4)
+            .Select(i => ScalarAsync(client, $"SELECT toUInt64({i}) AS value")));
+
+        Assert.Multiple(async () =>
+        {
+            Assert.That(await onTheSession, Is.EqualTo(1UL));
+            Assert.That(onTheClient, Is.EqualTo(new ulong[] { 0, 1, 2, 3 }));
+        });
+    }
+
+    [Test]
+    public async Task IClickHouseTcpSession_EveryOperationRunsOnThePinnedConnection()
+    {
+        // The session delegates each operation to an inner client, so the risk is a member wired to the wrong
+        // place. A temporary table catches that: every tier below has to reach the one connection that owns it, so
+        // a misrouted member fails outright rather than quietly using another connection.
+        await using ClickHouseTcpClient client = TcpServerFixture.CreateClient();
+        await using IClickHouseTcpSession session = await client.OpenSessionAsync(None);
+        string table = UniqueTableName();
+
+        await session.PingAsync(None);
+        await session.ExecuteAsync($"CREATE TEMPORARY TABLE {table} (value UInt64)", cancellationToken: None);
+
+        IColumn[] columns = [PrimitiveColumn<ulong>.FromValues("value", "UInt64", [1UL])];
+        await session.InsertAsync($"INSERT INTO {table} (value) VALUES", columns, cancellationToken: None);
+        await session.InsertAsync($"INSERT INTO {table} (value) VALUES", [new ValueRow { Value = 2 }], cancellationToken: None);
+        await session.InsertAsync($"INSERT INTO {table} (value) VALUES", [new object[] { 3UL }], cancellationToken: None);
+
+        var untyped = new List<ulong>();
+        await foreach (object[] row in session.QueryAsync($"SELECT value FROM {table} ORDER BY value", cancellationToken: None))
+        {
+            untyped.Add((ulong)row[0]);
+        }
+
+        var typed = new List<ulong>();
+        await foreach (ValueRow row in session.QueryAsync<ValueRow>($"SELECT value FROM {table} ORDER BY value", cancellationToken: None))
+        {
+            typed.Add(row.Value);
+        }
+
+        var streamed = new List<ulong>();
+        await foreach (Block block in session.StreamAsync($"SELECT value FROM {table} ORDER BY value", cancellationToken: None))
+        {
+            streamed.AddRange(((IColumn<ulong>)block[0]).Values.ToArray());
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(untyped, Is.EqualTo(new ulong[] { 1, 2, 3 }));
+            Assert.That(typed, Is.EqualTo(new ulong[] { 1, 2, 3 }));
+            Assert.That(streamed, Is.EqualTo(new ulong[] { 1, 2, 3 }));
+        });
+    }
+
+    [Test]
+    public async Task Options_OnASession_AreTheVeryOptionsOfTheClientItCameFrom()
+    {
+        // With custom settings present, the options carry a dictionary that is copied whenever a client is built
+        // over them — so this passes only because the session is handed the copy its parent already owns. An
+        // equal-looking copy would satisfy a property-by-property check and still break record equality.
+        await using ClickHouseTcpClient client = new(TcpServerFixture.Options() with
+        {
+            CustomSettings = new Dictionary<string, string> { ["max_threads"] = "3" },
+        });
+        await using IClickHouseTcpSession session = await client.OpenSessionAsync(None);
+
+        Assert.That(session.Options, Is.SameAs(client.Options));
+    }
+
+    [Test]
+    public async Task OpenSessionAsync_AfterTheClientIsDisposed_ThrowsObjectDisposed()
+    {
+        ClickHouseTcpClient client = TcpServerFixture.CreateClient();
+        await client.DisposeAsync();
+
+        Assert.That(async () => await client.OpenSessionAsync(None), Throws.TypeOf<ObjectDisposedException>());
+    }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpSessionIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpSessionIntegrationTests.cs
@@ -283,7 +283,7 @@ public class ClickHouseTcpSessionIntegrationTests
     }
 
     [Test]
-    public async Task IsOpen_AfterAQueryTheServerRejects_StaysTrue()
+    public async Task IsOpen_AfterAQueryTheServerRejects_IsFalseAndFurtherOperationsSayWhy()
     {
         await using ClickHouseTcpClient client = TcpServerFixture.CreateClient();
         await using IClickHouseTcpSession session = await client.OpenSessionAsync(None);
@@ -294,12 +294,14 @@ public class ClickHouseTcpSessionIntegrationTests
             async () => await session.ExecuteAsync("SELECT * FROM no_such_table_here", cancellationToken: None),
             Throws.TypeOf<ClickHouseServerException>());
 
-        // An error the server raised over a connection it still owns costs nothing but the query: the session's
-        // temporary table is still there, so the session is still worth keeping.
-        Assert.Multiple(async () =>
+        // An Exception packet does not say whether the server will accept another request, so the connection is
+        // retired. Unlike a pooled client, a session cannot redial without losing the state it exists to preserve.
+        Assert.Multiple(() =>
         {
-            Assert.That(session.IsOpen, Is.True);
-            Assert.That(await ScalarAsync(session, $"SELECT count() AS value FROM {table}"), Is.EqualTo(0UL));
+            Assert.That(session.IsOpen, Is.False);
+            Assert.That(
+                async () => await session.ExecuteAsync($"SELECT count() FROM {table}", cancellationToken: None),
+                Throws.TypeOf<InvalidOperationException>().With.Message.Contains("Open a new session"));
         });
     }
 

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpSessionIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpSessionIntegrationTests.cs
@@ -351,8 +351,8 @@ public class ClickHouseTcpSessionIntegrationTests
 
         IColumn[] columns = [PrimitiveColumn<ulong>.FromValues("value", "UInt64", [1UL])];
         await session.InsertAsync($"INSERT INTO {table} (value) VALUES", columns, cancellationToken: None);
-        await session.InsertAsync($"INSERT INTO {table} (value) VALUES", [new ValueRow { Value = 2 }], cancellationToken: None);
-        await session.InsertAsync($"INSERT INTO {table} (value) VALUES", [new object[] { 3UL }], cancellationToken: None);
+        await session.InsertRowsAsync($"INSERT INTO {table} (value) VALUES", [new ValueRow { Value = 2 }], cancellationToken: None);
+        await session.InsertRowsAsync($"INSERT INTO {table} (value) VALUES", [new object[] { 3UL }], cancellationToken: None);
 
         var untyped = new List<ulong>();
         await foreach (object[] row in session.QueryAsync($"SELECT value FROM {table} ORDER BY value", cancellationToken: None))

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpSessionIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpSessionIntegrationTests.cs
@@ -9,11 +9,7 @@ using ClickHouse.Driver.Tcp.Types;
 
 namespace ClickHouse.Driver.Tcp.Tests.Integration;
 
-// A session is only worth having if the server agrees that it is one connection, so everything that defines one —
-// state carried between operations, state kept out of everyone else's, and the connection closed rather than pooled
-// afterwards — is asserted against a real server. A temporary table is the marker throughout: the server scopes it
-// to the connection that made it, so its visibility says which connection ran a query without the client having to
-// claim anything about its own pool.
+// Uses connection-scoped temporary tables to verify session persistence, isolation, and disposal on a real server.
 [TestFixture]
 [Category("Integration")]
 public class ClickHouseTcpSessionIntegrationTests
@@ -28,8 +24,7 @@ public class ClickHouseTcpSessionIntegrationTests
     }
 
     /// <summary>
-    /// A client whose pool is one connection wide, so a session leaves nothing behind it: whatever the client does
-    /// next must use the very connection the session gave back, which is what makes "was it pooled?" observable.
+    /// Limits the pool to one slot so subsequent operations expose connection reuse or a leaked lease.
     /// </summary>
     private static ClickHouseTcpClient SingleConnectionClient()
         => new(TcpServerFixture.Options() with { MaxPoolSize = 1, PoolTimeout = TimeSpan.FromSeconds(10) });
@@ -64,8 +59,7 @@ public class ClickHouseTcpSessionIntegrationTests
         await using ClickHouseTcpClient client = TcpServerFixture.CreateClient();
         await using IClickHouseTcpSession session = await client.OpenSessionAsync(None);
 
-        // Read back from system.settings rather than the value we sent: that view reports what the server holds for
-        // this connection, so it answers whether the SET survived rather than whether it parsed.
+        // Read system.settings to verify SET persists across operations.
         await session.ExecuteAsync("SET max_threads = 3", cancellationToken: None);
 
         ulong threads = await ScalarAsync(
@@ -83,8 +77,7 @@ public class ClickHouseTcpSessionIntegrationTests
 
         await session.ExecuteAsync($"CREATE TEMPORARY TABLE {table} (value UInt64)", cancellationToken: None);
 
-        // The session holds its connection, so the client is served from the rest of the pool and sees no such
-        // table. This is the pinning itself: without it the client could land on the session's connection.
+        // Client operations must not reuse the session's pinned connection.
         Assert.That(
             async () => await client.ExecuteAsync($"SELECT * FROM {table}", cancellationToken: None),
             Throws.TypeOf<ClickHouseServerException>());
@@ -97,8 +90,7 @@ public class ClickHouseTcpSessionIntegrationTests
         await using IClickHouseTcpSession first = await client.OpenSessionAsync(None);
         await using IClickHouseTcpSession second = await client.OpenSessionAsync(None);
 
-        // One name, two sessions: the creates can only both succeed if each landed on its own connection, and the
-        // reads then say which rows each session's table holds.
+        // Use the same table name in both sessions to verify independent connection-local state.
         string table = UniqueTableName();
         await first.ExecuteAsync($"CREATE TEMPORARY TABLE {table} (value UInt64)", cancellationToken: None);
         await second.ExecuteAsync($"CREATE TEMPORARY TABLE {table} (value UInt64)", cancellationToken: None);
@@ -122,8 +114,7 @@ public class ClickHouseTcpSessionIntegrationTests
         await session.ExecuteAsync($"CREATE TEMPORARY TABLE {table} (value UInt64)", cancellationToken: None);
         await session.DisposeAsync();
 
-        // The pool is one wide, so this query runs on whatever the session gave back. A pooled connection would
-        // still have the temporary table on it; a closed one is replaced by a dial to a server that never saw it.
+        // With one pool slot, reusing the session's connection would expose its temporary table.
         Assert.That(
             async () => await client.ExecuteAsync($"SELECT * FROM {table}", cancellationToken: None),
             Throws.TypeOf<ClickHouseServerException>());
@@ -138,19 +129,15 @@ public class ClickHouseTcpSessionIntegrationTests
         await session.PingAsync(None);
         await session.DisposeAsync();
 
-        // The only slot the pool has. Had disposal closed the connection without returning the lease, this would
-        // wait out PoolTimeout and fail instead.
+        // A leaked lease would exhaust the single-slot pool and cause a timeout.
         Assert.That(await ScalarAsync(client, "SELECT toUInt64(1) AS value"), Is.EqualTo(1UL));
     }
 
     [Test]
     public async Task DisposeAsync_WithAStreamNobodyAdvancesOrDisposes_DoesNotGetTheSlotBack()
     {
-        // The caveat on the abort path, pinned rather than left to be discovered. Aborting the transport frees an
-        // operation parked on the socket; an enumerator the caller stopped advancing is parked at its yield
-        // instead, so nothing resumes it, nothing disposes its lease, and the slot stays out. Disposal still
-        // returns promptly and reports nothing — it cannot return the lease itself without letting the pool
-        // terminate a connection a live operation may still be reading into.
+        // Transport abort cannot resume an enumerator suspended at yield; its lease remains held until disposal.
+        // Session disposal cannot return that lease while the operation may still access connection buffers.
         await using ClickHouseTcpClient client = new(TcpServerFixture.Options() with
         {
             MaxPoolSize = 1,
@@ -182,18 +169,15 @@ public class ClickHouseTcpSessionIntegrationTests
 
         await using IClickHouseTcpSession holder = await client.OpenSessionAsync(None);
 
-        // A session competes for a connection like any other operation, and holds one for its whole life, so the
-        // pool being one wide is the pool being full.
+        // The open session holds the only pool slot.
         Assert.That(async () => await client.OpenSessionAsync(None), Throws.TypeOf<TimeoutException>());
     }
 
     [Test]
     public async Task ExecuteAsync_AfterTheClientIsDisposed_ReportsTheSessionAsOverRatherThanTheConnection()
     {
-        // Disposing the client first is the wrong order — its drain aborts the session's connection — and the
-        // session learns of it only when asked. Because it is asked before each operation, and not merely after
-        // the last one, this reports a finished session rather than letting the connection's own internal
-        // "terminated and cannot be reused" reach the caller.
+        // Client disposal aborts the pinned connection. Subsequent access must report a closed session,
+        // not an internal connection-reuse error.
         ClickHouseTcpClient client = new(TcpServerFixture.Options() with
         {
             MaxPoolSize = 1,
@@ -232,8 +216,7 @@ public class ClickHouseTcpSessionIntegrationTests
         await using ClickHouseTcpClient client = TcpServerFixture.CreateClient();
         await using IClickHouseTcpSession session = await client.OpenSessionAsync(None);
 
-        // The enumerator holds the connection between blocks, which is exactly when a second operation would write
-        // its Query packet into the middle of this result.
+        // Keep the stream open between blocks to test rejection of interleaved operations.
         IAsyncEnumerator<Block> stream = session
             .StreamAsync("SELECT number FROM system.numbers LIMIT 100000", cancellationToken: None)
             .GetAsyncEnumerator(None);
@@ -241,13 +224,10 @@ public class ClickHouseTcpSessionIntegrationTests
         {
             Assert.That(await stream.MoveNextAsync(), Is.True);
 
-            // Parked between blocks the connection is mid-response and so not reusable, which is the trap in
-            // testing it for liveness before each operation: a test that ran now would read "not reusable" and
-            // condemn a session that is working perfectly.
+            // A mid-response connection is not reusable, but its active session remains open.
             Assert.That(session.IsOpen, Is.True);
 
-            // The connection refuses a second operation too, so the message is what says the session caught this
-            // first — and the session's message is the one that mentions the enumerator still holding it.
+            // Match the message to verify rejection by the session rather than the connection.
             Assert.That(
                 async () => await session.ExecuteAsync("SELECT 1", cancellationToken: None),
                 Throws.InvalidOperationException.With.Message.Contains("The session is already running an operation"));
@@ -264,9 +244,7 @@ public class ClickHouseTcpSessionIntegrationTests
         await using ClickHouseTcpClient client = TcpServerFixture.CreateClient();
         await using IClickHouseTcpSession session = await client.OpenSessionAsync(None);
 
-        // Stopping mid-result leaves the rest of it coming, so the connection cannot carry anything else and is
-        // closed. On the client that costs a redial; on a session it is the end of the session, because the state
-        // the session existed for went with the connection.
+        // Early stream disposal closes the connection; the session cannot reconnect without losing its state.
         await foreach (Block block in session.StreamAsync("SELECT number FROM system.numbers LIMIT 100000", cancellationToken: None))
         {
             _ = block.RowCount;
@@ -294,8 +272,7 @@ public class ClickHouseTcpSessionIntegrationTests
             async () => await session.ExecuteAsync("SELECT * FROM no_such_table_here", cancellationToken: None),
             Throws.TypeOf<ClickHouseServerException>());
 
-        // An Exception packet does not say whether the server will accept another request, so the connection is
-        // retired. Unlike a pooled client, a session cannot redial without losing the state it exists to preserve.
+        // A server exception retires the connection; the session must fail rather than reconnect without its state.
         Assert.Multiple(() =>
         {
             Assert.That(session.IsOpen, Is.False);
@@ -325,8 +302,7 @@ public class ClickHouseTcpSessionIntegrationTests
         await using ClickHouseTcpClient client = TcpServerFixture.CreateClient();
         await using IClickHouseTcpSession session = await client.OpenSessionAsync(None);
 
-        // The session owns one connection; the pool serves the client from the others, including concurrently with
-        // the session's own operation.
+        // Client operations use other pooled connections while the session runs a query.
         Task<ulong> onTheSession = ScalarAsync(session, "SELECT toUInt64(sleep(0.5) + 1) AS value");
         ulong[] onTheClient = await Task.WhenAll(Enumerable.Range(0, 4)
             .Select(i => ScalarAsync(client, $"SELECT toUInt64({i}) AS value")));
@@ -341,9 +317,7 @@ public class ClickHouseTcpSessionIntegrationTests
     [Test]
     public async Task IClickHouseTcpSession_EveryOperationRunsOnThePinnedConnection()
     {
-        // The session delegates each operation to an inner client, so the risk is a member wired to the wrong
-        // place. A temporary table catches that: every tier below has to reach the one connection that owns it, so
-        // a misrouted member fails outright rather than quietly using another connection.
+        // Temporary-table access detects any insert or query overload routed off the pinned connection.
         await using ClickHouseTcpClient client = TcpServerFixture.CreateClient();
         await using IClickHouseTcpSession session = await client.OpenSessionAsync(None);
         string table = UniqueTableName();
@@ -385,9 +359,7 @@ public class ClickHouseTcpSessionIntegrationTests
     [Test]
     public async Task Options_OnASession_AreTheVeryOptionsOfTheClientItCameFrom()
     {
-        // With custom settings present, the options carry a dictionary that is copied whenever a client is built
-        // over them — so this passes only because the session is handed the copy its parent already owns. An
-        // equal-looking copy would satisfy a property-by-property check and still break record equality.
+        // Custom settings exercise dictionary copying; the session must expose the parent's options instance.
         await using ClickHouseTcpClient client = new(TcpServerFixture.Options() with
         {
             CustomSettings = new Dictionary<string, string> { ["max_threads"] = "3" },

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClient.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClient.cs
@@ -94,10 +94,9 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
     /// <param name="source">The source the client rents its connections from.</param>
     /// <param name="options">The client configuration, or null for the defaults.</param>
     /// <param name="optionsAreOwned">
-    /// True when <paramref name="options"/> already holds a private snapshot of its custom settings, so this
-    /// client can share it rather than take another copy. Only a session passes true, handing over the options its
-    /// parent client already owns — which also makes <c>session.Options</c> the very instance
-    /// <c>client.Options</c> is, rather than an equal-looking copy.
+    /// True when <paramref name="options"/> already holds a private snapshot of its custom settings, so this client
+    /// can share it rather than copy it again. Only a session passes true, which also makes <c>session.Options</c>
+    /// the very instance <c>client.Options</c> is rather than an equal-looking copy.
     /// </param>
     internal ClickHouseTcpClient(
         IConnectionSource source,
@@ -118,8 +117,7 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
     /// <summary>
     /// The compiled POCO read and write plans. Per-client, as HTTP's registry is: the client is meant to be a
     /// singleton, so the reflection and the compiles are amortized anyway, and a per-client cache cannot pin a type
-    /// whose AssemblyLoadContext the caller unloads. A session shares the registry of the client it came from, so
-    /// running the same query through a session costs no second compile.
+    /// whose AssemblyLoadContext the caller unloads. A session shares the registry of the client it came from.
     /// </summary>
     internal PocoTypeRegistry PocoTypes { get; init; } = new();
 
@@ -422,21 +420,14 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
     /// one operation to the next — a temporary table stays visible, and a <c>SET</c> keeps applying.
     /// </summary>
     /// <remarks>
-    /// <para>
     /// <b>Dispose it, and keep it short.</b> The session holds one of the pool's
-    /// <see cref="ClickHouseTcpClientOptions.MaxPoolSize"/> connections for its whole lifetime, so a session left
-    /// open is capacity the client cannot use, and as many sessions as the pool is wide leaves nothing for anything
-    /// else — including for opening the next session, which then waits out
-    /// <see cref="ClickHouseTcpClientOptions.PoolTimeout"/>. Disposal closes the connection rather than pooling it,
-    /// since it carries the session's state, so it also costs the next caller a reconnect. Dispose the sessions
-    /// before the client, too: an open one holds a slot the client's own disposal waits out
-    /// <see cref="ClickHouseTcpClientOptions.PoolTimeout"/> for before aborting it.
-    /// </para>
-    /// <para>
-    /// The session runs one operation at a time and refuses a second started while the first is still going; the
-    /// client itself is what runs operations concurrently. Both may be used at once — a session's connection is its
-    /// own, and the pool keeps serving the client from the rest.
-    /// </para>
+    /// <see cref="ClickHouseTcpClientOptions.MaxPoolSize"/> connections for its whole lifetime, so as many sessions as
+    /// the pool is wide leaves nothing for anything else, including for opening the next session — which then waits
+    /// out <see cref="ClickHouseTcpClientOptions.PoolTimeout"/>. Disposal closes the connection rather than pooling
+    /// it, since it carries the session's state, so it costs the next caller a reconnect. Dispose the sessions before
+    /// the client: an open one holds a slot the client's own disposal waits out <c>PoolTimeout</c> for. A session runs
+    /// one operation at a time, while the client itself runs them concurrently; both may be used at once, the
+    /// session's connection being its own.
     /// </remarks>
     /// <param name="cancellationToken">A token to observe while waiting for and establishing the connection.</param>
     /// <returns>A session pinned to one connection.</returns>

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClient.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClient.cs
@@ -31,6 +31,13 @@ namespace ClickHouse.Driver.Tcp;
 /// </para>
 ///
 /// <para>
+/// An operation runs on whichever connection the pool hands it, which may or may not be the one before it used.
+/// So server-side state a connection holds — a temporary table, a <c>SET</c> — is neither reliably still there for
+/// the next operation nor reliably gone from it. Where that state is the point, use
+/// <see cref="OpenSessionAsync"/>, which pins one connection for as long as the session lives.
+/// </para>
+///
+/// <para>
 /// This type is experimental: its surface may change in a future release. Suppress diagnostic
 /// <c>CHTCP0001</c> to acknowledge that.
 /// </para>
@@ -62,12 +69,6 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
 
     private readonly IConnectionSource source;
 
-    // Per-client, as HTTP's registry is: the client is meant to be a singleton, so the reflection and the compiles
-    // are amortized anyway. It does hold its Type keys and compiled delegates strongly, so it pins a collectible
-    // AssemblyLoadContext for as long as the client is reachable; scoping it to the client is what makes disposing
-    // the client release them, rather than holding them for the process. See PocoTypeRegistry.
-    private readonly PocoTypeRegistry pocoTypes = new();
-
     /// <summary>Creates a client from options.</summary>
     /// <param name="options">The client configuration (endpoint, credentials, timeouts, client-level settings).</param>
     /// <exception cref="ArgumentNullException"><paramref name="options"/> is null.</exception>
@@ -90,10 +91,22 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
     }
 
     /// <summary>Test/pool seam: builds a client over an arbitrary connection source.</summary>
-    internal ClickHouseTcpClient(IConnectionSource source, ClickHouseTcpClientOptions options = null)
+    /// <param name="source">The source the client rents its connections from.</param>
+    /// <param name="options">The client configuration, or null for the defaults.</param>
+    /// <param name="optionsAreOwned">
+    /// True when <paramref name="options"/> already holds a private snapshot of its custom settings, so this
+    /// client can share it rather than take another copy. Only a session passes true, handing over the options its
+    /// parent client already owns — which also makes <c>session.Options</c> the very instance
+    /// <c>client.Options</c> is, rather than an equal-looking copy.
+    /// </param>
+    internal ClickHouseTcpClient(
+        IConnectionSource source,
+        ClickHouseTcpClientOptions options = null,
+        bool optionsAreOwned = false)
     {
         this.source = source;
-        Options = (options ?? new ClickHouseTcpClientOptions()).WithOwnedCustomSettings();
+        ClickHouseTcpClientOptions resolved = options ?? new ClickHouseTcpClientOptions();
+        Options = optionsAreOwned ? resolved : resolved.WithOwnedCustomSettings();
     }
 
     /// <summary>
@@ -101,6 +114,14 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
     /// operation. Init-only, so it reflects construction and never changes.
     /// </summary>
     public ClickHouseTcpClientOptions Options { get; }
+
+    /// <summary>
+    /// The compiled POCO read and write plans. Per-client, as HTTP's registry is: the client is meant to be a
+    /// singleton, so the reflection and the compiles are amortized anyway, and a per-client cache cannot pin a type
+    /// whose AssemblyLoadContext the caller unloads. A session shares the registry of the client it came from, so
+    /// running the same query through a session costs no second compile.
+    /// </summary>
+    internal PocoTypeRegistry PocoTypes { get; init; } = new();
 
     /// <summary>
     /// Runs a query and streams its result as a sequence of <see cref="Block"/>s — the low-level columnar tier,
@@ -224,7 +245,7 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
             // check also covers the header changing mid-enumeration, which the cache then serves.
             if (plan is null || !plan.MatchesHeader(block))
             {
-                plan = pocoTypes.ReadPlanFor<T>(block, forcedTier: null);
+                plan = PocoTypes.ReadPlanFor<T>(block, forcedTier: null);
             }
 
             T[] rows = ArrayPool<T>.Shared.Rent(Math.Min(MaterializationWindowRows, block.RowCount));
@@ -342,7 +363,7 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
         await lease.Connection.InsertAsync(
             sql,
             buffer.Count,
-            schema => pocoTypes.WritePlanFor<T>(schema).CreateSource(buffer, blockRows),
+            schema => PocoTypes.WritePlanFor<T>(schema).CreateSource(buffer, blockRows),
             settings,
             parameters,
             options?.QueryId,
@@ -394,6 +415,57 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
     /// </remarks>
     internal static int? ResolveMaxRowsPerBlock(ClickHouseTcpInsertOptions options)
         => (options ?? DefaultInsertOptions).MaxRowsPerBlock;
+
+    /// <summary>
+    /// Opens a session: one connection, taken from this client's pool and held until the session is disposed, that
+    /// every operation on the returned object runs over. Server-side state a connection owns therefore survives from
+    /// one operation to the next — a temporary table stays visible, and a <c>SET</c> keeps applying.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Dispose it, and keep it short.</b> The session holds one of the pool's
+    /// <see cref="ClickHouseTcpClientOptions.MaxPoolSize"/> connections for its whole lifetime, so a session left
+    /// open is capacity the client cannot use, and as many sessions as the pool is wide leaves nothing for anything
+    /// else — including for opening the next session, which then waits out
+    /// <see cref="ClickHouseTcpClientOptions.PoolTimeout"/>. Disposal closes the connection rather than pooling it,
+    /// since it carries the session's state, so it also costs the next caller a reconnect. Dispose the sessions
+    /// before the client, too: an open one holds a slot the client's own disposal waits out
+    /// <see cref="ClickHouseTcpClientOptions.PoolTimeout"/> for before aborting it.
+    /// </para>
+    /// <para>
+    /// The session runs one operation at a time and refuses a second started while the first is still going; the
+    /// client itself is what runs operations concurrently. Both may be used at once — a session's connection is its
+    /// own, and the pool keeps serving the client from the rest.
+    /// </para>
+    /// </remarks>
+    /// <param name="cancellationToken">A token to observe while waiting for and establishing the connection.</param>
+    /// <returns>A session pinned to one connection.</returns>
+    /// <exception cref="TimeoutException">No connection became available within
+    /// <see cref="ClickHouseTcpClientOptions.PoolTimeout"/>.</exception>
+    /// <exception cref="ObjectDisposedException">This client has been disposed.</exception>
+    public async ValueTask<IClickHouseTcpSession> OpenSessionAsync(CancellationToken cancellationToken = default)
+    {
+        IConnectionLease lease = await source.RentAsync(cancellationToken).ConfigureAwait(false);
+        var pinned = new PinnedConnectionSource(lease);
+        try
+        {
+            // The session's operations are this client's, run over the pinned source. The registry is shared so a
+            // plan compiled either side serves both.
+            var operations = new ClickHouseTcpClient(pinned, Options, optionsAreOwned: true)
+            {
+                PocoTypes = PocoTypes,
+            };
+
+            return new ClickHouseTcpSession(pinned, operations);
+        }
+        catch
+        {
+            // Nothing here is expected to throw, but a connection this method fails to hand over is one nobody can
+            // return: the caller has no session to dispose, and the pool is a slot short for the rest of its life.
+            await pinned.DisposeAsync().ConfigureAwait(false);
+            throw;
+        }
+    }
 
     /// <summary>Checks connectivity by sending a Ping and awaiting the Pong.</summary>
     /// <param name="cancellationToken">A token to observe for cancellation.</param>

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClient.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClient.cs
@@ -31,10 +31,9 @@ namespace ClickHouse.Driver.Tcp;
 /// </para>
 ///
 /// <para>
-/// An operation runs on whichever connection the pool hands it, which may or may not be the one before it used.
-/// So server-side state a connection holds — a temporary table, a <c>SET</c> — is neither reliably still there for
-/// the next operation nor reliably gone from it. Where that state is the point, use
-/// <see cref="OpenSessionAsync"/>, which pins one connection for as long as the session lives.
+/// Pooled operations may reuse a connection or use different ones; connection state is neither isolated nor
+/// guaranteed to persist between calls. Use <see cref="OpenSessionAsync"/> for temporary tables and <c>SET</c>
+/// settings that must persist across operations.
 /// </para>
 ///
 /// <para>
@@ -91,12 +90,11 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
     }
 
     /// <summary>Test/pool seam: builds a client over an arbitrary connection source.</summary>
-    /// <param name="source">The source the client rents its connections from.</param>
+    /// <param name="source">The connection source.</param>
     /// <param name="options">The client configuration, or null for the defaults.</param>
     /// <param name="optionsAreOwned">
-    /// True when <paramref name="options"/> already holds a private snapshot of its custom settings, so this client
-    /// can share it rather than copy it again. Only a session passes true, which also makes <c>session.Options</c>
-    /// the very instance <c>client.Options</c> is rather than an equal-looking copy.
+    /// True to reuse options whose custom settings are already privately owned. Sessions use this to share
+    /// the parent client's options instance.
     /// </param>
     internal ClickHouseTcpClient(
         IConnectionSource source,
@@ -115,9 +113,7 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
     public ClickHouseTcpClientOptions Options { get; }
 
     /// <summary>
-    /// The compiled POCO read and write plans. Per-client, as HTTP's registry is: the client is meant to be a
-    /// singleton, so the reflection and the compiles are amortized anyway, and a per-client cache cannot pin a type
-    /// whose AssemblyLoadContext the caller unloads. A session shares the registry of the client it came from.
+    /// Compiled POCO read and write plans, shared with this client's sessions.
     /// </summary>
     internal PocoTypeRegistry PocoTypes { get; init; } = new();
 
@@ -414,34 +410,14 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
     internal static int? ResolveMaxRowsPerBlock(ClickHouseTcpInsertOptions options)
         => (options ?? DefaultInsertOptions).MaxRowsPerBlock;
 
-    /// <summary>
-    /// Opens a session: one connection, taken from this client's pool and held until the session is disposed, that
-    /// every operation on the returned object runs over. Server-side state a connection owns therefore survives from
-    /// one operation to the next — a temporary table stays visible, and a <c>SET</c> keeps applying.
-    /// </summary>
-    /// <remarks>
-    /// <b>Dispose it, and keep it short.</b> The session holds one of the pool's
-    /// <see cref="ClickHouseTcpClientOptions.MaxPoolSize"/> connections for its whole lifetime, so as many sessions as
-    /// the pool is wide leaves nothing for anything else, including for opening the next session — which then waits
-    /// out <see cref="ClickHouseTcpClientOptions.PoolTimeout"/>. Disposal closes the connection rather than pooling
-    /// it, since it carries the session's state, so it costs the next caller a reconnect. Dispose the sessions before
-    /// the client: an open one holds a slot the client's own disposal waits out <c>PoolTimeout</c> for. A session runs
-    /// one operation at a time, while the client itself runs them concurrently; both may be used at once, the
-    /// session's connection being its own.
-    /// </remarks>
-    /// <param name="cancellationToken">A token to observe while waiting for and establishing the connection.</param>
-    /// <returns>A session pinned to one connection.</returns>
-    /// <exception cref="TimeoutException">No connection became available within
-    /// <see cref="ClickHouseTcpClientOptions.PoolTimeout"/>.</exception>
-    /// <exception cref="ObjectDisposedException">This client has been disposed.</exception>
+    /// <inheritdoc/>
     public async ValueTask<IClickHouseTcpSession> OpenSessionAsync(CancellationToken cancellationToken = default)
     {
         IConnectionLease lease = await source.RentAsync(cancellationToken).ConfigureAwait(false);
         var pinned = new PinnedConnectionSource(lease);
         try
         {
-            // The session's operations are this client's, run over the pinned source. The registry is shared so a
-            // plan compiled either side serves both.
+            // Reuse client operations and compiled plans on the pinned connection.
             var operations = new ClickHouseTcpClient(pinned, Options, optionsAreOwned: true)
             {
                 PocoTypes = PocoTypes,
@@ -451,8 +427,7 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient
         }
         catch
         {
-            // Nothing here is expected to throw, but a connection this method fails to hand over is one nobody can
-            // return: the caller has no session to dispose, and the pool is a slot short for the rest of its life.
+            // Release the pool slot if session construction fails.
             await pinned.DisposeAsync().ConfigureAwait(false);
             throw;
         }

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpSession.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpSession.cs
@@ -15,7 +15,7 @@ namespace ClickHouse.Driver.Tcp;
 /// <remarks>
 /// The operations are the client's own, run over a source that hands out the pinned connection instead of a pooled
 /// one (<see cref="PinnedConnectionSource"/>). Nothing here re-implements a query or an insert, so a session cannot
-/// drift from the client, and the pinning rules live in one place rather than in each operation.
+/// drift from the client.
 /// </remarks>
 [Experimental("CHTCP0001")]
 internal sealed class ClickHouseTcpSession : IClickHouseTcpSession
@@ -101,16 +101,11 @@ internal sealed class ClickHouseTcpSession : IClickHouseTcpSession
     /// unaffected and keeps working.
     /// </summary>
     /// <returns>
-    /// A task that completes when the session is closed — which is not always when its connection is: an operation
+    /// A task that completes when the session is closed, which is not always when its connection is: an operation
     /// still running is aborted rather than waited for, and it is that operation's unwinding, not this call, that
-    /// gives the slot back. See <see cref="PinnedConnectionSource.DisposeAsync"/> for what that costs when the
-    /// operation is one nothing can resume.
+    /// gives the slot back — see <see cref="PinnedConnectionSource.DisposeAsync"/> for what that costs when nothing
+    /// can resume the operation. A second call does nothing rather than waiting for the first, a session having one
+    /// owner.
     /// </returns>
-    /// <remarks>
-    /// Disposing the inner client disposes the pinned source, which is where the closing happens. The inner client
-    /// owns no pool of its own, so there is nothing else to tear down. A second call does nothing rather than
-    /// waiting for the first, a session having one owner; the pool, which does not, makes concurrent disposals
-    /// wait.
-    /// </remarks>
     public ValueTask DisposeAsync() => operations.DisposeAsync();
 }

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpSession.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpSession.cs
@@ -1,0 +1,116 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Client;
+using ClickHouse.Driver.Tcp.Format;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp;
+
+/// <summary>
+/// A session over one pinned connection. Opened with <see cref="ClickHouseTcpClient.OpenSessionAsync"/>; see
+/// <see cref="IClickHouseTcpSession"/> for what pinning buys and what it costs.
+/// </summary>
+/// <remarks>
+/// The operations are the client's own, run over a source that hands out the pinned connection instead of a pooled
+/// one (<see cref="PinnedConnectionSource"/>). Nothing here re-implements a query or an insert, so a session cannot
+/// drift from the client, and the pinning rules live in one place rather than in each operation.
+/// </remarks>
+[Experimental("CHTCP0001")]
+internal sealed class ClickHouseTcpSession : IClickHouseTcpSession
+{
+    private readonly PinnedConnectionSource pinned;
+    private readonly ClickHouseTcpClient operations;
+
+    /// <summary>Builds a session over an already-pinned connection.</summary>
+    /// <param name="pinned">The source holding the pinned connection's lease.</param>
+    /// <param name="operations">A client running over <paramref name="pinned"/>.</param>
+    internal ClickHouseTcpSession(PinnedConnectionSource pinned, ClickHouseTcpClient operations)
+    {
+        this.pinned = pinned;
+        this.operations = operations;
+    }
+
+    /// <inheritdoc/>
+    public ClickHouseTcpClientOptions Options => operations.Options;
+
+    /// <inheritdoc/>
+    public bool IsOpen => pinned.IsOpen;
+
+    /// <inheritdoc/>
+    public IAsyncEnumerable<Block> StreamAsync(
+        string sql,
+        ClickHouseTcpQueryOptions options = null,
+        CancellationToken cancellationToken = default)
+        => operations.StreamAsync(sql, options, cancellationToken);
+
+    /// <inheritdoc/>
+    public IAsyncEnumerable<object[]> QueryAsync(
+        string sql,
+        ClickHouseTcpQueryOptions options = null,
+        CancellationToken cancellationToken = default)
+        => operations.QueryAsync(sql, options, cancellationToken);
+
+    /// <inheritdoc/>
+    public IAsyncEnumerable<T> QueryAsync<T>(
+        string sql,
+        ClickHouseTcpQueryOptions options = null,
+        CancellationToken cancellationToken = default)
+        where T : class
+        => operations.QueryAsync<T>(sql, options, cancellationToken);
+
+    /// <inheritdoc/>
+    public ValueTask ExecuteAsync(
+        string sql,
+        ClickHouseTcpQueryOptions options = null,
+        CancellationToken cancellationToken = default)
+        => operations.ExecuteAsync(sql, options, cancellationToken);
+
+    /// <inheritdoc/>
+    public ValueTask InsertAsync(
+        string sql,
+        IReadOnlyList<IColumn> columns,
+        ClickHouseTcpInsertOptions options = null,
+        CancellationToken cancellationToken = default)
+        => operations.InsertAsync(sql, columns, options, cancellationToken);
+
+    /// <inheritdoc/>
+    public ValueTask InsertAsync<T>(
+        string sql,
+        IEnumerable<T> rows,
+        ClickHouseTcpInsertOptions options = null,
+        CancellationToken cancellationToken = default)
+        where T : class
+        => operations.InsertAsync(sql, rows, options, cancellationToken);
+
+    /// <inheritdoc/>
+    public ValueTask InsertAsync(
+        string sql,
+        IEnumerable<object[]> rows,
+        ClickHouseTcpInsertOptions options = null,
+        CancellationToken cancellationToken = default)
+        => operations.InsertAsync(sql, rows, options, cancellationToken);
+
+    /// <inheritdoc/>
+    public ValueTask PingAsync(CancellationToken cancellationToken = default)
+        => operations.PingAsync(cancellationToken);
+
+    /// <summary>
+    /// Ends the session, closing its connection rather than pooling it. The client the session came from is
+    /// unaffected and keeps working.
+    /// </summary>
+    /// <returns>
+    /// A task that completes when the session is closed — which is not always when its connection is: an operation
+    /// still running is aborted rather than waited for, and it is that operation's unwinding, not this call, that
+    /// gives the slot back. See <see cref="PinnedConnectionSource.DisposeAsync"/> for what that costs when the
+    /// operation is one nothing can resume.
+    /// </returns>
+    /// <remarks>
+    /// Disposing the inner client disposes the pinned source, which is where the closing happens. The inner client
+    /// owns no pool of its own, so there is nothing else to tear down. A second call does nothing rather than
+    /// waiting for the first, a session having one owner; the pool, which does not, makes concurrent disposals
+    /// wait.
+    /// </remarks>
+    public ValueTask DisposeAsync() => operations.DisposeAsync();
+}

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpSession.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpSession.cs
@@ -76,21 +76,21 @@ internal sealed class ClickHouseTcpSession : IClickHouseTcpSession
         => operations.InsertAsync(sql, columns, options, cancellationToken);
 
     /// <inheritdoc/>
-    public ValueTask InsertAsync<T>(
+    public ValueTask InsertRowsAsync<T>(
         string sql,
-        IEnumerable<T> rows,
+        IReadOnlyList<T> rows,
         ClickHouseTcpInsertOptions options = null,
         CancellationToken cancellationToken = default)
         where T : class
-        => operations.InsertAsync(sql, rows, options, cancellationToken);
+        => operations.InsertRowsAsync(sql, rows, options, cancellationToken);
 
     /// <inheritdoc/>
-    public ValueTask InsertAsync(
+    public ValueTask InsertRowsAsync(
         string sql,
-        IEnumerable<object[]> rows,
+        IReadOnlyList<object[]> rows,
         ClickHouseTcpInsertOptions options = null,
         CancellationToken cancellationToken = default)
-        => operations.InsertAsync(sql, rows, options, cancellationToken);
+        => operations.InsertRowsAsync(sql, rows, options, cancellationToken);
 
     /// <inheritdoc/>
     public ValueTask PingAsync(CancellationToken cancellationToken = default)

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpSession.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpSession.cs
@@ -9,14 +9,9 @@ using ClickHouse.Driver.Tcp.Types;
 namespace ClickHouse.Driver.Tcp;
 
 /// <summary>
-/// A session over one pinned connection. Opened with <see cref="ClickHouseTcpClient.OpenSessionAsync"/>; see
-/// <see cref="IClickHouseTcpSession"/> for what pinning buys and what it costs.
+/// Implements <see cref="IClickHouseTcpSession"/> by delegating to a client backed by a
+/// <see cref="PinnedConnectionSource"/>.
 /// </summary>
-/// <remarks>
-/// The operations are the client's own, run over a source that hands out the pinned connection instead of a pooled
-/// one (<see cref="PinnedConnectionSource"/>). Nothing here re-implements a query or an insert, so a session cannot
-/// drift from the client.
-/// </remarks>
 [Experimental("CHTCP0001")]
 internal sealed class ClickHouseTcpSession : IClickHouseTcpSession
 {
@@ -97,15 +92,12 @@ internal sealed class ClickHouseTcpSession : IClickHouseTcpSession
         => operations.PingAsync(cancellationToken);
 
     /// <summary>
-    /// Ends the session, closing its connection rather than pooling it. The client the session came from is
-    /// unaffected and keeps working.
+    /// Ends the session and closes its connection without disposing the parent client.
     /// </summary>
-    /// <returns>
-    /// A task that completes when the session is closed, which is not always when its connection is: an operation
-    /// still running is aborted rather than waited for, and it is that operation's unwinding, not this call, that
-    /// gives the slot back — see <see cref="PinnedConnectionSource.DisposeAsync"/> for what that costs when nothing
-    /// can resume the operation. A second call does nothing rather than waiting for the first, a session having one
-    /// owner.
-    /// </returns>
+    /// <remarks>
+    /// Active operations are aborted without waiting for their pool slot to be released; see
+    /// <see cref="PinnedConnectionSource.DisposeAsync"/>. Repeated calls return immediately.
+    /// </remarks>
+    /// <returns>A task that completes when disposal has finished or an active operation has been aborted.</returns>
     public ValueTask DisposeAsync() => operations.DisposeAsync();
 }

--- a/ClickHouse.Driver.Tcp/Client/IClickHouseTcpClient.cs
+++ b/ClickHouse.Driver.Tcp/Client/IClickHouseTcpClient.cs
@@ -1,12 +1,14 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace ClickHouse.Driver.Tcp;
 
 /// <summary>
 /// The contract of a ClickHouse client that speaks the native TCP protocol. It runs every
 /// <see cref="IClickHouseTcpOperations"/> member over a pool, so consecutive operations need not land on the same
-/// connection. <see cref="ClickHouseTcpClient"/> is the implementation; code against this interface to substitute
-/// a test double.
+/// connection, and adds the one thing that pins them to one: <see cref="OpenSessionAsync"/>.
+/// <see cref="ClickHouseTcpClient"/> is the implementation; code against this interface to substitute a test double.
 ///
 /// <para>
 /// This type is experimental: its surface may change in a future release. Suppress diagnostic
@@ -16,4 +18,21 @@ namespace ClickHouse.Driver.Tcp;
 [Experimental("CHTCP0001")]
 public interface IClickHouseTcpClient : IClickHouseTcpOperations
 {
+    /// <summary>
+    /// Opens a session: one connection, taken from the pool and held until the session is disposed, that every
+    /// operation on the returned object runs over. That is what carries the server-side state a single connection
+    /// owns — temporary tables, and the settings a <c>SET</c> statement changes — from one operation to the next.
+    /// </summary>
+    /// <remarks>
+    /// <b>Dispose it, and keep it short.</b> A session holds one of the pool's
+    /// <see cref="ClickHouseTcpClientOptions.MaxPoolSize"/> connections for its whole lifetime, so as many
+    /// sessions as the pool is wide leaves nothing for anything else. Disposal closes the connection rather than
+    /// pooling it — see <see cref="IClickHouseTcpSession"/> for why — so it costs a reconnect.
+    /// </remarks>
+    /// <param name="cancellationToken">A token to observe while waiting for and establishing the connection.</param>
+    /// <returns>A session pinned to one connection.</returns>
+    /// <exception cref="System.TimeoutException">No connection became available within
+    /// <see cref="ClickHouseTcpClientOptions.PoolTimeout"/>.</exception>
+    /// <exception cref="System.ObjectDisposedException">The client has been disposed.</exception>
+    ValueTask<IClickHouseTcpSession> OpenSessionAsync(CancellationToken cancellationToken = default);
 }

--- a/ClickHouse.Driver.Tcp/Client/IClickHouseTcpClient.cs
+++ b/ClickHouse.Driver.Tcp/Client/IClickHouseTcpClient.cs
@@ -20,14 +20,14 @@ public interface IClickHouseTcpClient : IClickHouseTcpOperations
 {
     /// <summary>
     /// Opens a session: one connection, taken from the pool and held until the session is disposed, that every
-    /// operation on the returned object runs over. That is what carries the server-side state a single connection
-    /// owns — temporary tables, and the settings a <c>SET</c> statement changes — from one operation to the next.
+    /// operation on the returned object runs over. That is what carries a connection's server-side state — a
+    /// temporary table, a <c>SET</c> — from one operation to the next.
     /// </summary>
     /// <remarks>
     /// <b>Dispose it, and keep it short.</b> A session holds one of the pool's
-    /// <see cref="ClickHouseTcpClientOptions.MaxPoolSize"/> connections for its whole lifetime, so as many
-    /// sessions as the pool is wide leaves nothing for anything else. Disposal closes the connection rather than
-    /// pooling it — see <see cref="IClickHouseTcpSession"/> for why — so it costs a reconnect.
+    /// <see cref="ClickHouseTcpClientOptions.MaxPoolSize"/> connections for its whole lifetime, so as many sessions
+    /// as the pool is wide leaves nothing for anything else. Disposal closes the connection rather than pooling it
+    /// (see <see cref="IClickHouseTcpSession"/>), so it costs a reconnect.
     /// </remarks>
     /// <param name="cancellationToken">A token to observe while waiting for and establishing the connection.</param>
     /// <returns>A session pinned to one connection.</returns>

--- a/ClickHouse.Driver.Tcp/Client/IClickHouseTcpClient.cs
+++ b/ClickHouse.Driver.Tcp/Client/IClickHouseTcpClient.cs
@@ -1,17 +1,12 @@
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Threading;
-using System.Threading.Tasks;
-using ClickHouse.Driver.Tcp.Format;
-using ClickHouse.Driver.Tcp.Types;
 
 namespace ClickHouse.Driver.Tcp;
 
 /// <summary>
-/// The contract of a ClickHouse client that speaks the native TCP protocol: run queries and stream results,
-/// execute statements, and insert data columnwise or row by row. <see cref="ClickHouseTcpClient"/> is the
-/// implementation; code against this interface to substitute a test double.
+/// The contract of a ClickHouse client that speaks the native TCP protocol. It runs every
+/// <see cref="IClickHouseTcpOperations"/> member over a pool, so consecutive operations need not land on the same
+/// connection. <see cref="ClickHouseTcpClient"/> is the implementation; code against this interface to substitute
+/// a test double.
 ///
 /// <para>
 /// This type is experimental: its surface may change in a future release. Suppress diagnostic
@@ -19,167 +14,6 @@ namespace ClickHouse.Driver.Tcp;
 /// </para>
 /// </summary>
 [Experimental("CHTCP0001")]
-public interface IClickHouseTcpClient : IAsyncDisposable
+public interface IClickHouseTcpClient : IClickHouseTcpOperations
 {
-    /// <summary>
-    /// The configuration this client was built with, including the client-level settings applied to every
-    /// operation.
-    /// </summary>
-    ClickHouseTcpClientOptions Options { get; }
-
-    /// <summary>
-    /// Runs a query and streams its result as a sequence of <see cref="Block"/>s — the low-level columnar tier,
-    /// with no per-row materialization.
-    /// </summary>
-    /// <remarks>
-    /// <b>Blocks are borrowed.</b> Each yielded <see cref="Block"/> is valid only for the current iteration, and
-    /// the consumer must not dispose one or retain it, its columns, or an <see cref="IColumn{T}.Values"/> span
-    /// past that point — copy out what must outlive the loop body. Enumerate with <c>await foreach</c> (or
-    /// otherwise dispose the enumerator) so the underlying connection is released. An implementation must honor
-    /// this contract.
-    /// </remarks>
-    /// <param name="sql">The SQL text.</param>
-    /// <param name="options">Per-query options (query id, settings, parameters), or null for the client defaults.</param>
-    /// <param name="cancellationToken">A token to observe for cancellation.</param>
-    /// <returns>An async stream of the result's row-bearing blocks, each valid only for its own iteration.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="sql"/> is null.</exception>
-    IAsyncEnumerable<Block> StreamAsync(
-        string sql,
-        ClickHouseTcpQueryOptions options = null,
-        CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Runs a query and streams its result one row at a time as <c>object[]</c>, each entry the boxed value of a
-    /// column in header order. Each returned array is owned and safe to retain past the enumeration.
-    /// </summary>
-    /// <remarks>
-    /// <c>LowCardinality</c> values may be shared within a block; array-valued entries must not be mutated in place.
-    /// </remarks>
-    /// <param name="sql">The SQL text.</param>
-    /// <param name="options">Per-query options (query id, settings, parameters), or null for the client defaults.</param>
-    /// <param name="cancellationToken">A token to observe for cancellation.</param>
-    /// <returns>An async stream of result rows.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="sql"/> is null.</exception>
-    IAsyncEnumerable<object[]> QueryAsync(
-        string sql,
-        ClickHouseTcpQueryOptions options = null,
-        CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Runs a query and streams its result one row at a time as <typeparamref name="T"/>, filling each property
-    /// from the column of the same name (ignoring case, and then underscores). A column no property maps to is
-    /// skipped, and a property no column maps to keeps its default.
-    /// </summary>
-    /// <remarks>
-    /// Rows remain valid after enumeration advances. Element instances may still be shared where the column's
-    /// representation does; see <see cref="ClickHouseTcpClient.QueryAsync{T}"/>.
-    /// </remarks>
-    /// <typeparam name="T">The row type.</typeparam>
-    /// <param name="sql">The SQL text.</param>
-    /// <param name="options">Per-query options (query id, settings, parameters), or null for the client defaults.</param>
-    /// <param name="cancellationToken">A token to observe for cancellation.</param>
-    /// <returns>An async stream of result rows.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="sql"/> is null.</exception>
-    /// <exception cref="InvalidOperationException"><typeparamref name="T"/> cannot be mapped to the result.</exception>
-    IAsyncEnumerable<T> QueryAsync<T>(
-        string sql,
-        ClickHouseTcpQueryOptions options = null,
-        CancellationToken cancellationToken = default)
-        where T : class;
-
-    /// <summary>
-    /// Runs a statement that produces no result rows (DDL, or DML other than an <c>INSERT ... VALUES</c>) and
-    /// returns once the server acknowledges it. Any result blocks are drained and discarded.
-    /// </summary>
-    /// <param name="sql">The SQL text.</param>
-    /// <param name="options">Per-query options (query id, settings, parameters), or null for the client defaults.</param>
-    /// <param name="cancellationToken">A token to observe for cancellation.</param>
-    /// <returns>A task that completes when the statement is acknowledged.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="sql"/> is null.</exception>
-    ValueTask ExecuteAsync(
-        string sql,
-        ClickHouseTcpQueryOptions options = null,
-        CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Inserts columnar data. The columns are matched to the target's schema <b>by name</b> (order is free, and a
-    /// named subset inserts only those columns, the server filling the rest from their defaults); values are
-    /// serialized as the target's resolved type. Zero rows is a no-op.
-    /// </summary>
-    /// <param name="sql">The <c>INSERT INTO … VALUES</c> statement, with no inline <c>VALUES (...)</c> literal.</param>
-    /// <param name="columns">The row data, matched to the target columns by name.</param>
-    /// <param name="options">Per-insert options (query id, settings, parameters, block sizing), or null for the client defaults.</param>
-    /// <param name="cancellationToken">A token to observe for cancellation.</param>
-    /// <returns>A task that completes when the server acknowledges the insert.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="sql"/> or <paramref name="columns"/> is null.</exception>
-    /// <exception cref="ArgumentException">The columns' row counts differ, names are not unique, do not match the target schema, or a CLR type is not writable as its target type.</exception>
-    ValueTask InsertAsync(
-        string sql,
-        IReadOnlyList<IColumn> columns,
-        ClickHouseTcpInsertOptions options = null,
-        CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Inserts rows by mapping the target columns to properties of <typeparamref name="T"/>. Names match case- and
-    /// underscore-insensitively; <see cref="ClickHouseTcpColumnAttribute"/> can rename a property and
-    /// <see cref="ClickHouseTcpNotMappedAttribute"/> can exclude one.
-    /// </summary>
-    /// <remarks>
-    /// Every column targeted by the INSERT must have a compatible public getter. Other properties
-    /// are ignored. Rows must be materialized and must not be modified until the operation completes. An empty list
-    /// still validates the mapping.
-    ///
-    /// <para>
-    /// Rows are converted to columns one wire block at a time (see
-    /// <see cref="ClickHouseTcpInsertOptions.MaxRowsPerBlock"/>), so the list is read as the insert runs rather
-    /// than copied up front. A value the target cannot take — a null for a non-nullable column, say — is
-    /// therefore found when its own block is converted, and the blocks before it have already been sent.
-    /// </para>
-    /// </remarks>
-    /// <typeparam name="T">The row type.</typeparam>
-    /// <param name="sql">The <c>INSERT INTO … VALUES</c> statement, with no inline <c>VALUES (...)</c> literal.</param>
-    /// <param name="rows">The materialized rows to insert, each non-null.</param>
-    /// <param name="options">Per-insert options (query id, settings, parameters, block sizing), or null for the client defaults.</param>
-    /// <param name="cancellationToken">A token to observe for cancellation.</param>
-    /// <returns>A task that completes when the server acknowledges the insert.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="sql"/> or <paramref name="rows"/> is null.</exception>
-    /// <exception cref="ArgumentException">A row is null, or <typeparamref name="T"/> is a column type — pass columns
-    /// to <see cref="InsertAsync"/> instead.</exception>
-    /// <exception cref="InvalidOperationException"><typeparamref name="T"/> cannot fill the target, or a value is
-    /// null where the target does not allow it.</exception>
-    ValueTask InsertRowsAsync<T>(
-        string sql,
-        IReadOnlyList<T> rows,
-        ClickHouseTcpInsertOptions options = null,
-        CancellationToken cancellationToken = default)
-        where T : class;
-
-    /// <summary>
-    /// Inserts untyped rows, matching each <c>object[]</c> to the target columns by position.
-    /// </summary>
-    /// <remarks>
-    /// A column uses the CLR type of its first non-null value, wherever in the insert that row is; later values
-    /// must use the same type unless the target is <c>Variant</c> or <c>Dynamic</c>. Rows must not be modified
-    /// until the operation completes, since they are converted one wire block at a time as the insert runs. Value
-    /// types are boxed because each row stores its values as <see cref="object"/>.
-    /// </remarks>
-    /// <param name="sql">The <c>INSERT INTO … VALUES</c> statement, with no inline <c>VALUES (...)</c> literal.</param>
-    /// <param name="rows">The materialized rows to insert, each non-null and one value long per target column.</param>
-    /// <param name="options">Per-insert options (query id, settings, parameters, block sizing), or null for the client defaults.</param>
-    /// <param name="cancellationToken">A token to observe for cancellation.</param>
-    /// <returns>A task that completes when the server acknowledges the insert.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="sql"/> or <paramref name="rows"/> is null.</exception>
-    /// <exception cref="ArgumentException">A row is null or has the wrong number of values.</exception>
-    /// <exception cref="InvalidOperationException">A value has an unsupported or inconsistent CLR type, is null
-    /// where the target does not allow it, or the target cannot be built from rows.</exception>
-    ValueTask InsertRowsAsync(
-        string sql,
-        IReadOnlyList<object[]> rows,
-        ClickHouseTcpInsertOptions options = null,
-        CancellationToken cancellationToken = default);
-
-    /// <summary>Checks connectivity by sending a Ping and awaiting the Pong.</summary>
-    /// <param name="cancellationToken">A token to observe for cancellation.</param>
-    /// <returns>A task that completes when the server answers.</returns>
-    ValueTask PingAsync(CancellationToken cancellationToken = default);
 }

--- a/ClickHouse.Driver.Tcp/Client/IClickHouseTcpClient.cs
+++ b/ClickHouse.Driver.Tcp/Client/IClickHouseTcpClient.cs
@@ -5,10 +5,8 @@ using System.Threading.Tasks;
 namespace ClickHouse.Driver.Tcp;
 
 /// <summary>
-/// The contract of a ClickHouse client that speaks the native TCP protocol. It runs every
-/// <see cref="IClickHouseTcpOperations"/> member over a pool, so consecutive operations need not land on the same
-/// connection, and adds the one thing that pins them to one: <see cref="OpenSessionAsync"/>.
-/// <see cref="ClickHouseTcpClient"/> is the implementation; code against this interface to substitute a test double.
+/// A pooled native TCP client. Use <see cref="OpenSessionAsync"/> to run operations on one connection.
+/// Implemented by <see cref="ClickHouseTcpClient"/>.
 ///
 /// <para>
 /// This type is experimental: its surface may change in a future release. Suppress diagnostic
@@ -19,15 +17,18 @@ namespace ClickHouse.Driver.Tcp;
 public interface IClickHouseTcpClient : IClickHouseTcpOperations
 {
     /// <summary>
-    /// Opens a session: one connection, taken from the pool and held until the session is disposed, that every
-    /// operation on the returned object runs over. That is what carries a connection's server-side state — a
-    /// temporary table, a <c>SET</c> — from one operation to the next.
+    /// Reserves one pooled connection for a session, preserving temporary tables and <c>SET</c> settings
+    /// across its operations.
     /// </summary>
     /// <remarks>
-    /// <b>Dispose it, and keep it short.</b> A session holds one of the pool's
-    /// <see cref="ClickHouseTcpClientOptions.MaxPoolSize"/> connections for its whole lifetime, so as many sessions
-    /// as the pool is wide leaves nothing for anything else. Disposal closes the connection rather than pooling it
-    /// (see <see cref="IClickHouseTcpSession"/>), so it costs a reconnect.
+    /// Each session occupies one of <see cref="ClickHouseTcpClientOptions.MaxPoolSize"/> pool slots. Keep sessions
+    /// short-lived and dispose them before the client to avoid delaying client disposal by
+    /// <see cref="ClickHouseTcpClientOptions.PoolTimeout"/>. Disposal closes the connection rather than reusing it,
+    /// so a replacement requires a new connection.
+    /// <para>
+    /// A session allows one operation at a time. The client can still run concurrent operations on other
+    /// connections; see <see cref="IClickHouseTcpSession"/> for session lifetime and streaming requirements.
+    /// </para>
     /// </remarks>
     /// <param name="cancellationToken">A token to observe while waiting for and establishing the connection.</param>
     /// <returns>A session pinned to one connection.</returns>

--- a/ClickHouse.Driver.Tcp/Client/IClickHouseTcpOperations.cs
+++ b/ClickHouse.Driver.Tcp/Client/IClickHouseTcpOperations.cs
@@ -1,0 +1,187 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Format;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp;
+
+/// <summary>
+/// What can be run against a ClickHouse server over the native TCP protocol: queries and streamed results,
+/// statements, and inserts columnwise or row by row. Both <see cref="IClickHouseTcpClient"/>, which spreads its
+/// operations over a pool, and <see cref="IClickHouseTcpSession"/>, which runs them all on one pinned
+/// connection, offer this surface — so code that only runs operations should take this interface and work with
+/// either. Code against it to substitute a test double.
+///
+/// <para>
+/// This type is experimental: its surface may change in a future release. Suppress diagnostic
+/// <c>CHTCP0001</c> to acknowledge that.
+/// </para>
+/// </summary>
+[Experimental("CHTCP0001")]
+public interface IClickHouseTcpOperations : IAsyncDisposable
+{
+    /// <summary>
+    /// The configuration these operations run under, including the client-level settings applied to every one of
+    /// them. A session reports the options of the client it was opened from.
+    /// </summary>
+    ClickHouseTcpClientOptions Options { get; }
+
+    /// <summary>
+    /// Runs a query and streams its result as a sequence of <see cref="Block"/>s — the low-level columnar tier,
+    /// with no per-row materialization.
+    /// </summary>
+    /// <remarks>
+    /// <b>Blocks are borrowed.</b> Each yielded <see cref="Block"/> is valid only for the current iteration, and
+    /// the consumer must not dispose one or retain it, its columns, or an <see cref="IColumn{T}.Values"/> span
+    /// past that point — copy out what must outlive the loop body. Enumerate with <c>await foreach</c> (or
+    /// otherwise dispose the enumerator) so the underlying connection is released. An implementation must honor
+    /// this contract.
+    /// </remarks>
+    /// <param name="sql">The SQL text.</param>
+    /// <param name="options">Per-query options (query id, settings, parameters), or null for the client defaults.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>An async stream of the result's row-bearing blocks, each valid only for its own iteration.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="sql"/> is null.</exception>
+    IAsyncEnumerable<Block> StreamAsync(
+        string sql,
+        ClickHouseTcpQueryOptions options = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Runs a query and streams its result one row at a time as <c>object[]</c>, each entry the boxed value of a
+    /// column in header order. Each returned array is owned and safe to retain past the enumeration.
+    /// </summary>
+    /// <remarks>
+    /// <c>LowCardinality</c> values may be shared within a block; array-valued entries must not be mutated in place.
+    /// </remarks>
+    /// <param name="sql">The SQL text.</param>
+    /// <param name="options">Per-query options (query id, settings, parameters), or null for the client defaults.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>An async stream of result rows.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="sql"/> is null.</exception>
+    IAsyncEnumerable<object[]> QueryAsync(
+        string sql,
+        ClickHouseTcpQueryOptions options = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Runs a query and streams its result one row at a time as <typeparamref name="T"/>, filling each property
+    /// from the column of the same name (ignoring case, and then underscores). A column no property maps to is
+    /// skipped, and a property no column maps to keeps its default.
+    /// </summary>
+    /// <remarks>
+    /// Rows remain valid after enumeration advances. Element instances may still be shared where the column's
+    /// representation does; see <see cref="ClickHouseTcpClient.QueryAsync{T}"/>.
+    /// </remarks>
+    /// <typeparam name="T">The row type.</typeparam>
+    /// <param name="sql">The SQL text.</param>
+    /// <param name="options">Per-query options (query id, settings, parameters), or null for the client defaults.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>An async stream of result rows.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="sql"/> is null.</exception>
+    /// <exception cref="InvalidOperationException"><typeparamref name="T"/> cannot be mapped to the result.</exception>
+    IAsyncEnumerable<T> QueryAsync<T>(
+        string sql,
+        ClickHouseTcpQueryOptions options = null,
+        CancellationToken cancellationToken = default)
+        where T : class;
+
+    /// <summary>
+    /// Runs a statement that produces no result rows (DDL, or DML other than an <c>INSERT ... VALUES</c>) and
+    /// returns once the server acknowledges it. Any result blocks are drained and discarded.
+    /// </summary>
+    /// <param name="sql">The SQL text.</param>
+    /// <param name="options">Per-query options (query id, settings, parameters), or null for the client defaults.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>A task that completes when the statement is acknowledged.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="sql"/> is null.</exception>
+    ValueTask ExecuteAsync(
+        string sql,
+        ClickHouseTcpQueryOptions options = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Inserts columnar data. The columns are matched to the target's schema <b>by name</b> (order is free, and a
+    /// named subset inserts only those columns, the server filling the rest from their defaults); values are
+    /// serialized as the target's resolved type. Zero rows is a no-op.
+    /// </summary>
+    /// <param name="sql">The <c>INSERT INTO … VALUES</c> statement, with no inline <c>VALUES (...)</c> literal.</param>
+    /// <param name="columns">The row data, matched to the target columns by name.</param>
+    /// <param name="options">Per-insert options (query id, settings, parameters, block sizing), or null for the client defaults.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>A task that completes when the server acknowledges the insert.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="sql"/> or <paramref name="columns"/> is null.</exception>
+    /// <exception cref="ArgumentException">The columns' row counts differ, names are not unique, do not match the target schema, or a CLR type is not writable as its target type.</exception>
+    ValueTask InsertAsync(
+        string sql,
+        IReadOnlyList<IColumn> columns,
+        ClickHouseTcpInsertOptions options = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Inserts rows by mapping the target columns to properties of <typeparamref name="T"/>. Names match case- and
+    /// underscore-insensitively; <see cref="ClickHouseTcpColumnAttribute"/> can rename a property and
+    /// <see cref="ClickHouseTcpNotMappedAttribute"/> can exclude one.
+    /// </summary>
+    /// <remarks>
+    /// Every column targeted by the INSERT must have a compatible public getter. Other properties are ignored. Rows
+    /// must be materialized and must not be modified until the operation completes. An empty list still validates
+    /// the mapping.
+    ///
+    /// <para>
+    /// Rows are converted to columns one wire block at a time (see
+    /// <see cref="ClickHouseTcpInsertOptions.MaxRowsPerBlock"/>), so the list is read as the insert runs rather
+    /// than copied up front. A value the target cannot take — a null for a non-nullable column, say — is
+    /// therefore found when its own block is converted, and the blocks before it have already been sent.
+    /// </para>
+    /// </remarks>
+    /// <typeparam name="T">The row type.</typeparam>
+    /// <param name="sql">The <c>INSERT INTO … VALUES</c> statement, with no inline <c>VALUES (...)</c> literal.</param>
+    /// <param name="rows">The materialized rows to insert, each non-null.</param>
+    /// <param name="options">Per-insert options (query id, settings, parameters, block sizing), or null for the client defaults.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>A task that completes when the server acknowledges the insert.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="sql"/> or <paramref name="rows"/> is null.</exception>
+    /// <exception cref="ArgumentException">A row is null, or <typeparamref name="T"/> is a column type — pass columns
+    /// to <see cref="InsertAsync"/> instead.</exception>
+    /// <exception cref="InvalidOperationException"><typeparamref name="T"/> cannot fill the target, or a value is
+    /// null where the target does not allow it.</exception>
+    ValueTask InsertRowsAsync<T>(
+        string sql,
+        IReadOnlyList<T> rows,
+        ClickHouseTcpInsertOptions options = null,
+        CancellationToken cancellationToken = default)
+        where T : class;
+
+    /// <summary>
+    /// Inserts untyped rows, matching each <c>object[]</c> to the target columns by position.
+    /// </summary>
+    /// <remarks>
+    /// A column uses the CLR type of its first non-null value, wherever in the insert that row is; later values
+    /// must use the same type unless the target is <c>Variant</c> or <c>Dynamic</c>. Rows must not be modified
+    /// until the operation completes, since they are converted one wire block at a time as the insert runs. Value
+    /// types are boxed because each row stores its values as <see cref="object"/>.
+    /// </remarks>
+    /// <param name="sql">The <c>INSERT INTO … VALUES</c> statement, with no inline <c>VALUES (...)</c> literal.</param>
+    /// <param name="rows">The materialized rows to insert, each non-null and one value long per target column.</param>
+    /// <param name="options">Per-insert options (query id, settings, parameters, block sizing), or null for the client defaults.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>A task that completes when the server acknowledges the insert.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="sql"/> or <paramref name="rows"/> is null.</exception>
+    /// <exception cref="ArgumentException">A row is null or has the wrong number of values.</exception>
+    /// <exception cref="InvalidOperationException">A value has an unsupported or inconsistent CLR type, is null
+    /// where the target does not allow it, or the target cannot be built from rows.</exception>
+    ValueTask InsertRowsAsync(
+        string sql,
+        IReadOnlyList<object[]> rows,
+        ClickHouseTcpInsertOptions options = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Checks connectivity by sending a Ping and awaiting the Pong.</summary>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>A task that completes when the server answers.</returns>
+    ValueTask PingAsync(CancellationToken cancellationToken = default);
+}

--- a/ClickHouse.Driver.Tcp/Client/IClickHouseTcpOperations.cs
+++ b/ClickHouse.Driver.Tcp/Client/IClickHouseTcpOperations.cs
@@ -9,11 +9,8 @@ using ClickHouse.Driver.Tcp.Types;
 namespace ClickHouse.Driver.Tcp;
 
 /// <summary>
-/// What can be run against a ClickHouse server over the native TCP protocol: queries and streamed results,
-/// statements, and inserts columnwise or row by row. Both <see cref="IClickHouseTcpClient"/>, which spreads its
-/// operations over a pool, and <see cref="IClickHouseTcpSession"/>, which runs them all on one pinned
-/// connection, offer this surface — so code that only runs operations should take this interface and work with
-/// either. Code against it to substitute a test double.
+/// Query, execution, and insert operations shared by <see cref="IClickHouseTcpClient"/> and
+/// <see cref="IClickHouseTcpSession"/>. Use this interface for code that accepts either a pooled client or a session.
 ///
 /// <para>
 /// This type is experimental: its surface may change in a future release. Suppress diagnostic
@@ -24,8 +21,7 @@ namespace ClickHouse.Driver.Tcp;
 public interface IClickHouseTcpOperations : IAsyncDisposable
 {
     /// <summary>
-    /// The configuration these operations run under, including the client-level settings applied to every one of
-    /// them. A session reports the options of the client it was opened from.
+    /// Client configuration and settings applied to every operation. Sessions share their parent client's options.
     /// </summary>
     ClickHouseTcpClientOptions Options { get; }
 

--- a/ClickHouse.Driver.Tcp/Client/IClickHouseTcpSession.cs
+++ b/ClickHouse.Driver.Tcp/Client/IClickHouseTcpSession.cs
@@ -36,8 +36,8 @@ public interface IClickHouseTcpSession : IClickHouseTcpOperations
     /// The connection is tested when an operation ends and again before the next one starts, so a drop while the
     /// session sat idle is caught. True is still not a promise that the next operation will work, since nothing rules
     /// out a drop between this answer and its use: treat false as certain and true as "nothing known to be wrong". An
-    /// operation leaves the connection unusable by failing at the transport or protocol level, by being cancelled, or
-    /// by streaming a result abandoned part-way; a server-side error in a query the server accepted does not.
+    /// operation leaves the connection unusable by failing at the transport or protocol level, by receiving a
+    /// server-side error, by being cancelled, or by streaming a result abandoned part-way.
     /// </remarks>
     bool IsOpen { get; }
 }

--- a/ClickHouse.Driver.Tcp/Client/IClickHouseTcpSession.cs
+++ b/ClickHouse.Driver.Tcp/Client/IClickHouseTcpSession.cs
@@ -1,0 +1,52 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace ClickHouse.Driver.Tcp;
+
+/// <summary>
+/// A run of operations over one pinned connection, opened with
+/// <see cref="IClickHouseTcpClient.OpenSessionAsync"/>. Everything a single connection remembers is therefore
+/// still there for the next operation: temporary tables, and the settings a <c>SET</c> statement changed.
+///
+/// <para>
+/// <b>One operation at a time.</b> The protocol carries one query per connection, so a session serves one owner
+/// and does not multiplex: a second operation started while the first is still running is refused rather than
+/// interleaved on the wire, and a streamed result holds the connection until it is read to the end or its
+/// enumerator is disposed.
+/// </para>
+///
+/// <para>
+/// <b>Disposal closes the connection</b> instead of returning it to the pool. A connection that has been in a
+/// session carries the state the session put there, and handing that to an unrelated caller would leak temporary
+/// tables and altered settings into their queries — so the socket is closed and the next caller dials a fresh one.
+/// </para>
+///
+/// <para>
+/// This type is experimental: its surface may change in a future release. Suppress diagnostic
+/// <c>CHTCP0001</c> to acknowledge that.
+/// </para>
+/// </summary>
+[Experimental("CHTCP0001")]
+public interface IClickHouseTcpSession : IClickHouseTcpOperations
+{
+    /// <summary>
+    /// Whether anything has been seen to end the session: false once it is disposed, and false once an operation
+    /// has left its connection unusable — which takes the session's server-side state with it, so the answer is to
+    /// open another session, not to retry on this one.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>True is not a promise that the next operation will work.</b> This reports what the session has already
+    /// observed, and it observes only at the end of an operation; a connection the server drops while the session
+    /// sits idle is still reported as open, and no answer could be better than that one, since the connection may
+    /// be dropped in the moment between the answer and its use. Treat false as certain and true as "nothing known
+    /// to be wrong".
+    /// </para>
+    /// <para>
+    /// An operation leaves the connection unusable by failing at the transport or protocol level, by being
+    /// cancelled, and by streaming a result that is abandoned part-way — the rest of that result is still coming,
+    /// so the connection cannot carry anything else. A server-side error in a query the server accepted, by
+    /// contrast, leaves the connection, and so the session, usable.
+    /// </para>
+    /// </remarks>
+    bool IsOpen { get; }
+}

--- a/ClickHouse.Driver.Tcp/Client/IClickHouseTcpSession.cs
+++ b/ClickHouse.Driver.Tcp/Client/IClickHouseTcpSession.cs
@@ -4,20 +4,19 @@ namespace ClickHouse.Driver.Tcp;
 
 /// <summary>
 /// A run of operations over one pinned connection, opened with
-/// <see cref="IClickHouseTcpClient.OpenSessionAsync"/>. Everything a single connection remembers is therefore
-/// still there for the next operation: temporary tables, and the settings a <c>SET</c> statement changed.
+/// <see cref="IClickHouseTcpClient.OpenSessionAsync"/>. State a single connection holds — temporary tables, and what
+/// a <c>SET</c> changed — therefore survives from one operation to the next.
 ///
 /// <para>
-/// <b>One operation at a time.</b> The protocol carries one query per connection, so a session serves one owner
-/// and does not multiplex: a second operation started while the first is still running is refused rather than
-/// interleaved on the wire, and a streamed result holds the connection until it is read to the end or its
-/// enumerator is disposed.
+/// <b>One operation at a time.</b> The protocol carries one query per connection, so a second operation started
+/// while the first is still running is refused rather than interleaved, and a streamed result holds the connection
+/// until it is read to the end or its enumerator is disposed.
 /// </para>
 ///
 /// <para>
-/// <b>Disposal closes the connection</b> instead of returning it to the pool. A connection that has been in a
-/// session carries the state the session put there, and handing that to an unrelated caller would leak temporary
-/// tables and altered settings into their queries — so the socket is closed and the next caller dials a fresh one.
+/// <b>Disposal closes the connection</b> instead of pooling it, so an unrelated caller cannot inherit the session's
+/// temporary tables and altered settings. A streamed result left suspended mid-enumeration and never disposed is the
+/// exception: disposal cannot free its pool slot either, and the pool stays a slot short until the client is disposed.
 /// </para>
 ///
 /// <para>
@@ -29,24 +28,16 @@ namespace ClickHouse.Driver.Tcp;
 public interface IClickHouseTcpSession : IClickHouseTcpOperations
 {
     /// <summary>
-    /// Whether anything has been seen to end the session: false once it is disposed, and false once an operation
-    /// has left its connection unusable — which takes the session's server-side state with it, so the answer is to
-    /// open another session, not to retry on this one.
+    /// Whether anything has been seen to end the session: false once it is disposed, and false once its connection is
+    /// found unusable — which takes the session's server-side state with it, so the answer is to open another session,
+    /// not to retry on this one.
     /// </summary>
     /// <remarks>
-    /// <para>
-    /// <b>True is not a promise that the next operation will work.</b> This reports what the session has already
-    /// observed, and it observes only at the end of an operation; a connection the server drops while the session
-    /// sits idle is still reported as open, and no answer could be better than that one, since the connection may
-    /// be dropped in the moment between the answer and its use. Treat false as certain and true as "nothing known
-    /// to be wrong".
-    /// </para>
-    /// <para>
-    /// An operation leaves the connection unusable by failing at the transport or protocol level, by being
-    /// cancelled, and by streaming a result that is abandoned part-way — the rest of that result is still coming,
-    /// so the connection cannot carry anything else. A server-side error in a query the server accepted, by
-    /// contrast, leaves the connection, and so the session, usable.
-    /// </para>
+    /// The connection is tested when an operation ends and again before the next one starts, so a drop while the
+    /// session sat idle is caught. True is still not a promise that the next operation will work, since nothing rules
+    /// out a drop between this answer and its use: treat false as certain and true as "nothing known to be wrong". An
+    /// operation leaves the connection unusable by failing at the transport or protocol level, by being cancelled, or
+    /// by streaming a result abandoned part-way; a server-side error in a query the server accepted does not.
     /// </remarks>
     bool IsOpen { get; }
 }

--- a/ClickHouse.Driver.Tcp/Client/IClickHouseTcpSession.cs
+++ b/ClickHouse.Driver.Tcp/Client/IClickHouseTcpSession.cs
@@ -3,41 +3,36 @@ using System.Diagnostics.CodeAnalysis;
 namespace ClickHouse.Driver.Tcp;
 
 /// <summary>
-/// A run of operations over one pinned connection, opened with
-/// <see cref="IClickHouseTcpClient.OpenSessionAsync"/>. State a single connection holds — temporary tables, and what
-/// a <c>SET</c> changed — therefore survives from one operation to the next.
-///
+/// Sequential operations on one connection, preserving temporary tables and <c>SET</c> settings.
+/// Created by <see cref="IClickHouseTcpClient.OpenSessionAsync"/>.
+/// </summary>
+/// <remarks>
 /// <para>
-/// <b>One operation at a time.</b> The protocol carries one query per connection, so a second operation started
-/// while the first is still running is refused rather than interleaved, and a streamed result holds the connection
-/// until it is read to the end or its enumerator is disposed.
+/// Concurrent operations are rejected. A streamed result holds the session until fully read or its enumerator
+/// is disposed. Use <c>await foreach</c> to ensure the enumerator is disposed.
 /// </para>
 ///
 /// <para>
-/// <b>Disposal closes the connection</b> instead of pooling it, so an unrelated caller cannot inherit the session's
-/// temporary tables and altered settings. A streamed result left suspended mid-enumeration and never disposed is the
-/// exception: disposal cannot free its pool slot either, and the pool stays a slot short until the client is disposed.
+/// Disposal closes the connection to prevent other callers from inheriting session state. It aborts an active
+/// operation without waiting; the pool slot is released when that operation exits. An undisposed enumerator
+/// suspended mid-stream keeps the slot occupied even after session disposal, until the client is disposed.
 /// </para>
 ///
 /// <para>
 /// This type is experimental: its surface may change in a future release. Suppress diagnostic
 /// <c>CHTCP0001</c> to acknowledge that.
 /// </para>
-/// </summary>
+/// </remarks>
 [Experimental("CHTCP0001")]
 public interface IClickHouseTcpSession : IClickHouseTcpOperations
 {
     /// <summary>
-    /// Whether anything has been seen to end the session: false once it is disposed, and false once its connection is
-    /// found unusable — which takes the session's server-side state with it, so the answer is to open another session,
-    /// not to retry on this one.
+    /// Whether the session is undisposed and its connection is not known to be unusable.
     /// </summary>
     /// <remarks>
-    /// The connection is tested when an operation ends and again before the next one starts, so a drop while the
-    /// session sat idle is caught. True is still not a promise that the next operation will work, since nothing rules
-    /// out a drop between this answer and its use: treat false as certain and true as "nothing known to be wrong". An
-    /// operation leaves the connection unusable by failing at the transport or protocol level, by receiving a
-    /// server-side error, by being cancelled, or by streaming a result abandoned part-way.
+    /// Once false, it remains false; open a new session to continue. True does not guarantee the next operation
+    /// will succeed. Transport, protocol, or server errors, cancellation, and incomplete result streams can make
+    /// the connection unusable. Connection health is checked between operations, not while one is running.
     /// </remarks>
     bool IsOpen { get; }
 }

--- a/ClickHouse.Driver.Tcp/Client/PinnedConnectionSource.cs
+++ b/ClickHouse.Driver.Tcp/Client/PinnedConnectionSource.cs
@@ -1,0 +1,270 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Protocol;
+
+namespace ClickHouse.Driver.Tcp.Client;
+
+/// <summary>
+/// A connection source that hands out the same connection every time: the one a session pinned. It holds a lease
+/// on the underlying source for its whole lifetime, so the connection is never anyone else's in between, which is
+/// what carries a session's temporary tables and settings from one operation to the next.
+///
+/// <para>
+/// It is the same seam the pool is, so a session runs the ordinary client code over it and needs no session-aware
+/// operations of its own. What it adds is the bookkeeping that pinning brings with it: exactly one operation at a
+/// time, a connection lost mid-session reported as such rather than as a wall of transport errors, and, on
+/// disposal, the connection closed instead of handed back.
+/// </para>
+/// </summary>
+/// <remarks>
+/// Every state change is made under <c>gate</c>, and the slow parts — closing the socket, returning the lease —
+/// are done outside it. Contention is not the reason for the lock: the states interlock (a rent must not start
+/// while disposal is deciding whether the connection is idle, and vice versa), and one lock is cheaper to reason
+/// about than the interlocked pairs that would replace it. The path it guards runs once per operation.
+/// </remarks>
+internal sealed class PinnedConnectionSource : IConnectionSource
+{
+    /// <summary>
+    /// The type an <see cref="ObjectDisposedException"/> from here names: the session the caller holds, not this
+    /// internal source. Spelled out rather than taken from <c>nameof</c>, because CHTCP0001 objects to naming the
+    /// <c>[Experimental]</c> session type from ordinary internal code.
+    /// </summary>
+    private const string SessionTypeName = "ClickHouseTcpSession";
+
+    private readonly IConnectionLease lease;
+    private readonly object gate = new();
+
+    // An operation holds the connection: rented and not yet released.
+    private bool busy;
+
+    // The connection was lost, so nothing more can run on it. Latched by HasLostTheConnection, which is asked at
+    // both ends of an operation.
+    private bool faulted;
+
+    private bool disposed;
+
+    // The lease has been given back to the pool. Guards against doing it twice, which would release a permit the
+    // source does not hold and let the pool run one operation over its limit.
+    private bool returned;
+
+    /// <summary>Pins the connection behind a lease for the lifetime of this source.</summary>
+    /// <param name="lease">The lease to hold, taken from the client's own source.</param>
+    internal PinnedConnectionSource(IConnectionLease lease) => this.lease = lease;
+
+    /// <summary>
+    /// Whether the pinned connection can still carry an operation: the source is neither disposed nor holding a
+    /// connection that was lost.
+    /// </summary>
+    /// <remarks>
+    /// A session running an operation is open on what is known so far, and is not tested further: a connection
+    /// mid-operation is not reusable by definition, so asking would condemn every session that is busy.
+    /// </remarks>
+    internal bool IsOpen
+    {
+        get
+        {
+            lock (gate)
+            {
+                if (disposed)
+                {
+                    return false;
+                }
+
+                return busy ? !faulted : !HasLostTheConnection();
+            }
+        }
+    }
+
+    /// <inheritdoc/>
+    /// <exception cref="InvalidOperationException">An operation is already running on this connection, or the
+    /// connection has been lost.</exception>
+    public ValueTask<IConnectionLease> RentAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        lock (gate)
+        {
+            if (disposed)
+            {
+                throw new ObjectDisposedException(SessionTypeName);
+            }
+
+            // Tested before the connection is, and not only to report the likelier mistake first: a connection
+            // carrying an operation is not reusable, so asking the question below while one runs would condemn a
+            // session that is merely busy.
+            if (busy)
+            {
+                throw new InvalidOperationException(
+                    "The session is already running an operation, and one connection carries one query at a time. Run the operations one after another, or use the client itself to run them at once over separate connections. A streamed result holds the session until it is read to the end or its enumerator is disposed.");
+            }
+
+            if (HasLostTheConnection())
+            {
+                throw new InvalidOperationException(
+                    "The session's connection can no longer be used, so its temporary tables and settings are gone with it. That follows a failed or cancelled operation, a streamed result that was not read to the end, or the server closing the connection. Open a new session to continue.");
+            }
+
+            busy = true;
+        }
+
+        // The pinned lease is a token for one operation, not a second claim on the connection: it releases the
+        // gate above rather than the underlying lease, which this source holds until it is disposed.
+        return new ValueTask<IConnectionLease>(new PinnedLease(this));
+    }
+
+    /// <summary>
+    /// Ends the session: closes the pinned connection and gives the lease back, so the pool accounts for the slot
+    /// again and opens a fresh connection for the next caller. Idempotent.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The connection is closed rather than returned reusable, because a session leaves its state on it and the
+    /// next caller must not inherit that. Disposal during an operation cannot close it that way — the buffers the
+    /// operation is reading into would go back to the pool underneath it — so it aborts the transport instead,
+    /// which is safe to race with, and leaves the return to the operation's own unwinding.
+    /// </para>
+    /// <para>
+    /// <b>That hands the return to something this call cannot make happen.</b> Aborting frees an operation parked
+    /// on the socket, and that is the case it is for. An operation parked anywhere else does not resume: a
+    /// streamed result whose consumer stopped advancing is suspended at its <c>yield</c>, not on a read, so
+    /// closing the socket reaches nothing and the lease is never returned — the pool is short a slot until the
+    /// client itself is disposed. Disposal still returns promptly and reports nothing, because the alternative is
+    /// worse: returning the lease here would let the pool terminate a connection whose buffers a live operation
+    /// still points at. The client has the same hazard for an abandoned enumerator; a session cannot do better,
+    /// only say so.
+    /// </para>
+    /// </remarks>
+    public async ValueTask DisposeAsync()
+    {
+        bool abort;
+        lock (gate)
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            disposed = true;
+
+            // `returned` cannot be set yet: only this method and ReleaseAsync's disposed branch set it, and both
+            // are reachable only once `disposed` is, which the early return above has just ruled out.
+            abort = busy;
+            returned = !abort;
+        }
+
+        if (abort)
+        {
+            // Marks the connection final, so the pool cannot reuse it whatever happens next, and frees an
+            // operation parked on a read that will never arrive.
+            lease.Connection.AbortTransport();
+            return;
+        }
+
+        await ReturnAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Takes the connection back from a finished operation. While the session is open the connection stays pinned,
+    /// and only its usability is recorded; a session disposed mid-operation is completed here instead, this being
+    /// the first moment the connection is idle enough to close.
+    /// </summary>
+    private ValueTask ReleaseAsync()
+    {
+        lock (gate)
+        {
+            busy = false;
+
+            if (!disposed)
+            {
+                // Asked now as well as before the next operation, so an operation that broke the connection is
+                // reported as such even if nothing runs on the session again — which is what IsOpen reports.
+                HasLostTheConnection();
+                return default;
+            }
+
+            if (returned)
+            {
+                return default;
+            }
+
+            returned = true;
+        }
+
+        return ReturnAsync();
+    }
+
+    /// <summary>
+    /// Whether the pinned connection has been lost, latching the answer once it has. Call under <c>gate</c>, and
+    /// only when no operation is running: mid-operation the connection is legitimately not reusable, so the
+    /// question does not apply and the callers both exclude that case.
+    /// </summary>
+    /// <returns>True when nothing more can run on this session.</returns>
+    /// <remarks>
+    /// <para>
+    /// The predicate is the pool's, <see cref="ClickHouseTcpConnection.IsReusable"/>, and it is asked at both ends
+    /// of an operation for the reason the pool asks at both ends of a lease. Asked on release it catches what the
+    /// operation did to the connection: terminated it, or left it out of step by not reading the whole result.
+    /// Asked before the next operation it catches what happened while the session sat idle — a proxy or the server
+    /// dropping a connection nobody was using, which is the case release cannot see, because at release nothing
+    /// has had time to happen yet.
+    /// </para>
+    /// <para>
+    /// The answer latches because the causes are all final, and because the test must not be able to change its
+    /// mind between <see cref="IsOpen"/> saying the session is finished and the next operation acting on it.
+    /// </para>
+    /// <para>
+    /// <b>A false positive costs more here than it does in the pool.</b> The test polls the raw socket, and
+    /// <see cref="ClickHouseTcpConnection.IsReusable"/> records that under TLS a record carrying no application
+    /// data — a late session ticket — can make a healthy connection look readable. The pool pays a reconnect for
+    /// that; a session pays the temporary tables and settings it exists for. The risk is the same one the pool
+    /// already runs and has not been seen against ClickHouse, so it is accepted rather than worked around, but a
+    /// session dying for no visible reason under TLS is the first thing to suspect here.
+    /// </para>
+    /// </remarks>
+    private bool HasLostTheConnection()
+    {
+        faulted = faulted || !lease.Connection.IsReusable;
+        return faulted;
+    }
+
+    /// <summary>Closes the pinned connection and returns the lease, in that order.</summary>
+    /// <remarks>
+    /// The order is the whole point: the pool decides a returned connection's fate from its state, so it has to be
+    /// terminated before it is handed back or the pool would keep a connection carrying this session's temporary
+    /// tables and settings. Terminating can throw, from a socket that fails to close, and there is nothing useful
+    /// to do about it — the connection is being discarded either way, and letting it escape would fail a disposal
+    /// that has otherwise done its job and leave the pool a slot short.
+    /// </remarks>
+    private async ValueTask ReturnAsync()
+    {
+        try
+        {
+            lease.Connection.Terminate();
+        }
+        catch (Exception e) when (e is not OutOfMemoryException and not StackOverflowException)
+        {
+        }
+        finally
+        {
+            await lease.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// The lease one operation runs under. Disposing it hands the connection back to the session rather than to
+    /// the pool, which is what keeps the connection pinned across operations.
+    /// </summary>
+    private sealed class PinnedLease : IConnectionLease
+    {
+        private readonly PinnedConnectionSource source;
+        private int released;
+
+        internal PinnedLease(PinnedConnectionSource source) => this.source = source;
+
+        public ClickHouseTcpConnection Connection => source.lease.Connection;
+
+        public ValueTask DisposeAsync()
+            => Interlocked.Exchange(ref released, 1) == 0 ? source.ReleaseAsync() : default;
+    }
+}

--- a/ClickHouse.Driver.Tcp/Client/PinnedConnectionSource.cs
+++ b/ClickHouse.Driver.Tcp/Client/PinnedConnectionSource.cs
@@ -6,30 +6,19 @@ using ClickHouse.Driver.Tcp.Protocol;
 namespace ClickHouse.Driver.Tcp.Client;
 
 /// <summary>
-/// A connection source that hands out the same connection every time: the one a session pinned. It holds a lease
-/// on the underlying source for its whole lifetime, so the connection is never anyone else's in between, which is
-/// what carries a session's temporary tables and settings from one operation to the next.
-///
-/// <para>
-/// It is the same seam the pool is, so a session runs the ordinary client code over it and needs no session-aware
-/// operations of its own. What it adds is the bookkeeping that pinning brings with it: exactly one operation at a
-/// time, a connection lost mid-session reported as such rather than as a wall of transport errors, and, on
-/// disposal, the connection closed instead of handed back.
-/// </para>
+/// A connection source that hands out the same connection every time: the one a session pinned. It holds a lease on
+/// the underlying source for its whole lifetime, so the connection is never anyone else's in between — which is what
+/// carries a session's temporary tables and settings from one operation to the next.
 /// </summary>
 /// <remarks>
-/// Every state change is made under <c>gate</c>, and the slow parts — closing the socket, returning the lease —
-/// are done outside it. Contention is not the reason for the lock: the states interlock (a rent must not start
-/// while disposal is deciding whether the connection is idle, and vice versa), and one lock is cheaper to reason
-/// about than the interlocked pairs that would replace it. The path it guards runs once per operation.
+/// Being the seam the pool is, it lets a session run the ordinary client code. It adds only the bookkeeping pinning
+/// brings: one operation at a time, a lost connection reported as such, and, on disposal, the connection closed
+/// instead of handed back. Every state change is made under <c>gate</c>, and the slow parts outside it. The lock is
+/// for interlocking, not contention: a rent must not start while disposal is deciding whether the connection is idle.
 /// </remarks>
 internal sealed class PinnedConnectionSource : IConnectionSource
 {
-    /// <summary>
-    /// The type an <see cref="ObjectDisposedException"/> from here names: the session the caller holds, not this
-    /// internal source. Spelled out rather than taken from <c>nameof</c>, because CHTCP0001 objects to naming the
-    /// <c>[Experimental]</c> session type from ordinary internal code.
-    /// </summary>
+    // Not nameof: CHTCP0001 objects to naming the [Experimental] session type from ordinary internal code.
     private const string SessionTypeName = "ClickHouseTcpSession";
 
     private readonly IConnectionLease lease;
@@ -38,14 +27,13 @@ internal sealed class PinnedConnectionSource : IConnectionSource
     // An operation holds the connection: rented and not yet released.
     private bool busy;
 
-    // The connection was lost, so nothing more can run on it. Latched by HasLostTheConnection, which is asked at
-    // both ends of an operation.
+    // The connection was lost, so nothing more can run on it. Latched by HasLostTheConnection.
     private bool faulted;
 
     private bool disposed;
 
-    // The lease has been given back to the pool. Guards against doing it twice, which would release a permit the
-    // source does not hold and let the pool run one operation over its limit.
+    // The lease has been given back to the pool. Doing that twice would release a permit the source does not hold,
+    // letting the pool run one operation over its limit.
     private bool returned;
 
     /// <summary>Pins the connection behind a lease for the lifetime of this source.</summary>
@@ -53,13 +41,9 @@ internal sealed class PinnedConnectionSource : IConnectionSource
     internal PinnedConnectionSource(IConnectionLease lease) => this.lease = lease;
 
     /// <summary>
-    /// Whether the pinned connection can still carry an operation: the source is neither disposed nor holding a
-    /// connection that was lost.
+    /// Whether the pinned connection can still carry an operation. Mid-operation it reports what is known so far, a
+    /// busy connection not being reusable by definition.
     /// </summary>
-    /// <remarks>
-    /// A session running an operation is open on what is known so far, and is not tested further: a connection
-    /// mid-operation is not reusable by definition, so asking would condemn every session that is busy.
-    /// </remarks>
     internal bool IsOpen
     {
         get
@@ -90,9 +74,8 @@ internal sealed class PinnedConnectionSource : IConnectionSource
                 throw new ObjectDisposedException(SessionTypeName);
             }
 
-            // Tested before the connection is, and not only to report the likelier mistake first: a connection
-            // carrying an operation is not reusable, so asking the question below while one runs would condemn a
-            // session that is merely busy.
+            // Before the connection is tested: a connection carrying an operation is not reusable, so asking the
+            // question below while one runs would condemn a session that is merely busy.
             if (busy)
             {
                 throw new InvalidOperationException(
@@ -108,32 +91,22 @@ internal sealed class PinnedConnectionSource : IConnectionSource
             busy = true;
         }
 
-        // The pinned lease is a token for one operation, not a second claim on the connection: it releases the
-        // gate above rather than the underlying lease, which this source holds until it is disposed.
+        // A token for one operation, not a second claim: disposing it releases the gate above, not the underlying
+        // lease, which this source holds until it is disposed.
         return new ValueTask<IConnectionLease>(new PinnedLease(this));
     }
 
     /// <summary>
     /// Ends the session: closes the pinned connection and gives the lease back, so the pool accounts for the slot
-    /// again and opens a fresh connection for the next caller. Idempotent.
+    /// again. Idempotent.
     /// </summary>
     /// <remarks>
-    /// <para>
-    /// The connection is closed rather than returned reusable, because a session leaves its state on it and the
-    /// next caller must not inherit that. Disposal during an operation cannot close it that way — the buffers the
-    /// operation is reading into would go back to the pool underneath it — so it aborts the transport instead,
-    /// which is safe to race with, and leaves the return to the operation's own unwinding.
-    /// </para>
-    /// <para>
-    /// <b>That hands the return to something this call cannot make happen.</b> Aborting frees an operation parked
-    /// on the socket, and that is the case it is for. An operation parked anywhere else does not resume: a
-    /// streamed result whose consumer stopped advancing is suspended at its <c>yield</c>, not on a read, so
-    /// closing the socket reaches nothing and the lease is never returned — the pool is short a slot until the
-    /// client itself is disposed. Disposal still returns promptly and reports nothing, because the alternative is
-    /// worse: returning the lease here would let the pool terminate a connection whose buffers a live operation
-    /// still points at. The client has the same hazard for an abandoned enumerator; a session cannot do better,
-    /// only say so.
-    /// </para>
+    /// The connection is closed rather than pooled because the next caller must not inherit a session's state. During
+    /// an operation it cannot be closed that way — the buffers being read into would go back to the pool underneath it
+    /// — so disposal aborts the transport, which is safe to race with, and leaves the return to the operation's
+    /// unwinding. That frees an operation parked on the socket but not one parked at a <c>yield</c>: a streamed result
+    /// whose consumer stopped advancing never returns its lease, and the pool is short a slot until the client is
+    /// disposed. Returning it here instead would let the pool terminate a connection a live operation still reads into.
     /// </remarks>
     public async ValueTask DisposeAsync()
     {
@@ -147,16 +120,16 @@ internal sealed class PinnedConnectionSource : IConnectionSource
 
             disposed = true;
 
-            // `returned` cannot be set yet: only this method and ReleaseAsync's disposed branch set it, and both
-            // are reachable only once `disposed` is, which the early return above has just ruled out.
+            // `returned` cannot be set yet: only this method and ReleaseAsync's disposed branch set it, and both are
+            // reachable only once `disposed` is.
             abort = busy;
             returned = !abort;
         }
 
         if (abort)
         {
-            // Marks the connection final, so the pool cannot reuse it whatever happens next, and frees an
-            // operation parked on a read that will never arrive.
+            // Marks the connection final, so the pool cannot reuse it whatever happens next, and frees an operation
+            // parked on a read that will never arrive.
             lease.Connection.AbortTransport();
             return;
         }
@@ -165,9 +138,8 @@ internal sealed class PinnedConnectionSource : IConnectionSource
     }
 
     /// <summary>
-    /// Takes the connection back from a finished operation. While the session is open the connection stays pinned,
-    /// and only its usability is recorded; a session disposed mid-operation is completed here instead, this being
-    /// the first moment the connection is idle enough to close.
+    /// Takes the connection back from a finished operation, keeping it pinned. A session disposed mid-operation is
+    /// completed here instead, this being the first moment the connection is idle enough to close.
     /// </summary>
     private ValueTask ReleaseAsync()
     {
@@ -177,8 +149,8 @@ internal sealed class PinnedConnectionSource : IConnectionSource
 
             if (!disposed)
             {
-                // Asked now as well as before the next operation, so an operation that broke the connection is
-                // reported as such even if nothing runs on the session again — which is what IsOpen reports.
+                // So an operation that broke the connection is reported as such even if nothing runs on the session
+                // again, which is what IsOpen reports.
                 HasLostTheConnection();
                 return default;
             }
@@ -195,32 +167,18 @@ internal sealed class PinnedConnectionSource : IConnectionSource
     }
 
     /// <summary>
-    /// Whether the pinned connection has been lost, latching the answer once it has. Call under <c>gate</c>, and
-    /// only when no operation is running: mid-operation the connection is legitimately not reusable, so the
-    /// question does not apply and the callers both exclude that case.
+    /// Whether the pinned connection has been lost, latching the answer once it has. Call under <c>gate</c>, and only
+    /// when no operation is running: mid-operation the connection is legitimately not reusable, so the question does
+    /// not apply.
     /// </summary>
     /// <returns>True when nothing more can run on this session.</returns>
     /// <remarks>
-    /// <para>
-    /// The predicate is the pool's, <see cref="ClickHouseTcpConnection.IsReusable"/>, and it is asked at both ends
-    /// of an operation for the reason the pool asks at both ends of a lease. Asked on release it catches what the
-    /// operation did to the connection: terminated it, or left it out of step by not reading the whole result.
-    /// Asked before the next operation it catches what happened while the session sat idle — a proxy or the server
-    /// dropping a connection nobody was using, which is the case release cannot see, because at release nothing
-    /// has had time to happen yet.
-    /// </para>
-    /// <para>
-    /// The answer latches because the causes are all final, and because the test must not be able to change its
-    /// mind between <see cref="IsOpen"/> saying the session is finished and the next operation acting on it.
-    /// </para>
-    /// <para>
-    /// <b>A false positive costs more here than it does in the pool.</b> The test polls the raw socket, and
-    /// <see cref="ClickHouseTcpConnection.IsReusable"/> records that under TLS a record carrying no application
-    /// data — a late session ticket — can make a healthy connection look readable. The pool pays a reconnect for
-    /// that; a session pays the temporary tables and settings it exists for. The risk is the same one the pool
-    /// already runs and has not been seen against ClickHouse, so it is accepted rather than worked around, but a
-    /// session dying for no visible reason under TLS is the first thing to suspect here.
-    /// </para>
+    /// The predicate is the pool's, <see cref="ClickHouseTcpConnection.IsReusable"/>, asked at both ends of an
+    /// operation as the pool asks at both ends of a lease: on release it catches what the operation did to the
+    /// connection, before the next one what happened while the session sat idle. It latches because the causes are
+    /// final. A false positive costs more here than in the pool — a reconnect there, the temporary tables and settings
+    /// a session exists for here — so a session dying for no visible reason under TLS is the first thing to suspect
+    /// (see <see cref="ClickHouseTcpConnection.IsReusable"/> on late session tickets).
     /// </remarks>
     private bool HasLostTheConnection()
     {
@@ -230,11 +188,10 @@ internal sealed class PinnedConnectionSource : IConnectionSource
 
     /// <summary>Closes the pinned connection and returns the lease, in that order.</summary>
     /// <remarks>
-    /// The order is the whole point: the pool decides a returned connection's fate from its state, so it has to be
-    /// terminated before it is handed back or the pool would keep a connection carrying this session's temporary
-    /// tables and settings. Terminating can throw, from a socket that fails to close, and there is nothing useful
-    /// to do about it — the connection is being discarded either way, and letting it escape would fail a disposal
-    /// that has otherwise done its job and leave the pool a slot short.
+    /// The order is the whole point: the pool decides a returned connection's fate from its state, so terminating has
+    /// to come first or the pool would keep one carrying this session's temporary tables and settings. A throw from
+    /// <c>Terminate</c> is swallowed because the connection is discarded either way, and letting it escape would
+    /// leave the pool a slot short.
     /// </remarks>
     private async ValueTask ReturnAsync()
     {
@@ -252,8 +209,8 @@ internal sealed class PinnedConnectionSource : IConnectionSource
     }
 
     /// <summary>
-    /// The lease one operation runs under. Disposing it hands the connection back to the session rather than to
-    /// the pool, which is what keeps the connection pinned across operations.
+    /// The lease one operation runs under. Disposing it hands the connection back to the session rather than to the
+    /// pool, which is what keeps it pinned across operations.
     /// </summary>
     private sealed class PinnedLease : IConnectionLease
     {

--- a/ClickHouse.Driver.Tcp/Client/PinnedConnectionSource.cs
+++ b/ClickHouse.Driver.Tcp/Client/PinnedConnectionSource.cs
@@ -6,43 +6,38 @@ using ClickHouse.Driver.Tcp.Protocol;
 namespace ClickHouse.Driver.Tcp.Client;
 
 /// <summary>
-/// A connection source that hands out the same connection every time: the one a session pinned. It holds a lease on
-/// the underlying source for its whole lifetime, so the connection is never anyone else's in between — which is what
-/// carries a session's temporary tables and settings from one operation to the next.
+/// Holds one connection lease for a session and lends it to one operation at a time.
 /// </summary>
 /// <remarks>
-/// Being the seam the pool is, it lets a session run the ordinary client code. It adds only the bookkeeping pinning
-/// brings: one operation at a time, a lost connection reported as such, and, on disposal, the connection closed
-/// instead of handed back. Every state change is made under <c>gate</c>, and the slow parts outside it. The lock is
-/// for interlocking, not contention: a rent must not start while disposal is deciding whether the connection is idle.
+/// State changes are guarded by <c>gate</c> so renting cannot race with disposal. Transport teardown and lease
+/// return run outside the lock. The connection is closed on disposal to keep session state out of the pool.
 /// </remarks>
 internal sealed class PinnedConnectionSource : IConnectionSource
 {
-    // Not nameof: CHTCP0001 objects to naming the [Experimental] session type from ordinary internal code.
+    // A string literal avoids CHTCP0001 when referencing the experimental session type.
     private const string SessionTypeName = "ClickHouseTcpSession";
 
     private readonly IConnectionLease lease;
     private readonly object gate = new();
 
-    // An operation holds the connection: rented and not yet released.
+    // True while an operation holds the connection.
     private bool busy;
 
-    // The connection was lost, so nothing more can run on it. Latched by HasLostTheConnection.
+    // Permanently set by HasLostTheConnection when the connection becomes unusable.
     private bool faulted;
 
     private bool disposed;
 
-    // The lease has been given back to the pool. Doing that twice would release a permit the source does not hold,
-    // letting the pool run one operation over its limit.
+    // Guards the single pool return; returning twice would over-release the pool's permit.
     private bool returned;
 
     /// <summary>Pins the connection behind a lease for the lifetime of this source.</summary>
-    /// <param name="lease">The lease to hold, taken from the client's own source.</param>
+    /// <param name="lease">The lease owned by this source.</param>
     internal PinnedConnectionSource(IConnectionLease lease) => this.lease = lease;
 
     /// <summary>
-    /// Whether the pinned connection can still carry an operation. Mid-operation it reports what is known so far, a
-    /// busy connection not being reusable by definition.
+    /// Whether the session is undisposed and the connection is not known to be unusable.
+    /// Skips the reusability check during an active operation.
     /// </summary>
     internal bool IsOpen
     {
@@ -74,8 +69,7 @@ internal sealed class PinnedConnectionSource : IConnectionSource
                 throw new ObjectDisposedException(SessionTypeName);
             }
 
-            // Before the connection is tested: a connection carrying an operation is not reusable, so asking the
-            // question below while one runs would condemn a session that is merely busy.
+            // A busy connection is not reusable; reject concurrency before testing connection health.
             if (busy)
             {
                 throw new InvalidOperationException(
@@ -91,22 +85,17 @@ internal sealed class PinnedConnectionSource : IConnectionSource
             busy = true;
         }
 
-        // A token for one operation, not a second claim: disposing it releases the gate above, not the underlying
-        // lease, which this source holds until it is disposed.
+        // Disposing this lease releases the operation, not the session's underlying lease.
         return new ValueTask<IConnectionLease>(new PinnedLease(this));
     }
 
     /// <summary>
-    /// Ends the session: closes the pinned connection and gives the lease back, so the pool accounts for the slot
-    /// again. Idempotent.
+    /// Ends the session, closing an idle connection or aborting an active operation. Idempotent.
     /// </summary>
     /// <remarks>
-    /// The connection is closed rather than pooled because the next caller must not inherit a session's state. During
-    /// an operation it cannot be closed that way — the buffers being read into would go back to the pool underneath it
-    /// — so disposal aborts the transport, which is safe to race with, and leaves the return to the operation's
-    /// unwinding. That frees an operation parked on the socket but not one parked at a <c>yield</c>: a streamed result
-    /// whose consumer stopped advancing never returns its lease, and the pool is short a slot until the client is
-    /// disposed. Returning it here instead would let the pool terminate a connection a live operation still reads into.
+    /// An active operation may still use connection buffers, so only its transport is aborted here. The operation
+    /// returns the lease through <see cref="ReleaseAsync"/> when it exits. An undisposed enumerator suspended at
+    /// a <c>yield</c> cannot be resumed by aborting the transport and keeps the pool slot until client disposal.
     /// </remarks>
     public async ValueTask DisposeAsync()
     {
@@ -120,16 +109,14 @@ internal sealed class PinnedConnectionSource : IConnectionSource
 
             disposed = true;
 
-            // `returned` cannot be set yet: only this method and ReleaseAsync's disposed branch set it, and both are
-            // reachable only once `disposed` is.
+            // No return can have started before disposal; reserve it here only if idle.
             abort = busy;
             returned = !abort;
         }
 
         if (abort)
         {
-            // Marks the connection final, so the pool cannot reuse it whatever happens next, and frees an operation
-            // parked on a read that will never arrive.
+            // Unblock pending I/O without releasing buffers the operation may still use.
             lease.Connection.AbortTransport();
             return;
         }
@@ -138,8 +125,7 @@ internal sealed class PinnedConnectionSource : IConnectionSource
     }
 
     /// <summary>
-    /// Takes the connection back from a finished operation, keeping it pinned. A session disposed mid-operation is
-    /// completed here instead, this being the first moment the connection is idle enough to close.
+    /// Releases an operation's claim. Keeps the connection pinned unless the session has been disposed.
     /// </summary>
     private ValueTask ReleaseAsync()
     {
@@ -149,8 +135,7 @@ internal sealed class PinnedConnectionSource : IConnectionSource
 
             if (!disposed)
             {
-                // So an operation that broke the connection is reported as such even if nothing runs on the session
-                // again, which is what IsOpen reports.
+                // Record operation failures for IsOpen and subsequent rents.
                 HasLostTheConnection();
                 return default;
             }
@@ -167,18 +152,13 @@ internal sealed class PinnedConnectionSource : IConnectionSource
     }
 
     /// <summary>
-    /// Whether the pinned connection has been lost, latching the answer once it has. Call under <c>gate</c>, and only
-    /// when no operation is running: mid-operation the connection is legitimately not reusable, so the question does
-    /// not apply.
+    /// Checks connection reusability and permanently records failure.
     /// </summary>
-    /// <returns>True when nothing more can run on this session.</returns>
+    /// <returns>True if the connection is unusable or was previously found unusable.</returns>
     /// <remarks>
-    /// The predicate is the pool's, <see cref="ClickHouseTcpConnection.IsReusable"/>, asked at both ends of an
-    /// operation as the pool asks at both ends of a lease: on release it catches what the operation did to the
-    /// connection, before the next one what happened while the session sat idle. It latches because the causes are
-    /// final. A false positive costs more here than in the pool — a reconnect there, the temporary tables and settings
-    /// a session exists for here — so a session dying for no visible reason under TLS is the first thing to suspect
-    /// (see <see cref="ClickHouseTcpConnection.IsReusable"/> on late session tickets).
+    /// Call under <c>gate</c> only when idle: <see cref="ClickHouseTcpConnection.IsReusable"/> is false during an
+    /// operation. Checks before and after operations detect both idle disconnects and operation failures.
+    /// The same TLS liveness limitations as <see cref="ClickHouseTcpConnection.IsReusable"/> apply.
     /// </remarks>
     private bool HasLostTheConnection()
     {
@@ -188,10 +168,8 @@ internal sealed class PinnedConnectionSource : IConnectionSource
 
     /// <summary>Closes the pinned connection and returns the lease, in that order.</summary>
     /// <remarks>
-    /// The order is the whole point: the pool decides a returned connection's fate from its state, so terminating has
-    /// to come first or the pool would keep one carrying this session's temporary tables and settings. A throw from
-    /// <c>Terminate</c> is swallowed because the connection is discarded either way, and letting it escape would
-    /// leave the pool a slot short.
+    /// Terminate before returning so the pool cannot reuse session state. Suppress non-fatal termination errors
+    /// and always return the lease to release the pool slot.
     /// </remarks>
     private async ValueTask ReturnAsync()
     {
@@ -209,8 +187,7 @@ internal sealed class PinnedConnectionSource : IConnectionSource
     }
 
     /// <summary>
-    /// The lease one operation runs under. Disposing it hands the connection back to the session rather than to the
-    /// pool, which is what keeps it pinned across operations.
+    /// An operation's lease. Disposal releases it to the session rather than the pool.
     /// </summary>
     private sealed class PinnedLease : IConnectionLease
     {


### PR DESCRIPTION
Stacked on #577. Review only the last two commits; the base carries the rest of the stack.

Epic O of the native-TCP client. A session pins one pooled connection for its lifetime, so the state a single connection owns — temporary tables, and the settings a `SET` changes — is still there for the next operation.

```csharp
await using IClickHouseTcpSession session = await client.OpenSessionAsync(ct);

await session.ExecuteAsync("CREATE TEMPORARY TABLE tmp (x UInt32)");
await session.InsertAsync("INSERT INTO tmp (x) VALUES", columns);
await foreach (Row row in session.QueryAsync<Row>("SELECT * FROM tmp")) { }
```

## How it works

`PinnedConnectionSource` is an `IConnectionSource` that hands out the one lease it holds. Because that is the same seam the pool plugs into, a session runs the ordinary client code over it and implements no operation of its own, so it cannot drift from the client. The inner client shares the parent's POCO registry, so a session costs no second plan compile.

**The interface is split three ways.** `IClickHouseTcpOperations` holds every operation; `IClickHouseTcpClient` adds `OpenSessionAsync` and `IClickHouseTcpSession` adds `IsOpen`. So code that only runs operations takes the base interface and accepts either, and a session cannot offer a nested `OpenSessionAsync` that would silently pin a *different* connection. The first commit is that move on its own — no behaviour change, and callers still compile because the members are inherited. The concrete session class is `internal`, since `OpenSessionAsync` returns the interface and a public sealed class nobody can construct or name in a signature would add nothing.

**Disposal terminates the connection before returning the lease.** That order is the guarantee, not a detail: the pool decides a returned connection's fate from its state, so one still `Ready` on return is one the pool *keeps*, carrying this session's temporary tables into an unrelated caller's queries. Disposal during an operation cannot terminate — that would return the reader's pooled buffers underneath a live read — so it aborts the transport, which is safe to race with, and the operation completes the return as it unwinds.

**Liveness is tested at both ends of an operation.** On release that catches what the operation did to the connection; before the next operation it catches one dropped while the session sat idle, which release cannot see because at release nothing has had time to go wrong. That is what turns the connection's internal "terminated and cannot be reused" into a session-aware message. Two traps follow, both pinned by tests: a connection mid-operation is not reusable *by definition*, so both callers must exclude the busy case or every busy session is condemned; and the answer must latch, or `IsOpen` could say the session is finished and the next operation disagree.

## Known caveat, documented and pinned rather than fixed

Aborting frees an operation parked on the socket, but a stream enumerator nobody disposes is parked at its `yield`, so nothing resumes it, its lease is never returned, and the pool is short a slot until the client itself is disposed — while `DisposeAsync` returns promptly. Returning the lease from disposal instead is worse: the pool would then terminate a connection whose buffers a live operation may still point at.

The trigger is narrower than it looks. `await foreach` compiles to a `try`/`finally` that disposes the enumerator, so an ordinary `break` is fine; it takes a hand-rolled `GetAsyncEnumerator` that is never disposed, which already leaks a slot on the plain client. `DisposeAsync_WithAStreamNobodyAdvancesOrDisposes_DoesNotGetTheSlotBack` pins the behaviour at `MaxPoolSize = 1`.

## Tests

31 new tests, all green; whole TCP suite 3123 passing.

Integration (15) asserts everything that defines a session against a real server, using a temporary table as the marker — the server scopes one to the connection that made it, so its visibility reports which connection ran a query without the client having to claim anything about its own pool. Kill-on-dispose is proved at `MaxPoolSize = 1`, where the next query must land on whatever the session gave back.

Unit (16) covers only what a live session cannot show: the terminate-before-return *order*, disposal with an operation still running, and a 200-iteration three-way race on disposal, since over-releasing the pool's permit is the failure that would not announce itself.

Each load-bearing behaviour was mutated away and confirmed to fail exactly its own tests. One mutation caught a weak assertion: the concurrency test was satisfied by the *connection's* busy guard rather than the session's, so it now pins the session's own message.

## Notes for review

- No changelog fragment, per the practice for this stack (R3 sweeps it at the end).
- No docs change: nothing under `docs/` covers the TCP client yet.
- A follow-up is filed to add a session case to the Cloud suite. Nothing exercises a session over TLS, which is where the one accepted risk here would surface: the liveness test polls the raw socket, and under TLS a record carrying no application data can make a healthy connection look readable. The pool pays a reconnect for that; a session pays the state it exists for. Same probability, never observed against ClickHouse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
