### PR TITLE
TCP K5: Add QBit(T, N) support

### DIFF
--- a/ClickHouse.Driver.Tcp.Tests/Integration/QBitIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/QBitIntegrationTests.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Format;
+using ClickHouse.Driver.Tcp.Tests.Utilities;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Tests.Integration;
+
+/// <summary>
+/// The two <em>asymmetric</em> checks on <c>QBit(T, N)</c> that the insert round-trip corpus cannot make. A
+/// round-trip writes and reads with the same client code, so a layout error that is self-consistent — the bit
+/// order within a row, say — round-trips perfectly while putting bytes on the wire the server reads as different
+/// values. Each test here has exactly one side done by the client and the other by the server.
+///
+/// <para>
+/// This is not hypothetical: the byte order within a row runs opposite to the element order, and every fixture
+/// narrower than 9 elements is one byte per row, where that is unobservable. These tests use a dimension wide
+/// enough to see it.
+/// </para>
+/// </summary>
+[TestFixture]
+[Category("Integration")]
+[RequiresServerFeature(TcpFeature.QBit)]
+public class QBitIntegrationTests
+{
+    private static readonly CancellationToken None = CancellationToken.None;
+
+    // 17 elements is two whole 8-element groups plus a tail, so it spans three bytes per row and pins the byte
+    // order. The values are distinct and asymmetric across the group boundary, so a swapped byte is a wrong value
+    // rather than a coincidence.
+    private const int Dimension = 17;
+    private const string Float32Type = "QBit(Float32, 17)";
+
+    private static float[] Vector() => Enumerable.Range(0, Dimension).Select(i => (i * 3f) - 20f).ToArray();
+
+    [Test]
+    public async Task InsertAsync_QBitWrittenByTheClient_IsReadBackByTheServerAsTheSameVector()
+    {
+        // The client transposes; the server de-transposes. toString() makes the server do that work and hand back
+        // its own rendering, so nothing about the client's read path is involved in the comparison.
+        await using var client = TcpServerFixture.CreateClient();
+        string table = UniqueTableName();
+
+        await Drain(client, $"CREATE TABLE {table} (v {Float32Type}) ENGINE = Memory");
+        try
+        {
+            float[] vector = Vector();
+            using var column = new ArrayColumn<float[]>("v", Float32Type, new[] { vector });
+            await client.InsertAsync($"INSERT INTO {table} (v) VALUES", new IColumn[] { column }, cancellationToken: None);
+
+            string rendered = await ScalarStringAsync(client, $"SELECT toString(v) FROM {table}");
+
+            Assert.That(rendered, Is.EqualTo(Expected(vector)));
+        }
+        finally
+        {
+            await Drain(client, $"DROP TABLE IF EXISTS {table}");
+        }
+    }
+
+    [Test]
+    public async Task StreamAsync_QBitWrittenByTheServer_DecodesToTheSameVector()
+    {
+        // The mirror: the server transposes (it parses the VALUES literal), the client de-transposes. Together
+        // with the test above this pins both directions against an independent implementation.
+        await using var client = TcpServerFixture.CreateClient();
+        string table = UniqueTableName();
+
+        await Drain(client, $"CREATE TABLE {table} (v {Float32Type}) ENGINE = Memory");
+        try
+        {
+            float[] vector = Vector();
+            string literal = string.Join(",", vector.Select(v => v.ToString("R", CultureInfo.InvariantCulture)));
+            await Drain(client, $"INSERT INTO {table} VALUES ([{literal}])");
+
+            float[] decoded = null;
+            await foreach (Block block in client.StreamAsync($"SELECT v FROM {table}", cancellationToken: None))
+            {
+                decoded = (float[])block[0].GetValue(0);
+            }
+
+            CollectionAssert.AreEqual(vector, decoded);
+        }
+        finally
+        {
+            await Drain(client, $"DROP TABLE IF EXISTS {table}");
+        }
+    }
+
+    [Test]
+    public async Task GetPlane_QBitWrittenByTheServer_AgreesWithTheServersOwnBitExtraction()
+    {
+        // IQBitColumn is the whole point of the type — a caller reading the high planes to approximate a distance
+        // — and no round-trip touches it. bitTest on the server's own value is the independent answer for whether
+        // element i has bit b set, so the plane the client hands out can be checked bit by bit against it.
+        await using var client = TcpServerFixture.CreateClient();
+        string table = UniqueTableName();
+
+        await Drain(client, $"CREATE TABLE {table} (v {Float32Type}) ENGINE = Memory");
+        try
+        {
+            float[] vector = Vector();
+            string literal = string.Join(",", vector.Select(v => v.ToString("R", CultureInfo.InvariantCulture)));
+            await Drain(client, $"INSERT INTO {table} VALUES ([{literal}])");
+
+            byte[] signPlane = null;
+            await foreach (Block block in client.StreamAsync($"SELECT v FROM {table}", cancellationToken: None))
+            {
+                signPlane = ((IQBitColumn)block[0]).GetPlane(31).ToArray();
+            }
+
+            // The sign bit of element i, straight from the client's plane.
+            for (int i = 0; i < Dimension; i++)
+            {
+                int slot = signPlane.Length - 1 - (i / 8);
+                bool negativeInPlane = (signPlane[slot] & (1 << (i % 8))) != 0;
+                Assert.That(negativeInPlane, Is.EqualTo(vector[i] < 0 || float.IsNegative(vector[i])), $"element {i}");
+            }
+        }
+        finally
+        {
+            await Drain(client, $"DROP TABLE IF EXISTS {table}");
+        }
+    }
+
+    private static string Expected(float[] vector)
+        => "[" + string.Join(",", vector.Select(v => v.ToString("R", CultureInfo.InvariantCulture))) + "]";
+
+    private static string UniqueTableName() => $"tcp_qbit_test_{Guid.NewGuid():N}";
+
+    private static async Task<string> ScalarStringAsync(ClickHouseTcpClient client, string sql)
+    {
+        string value = null;
+        await foreach (Block block in client.StreamAsync(sql, cancellationToken: None))
+        {
+            if (block.RowCount > 0)
+            {
+                value = (string)block[0].GetValue(0);
+            }
+        }
+
+        return value;
+    }
+
+    private static async Task Drain(ClickHouseTcpClient client, string sql)
+    {
+        await foreach (Block block in client.StreamAsync(sql, cancellationToken: None))
+        {
+            _ = block;
+        }
+    }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Integration/QBitIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/QBitIntegrationTests.cs
@@ -9,18 +9,6 @@ using ClickHouse.Driver.Tcp.Types;
 
 namespace ClickHouse.Driver.Tcp.Tests.Integration;
 
-/// <summary>
-/// The two <em>asymmetric</em> checks on <c>QBit(T, N)</c> that the insert round-trip corpus cannot make. A
-/// round-trip writes and reads with the same client code, so a layout error that is self-consistent — the bit
-/// order within a row, say — round-trips perfectly while putting bytes on the wire the server reads as different
-/// values. Each test here has exactly one side done by the client and the other by the server.
-///
-/// <para>
-/// This is not hypothetical: the byte order within a row runs opposite to the element order, and every fixture
-/// narrower than 9 elements is one byte per row, where that is unobservable. These tests use a dimension wide
-/// enough to see it.
-/// </para>
-/// </summary>
 [TestFixture]
 [Category("Integration")]
 [RequiresServerFeature(TcpFeature.QBit)]
@@ -28,24 +16,19 @@ public class QBitIntegrationTests
 {
     private static readonly CancellationToken None = CancellationToken.None;
 
-    // 17 elements is two whole 8-element groups plus a tail, so it spans three bytes per row and pins the byte
-    // order. The values are distinct and asymmetric across the group boundary, so a swapped byte is a wrong value
-    // rather than a coincidence.
+    // Spans two complete bitmap bytes and a partial third.
     private const int Dimension = 17;
     private const string Float32Type = "QBit(Float32, 17)";
     private const string Int8Type = "QBit(Int8, 17)";
 
     private static float[] Vector() => Enumerable.Range(0, Dimension).Select(i => (i * 3f) - 20f).ToArray();
 
-    // Spans the sign, both whole bytes and the one-element tail, with MinValue pinning the all-ones pattern.
     private static sbyte[] Int8Vector()
         => Enumerable.Range(0, Dimension).Select(i => i == 16 ? sbyte.MinValue : (sbyte)((i * 7) - 60)).ToArray();
 
     [Test]
     public async Task InsertAsync_QBitWrittenByTheClient_IsReadBackByTheServerAsTheSameVector()
     {
-        // The client transposes; the server de-transposes. toString() makes the server do that work and hand back
-        // its own rendering, so nothing about the client's read path is involved in the comparison.
         await using var client = TcpServerFixture.CreateClient();
         string table = UniqueTableName();
 
@@ -69,8 +52,6 @@ public class QBitIntegrationTests
     [Test]
     public async Task StreamAsync_QBitWrittenByTheServer_DecodesToTheSameVector()
     {
-        // The mirror: the server transposes (it parses the VALUES literal), the client de-transposes. Together
-        // with the test above this pins both directions against an independent implementation.
         await using var client = TcpServerFixture.CreateClient();
         string table = UniqueTableName();
 
@@ -98,9 +79,6 @@ public class QBitIntegrationTests
     [Test]
     public async Task GetPlane_QBitWrittenByTheServer_AgreesWithTheServersOwnBitExtraction()
     {
-        // IQBitColumn is the whole point of the type — a caller reading the high planes to approximate a distance
-        // — and no round-trip touches it. bitTest on the server's own value is the independent answer for whether
-        // element i has bit b set, so the plane the client hands out can be checked bit by bit against it.
         await using var client = TcpServerFixture.CreateClient();
         string table = UniqueTableName();
 
@@ -117,7 +95,6 @@ public class QBitIntegrationTests
                 signPlane = ((IQBitColumn)block[0]).GetPlane(31).ToArray();
             }
 
-            // The sign bit of element i, straight from the client's plane.
             for (int i = 0; i < Dimension; i++)
             {
                 int slot = signPlane.Length - 1 - (i / 8);
@@ -135,9 +112,6 @@ public class QBitIntegrationTests
     [RequiresServerFeature(TcpFeature.QBitInt8)]
     public async Task InsertAsync_Int8QBitWrittenByTheClient_IsReadBackByTheServerAsTheSameVector()
     {
-        // QBit(Int8, N) has its own hand-written transpose loop, so the Float32 check above does not cover it. The
-        // frozen byte fixture in the unit suite is 16 elements — two whole bytes — and this is the non-multiple-of-8
-        // width, where the last byte is partly unused. Server-side toString() keeps the client's read path out of it.
         await using var client = TcpServerFixture.CreateClient();
         string table = UniqueTableName();
 
@@ -151,6 +125,34 @@ public class QBitIntegrationTests
             string rendered = await ScalarStringAsync(client, $"SELECT toString(v) FROM {table}");
 
             Assert.That(rendered, Is.EqualTo("[" + string.Join(",", vector.Select(v => v.ToString(CultureInfo.InvariantCulture))) + "]"));
+        }
+        finally
+        {
+            await Drain(client, $"DROP TABLE IF EXISTS {table}");
+        }
+    }
+
+    [Test]
+    [RequiresServerFeature(TcpFeature.QBitInt8)]
+    public async Task StreamAsync_Int8QBitWrittenByTheServer_DecodesToTheSameVector()
+    {
+        await using var client = TcpServerFixture.CreateClient();
+        string table = UniqueTableName();
+
+        await Drain(client, $"CREATE TABLE {table} (v {Int8Type}) ENGINE = Memory");
+        try
+        {
+            sbyte[] vector = Int8Vector();
+            string literal = string.Join(",", vector.Select(v => v.ToString(CultureInfo.InvariantCulture)));
+            await Drain(client, $"INSERT INTO {table} VALUES ([{literal}])");
+
+            sbyte[] decoded = null;
+            await foreach (Block block in client.StreamAsync($"SELECT v FROM {table}", cancellationToken: None))
+            {
+                decoded = (sbyte[])block[0].GetValue(0);
+            }
+
+            CollectionAssert.AreEqual(vector, decoded);
         }
         finally
         {

--- a/ClickHouse.Driver.Tcp.Tests/Integration/QBitIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/QBitIntegrationTests.cs
@@ -33,8 +33,13 @@ public class QBitIntegrationTests
     // rather than a coincidence.
     private const int Dimension = 17;
     private const string Float32Type = "QBit(Float32, 17)";
+    private const string Int8Type = "QBit(Int8, 17)";
 
     private static float[] Vector() => Enumerable.Range(0, Dimension).Select(i => (i * 3f) - 20f).ToArray();
+
+    // Spans the sign, both whole bytes and the one-element tail, with MinValue pinning the all-ones pattern.
+    private static sbyte[] Int8Vector()
+        => Enumerable.Range(0, Dimension).Select(i => i == 16 ? sbyte.MinValue : (sbyte)((i * 7) - 60)).ToArray();
 
     [Test]
     public async Task InsertAsync_QBitWrittenByTheClient_IsReadBackByTheServerAsTheSameVector()
@@ -119,6 +124,33 @@ public class QBitIntegrationTests
                 bool negativeInPlane = (signPlane[slot] & (1 << (i % 8))) != 0;
                 Assert.That(negativeInPlane, Is.EqualTo(vector[i] < 0 || float.IsNegative(vector[i])), $"element {i}");
             }
+        }
+        finally
+        {
+            await Drain(client, $"DROP TABLE IF EXISTS {table}");
+        }
+    }
+
+    [Test]
+    [RequiresServerFeature(TcpFeature.QBitInt8)]
+    public async Task InsertAsync_Int8QBitWrittenByTheClient_IsReadBackByTheServerAsTheSameVector()
+    {
+        // QBit(Int8, N) has its own hand-written transpose loop, so the Float32 check above does not cover it. The
+        // frozen byte fixture in the unit suite is 16 elements — two whole bytes — and this is the non-multiple-of-8
+        // width, where the last byte is partly unused. Server-side toString() keeps the client's read path out of it.
+        await using var client = TcpServerFixture.CreateClient();
+        string table = UniqueTableName();
+
+        await Drain(client, $"CREATE TABLE {table} (v {Int8Type}) ENGINE = Memory");
+        try
+        {
+            sbyte[] vector = Int8Vector();
+            using var column = new ArrayColumn<sbyte[]>("v", Int8Type, new[] { vector });
+            await client.InsertAsync($"INSERT INTO {table} (v) VALUES", new IColumn[] { column }, cancellationToken: None);
+
+            string rendered = await ScalarStringAsync(client, $"SELECT toString(v) FROM {table}");
+
+            Assert.That(rendered, Is.EqualTo("[" + string.Join(",", vector.Select(v => v.ToString(CultureInfo.InvariantCulture))) + "]"));
         }
         finally
         {

--- a/ClickHouse.Driver.Tcp.Tests/Types/QBitColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/QBitColumnCodecTests.cs
@@ -1,0 +1,303 @@
+using System;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Protocol;
+using ClickHouse.Driver.Tcp.Tests.Utilities;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Tests.Types;
+
+/// <summary>
+/// Unit coverage for <c>QBit(T, N)</c>, limited to what a server round-trip cannot observe: the exact plane
+/// layout, the significance ordering <see cref="IQBitColumn.GetPlane"/> imposes on top of it, the type-resolution
+/// and write error paths, and the pooled <c>Values</c> cache. Per-type values are covered by
+/// <see cref="InsertRoundTripCase"/> against a real server.
+/// </summary>
+[TestFixture]
+public class QBitColumnCodecTests
+{
+    private const string Float32X4 = "QBit(Float32, 4)";
+
+    // Captured from a ClickHouse 26.6 `SELECT v FROM t FORMAT Native` where v is QBit(Float32, 4) holding one row
+    // of [1.0, 2.0, 3.0, 4.0] — the example documented on QBitColumnCodec. 32 planes, one byte per plane (one row
+    // of ceil(4/8) = 1 byte), most significant bit first.
+    private static readonly byte[] DocumentedBytes =
+    {
+        0x00, // bit 31 (sign): none of the four is negative
+        0x0E, // bit 30: set for 2.0, 3.0, 4.0 -> elements 1, 2, 3 -> 0b1110
+        0x01, // bit 29: only 1.0 (0x3F800000)
+        0x01, // bit 28
+        0x01, // bit 27
+        0x01, // bit 26
+        0x01, // bit 25
+        0x01, // bit 24
+        0x09, // bit 23: 1.0 and 4.0 -> elements 0 and 3 -> 0b1001
+        0x04, // bit 22: only 3.0 -> element 2 -> 0b0100
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    };
+
+    private static IColumnCodec Codec(string type) => ColumnCodecRegistry.Default.Resolve(type, ResolveContext.ForWrite);
+
+    [Test]
+    public async Task WriteColumn_DocumentedExample_ProducesTheServersOwnBytes()
+    {
+        IColumnCodec codec = Codec(Float32X4);
+        using var column = new ArrayColumn<float[]>("v", Float32X4, new[] { new[] { 1f, 2f, 3f, 4f } });
+
+        byte[] bytes = await CodecTestHarness.WriteAsync(w => codec.WriteColumn(w, column));
+
+        CollectionAssert.AreEqual(DocumentedBytes, bytes);
+    }
+
+    [Test]
+    public async Task ReadColumnAsync_TheServersOwnBytes_DecodesTheDocumentedVector()
+    {
+        IColumnCodec codec = Codec(Float32X4);
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(DocumentedBytes);
+
+        using IColumn read = await codec.ReadColumnAsync(reader, "v", Float32X4, 1, CodecTestHarness.None);
+
+        CollectionAssert.AreEqual(new[] { 1f, 2f, 3f, 4f }, (float[])read.GetValue(0));
+    }
+
+    [Test]
+    public async Task WriteColumn_RowSlice_EmitsEachPlaneStridedByTheSourceRowCount()
+    {
+        // The body is plane-major, so a row range is contiguous within a plane but the planes are strided by the
+        // *source* column's row count. Slicing the middle row of three is the shape that catches a write which
+        // strides by the slice length instead. Whole-column re-inserts never reach it.
+        IColumnCodec codec = Codec(Float32X4);
+        using var source = new ArrayColumn<float[]>("v", Float32X4, new[]
+        {
+            new[] { 0f, 0f, 0f, 0f },
+            new[] { 1f, 2f, 3f, 4f },
+            new[] { 0f, 0f, 0f, 0f },
+        });
+
+        byte[] dense = await CodecTestHarness.WriteAsync(w => codec.WriteColumn(w, source));
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(dense);
+        using IColumn read = await codec.ReadColumnAsync(reader, "v", Float32X4, 3, CodecTestHarness.None);
+
+        byte[] sliced = await CodecTestHarness.WriteSliceAsync(codec, read, start: 1, length: 1);
+
+        CollectionAssert.AreEqual(DocumentedBytes, sliced);
+    }
+
+    [Test]
+    public async Task GetPlane_ReadColumn_IndexesPlanesBySignificanceNotWireOrder()
+    {
+        // The wire stores planes most significant first; GetPlane takes the bit's significance, so bit 30 is the
+        // second plane on the wire. Nothing about this ordering is observable through a round-trip.
+        IColumnCodec codec = Codec(Float32X4);
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(DocumentedBytes);
+        using IColumn read = await codec.ReadColumnAsync(reader, "v", Float32X4, 1, CodecTestHarness.None);
+
+        var qbit = (IQBitColumn)read;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(qbit.Dimension, Is.EqualTo(4));
+            Assert.That(qbit.BitWidth, Is.EqualTo(32));
+            Assert.That(qbit.BytesPerRow, Is.EqualTo(1));
+            Assert.That(qbit.GetPlane(31)[0], Is.EqualTo(0x00), "sign plane");
+            Assert.That(qbit.GetPlane(30)[0], Is.EqualTo(0x0E), "bit 30: 2.0, 3.0, 4.0");
+            Assert.That(qbit.GetPlane(23)[0], Is.EqualTo(0x09), "bit 23: 1.0 and 4.0");
+            Assert.That(qbit.GetPlane(22)[0], Is.EqualTo(0x04), "bit 22: 3.0");
+            Assert.That(qbit.GetPlane(0)[0], Is.EqualTo(0x00), "no value has a bit that low set");
+        });
+    }
+
+    [Test]
+    public async Task GetPlane_MultipleRows_ReturnsEveryRowsBitmapForThatPlane()
+    {
+        // Rows are contiguous within a plane, so one plane spans the whole column. -0.0 sets only the sign bit,
+        // which makes the sign plane the one place the three rows differ.
+        IColumnCodec codec = Codec("QBit(Float32, 8)");
+        using var column = new ArrayColumn<float[]>("v", "QBit(Float32, 8)", new[]
+        {
+            new float[8],
+            new[] { 1f, 1f, 1f, 1f, 1f, 1f, 1f, 1f },
+            new[] { -0f, -0f, -0f, -0f, -0f, -0f, -0f, -0f },
+        });
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, "QBit(Float32, 8)", 3);
+        var qbit = (IQBitColumn)read;
+
+        CollectionAssert.AreEqual(new byte[] { 0x00, 0x00, 0xFF }, qbit.GetPlane(31).ToArray());
+    }
+
+    [TestCase(-1)]
+    [TestCase(32)]
+    public async Task GetPlane_BitOutsideTheWidth_Throws(int bit)
+    {
+        IColumnCodec codec = Codec(Float32X4);
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(DocumentedBytes);
+        using IColumn read = await codec.ReadColumnAsync(reader, "v", Float32X4, 1, CodecTestHarness.None);
+
+        Assert.That(() => ((IQBitColumn)read).GetPlane(bit), Throws.InstanceOf<ArgumentOutOfRangeException>());
+    }
+
+    [Test]
+    public async Task Values_ReadColumn_MaterializesEveryRowThroughThePooledCache()
+    {
+        // GetValue delegates to the same de-transpose, but Values is a separately materialized pooled cache that
+        // the round-trip's per-row comparison never touches.
+        IColumnCodec codec = Codec(Float32X4);
+        using var column = new ArrayColumn<float[]>("v", Float32X4, new[]
+        {
+            new[] { 1f, 2f, 3f, 4f },
+            new[] { -1f, -2f, -3f, -4f },
+        });
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, Float32X4, 2);
+        ReadOnlySpan<float[]> values = ((IColumn<float[]>)read).Values;
+
+        Assert.That(values.Length, Is.EqualTo(2));
+        CollectionAssert.AreEqual(new[] { 1f, 2f, 3f, 4f }, values[0]);
+        CollectionAssert.AreEqual(new[] { -1f, -2f, -3f, -4f }, values[1]);
+    }
+
+    [Test]
+    public async Task Values_ReadTwice_ReturnsTheSameCachedArrays()
+    {
+        IColumnCodec codec = Codec(Float32X4);
+        using var column = new ArrayColumn<float[]>("v", Float32X4, new[] { new[] { 1f, 2f, 3f, 4f } });
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, Float32X4, 1);
+        var typed = (IColumn<float[]>)read;
+
+        Assert.That(typed.Values[0], Is.SameAs(typed.Values[0]));
+    }
+
+    [Test]
+    public async Task ReadColumnAsync_ZeroRows_ReadsNoBytesAndDecodesAnEmptyColumn()
+    {
+        IColumnCodec codec = Codec(Float32X4);
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(Array.Empty<byte>());
+
+        using IColumn read = await codec.ReadColumnAsync(reader, "v", Float32X4, 0, CodecTestHarness.None);
+
+        Assert.That(read.RowCount, Is.Zero);
+        Assert.That(((IColumn<float[]>)read).Values.Length, Is.Zero);
+    }
+
+    [Test]
+    public async Task GetValue_RowPastTheRowCount_Throws()
+    {
+        IColumnCodec codec = Codec(Float32X4);
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(DocumentedBytes);
+        using IColumn read = await codec.ReadColumnAsync(reader, "v", Float32X4, 1, CodecTestHarness.None);
+
+        Assert.That(() => read.GetValue(1), Throws.InstanceOf<IndexOutOfRangeException>());
+    }
+
+    [Test]
+    public void Resolve_Float64_SurfacesDoubleVectorsAndSixtyFourPlanes()
+    {
+        IColumnCodec codec = Codec("QBit(Float64, 3)");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(codec.ElementType, Is.EqualTo(typeof(double[])));
+            Assert.That(codec.TypeName, Is.EqualTo("QBit(Float64, 3)"));
+            Assert.That(codec.NullPlaceholder, Is.EqualTo(new double[3]));
+        });
+    }
+
+    [Test]
+    public void Resolve_BFloat16_SurfacesWidenedFloatVectors()
+    {
+        IColumnCodec codec = Codec("QBit(BFloat16, 4)");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(codec.ElementType, Is.EqualTo(typeof(float[])));
+            Assert.That(codec.NullPlaceholder, Is.EqualTo(new float[4]));
+        });
+    }
+
+    [Test]
+    public async Task WriteThenRead_BFloat16_DropsTheLowMantissaBits()
+    {
+        // A brain-float keeps only the float's high 16 bits, so a value needing the low half comes back narrowed.
+        // The server normalizes nothing here — this is the client's own lossy narrowing, so no round-trip shows it.
+        const string Type = "QBit(BFloat16, 2)";
+        IColumnCodec codec = Codec(Type);
+        using var column = new ArrayColumn<float[]>("v", Type, new[] { new[] { 1.0001f, 2f } });
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, Type, 1);
+        var value = (float[])read.GetValue(0);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(value[0], Is.EqualTo(1f), "1.0001f narrows to 1f in a brain-float");
+            Assert.That(value[1], Is.EqualTo(2f), "2f is exactly representable");
+        });
+    }
+
+    [Test]
+    public void CanWrite_ColumnOfAnotherElementType_IsRefused()
+    {
+        IColumnCodec codec = Codec(Float32X4);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(codec.CanWrite(new ArrayColumn<float[]>("v", Float32X4, new[] { new[] { 1f, 2f, 3f, 4f } })), Is.True);
+            Assert.That(codec.CanWrite(new ArrayColumn<double[]>("v", Float32X4, new[] { new[] { 1d } })), Is.False);
+            Assert.That(codec.CanWrite(PrimitiveColumn<float>.FromValues("v", "Float32", new[] { 1f })), Is.False);
+            Assert.That(codec.CanWriteElementType(typeof(float[])), Is.True);
+            Assert.That(codec.CanWriteElementType(typeof(double[])), Is.False);
+        });
+    }
+
+    [Test]
+    public void WriteColumn_VectorOfTheWrongLength_ThrowsNamingTheRow()
+    {
+        IColumnCodec codec = Codec(Float32X4);
+        using var column = new ArrayColumn<float[]>("v", Float32X4, new[]
+        {
+            new[] { 1f, 2f, 3f, 4f },
+            new[] { 1f, 2f },
+        });
+
+        Assert.That(
+            async () => await CodecTestHarness.WriteAsync(w => codec.WriteColumn(w, column)),
+            Throws.ArgumentException.With.Message.Contains("row 1").And.Message.Contains("exactly 4"));
+    }
+
+    [Test]
+    public void WriteColumn_NullVector_ThrowsPointingAtNullable()
+    {
+        IColumnCodec codec = Codec(Float32X4);
+        using var column = new ArrayColumn<float[]>("v", Float32X4, new float[][] { null });
+
+        Assert.That(
+            async () => await CodecTestHarness.WriteAsync(w => codec.WriteColumn(w, column)),
+            Throws.ArgumentException.With.Message.Contains("Nullable"));
+    }
+
+    [TestCase("QBit(Float32)", TestName = "one argument")]
+    [TestCase("QBit(Float32, 4, 2)", TestName = "the stride form no server accepts")]
+    public void Resolve_WrongArgumentCount_ThrowsFormatException(string type)
+    {
+        Assert.That(() => Codec(type), Throws.InstanceOf<FormatException>().With.Message.Contains("exactly two"));
+    }
+
+    [TestCase("QBit(Float32, 0)")]
+    [TestCase("QBit(Float32, -1)")]
+    [TestCase("QBit(Float32, x)")]
+    public void Resolve_InvalidDimension_ThrowsFormatException(string type)
+    {
+        Assert.That(() => Codec(type), Throws.InstanceOf<FormatException>().With.Message.Contains("vector length"));
+    }
+
+    [TestCase("QBit(Int32, 4)")]
+    [TestCase("QBit(String, 4)")]
+    [TestCase("QBit(Float16, 4)")]
+    public void Resolve_ElementTypeTheServerRejects_ThrowsNotSupportedException(string type)
+    {
+        Assert.That(
+            () => Codec(type),
+            Throws.InstanceOf<NotSupportedException>().With.Message.Contains("BFloat16, Float32 and Float64"));
+    }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Types/QBitColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/QBitColumnCodecTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Threading.Tasks;
 using ClickHouse.Driver.Tcp.Protocol;
 using ClickHouse.Driver.Tcp.Tests.Utilities;
@@ -8,7 +9,7 @@ namespace ClickHouse.Driver.Tcp.Tests.Types;
 
 /// <summary>
 /// Unit coverage for <c>QBit(T, N)</c>, limited to what a server round-trip cannot observe: the exact plane
-/// layout, the significance ordering <see cref="IQBitColumn.GetPlane"/> imposes on top of it, the type-resolution
+/// layout, the significance ordering <see cref="IQBitColumn.GetPlane(int)"/> imposes on top of it, the type-resolution
 /// and write error paths, and the pooled <c>Values</c> cache. Per-type values are covered by
 /// <see cref="InsertRoundTripCase"/> against a real server.
 /// </summary>
@@ -47,6 +48,21 @@ public class QBitColumnCodecTests
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x00, 0x00, 0x00,
+    };
+
+    // Captured from a ClickHouse 26.7 `SELECT v FROM t FORMAT Native` where v is QBit(Int8, 16) holding one row of
+    // [1, -2, 3, -4, ... 15, -16] — the same input values as DocumentedBytes16, over a two's-complement encoding
+    // rather than IEEE-754. 8 planes of two bytes, most significant (the sign) first. Two bytes per row is what
+    // makes the reversed byte order within a bitmap observable at all.
+    private static readonly byte[] DocumentedInt8Bytes16 =
+    {
+        0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA,
+        0x55, 0xAA, 0x5A, 0x5A, 0x66, 0x66, 0x55, 0x55,
+    };
+
+    private static readonly sbyte[] DocumentedInt8Vector =
+    {
+        1, -2, 3, -4, 5, -6, 7, -8, 9, -10, 11, -12, 13, -14, 15, -16,
     };
 
     private static IColumnCodec Codec(string type) => ColumnCodecRegistry.Default.Resolve(type, ResolveContext.ForWrite);
@@ -306,11 +322,128 @@ public class QBitColumnCodecTests
             Throws.ArgumentException.With.Message.Contains("Nullable"));
     }
 
+    [Test]
+    public async Task WriteColumn_Int8Vector_ProducesTheServersOwnBytes()
+    {
+        const string Type = "QBit(Int8, 16)";
+        IColumnCodec codec = Codec(Type);
+        using var column = new ArrayColumn<sbyte[]>("v", Type, new[] { DocumentedInt8Vector });
+
+        byte[] bytes = await CodecTestHarness.WriteAsync(w => codec.WriteColumn(w, column));
+
+        CollectionAssert.AreEqual(DocumentedInt8Bytes16, bytes);
+    }
+
+    [Test]
+    public async Task ReadColumnAsync_Int8ServerBytes_DecodesTheTwosComplementVector()
+    {
+        // The negative values are what a de-transpose that rebuilt the byte through a signed accumulator would
+        // get wrong; the sign is just plane 0's bit, with no widening involved.
+        const string Type = "QBit(Int8, 16)";
+        IColumnCodec codec = Codec(Type);
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(DocumentedInt8Bytes16);
+
+        using IColumn read = await codec.ReadColumnAsync(reader, "v", Type, 1, CodecTestHarness.None);
+
+        CollectionAssert.AreEqual(DocumentedInt8Vector, (sbyte[])read.GetValue(0));
+        Assert.That(((IQBitColumn)read).BitWidth, Is.EqualTo(8));
+    }
+
+    [Test]
+    public void CanWrite_Int8Codec_AcceptsOnlySByteVectors()
+    {
+        IColumnCodec codec = Codec("QBit(Int8, 4)");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(codec.ElementType, Is.EqualTo(typeof(sbyte[])));
+            Assert.That(codec.CanWrite(new ArrayColumn<sbyte[]>("v", "QBit(Int8, 4)", new[] { new sbyte[4] })), Is.True);
+            Assert.That(codec.CanWrite(new ArrayColumn<float[]>("v", "QBit(Int8, 4)", new[] { new float[4] })), Is.False);
+            Assert.That(codec.NullPlaceholder, Is.EqualTo(new sbyte[4]));
+        });
+    }
+
+    [Test]
+    public async Task GetPlane_UnstridedColumn_ReportsOneGroupAndAgreesWithTheGroupOverload()
+    {
+        // Stride and GroupCount describe the strided QBit(T, N, stride) layout 26.7 added, which is not decoded
+        // yet — so every column reports a single group, and GetPlane(bit) is GetPlane(bit, 0). Pinning that keeps
+        // the two accessors from drifting apart when the strided layout does land.
+        IColumnCodec codec = Codec(Float32X4);
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(DocumentedBytes);
+        using IColumn read = await codec.ReadColumnAsync(reader, "v", Float32X4, 1, CodecTestHarness.None);
+        var qbit = (IQBitColumn)read;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(qbit.Stride, Is.EqualTo(qbit.Dimension));
+            Assert.That(qbit.GroupCount, Is.EqualTo(1));
+            Assert.That(qbit.GetPlane(30, 0).ToArray(), Is.EqualTo(qbit.GetPlane(30).ToArray()));
+        });
+    }
+
+    [Test]
+    public async Task GetPlane_GroupPastTheOnlyGroup_ThrowsArgumentOutOfRange()
+    {
+        IColumnCodec codec = Codec(Float32X4);
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(DocumentedBytes);
+        using IColumn read = await codec.ReadColumnAsync(reader, "v", Float32X4, 1, CodecTestHarness.None);
+        var qbit = (IQBitColumn)read;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(() => qbit.GetPlane(0, 1).ToArray(), Throws.InstanceOf<ArgumentOutOfRangeException>());
+            Assert.That(() => qbit.GetPlane(0, -1).ToArray(), Throws.InstanceOf<ArgumentOutOfRangeException>());
+        });
+    }
+
+    [TestCase(1, 3, TestName = "length runs past the last row")]
+    [TestCase(3, 1, TestName = "start is past the last row")]
+    [TestCase(0, -1, TestName = "negative length")]
+    public async Task WriteColumn_DenseSliceOutsideTheColumn_ThrowsArgumentOutOfRange(int start, int length)
+    {
+        // The dense path slices the blob per plane. The blob is rented and may be longer than the column, so an
+        // over-long range has to be bounded against RowCount rather than against the array — otherwise it would
+        // quietly emit stale pooled bytes instead of failing. Only the dense path can reach this.
+        IColumnCodec codec = Codec(Float32X4);
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(DocumentedBytes);
+        using IColumn dense = await codec.ReadColumnAsync(reader, "v", Float32X4, 1, CodecTestHarness.None);
+
+        Assert.That(
+            async () => await CodecTestHarness.WriteSliceAsync(codec, dense, start, length),
+            Throws.InstanceOf<ArgumentOutOfRangeException>());
+    }
+
+    [Test]
+    public void ReadColumnAsync_TruncatedPlaneBody_ThrowsEndOfStream()
+    {
+        // A body shorter than BitWidth * rows * BytesPerRow must fail rather than decode whatever the rented blob
+        // happened to contain. This also drives the catch that hands the rent back before rethrowing — that half
+        // is not observable from here, since ArrayPool gives no way to ask whether an array came home.
+        IColumnCodec codec = Codec(Float32X4);
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(new byte[] { 0x00, 0x0E });
+
+        Assert.That(
+            async () => await codec.ReadColumnAsync(reader, "v", Float32X4, 1, CodecTestHarness.None),
+            Throws.InstanceOf<EndOfStreamException>());
+    }
+
     [TestCase("QBit(Float32)", TestName = "one argument")]
-    [TestCase("QBit(Float32, 4, 2)", TestName = "the stride form no server accepts")]
+    [TestCase("QBit(Float32, 4, 2, 1)", TestName = "four arguments")]
     public void Resolve_WrongArgumentCount_ThrowsFormatException(string type)
     {
         Assert.That(() => Codec(type), Throws.InstanceOf<FormatException>().With.Message.Contains("exactly two"));
+    }
+
+    [Test]
+    public void Resolve_TheStrideFormAddedIn267_ThrowsNotSupportedException()
+    {
+        // 26.7 added QBit(T, N, stride), whose body is N / stride groups each carrying a full set of planes. The
+        // server prints the third argument only when stride != N, so this is always a genuinely strided column.
+        // Not decoded yet, and the error has to say which of the two it is rather than "wrong argument count".
+        Assert.That(
+            () => Codec("QBit(Float32, 16, 8)"),
+            Throws.InstanceOf<NotSupportedException>().With.Message.Contains("strided"));
     }
 
     [TestCase("QBit(Float32, 0)")]
@@ -321,6 +454,10 @@ public class QBitColumnCodecTests
         Assert.That(() => Codec(type), Throws.InstanceOf<FormatException>().With.Message.Contains("vector length"));
     }
 
+    // Int16 and UInt8 are the near misses: 26.7 widened the element type to Int8 only, so the neighbouring integer
+    // widths stay rejected and a codec that matched on "any integer" would let them through.
+    [TestCase("QBit(Int16, 4)")]
+    [TestCase("QBit(UInt8, 4)")]
     [TestCase("QBit(Int32, 4)")]
     [TestCase("QBit(String, 4)")]
     [TestCase("QBit(Float16, 4)")]
@@ -328,6 +465,6 @@ public class QBitColumnCodecTests
     {
         Assert.That(
             () => Codec(type),
-            Throws.InstanceOf<NotSupportedException>().With.Message.Contains("BFloat16, Float32 and Float64"));
+            Throws.InstanceOf<NotSupportedException>().With.Message.Contains("Int8, BFloat16, Float32 and Float64"));
     }
 }

--- a/ClickHouse.Driver.Tcp.Tests/Types/QBitColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/QBitColumnCodecTests.cs
@@ -7,39 +7,31 @@ using ClickHouse.Driver.Tcp.Types;
 
 namespace ClickHouse.Driver.Tcp.Tests.Types;
 
-/// <summary>
-/// Unit coverage for <c>QBit(T, N)</c>, limited to what a server round-trip cannot observe: the exact plane
-/// layout, the significance ordering <see cref="IQBitColumn.GetPlane(int)"/> imposes on top of it, the type-resolution
-/// and write error paths, and the pooled <c>Values</c> cache. Per-type values are covered by
-/// <see cref="InsertRoundTripCase"/> against a real server.
-/// </summary>
 [TestFixture]
 public class QBitColumnCodecTests
 {
     private const string Float32X4 = "QBit(Float32, 4)";
 
-    // Captured from a ClickHouse 26.6 `SELECT v FROM t FORMAT Native` where v is QBit(Float32, 4) holding one row
-    // of [1.0, 2.0, 3.0, 4.0] — the example documented on QBitColumnCodec. 32 planes, one byte per plane (one row
-    // of ceil(4/8) = 1 byte), most significant bit first.
+    // Server-produced Native body for one QBit(Float32, 4) row containing [1, 2, 3, 4]. Planes are
+    // ordered most-significant first.
     private static readonly byte[] DocumentedBytes =
     {
-        0x00, // bit 31 (sign): none of the four is negative
-        0x0E, // bit 30: set for 2.0, 3.0, 4.0 -> elements 1, 2, 3 -> 0b1110
-        0x01, // bit 29: only 1.0 (0x3F800000)
-        0x01, // bit 28
-        0x01, // bit 27
-        0x01, // bit 26
-        0x01, // bit 25
-        0x01, // bit 24
-        0x09, // bit 23: 1.0 and 4.0 -> elements 0 and 3 -> 0b1001
-        0x04, // bit 22: only 3.0 -> element 2 -> 0b0100
+        0x00, // Bit 31: no elements set.
+        0x0E, // Bit 30: elements 1, 2, and 3.
+        0x01, // Bits 29 through 24: element 0.
+        0x01,
+        0x01,
+        0x01,
+        0x01,
+        0x01,
+        0x09, // Bit 23: elements 0 and 3.
+        0x04, // Bit 22: element 2.
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     };
 
-    // Captured the same way, for QBit(Float32, 16) holding one row of [1, -2, 3, -4, ... 15, -16]. Two bytes per
-    // row per plane, so this is the only fixture that spans more than one 8-element group — the unit the vector
-    // write path works in. The signs alternate, which makes the sign plane 0xAA 0xAA.
+    // Server-produced Native body for one QBit(Float32, 16) row containing [1, -2, ..., 15, -16]. Each plane
+    // contains a two-byte row bitmap.
     private static readonly byte[] DocumentedBytes16 =
     {
         0xAA, 0xAA, 0xFF, 0xFE, 0x00, 0x01, 0x00, 0x01, 0x00, 0x01, 0x00, 0x01,
@@ -50,10 +42,8 @@ public class QBitColumnCodecTests
         0x00, 0x00, 0x00, 0x00,
     };
 
-    // Captured from a ClickHouse 26.7 `SELECT v FROM t FORMAT Native` where v is QBit(Int8, 16) holding one row of
-    // [1, -2, 3, -4, ... 15, -16] — the same input values as DocumentedBytes16, over a two's-complement encoding
-    // rather than IEEE-754. 8 planes of two bytes, most significant (the sign) first. Two bytes per row is what
-    // makes the reversed byte order within a bitmap observable at all.
+    // Server-produced Native body for one QBit(Int8, 16) row containing [1, -2, ..., 15, -16]. The eight planes
+    // encode two's-complement bytes, most-significant plane first.
     private static readonly byte[] DocumentedInt8Bytes16 =
     {
         0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA,
@@ -90,50 +80,29 @@ public class QBitColumnCodecTests
     }
 
     [Test]
-    public async Task WriteColumn_SpanningSeveralGroupsOfEight_ProducesTheServersOwnBytes()
+    public async Task WriteColumn_DenseRowSlice_ProducesTheServersOwnBytes()
     {
-        // 16 elements is two whole 8-element groups, which is the unit the vector write path works in; the
-        // dimension-4 fixture above never leaves the scalar tail. Pins the group loop against real server bytes.
         const string Type = "QBit(Float32, 16)";
         IColumnCodec codec = Codec(Type);
-        using var column = new ArrayColumn<float[]>("v", Type, new[]
+        using var source = new ArrayColumn<float[]>("v", Type, new[]
         {
+            new float[16],
             new[] { 1f, -2f, 3f, -4f, 5f, -6f, 7f, -8f, 9f, -10f, 11f, -12f, 13f, -14f, 15f, -16f },
-        });
-
-        byte[] bytes = await CodecTestHarness.WriteAsync(w => codec.WriteColumn(w, column));
-
-        CollectionAssert.AreEqual(DocumentedBytes16, bytes);
-    }
-
-    [Test]
-    public async Task WriteColumn_RowSlice_EmitsEachPlaneStridedByTheSourceRowCount()
-    {
-        // The body is plane-major, so a row range is contiguous within a plane but the planes are strided by the
-        // *source* column's row count. Slicing the middle row of three is the shape that catches a write which
-        // strides by the slice length instead. Whole-column re-inserts never reach it.
-        IColumnCodec codec = Codec(Float32X4);
-        using var source = new ArrayColumn<float[]>("v", Float32X4, new[]
-        {
-            new[] { 0f, 0f, 0f, 0f },
-            new[] { 1f, 2f, 3f, 4f },
-            new[] { 0f, 0f, 0f, 0f },
+            new float[16],
         });
 
         byte[] dense = await CodecTestHarness.WriteAsync(w => codec.WriteColumn(w, source));
         using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(dense);
-        using IColumn read = await codec.ReadColumnAsync(reader, "v", Float32X4, 3, CodecTestHarness.None);
+        using IColumn read = await codec.ReadColumnAsync(reader, "v", Type, 3, CodecTestHarness.None);
 
         byte[] sliced = await CodecTestHarness.WriteSliceAsync(codec, read, start: 1, length: 1);
 
-        CollectionAssert.AreEqual(DocumentedBytes, sliced);
+        CollectionAssert.AreEqual(DocumentedBytes16, sliced);
     }
 
     [Test]
     public async Task GetPlane_ReadColumn_IndexesPlanesBySignificanceNotWireOrder()
     {
-        // The wire stores planes most significant first; GetPlane takes the bit's significance, so bit 30 is the
-        // second plane on the wire. Nothing about this ordering is observable through a round-trip.
         IColumnCodec codec = Codec(Float32X4);
         using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(DocumentedBytes);
         using IColumn read = await codec.ReadColumnAsync(reader, "v", Float32X4, 1, CodecTestHarness.None);
@@ -156,8 +125,6 @@ public class QBitColumnCodecTests
     [Test]
     public async Task GetPlane_MultipleRows_ReturnsEveryRowsBitmapForThatPlane()
     {
-        // Rows are contiguous within a plane, so one plane spans the whole column. -0.0 sets only the sign bit,
-        // which makes the sign plane the one place the three rows differ.
         IColumnCodec codec = Codec("QBit(Float32, 8)");
         using var column = new ArrayColumn<float[]>("v", "QBit(Float32, 8)", new[]
         {
@@ -186,8 +153,6 @@ public class QBitColumnCodecTests
     [Test]
     public async Task Values_ReadColumn_MaterializesEveryRowThroughThePooledCache()
     {
-        // GetValue delegates to the same de-transpose, but Values is a separately materialized pooled cache that
-        // the round-trip's per-row comparison never touches.
         IColumnCodec codec = Codec(Float32X4);
         using var column = new ArrayColumn<float[]>("v", Float32X4, new[]
         {
@@ -211,8 +176,14 @@ public class QBitColumnCodecTests
 
         using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, Float32X4, 1);
         var typed = (IColumn<float[]>)read;
+        float[] first = typed.Values[0];
+        float[] second = typed.Values[0];
 
-        Assert.That(typed.Values[0], Is.SameAs(typed.Values[0]));
+        Assert.Multiple(() =>
+        {
+            Assert.That(second, Is.SameAs(first));
+            Assert.That(read.GetValue(0), Is.SameAs(first));
+        });
     }
 
     [Test]
@@ -259,25 +230,6 @@ public class QBitColumnCodecTests
         {
             Assert.That(codec.ElementType, Is.EqualTo(typeof(float[])));
             Assert.That(codec.NullPlaceholder, Is.EqualTo(new float[4]));
-        });
-    }
-
-    [Test]
-    public async Task WriteThenRead_BFloat16_DropsTheLowMantissaBits()
-    {
-        // A brain-float keeps only the float's high 16 bits, so a value needing the low half comes back narrowed.
-        // The server normalizes nothing here — this is the client's own lossy narrowing, so no round-trip shows it.
-        const string Type = "QBit(BFloat16, 2)";
-        IColumnCodec codec = Codec(Type);
-        using var column = new ArrayColumn<float[]>("v", Type, new[] { new[] { 1.0001f, 2f } });
-
-        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, Type, 1);
-        var value = (float[])read.GetValue(0);
-
-        Assert.Multiple(() =>
-        {
-            Assert.That(value[0], Is.EqualTo(1f), "1.0001f narrows to 1f in a brain-float");
-            Assert.That(value[1], Is.EqualTo(2f), "2f is exactly representable");
         });
     }
 
@@ -337,8 +289,6 @@ public class QBitColumnCodecTests
     [Test]
     public async Task ReadColumnAsync_Int8ServerBytes_DecodesTheTwosComplementVector()
     {
-        // The negative values are what a de-transpose that rebuilt the byte through a signed accumulator would
-        // get wrong; the sign is just plane 0's bit, with no widening involved.
         const string Type = "QBit(Int8, 16)";
         IColumnCodec codec = Codec(Type);
         using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(DocumentedInt8Bytes16);
@@ -366,9 +316,6 @@ public class QBitColumnCodecTests
     [Test]
     public async Task GetPlane_UnstridedColumn_ReportsOneGroupAndAgreesWithTheGroupOverload()
     {
-        // Stride and GroupCount describe the strided QBit(T, N, stride) layout 26.7 added, which is not decoded
-        // yet — so every column reports a single group, and GetPlane(bit) is GetPlane(bit, 0). Pinning that keeps
-        // the two accessors from drifting apart when the strided layout does land.
         IColumnCodec codec = Codec(Float32X4);
         using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(DocumentedBytes);
         using IColumn read = await codec.ReadColumnAsync(reader, "v", Float32X4, 1, CodecTestHarness.None);
@@ -397,14 +344,11 @@ public class QBitColumnCodecTests
         });
     }
 
-    [TestCase(1, 3, TestName = "length runs past the last row")]
-    [TestCase(3, 1, TestName = "start is past the last row")]
+    [TestCase(-1, 1, TestName = "negative start")]
     [TestCase(0, -1, TestName = "negative length")]
+    [TestCase(0, 2, TestName = "length runs past the last row")]
     public async Task WriteColumn_DenseSliceOutsideTheColumn_ThrowsArgumentOutOfRange(int start, int length)
     {
-        // The dense path slices the blob per plane. The blob is rented and may be longer than the column, so an
-        // over-long range has to be bounded against RowCount rather than against the array — otherwise it would
-        // quietly emit stale pooled bytes instead of failing. Only the dense path can reach this.
         IColumnCodec codec = Codec(Float32X4);
         using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(DocumentedBytes);
         using IColumn dense = await codec.ReadColumnAsync(reader, "v", Float32X4, 1, CodecTestHarness.None);
@@ -415,11 +359,20 @@ public class QBitColumnCodecTests
     }
 
     [Test]
+    public async Task WriteColumn_EmptySliceAtTheEnd_WritesNoBytes()
+    {
+        IColumnCodec codec = Codec(Float32X4);
+        using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(DocumentedBytes);
+        using IColumn dense = await codec.ReadColumnAsync(reader, "v", Float32X4, 1, CodecTestHarness.None);
+
+        byte[] bytes = await CodecTestHarness.WriteSliceAsync(codec, dense, start: 1, length: 0);
+
+        Assert.That(bytes, Is.Empty);
+    }
+
+    [Test]
     public void ReadColumnAsync_TruncatedPlaneBody_ThrowsEndOfStream()
     {
-        // A body shorter than BitWidth * rows * BytesPerRow must fail rather than decode whatever the rented blob
-        // happened to contain. This also drives the catch that hands the rent back before rethrowing — that half
-        // is not observable from here, since ArrayPool gives no way to ask whether an array came home.
         IColumnCodec codec = Codec(Float32X4);
         using ClickHouseBinaryReader reader = CodecTestHarness.ReaderOver(new byte[] { 0x00, 0x0E });
 
@@ -438,9 +391,6 @@ public class QBitColumnCodecTests
     [Test]
     public void Resolve_TheStrideFormAddedIn267_ThrowsNotSupportedException()
     {
-        // 26.7 added QBit(T, N, stride), whose body is N / stride groups each carrying a full set of planes. The
-        // server prints the third argument only when stride != N, so this is always a genuinely strided column.
-        // Not decoded yet, and the error has to say which of the two it is rather than "wrong argument count".
         Assert.That(
             () => Codec("QBit(Float32, 16, 8)"),
             Throws.InstanceOf<NotSupportedException>().With.Message.Contains("strided"));
@@ -454,12 +404,8 @@ public class QBitColumnCodecTests
         Assert.That(() => Codec(type), Throws.InstanceOf<FormatException>().With.Message.Contains("vector length"));
     }
 
-    // Int16 and UInt8 are the near misses: 26.7 widened the element type to Int8 only, so the neighbouring integer
-    // widths stay rejected and a codec that matched on "any integer" would let them through.
     [TestCase("QBit(Int16, 4)")]
     [TestCase("QBit(UInt8, 4)")]
-    [TestCase("QBit(Int32, 4)")]
-    [TestCase("QBit(String, 4)")]
     [TestCase("QBit(Float16, 4)")]
     public void Resolve_ElementTypeTheServerRejects_ThrowsNotSupportedException(string type)
     {

--- a/ClickHouse.Driver.Tcp.Tests/Types/QBitColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/QBitColumnCodecTests.cs
@@ -36,6 +36,19 @@ public class QBitColumnCodecTests
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     };
 
+    // Captured the same way, for QBit(Float32, 16) holding one row of [1, -2, 3, -4, ... 15, -16]. Two bytes per
+    // row per plane, so this is the only fixture that spans more than one 8-element group — the unit the vector
+    // write path works in. The signs alternate, which makes the sign plane 0xAA 0xAA.
+    private static readonly byte[] DocumentedBytes16 =
+    {
+        0xAA, 0xAA, 0xFF, 0xFE, 0x00, 0x01, 0x00, 0x01, 0x00, 0x01, 0x00, 0x01,
+        0x00, 0x01, 0xFF, 0x81, 0x80, 0x79, 0x78, 0x64, 0x66, 0x50, 0x55, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00,
+    };
+
     private static IColumnCodec Codec(string type) => ColumnCodecRegistry.Default.Resolve(type, ResolveContext.ForWrite);
 
     [Test]
@@ -58,6 +71,23 @@ public class QBitColumnCodecTests
         using IColumn read = await codec.ReadColumnAsync(reader, "v", Float32X4, 1, CodecTestHarness.None);
 
         CollectionAssert.AreEqual(new[] { 1f, 2f, 3f, 4f }, (float[])read.GetValue(0));
+    }
+
+    [Test]
+    public async Task WriteColumn_SpanningSeveralGroupsOfEight_ProducesTheServersOwnBytes()
+    {
+        // 16 elements is two whole 8-element groups, which is the unit the vector write path works in; the
+        // dimension-4 fixture above never leaves the scalar tail. Pins the group loop against real server bytes.
+        const string Type = "QBit(Float32, 16)";
+        IColumnCodec codec = Codec(Type);
+        using var column = new ArrayColumn<float[]>("v", Type, new[]
+        {
+            new[] { 1f, -2f, 3f, -4f, 5f, -6f, 7f, -8f, 9f, -10f, 11f, -12f, 13f, -14f, 15f, -16f },
+        });
+
+        byte[] bytes = await CodecTestHarness.WriteAsync(w => codec.WriteColumn(w, column));
+
+        CollectionAssert.AreEqual(DocumentedBytes16, bytes);
     }
 
     [Test]

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
@@ -1432,6 +1432,30 @@ public sealed class InsertRoundTripCase
                     new[] { 0d, -0d, double.NaN },
                 }));
 
+            // Dimensions of 8 and above reach the vector write path, which works a group of 8 elements at a time;
+            // everything narrower is handled entirely by its scalar tail. 17 is two whole groups plus one element,
+            // so it covers the group loop and the tail together, and it is an embedding-shaped width rather than
+            // the hand-checked fixtures above.
+            yield return Same(
+                "QBit(Float32, 17)",
+                "QBit(Float32, 17)",
+                name => new ArrayColumn<float[]>(name, "QBit(Float32, 17)", new[]
+                {
+                    Ramp(17, i => (i * 0.5f) - 4f),
+                    Ramp(17, i => i % 2 == 0 ? float.MaxValue : float.MinValue),
+                }));
+
+            // The Float64 group loop takes two extracts per plane byte, where the Float32 one takes a single
+            // extract, so it needs its own multi-group case.
+            yield return Same(
+                "QBit(Float64, 17)",
+                "QBit(Float64, 17)",
+                name => new ArrayColumn<double[]>(name, "QBit(Float64, 17)", new[]
+                {
+                    Ramp(17, i => (i * 0.25d) - 2d),
+                    Ramp(17, i => i % 2 == 0 ? double.MaxValue : double.MinValue),
+                }));
+
             // BFloat16 keeps only the float's high 16 bits, so every value here is one a brain-float represents
             // exactly — otherwise the round-trip would compare the narrowed value against the original.
             yield return Same(
@@ -1702,6 +1726,19 @@ public sealed class InsertRoundTripCase
     /// <summary>A case that inserts and reads back the same column — the common shape.</summary>
     private static InsertRoundTripCase Same(string label, string clickHouseType, Func<string, IColumn> build, IReadOnlyDictionary<string, string> settings = null)
         => new(label, clickHouseType, build, build, settings);
+
+    /// <summary>A vector of <paramref name="length"/> values from their index — for the wider QBit dimensions,
+    /// where spelling out every element would obscure the width being tested.</summary>
+    private static T[] Ramp<T>(int length, Func<int, T> value)
+    {
+        var values = new T[length];
+        for (int i = 0; i < length; i++)
+        {
+            values[i] = value(i);
+        }
+
+        return values;
+    }
 
     /// <summary>Enables the experimental BFloat16 type for the round-trip.</summary>
     private static readonly IReadOnlyDictionary<string, string> BFloat16Settings = new Dictionary<string, string>(StringComparer.Ordinal)

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
@@ -27,7 +27,12 @@ public sealed class InsertRoundTripCase
     private readonly Func<string, IColumn> buildInsert;
     private readonly Func<string, IColumn> buildExpected;
 
-    private InsertRoundTripCase(string label, string clickHouseType, Func<string, IColumn> buildInsert, Func<string, IColumn> buildExpected, IReadOnlyDictionary<string, string> settings)
+    private InsertRoundTripCase(
+        string label,
+        string clickHouseType,
+        Func<string, IColumn> buildInsert,
+        Func<string, IColumn> buildExpected,
+        IReadOnlyDictionary<string, string> settings)
     {
         Label = label;
         ClickHouseType = clickHouseType;
@@ -1393,11 +1398,6 @@ public sealed class InsertRoundTripCase
             yield return Same("Geometry", "Geometry", name => BuildGeometryColumn(name));
         }
 
-        // QBit(T, N): the vector's bit planes transposed, so the values a row round-trips through are spread one
-        // bit at a time across the whole body. The insert source is the ergonomic ArrayColumn<float[]>, which
-        // takes the transposing write path; the dense read-back is re-inserted by the shared dense case below,
-        // which is what covers the plane-copy path. Signed zero, infinity and NaN pin the sign and exponent
-        // planes, which an all-positive vector leaves untouched.
         if (TcpServerFeatures.Has(TcpFeature.QBit))
         {
             yield return Same(
@@ -1410,18 +1410,6 @@ public sealed class InsertRoundTripCase
                     new[] { float.Epsilon, float.PositiveInfinity, float.NegativeInfinity, float.NaN },
                 }));
 
-            // A dimension that is not a multiple of 8 leaves the high bits of each row's last plane byte unused;
-            // 9 spans two bytes so a mis-set stride shows up as a shifted element rather than a lost one.
-            yield return Same(
-                "QBit(Float32, 9)",
-                "QBit(Float32, 9)",
-                name => new ArrayColumn<float[]>(name, "QBit(Float32, 9)", new[]
-                {
-                    new[] { 1f, 2f, 3f, 4f, 5f, 6f, 7f, 8f, 9f },
-                    new[] { -1f, 0f, -0f, 0.5f, -0.5f, 1e10f, -1e10f, 1e-10f, -1e-10f },
-                }));
-
-            // Float64 is the 64-plane path and its own accumulator width.
             yield return Same(
                 "QBit(Float64, 3)",
                 "QBit(Float64, 3)",
@@ -1432,10 +1420,6 @@ public sealed class InsertRoundTripCase
                     new[] { 0d, -0d, double.NaN },
                 }));
 
-            // Dimensions of 8 and above reach the vector write path, which works a group of 8 elements at a time;
-            // everything narrower is handled entirely by its scalar tail. 17 is two whole groups plus one element,
-            // so it covers the group loop and the tail together, and it is an embedding-shaped width rather than
-            // the hand-checked fixtures above.
             yield return Same(
                 "QBit(Float32, 17)",
                 "QBit(Float32, 17)",
@@ -1445,8 +1429,6 @@ public sealed class InsertRoundTripCase
                     Ramp(17, i => i % 2 == 0 ? float.MaxValue : float.MinValue),
                 }));
 
-            // The Float64 group loop takes two extracts per plane byte, where the Float32 one takes a single
-            // extract, so it needs its own multi-group case.
             yield return Same(
                 "QBit(Float64, 17)",
                 "QBit(Float64, 17)",
@@ -1456,19 +1438,21 @@ public sealed class InsertRoundTripCase
                     Ramp(17, i => i % 2 == 0 ? double.MaxValue : double.MinValue),
                 }));
 
-            // BFloat16 keeps only the float's high 16 bits, so every value here is one a brain-float represents
-            // exactly — otherwise the round-trip would compare the narrowed value against the original.
-            yield return Same(
+            yield return new InsertRoundTripCase(
                 "QBit(BFloat16, 4)",
                 "QBit(BFloat16, 4)",
                 name => new ArrayColumn<float[]>(name, "QBit(BFloat16, 4)", new[]
                 {
+                    new[] { 1.0001f, 2f, -3f, 0f },
+                    new[] { -0f, 0.5f, -0.5f, 256f },
+                }),
+                name => new ArrayColumn<float[]>(name, "QBit(BFloat16, 4)", new[]
+                {
                     new[] { 1f, 2f, -3f, 0f },
                     new[] { -0f, 0.5f, -0.5f, 256f },
-                }));
+                }),
+                settings: null);
 
-            // Nullable(QBit(...)) is accepted by the server and round-trips NULL, which is the only thing that
-            // reads the codec's all-zero placeholder vector.
             yield return Same(
                 "Nullable(QBit(Float32, 4))",
                 "Nullable(QBit(Float32, 4))",
@@ -1479,11 +1463,26 @@ public sealed class InsertRoundTripCase
                     new[] { -1f, -2f, -3f, -4f },
                 }));
 
-            // QBit(Int8, N) arrived in 26.7. Its 8 planes are the element's raw two's-complement byte, so
-            // MinValue/-1 pin the sign plane and the all-ones pattern that a widening bug would drop. Dimension 17
-            // is three bytes per row and crosses two whole 8-element groups plus a tail. The byte order itself is
-            // *not* what these prove — writing and reading share QBitLayout.ByteOfGroup, so a reversed convention
-            // round-trips clean; DocumentedInt8Bytes16 and QBitIntegrationTests are what pin it.
+            yield return Same(
+                "Nullable(QBit(BFloat16, 4))",
+                "Nullable(QBit(BFloat16, 4))",
+                name => new ArrayColumn<float[]>(name, "Nullable(QBit(BFloat16, 4))", new[]
+                {
+                    new[] { 1f, 2f, -3f, 0f },
+                    null,
+                    new[] { -0f, 0.5f, -0.5f, 256f },
+                }));
+
+            yield return Same(
+                "Nullable(QBit(Float64, 3))",
+                "Nullable(QBit(Float64, 3))",
+                name => new ArrayColumn<double[]>(name, "Nullable(QBit(Float64, 3))", new[]
+                {
+                    new[] { 1d, -2d, 3.5d },
+                    null,
+                    new[] { 0d, -0d, double.NaN },
+                }));
+
             if (TcpServerFeatures.Has(TcpFeature.QBitInt8))
             {
                 yield return Same(
@@ -1755,8 +1754,6 @@ public sealed class InsertRoundTripCase
     private static InsertRoundTripCase Same(string label, string clickHouseType, Func<string, IColumn> build, IReadOnlyDictionary<string, string> settings = null)
         => new(label, clickHouseType, build, build, settings);
 
-    /// <summary>A vector of <paramref name="length"/> values from their index — for the wider QBit dimensions,
-    /// where spelling out every element would obscure the width being tested.</summary>
     private static T[] Ramp<T>(int length, Func<int, T> value)
     {
         var values = new T[length];

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
@@ -1393,6 +1393,69 @@ public sealed class InsertRoundTripCase
             yield return Same("Geometry", "Geometry", name => BuildGeometryColumn(name));
         }
 
+        // QBit(T, N): the vector's bit planes transposed, so the values a row round-trips through are spread one
+        // bit at a time across the whole body. The insert source is the ergonomic ArrayColumn<float[]>, which
+        // takes the transposing write path; the dense read-back is re-inserted by the shared dense case below,
+        // which is what covers the plane-copy path. Signed zero, infinity and NaN pin the sign and exponent
+        // planes, which an all-positive vector leaves untouched.
+        if (TcpServerFeatures.Has(TcpFeature.QBit))
+        {
+            yield return Same(
+                "QBit(Float32, 4)",
+                "QBit(Float32, 4)",
+                name => new ArrayColumn<float[]>(name, "QBit(Float32, 4)", new[]
+                {
+                    new[] { 1f, 2f, 3f, 4f },
+                    new[] { 0f, -0f, float.MaxValue, float.MinValue },
+                    new[] { float.Epsilon, float.PositiveInfinity, float.NegativeInfinity, float.NaN },
+                }));
+
+            // A dimension that is not a multiple of 8 leaves the high bits of each row's last plane byte unused;
+            // 9 spans two bytes so a mis-set stride shows up as a shifted element rather than a lost one.
+            yield return Same(
+                "QBit(Float32, 9)",
+                "QBit(Float32, 9)",
+                name => new ArrayColumn<float[]>(name, "QBit(Float32, 9)", new[]
+                {
+                    new[] { 1f, 2f, 3f, 4f, 5f, 6f, 7f, 8f, 9f },
+                    new[] { -1f, 0f, -0f, 0.5f, -0.5f, 1e10f, -1e10f, 1e-10f, -1e-10f },
+                }));
+
+            // Float64 is the 64-plane path and its own accumulator width.
+            yield return Same(
+                "QBit(Float64, 3)",
+                "QBit(Float64, 3)",
+                name => new ArrayColumn<double[]>(name, "QBit(Float64, 3)", new[]
+                {
+                    new[] { 1d, -2d, 3.5d },
+                    new[] { double.MaxValue, double.MinValue, double.Epsilon },
+                    new[] { 0d, -0d, double.NaN },
+                }));
+
+            // BFloat16 keeps only the float's high 16 bits, so every value here is one a brain-float represents
+            // exactly — otherwise the round-trip would compare the narrowed value against the original.
+            yield return Same(
+                "QBit(BFloat16, 4)",
+                "QBit(BFloat16, 4)",
+                name => new ArrayColumn<float[]>(name, "QBit(BFloat16, 4)", new[]
+                {
+                    new[] { 1f, 2f, -3f, 0f },
+                    new[] { -0f, 0.5f, -0.5f, 256f },
+                }));
+
+            // Nullable(QBit(...)) is accepted by the server and round-trips NULL, which is the only thing that
+            // reads the codec's all-zero placeholder vector.
+            yield return Same(
+                "Nullable(QBit(Float32, 4))",
+                "Nullable(QBit(Float32, 4))",
+                name => new ArrayColumn<float[]>(name, "Nullable(QBit(Float32, 4))", new[]
+                {
+                    new[] { 1f, 2f, 3f, 4f },
+                    null,
+                    new[] { -1f, -2f, -3f, -4f },
+                }));
+        }
+
         // SimpleAggregateFunction(func, T) encodes as a bare T — the function only tells the server how to merge
         // rows — so these cases prove the alias is transparent, including when T is itself composite or nullable
         // and when the function carries parameters.

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
@@ -1478,6 +1478,34 @@ public sealed class InsertRoundTripCase
                     null,
                     new[] { -1f, -2f, -3f, -4f },
                 }));
+
+            // QBit(Int8, N) arrived in 26.7. Its 8 planes are the element's raw two's-complement byte, so
+            // MinValue/-1 pin the sign plane and the all-ones pattern that a widening bug would drop. Dimension 17
+            // is three bytes per row and crosses two whole 8-element groups plus a tail. The byte order itself is
+            // *not* what these prove — writing and reading share QBitLayout.ByteOfGroup, so a reversed convention
+            // round-trips clean; DocumentedInt8Bytes16 and QBitIntegrationTests are what pin it.
+            if (TcpServerFeatures.Has(TcpFeature.QBitInt8))
+            {
+                yield return Same(
+                    "QBit(Int8, 17)",
+                    "QBit(Int8, 17)",
+                    name => new ArrayColumn<sbyte[]>(name, "QBit(Int8, 17)", new[]
+                    {
+                        Ramp(17, i => (sbyte)(i - 8)),
+                        Ramp(17, i => i % 2 == 0 ? sbyte.MaxValue : sbyte.MinValue),
+                        Ramp(17, i => i == 0 ? (sbyte)-1 : (sbyte)0),
+                    }));
+
+                yield return Same(
+                    "Nullable(QBit(Int8, 4))",
+                    "Nullable(QBit(Int8, 4))",
+                    name => new ArrayColumn<sbyte[]>(name, "Nullable(QBit(Int8, 4))", new[]
+                    {
+                        new sbyte[] { 1, -2, sbyte.MaxValue, sbyte.MinValue },
+                        null,
+                        new sbyte[] { 0, -1, 0, -1 },
+                    }));
+            }
         }
 
         // SimpleAggregateFunction(func, T) encodes as a bare T — the function only tells the server how to merge

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/TcpFeature.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/TcpFeature.cs
@@ -42,6 +42,10 @@ public enum TcpFeature
     [SinceVersion("26.6")]
     NullableTuple = 1 << 6,
 
+    /// <summary>The <c>Int8</c> element type of <c>QBit</c>, which arrived later than the type itself.</summary>
+    [SinceVersion("26.7")]
+    QBitInt8 = 1 << 7,
+
     /// <summary>Every capability. What an unrecognised or unpinned server version resolves to.</summary>
     All = ~None,
 }

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/TcpFeature.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/TcpFeature.cs
@@ -42,7 +42,7 @@ public enum TcpFeature
     [SinceVersion("26.6")]
     NullableTuple = 1 << 6,
 
-    /// <summary>The <c>Int8</c> element type of <c>QBit</c>, which arrived later than the type itself.</summary>
+    /// <summary><c>QBit</c> columns with <c>Int8</c> elements.</summary>
     [SinceVersion("26.7")]
     QBitInt8 = 1 << 7,
 

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/TcpServerFeaturesTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/TcpServerFeaturesTests.cs
@@ -11,6 +11,8 @@ public class TcpServerFeaturesTests
     [TestCase("25.8", TcpFeature.Json, ExpectedResult = true, TestName = "The oldest matrix server has Json")]
     [TestCase("25.11", TcpFeature.QBit, ExpectedResult = true, TestName = "QBit arrives in 25.11")]
     [TestCase("25.10", TcpFeature.QBit, ExpectedResult = false, TestName = "QBit is gated one release later than it shipped")]
+    [TestCase("26.6", TcpFeature.QBitInt8, ExpectedResult = false, TestName = "QBit Int8 is unavailable before 26.7")]
+    [TestCase("26.7", TcpFeature.QBitInt8, ExpectedResult = true, TestName = "QBit Int8 arrives in 26.7")]
     [TestCase("26.5", TcpFeature.NullableTuple, ExpectedResult = false, TestName = "Nullable Tuple Beta is unavailable before 26.6")]
     [TestCase("26.6", TcpFeature.NullableTuple, ExpectedResult = true, TestName = "Nullable Tuple Beta arrives in 26.6")]
     [TestCase("26.6", TcpFeature.Geometry, ExpectedResult = true, TestName = "A recent server has Geometry")]

--- a/ClickHouse.Driver.Tcp/Types/Codecs/QBitColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/QBitColumnCodec.cs
@@ -11,32 +11,14 @@ using ClickHouse.Driver.Tcp.Protocol;
 namespace ClickHouse.Driver.Tcp.Types.Codecs;
 
 /// <summary>
-/// A codec for the ClickHouse <c>QBit(T, N)</c> column: an <c>N</c>-element vector stored with its bit planes
-/// transposed, so a vector search can read only the high-order planes and compute an approximate distance at
-/// reduced precision (<c>L2DistanceTransposed</c>, <c>cosineDistanceTransposed</c>).
-///
-/// <para>
-/// The column carries no state prefix. Its body is <c>bits(T)</c> planes, ordered from the <b>most</b>
-/// significant bit of <c>T</c> down to bit 0; each plane holds one <c>ceil(N / 8)</c>-byte bitmap per row, rows
-/// contiguous within the plane. Element <c>i</c> sits at bit <c>i % 8</c> of the bitmap byte
-/// <see cref="QBitLayout.ByteOfGroup"/> names — the bytes run in the reverse of the element order, so group 0 is
-/// the last byte. The body is plane-major and exactly <c>bits(T) * num_rows * ceil(N / 8)</c> bytes — every row
-/// the same width.
-/// </para>
-///
-/// <para>
-/// <c>T</c> is <c>Int8</c>, <c>BFloat16</c>, <c>Float32</c> or <c>Float64</c> only — <c>Int8</c> since 26.7 —
-/// and the server rejects any other element type. Note this is the <c>Native</c> layout: over <c>RowBinary</c>
-/// the same type is a plain array, which is why the HTTP driver's <c>QBitType</c> reads a length-prefixed run
-/// of values instead.
-/// </para>
+/// Encodes and decodes the Native layout of <c>QBit(T, N)</c>. The body has no state prefix and contains <c>bits(T)</c>
+/// planes in most-significant-first order. Each plane contains one big-endian <c>ceil(N / 8)</c>-byte bitmap per
+/// row. Element <c>i</c> is bit <c>i % 8</c> of byte <c>ceil(N / 8) - 1 - i / 8</c>. The body size is
+/// <c>bits(T) * rowCount * ceil(N / 8)</c> bytes. Supported element types are <c>Int8</c>, <c>BFloat16</c>,
+/// <c>Float32</c>, and <c>Float64</c>.
 /// </summary>
 internal abstract class QBitColumnCodec : IColumnCodec
 {
-    /// <summary>Initializes the shared geometry.</summary>
-    /// <param name="typeName">The canonical type string.</param>
-    /// <param name="dimension">The vector length <c>N</c>.</param>
-    /// <param name="bitWidth">The stored element's bit width — the number of planes.</param>
     protected QBitColumnCodec(string typeName, int dimension, int bitWidth)
     {
         TypeName = typeName;
@@ -45,41 +27,27 @@ internal abstract class QBitColumnCodec : IColumnCodec
         BytesPerRow = QBitLayout.BytesPerRow(dimension);
     }
 
-    /// <inheritdoc/>
     public string TypeName { get; }
 
-    /// <inheritdoc/>
     public abstract Type ElementType { get; }
 
-    /// <inheritdoc/>
     public abstract object NullPlaceholder { get; }
 
-    /// <summary>The vector length <c>N</c>.</summary>
     protected int Dimension { get; }
 
-    /// <summary>The number of bit planes — the stored element's bit width.</summary>
     protected int BitWidth { get; }
 
-    /// <summary>The bytes one row occupies within a single plane, <c>ceil(N / 8)</c>.</summary>
     protected int BytesPerRow { get; }
 
-    /// <summary>
-    /// The elements one group of planes covers. Always <see cref="Dimension"/>: the strided <c>QBit(T, N, stride)</c>
-    /// form is rejected in <see cref="Create"/>, so every column here is a single group.
-    /// </summary>
+    /// <summary>Gets the plane-group width. Strided types are rejected, so this equals <see cref="Dimension"/>.</summary>
     protected int Stride => Dimension;
 
-    /// <summary>Builds a <c>QBit(T, N)</c> codec from its element type and dimension arguments.</summary>
-    /// <param name="node">The parsed <c>QBit</c> type node.</param>
-    /// <returns>The codec.</returns>
-    /// <exception cref="FormatException">The type does not have exactly one element type and one positive integer dimension.</exception>
-    /// <exception cref="NotSupportedException">The element type is not one this client decodes, or the type is strided.</exception>
+    /// <summary>Creates a codec for an unstrided <c>QBit(T, N)</c> type.</summary>
+    /// <exception cref="FormatException">The argument count or dimension is invalid.</exception>
+    /// <exception cref="NotSupportedException">The element type or layout is unsupported.</exception>
     public static QBitColumnCodec Create(TypeNode node)
     {
-        // ClickHouse 26.7 added an optional third argument, the stride, which splits a row into N / stride groups
-        // that each carry their own full set of planes. The server only prints it when stride != N, so a
-        // three-argument type is always a genuinely strided column, whose group-major body this client does not
-        // decode yet.
+        // The three-argument form uses a group-major strided layout that this codec cannot decode.
         if (node.Arguments.Count == 3)
         {
             throw new NotSupportedException(
@@ -102,8 +70,6 @@ internal abstract class QBitColumnCodec : IColumnCodec
                 $"QBit type '{node}' has an invalid vector length '{token}'; expected a positive integer.");
         }
 
-        // The same four the server allows: BFloat16/Float32/Float64 from the start, and Int8 from 26.7. Every one
-        // is stored the same way — bits(T) planes over the element's raw bit pattern, most significant first.
         return element switch
         {
             "Int8" => new QBitSByteColumnCodec(typeName, dimension),
@@ -115,7 +81,6 @@ internal abstract class QBitColumnCodec : IColumnCodec
         };
     }
 
-    /// <inheritdoc/>
     public async ValueTask<IColumn> ReadColumnAsync(ClickHouseBinaryReader reader, string columnName, string columnType, int rowCount, CancellationToken cancellationToken)
     {
         if (rowCount == 0)
@@ -131,7 +96,7 @@ internal abstract class QBitColumnCodec : IColumnCodec
         }
         catch
         {
-            // The column never took ownership of the rent, so return it rather than leak it on a read failure.
+            // No column owns the rented buffer after a failed read.
             ArrayPool<byte>.Shared.Return(blob);
             throw;
         }
@@ -139,21 +104,12 @@ internal abstract class QBitColumnCodec : IColumnCodec
         return CreateColumn(columnName, columnType, blob, rowCount, pooled: true);
     }
 
-    /// <inheritdoc/>
     public abstract bool CanWrite(IColumn column);
 
-    /// <inheritdoc/>
     public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
     {
-        // A QBit column of the same geometry already holds the planes the wire wants, so the range is copied out
-        // plane by plane with no transposition — the hot path when a column read from the server is inserted
-        // straight back. One copy per plane rather than one for the whole range: the body is plane-major, so a
-        // row range is contiguous *within* a plane but the planes themselves are strided by the source's own row
-        // count, which is not this range's length unless the whole column is being written.
-        // The stride has to be compared too, not just the dimension and plane count: QBit(Float32, 16, 8) and
-        // QBit(Float32, 16) agree on both and even on total body size (2 groups x 32 planes x 1 byte against
-        // 32 planes x 2 bytes), so without this a strided source would blit a group-major body into an unstrided
-        // column with nothing to catch it. Always true today — no strided column resolves — and cheap to keep.
+        // A row range is contiguous within each plane, but planes are spaced by the source column's full row
+        // count. Dense copies require identical plane grouping; equal body sizes do not imply equal layouts.
         if (column is QBitColumn dense && dense.Dimension == Dimension && dense.BitWidth == BitWidth && dense.Stride == Stride)
         {
             for (int wireIndex = 0; wireIndex < BitWidth; wireIndex++)
@@ -167,33 +123,14 @@ internal abstract class QBitColumnCodec : IColumnCodec
         WriteTransposed(writer, column, start, length);
     }
 
-    /// <summary>Builds the decoded column over a plane blob.</summary>
-    /// <param name="name">The column name.</param>
-    /// <param name="typeName">The ClickHouse type string from the block header.</param>
-    /// <param name="blob">The plane blob.</param>
-    /// <param name="rowCount">The number of rows.</param>
-    /// <param name="pooled">Whether <paramref name="blob"/> was rented.</param>
-    /// <returns>The column.</returns>
     protected abstract IColumn CreateColumn(string name, string typeName, byte[] blob, int rowCount, bool pooled);
 
-    /// <summary>
-    /// Transposes an ergonomic per-row vector column into the plane-major body. Rents a scratch the size of the
-    /// slice's wire bytes, because plane-major output cannot be streamed a row at a time: plane 0 needs every row
-    /// before plane 1 begins. The dense path above avoids this entirely.
-    /// </summary>
-    /// <param name="writer">The writer to encode into.</param>
-    /// <param name="column">The column to transpose.</param>
-    /// <param name="start">The zero-based first row to write.</param>
-    /// <param name="length">The number of rows to write.</param>
+    /// <summary>Transposes row vectors into a plane-major body.</summary>
     protected abstract void WriteTransposed(ClickHouseBinaryWriter writer, IColumn column, int start, int length);
 
     /// <summary>
-    /// Rents a zeroed scratch buffer for the slice's plane-major body. Rented memory is dirty and the transpose
-    /// only ever sets bits, so the used region must be cleared first.
+    /// Rents scratch space and clears its used region because transpose implementations only set bits.
     /// </summary>
-    /// <param name="length">The number of rows the slice covers.</param>
-    /// <param name="byteCount">The used size of the returned buffer.</param>
-    /// <returns>The rented buffer, zeroed over <paramref name="byteCount"/> bytes.</returns>
     protected byte[] RentScratch(int length, out int byteCount)
     {
         byteCount = checked(BitWidth * length * BytesPerRow);
@@ -203,14 +140,9 @@ internal abstract class QBitColumnCodec : IColumnCodec
     }
 
     /// <summary>
-    /// Validates one row's vector and returns it, blaming the row when it is null or the wrong length. A QBit row
-    /// is never null on the wire — <c>Nullable</c> carries that and substitutes the placeholder at a null
-    /// position — and the vector length is fixed by the type, so neither can be silently padded.
+    /// Returns a non-null vector with exactly <see cref="Dimension"/> elements.
     /// </summary>
-    /// <param name="vector">The row's vector.</param>
-    /// <param name="row">The row index, for the message.</param>
-    /// <returns>The validated vector.</returns>
-    /// <exception cref="ArgumentException">The vector is null or not <see cref="Dimension"/> elements.</exception>
+    /// <exception cref="ArgumentException">The vector is null or its length differs from <see cref="Dimension"/>.</exception>
     protected T[] Validate<T>(T[] vector, int row)
     {
         if (vector is null)
@@ -232,41 +164,27 @@ internal abstract class QBitColumnCodec : IColumnCodec
 }
 
 /// <summary>
-/// The <c>QBit(Int8, N)</c> codec, added by ClickHouse 26.7: 8 planes over each element's raw two's-complement
-/// byte, most significant first, so plane 0 on the wire is the sign bit.
-///
-/// <para>
-/// Not vectorized yet. <c>Vector256&lt;byte&gt;.ExtractMostSignificantBits</c> would yield four plane bytes per
-/// extract against the <see cref="float"/> path's one, so the headroom is real; it wants a benchmark rather
-/// than a guess, and the follow-up is filed with the read-direction one.
-/// </para>
+/// Handles <c>QBit(Int8, N)</c> as eight most-significant-first planes over each element's two's-complement byte.
 /// </summary>
 internal sealed class QBitSByteColumnCodec : QBitColumnCodec
 {
     private sbyte[] nullPlaceholder;
 
-    /// <summary>Initializes the 8-bit integer codec.</summary>
-    /// <param name="typeName">The canonical type string.</param>
-    /// <param name="dimension">The vector length <c>N</c>.</param>
     public QBitSByteColumnCodec(string typeName, int dimension)
         : base(typeName, dimension, bitWidth: 8)
     {
     }
 
-    /// <inheritdoc/>
     public override Type ElementType => typeof(sbyte[]);
 
-    /// <summary>The all-zero placeholder vector; see <see cref="QBitFloatColumnCodec.NullPlaceholder"/>.</summary>
+    /// <summary>Gets the all-zero vector used for null positions in a nullable column.</summary>
     public override object NullPlaceholder => nullPlaceholder ??= new sbyte[Dimension];
 
-    /// <inheritdoc/>
     public override bool CanWrite(IColumn column) => column is IColumn<sbyte[]>;
 
-    /// <inheritdoc/>
     protected override IColumn CreateColumn(string name, string typeName, byte[] blob, int rowCount, bool pooled)
         => new QBitSByteColumn(name, typeName, Dimension, blob, rowCount, pooled);
 
-    /// <inheritdoc/>
     protected override void WriteTransposed(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
     {
         var typed = (IColumn<sbyte[]>)column;
@@ -280,7 +198,7 @@ internal sealed class QBitSByteColumnCodec : QBitColumnCodec
                 int rowBase = r * BytesPerRow;
                 for (int i = 0; i < vector.Length; i++)
                 {
-                    // Reinterpreted, not converted: a negative element is its two's-complement byte.
+                    // Preserve the element's two's-complement bit pattern.
                     uint raw = unchecked((byte)vector[i]);
                     int slot = QBitLayout.ByteOfGroup(i >> 3, BytesPerRow);
                     byte bit = (byte)(1 << (i & 7));
@@ -304,49 +222,34 @@ internal sealed class QBitSByteColumnCodec : QBitColumnCodec
 }
 
 /// <summary>
-/// The <c>QBit(Float32, N)</c> and <c>QBit(BFloat16, N)</c> codec. Both surface as <see cref="float"/>[]: a
-/// brain-float is the top 16 bits of an IEEE-754 <see cref="float"/>, so on write the low 16 bits are dropped —
-/// the same narrowing <see cref="BFloat16ColumnCodec"/> does for a plain <c>BFloat16</c> column.
+/// Handles <c>QBit(Float32, N)</c> and <c>QBit(BFloat16, N)</c> as <see cref="float"/> arrays. <c>BFloat16</c>
+/// retains only the high 16 bits of each value.
 /// </summary>
 internal sealed class QBitFloatColumnCodec : QBitColumnCodec
 {
     private float[] nullPlaceholder;
 
-    /// <summary>Initializes the single-precision codec.</summary>
-    /// <param name="typeName">The canonical type string.</param>
-    /// <param name="dimension">The vector length <c>N</c>.</param>
-    /// <param name="bitWidth">16 for <c>BFloat16</c>, 32 for <c>Float32</c>.</param>
     public QBitFloatColumnCodec(string typeName, int dimension, int bitWidth)
         : base(typeName, dimension, bitWidth)
     {
     }
 
-    /// <inheritdoc/>
     public override Type ElementType => typeof(float[]);
 
-    /// <summary>
-    /// The placeholder for a null row is an all-zero vector, so the values stream stays aligned at a
-    /// <c>Nullable(QBit(T, N))</c> null position — the width every row occupies. Built on first use: a codec is
-    /// resolved per column per block, so a pure read would otherwise allocate a vector per block that only the
-    /// Nullable write path ever touches.
-    /// </summary>
+    /// <summary>Gets the lazily allocated all-zero vector used for null positions in a nullable column.</summary>
     public override object NullPlaceholder => nullPlaceholder ??= new float[Dimension];
 
-    /// <inheritdoc/>
     public override bool CanWrite(IColumn column) => column is IColumn<float[]>;
 
-    /// <inheritdoc/>
     protected override IColumn CreateColumn(string name, string typeName, byte[] blob, int rowCount, bool pooled)
         => new QBitFloatColumn(name, typeName, Dimension, BitWidth, blob, rowCount, pooled);
 
-    /// <inheritdoc/>
     protected override void WriteTransposed(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
     {
         var typed = (IColumn<float[]>)column;
         byte[] scratch = RentScratch(length, out int byteCount);
         try
         {
-            // Hoisted out of the row loop, as UuidColumnCodec does: the answer is the same for every row.
             bool simd = Vector256.IsHardwareAccelerated;
             int planeStride = length * BytesPerRow;
             for (int r = 0; r < length; r++)
@@ -360,9 +263,7 @@ internal sealed class QBitFloatColumnCodec : QBitColumnCodec
                     TransposeGroups(scratch, vector, whole, rowBase, planeStride);
                 }
 
-                // The elements past the last whole group of 8, and every element when there is no hardware
-                // acceleration. They occupy byte `whole` of the row, which the vector path never writes, so the
-                // two cannot collide.
+                // Handle the tail, or the entire vector when SIMD is unavailable.
                 for (int i = whole << 3; i < vector.Length; i++)
                 {
                     uint raw = BitConverter.SingleToUInt32Bits(vector[i]);
@@ -370,8 +271,7 @@ internal sealed class QBitFloatColumnCodec : QBitColumnCodec
                     byte bit = (byte)(1 << (i & 7));
                     for (int wireIndex = 0; wireIndex < BitWidth; wireIndex++)
                     {
-                        // Plane `wireIndex` is bit 31 - wireIndex of the float, for a brain-float too: its 16
-                        // bits *are* the float's high half, so its planes are the float's top 16.
+                        // BFloat16 planes are the high 16 bits of the widened float.
                         if (((raw >> (31 - wireIndex)) & 1) != 0)
                         {
                             scratch[(wireIndex * planeStride) + rowBase + slot] |= bit;
@@ -389,17 +289,9 @@ internal sealed class QBitFloatColumnCodec : QBitColumnCodec
     }
 
     /// <summary>
-    /// Transposes the first <paramref name="whole"/> groups of 8 elements of one row.
-    /// <see cref="Vector256{T}.ExtractMostSignificantBits"/> gathers the top bit of 8 lanes into a byte, which
-    /// <em>is</em> one plane byte for 8 <see cref="float"/>s in the order the wire wants (element <c>i</c> at bit
-    /// <c>i</c>), so a plane costs one extract plus one shift rather than 8 test-and-sets. Walking the planes
-    /// most significant first is then just shifting the vector left one bit each step.
+    /// Transposes complete eight-element groups. Each <see cref="Vector256{T}.ExtractMostSignificantBits"/> call
+    /// produces one plane byte; shifting the lanes left exposes the next plane.
     /// </summary>
-    /// <param name="scratch">The zeroed plane-major slice buffer.</param>
-    /// <param name="vector">The row's vector.</param>
-    /// <param name="whole">The number of complete 8-element groups.</param>
-    /// <param name="rowBase">The row's byte offset within a plane.</param>
-    /// <param name="planeStride">The bytes one plane occupies for the whole slice.</param>
     private void TransposeGroups(byte[] scratch, float[] vector, int whole, int rowBase, int planeStride)
     {
         ref uint source = ref Unsafe.As<float, uint>(ref MemoryMarshal.GetArrayDataReference(vector));
@@ -416,33 +308,26 @@ internal sealed class QBitFloatColumnCodec : QBitColumnCodec
     }
 }
 
-/// <summary>The <c>QBit(Float64, N)</c> codec: 64 planes over each element's IEEE-754 double pattern.</summary>
+/// <summary>Handles <c>QBit(Float64, N)</c> as 64 planes over each element's IEEE-754 bit pattern.</summary>
 internal sealed class QBitDoubleColumnCodec : QBitColumnCodec
 {
     private double[] nullPlaceholder;
 
-    /// <summary>Initializes the double-precision codec.</summary>
-    /// <param name="typeName">The canonical type string.</param>
-    /// <param name="dimension">The vector length <c>N</c>.</param>
     public QBitDoubleColumnCodec(string typeName, int dimension)
         : base(typeName, dimension, bitWidth: 64)
     {
     }
 
-    /// <inheritdoc/>
     public override Type ElementType => typeof(double[]);
 
-    /// <summary>The all-zero placeholder vector; see <see cref="QBitFloatColumnCodec.NullPlaceholder"/>.</summary>
+    /// <summary>Gets the all-zero vector used for null positions in a nullable column.</summary>
     public override object NullPlaceholder => nullPlaceholder ??= new double[Dimension];
 
-    /// <inheritdoc/>
     public override bool CanWrite(IColumn column) => column is IColumn<double[]>;
 
-    /// <inheritdoc/>
     protected override IColumn CreateColumn(string name, string typeName, byte[] blob, int rowCount, bool pooled)
         => new QBitDoubleColumn(name, typeName, Dimension, blob, rowCount, pooled);
 
-    /// <inheritdoc/>
     protected override void WriteTransposed(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
     {
         var typed = (IColumn<double[]>)column;
@@ -486,16 +371,8 @@ internal sealed class QBitDoubleColumnCodec : QBitColumnCodec
     }
 
     /// <summary>
-    /// Transposes the first <paramref name="whole"/> groups of 8 elements of one row. A
-    /// <see cref="Vector256{T}"/> of <see cref="double"/> holds only 4 lanes, so a plane byte takes two extracts
-    /// — the low group in bits 3..0 and the high group in bits 7..4 — against the single extract the
-    /// <see cref="float"/> path needs.
+    /// Transposes complete eight-element groups. Each four-lane vector contributes one nibble to a plane byte.
     /// </summary>
-    /// <param name="scratch">The zeroed plane-major slice buffer.</param>
-    /// <param name="vector">The row's vector.</param>
-    /// <param name="whole">The number of complete 8-element groups.</param>
-    /// <param name="rowBase">The row's byte offset within a plane.</param>
-    /// <param name="planeStride">The bytes one plane occupies for the whole slice.</param>
     private void TransposeGroups(byte[] scratch, double[] vector, int whole, int rowBase, int planeStride)
     {
         ref ulong source = ref Unsafe.As<double, ulong>(ref MemoryMarshal.GetArrayDataReference(vector));

--- a/ClickHouse.Driver.Tcp/Types/Codecs/QBitColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/QBitColumnCodec.cs
@@ -1,0 +1,339 @@
+using System;
+using System.Buffers;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Protocol;
+
+namespace ClickHouse.Driver.Tcp.Types.Codecs;
+
+/// <summary>
+/// A codec for the ClickHouse <c>QBit(T, N)</c> column: an <c>N</c>-element vector stored with its bit planes
+/// transposed, so a vector search can read only the high-order planes and compute an approximate distance at
+/// reduced precision (<c>L2DistanceTransposed</c>, <c>cosineDistanceTransposed</c>).
+///
+/// <para>
+/// The column carries no state prefix. Its body is <c>bits(T)</c> planes, ordered from the <b>most</b>
+/// significant bit of <c>T</c> down to bit 0; each plane holds one <c>ceil(N / 8)</c>-byte bitmap per row, rows
+/// contiguous within the plane, and element <c>i</c> sits at bit <c>i % 8</c> of byte <c>i / 8</c>
+/// (least-significant bit first). So the body is plane-major and exactly
+/// <c>bits(T) * num_rows * ceil(N / 8)</c> bytes — every row the same width.
+/// </para>
+///
+/// <para>
+/// <c>T</c> is <c>BFloat16</c>, <c>Float32</c> or <c>Float64</c> only; the server rejects any other element
+/// type. Note this is the <c>Native</c> layout: over <c>RowBinary</c> the same type is a plain array, which is
+/// why the HTTP driver's <c>QBitType</c> reads a length-prefixed run of values instead.
+/// </para>
+/// </summary>
+internal abstract class QBitColumnCodec : IColumnCodec
+{
+    /// <summary>Initializes the shared geometry.</summary>
+    /// <param name="typeName">The canonical type string.</param>
+    /// <param name="dimension">The vector length <c>N</c>.</param>
+    /// <param name="bitWidth">The stored element's bit width — the number of planes.</param>
+    protected QBitColumnCodec(string typeName, int dimension, int bitWidth)
+    {
+        TypeName = typeName;
+        Dimension = dimension;
+        BitWidth = bitWidth;
+        BytesPerRow = (dimension + 7) / 8;
+    }
+
+    /// <inheritdoc/>
+    public string TypeName { get; }
+
+    /// <inheritdoc/>
+    public abstract Type ElementType { get; }
+
+    /// <inheritdoc/>
+    public abstract object NullPlaceholder { get; }
+
+    /// <summary>The vector length <c>N</c>.</summary>
+    protected int Dimension { get; }
+
+    /// <summary>The number of bit planes — the stored element's bit width.</summary>
+    protected int BitWidth { get; }
+
+    /// <summary>The bytes one row occupies within a single plane, <c>ceil(N / 8)</c>.</summary>
+    protected int BytesPerRow { get; }
+
+    /// <summary>Builds a <c>QBit(T, N)</c> codec from its element type and dimension arguments.</summary>
+    /// <param name="node">The parsed <c>QBit</c> type node.</param>
+    /// <returns>The codec.</returns>
+    /// <exception cref="FormatException">The type does not have exactly one element type and one positive integer dimension.</exception>
+    /// <exception cref="NotSupportedException">The element type is not one the server allows.</exception>
+    public static QBitColumnCodec Create(TypeNode node)
+    {
+        if (node.Arguments.Count != 2)
+        {
+            throw new FormatException(
+                $"QBit type '{node}' must have exactly two arguments: the element type and the vector length.");
+        }
+
+        string typeName = node.ToString();
+        string element = node.Arguments[0].Name.Trim();
+        string token = node.Arguments[1].Name.Trim();
+
+        if (!int.TryParse(token, NumberStyles.None, CultureInfo.InvariantCulture, out int dimension) || dimension <= 0)
+        {
+            throw new FormatException(
+                $"QBit type '{node}' has an invalid vector length '{token}'; expected a positive integer.");
+        }
+
+        // The same three the server allows; anything else is rejected at CREATE TABLE, so a column of one can
+        // only reach us from a server that has changed, not from a table a user could have made today.
+        return element switch
+        {
+            "BFloat16" => new QBitFloatColumnCodec(typeName, dimension, bitWidth: 16),
+            "Float32" => new QBitFloatColumnCodec(typeName, dimension, bitWidth: 32),
+            "Float64" => new QBitDoubleColumnCodec(typeName, dimension),
+            _ => throw new NotSupportedException(
+                $"QBit type '{node}' has element type '{element}'; only BFloat16, Float32 and Float64 are supported."),
+        };
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask<IColumn> ReadColumnAsync(ClickHouseBinaryReader reader, string columnName, string columnType, int rowCount, CancellationToken cancellationToken)
+    {
+        if (rowCount == 0)
+        {
+            return CreateColumn(columnName, columnType, Array.Empty<byte>(), rowCount: 0, pooled: false);
+        }
+
+        int byteCount = checked(BitWidth * rowCount * BytesPerRow);
+        byte[] blob = ArrayPool<byte>.Shared.Rent(byteCount);
+        try
+        {
+            await reader.ReadBytesAsync(blob.AsMemory(0, byteCount), cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            // The column never took ownership of the rent, so return it rather than leak it on a read failure.
+            ArrayPool<byte>.Shared.Return(blob);
+            throw;
+        }
+
+        return CreateColumn(columnName, columnType, blob, rowCount, pooled: true);
+    }
+
+    /// <inheritdoc/>
+    public abstract bool CanWrite(IColumn column);
+
+    /// <inheritdoc/>
+    public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
+    {
+        // A QBit column of the same geometry already holds the planes the wire wants, so the range is copied out
+        // plane by plane with no transposition — the hot path when a column read from the server is inserted
+        // straight back. One copy per plane rather than one for the whole range: the body is plane-major, so a
+        // row range is contiguous *within* a plane but the planes themselves are strided by the source's own row
+        // count, which is not this range's length unless the whole column is being written.
+        if (column is QBitColumn dense && dense.Dimension == Dimension && dense.BitWidth == BitWidth)
+        {
+            for (int wireIndex = 0; wireIndex < BitWidth; wireIndex++)
+            {
+                writer.WriteBytes(dense.WirePlane(wireIndex, start, length));
+            }
+
+            return;
+        }
+
+        WriteTransposed(writer, column, start, length);
+    }
+
+    /// <summary>Builds the decoded column over a plane blob.</summary>
+    /// <param name="name">The column name.</param>
+    /// <param name="typeName">The ClickHouse type string from the block header.</param>
+    /// <param name="blob">The plane blob.</param>
+    /// <param name="rowCount">The number of rows.</param>
+    /// <param name="pooled">Whether <paramref name="blob"/> was rented.</param>
+    /// <returns>The column.</returns>
+    protected abstract IColumn CreateColumn(string name, string typeName, byte[] blob, int rowCount, bool pooled);
+
+    /// <summary>
+    /// Transposes an ergonomic per-row vector column into the plane-major body. Rents a scratch the size of the
+    /// slice's wire bytes, because plane-major output cannot be streamed a row at a time: plane 0 needs every row
+    /// before plane 1 begins. The dense path above avoids this entirely.
+    /// </summary>
+    /// <param name="writer">The writer to encode into.</param>
+    /// <param name="column">The column to transpose.</param>
+    /// <param name="start">The zero-based first row to write.</param>
+    /// <param name="length">The number of rows to write.</param>
+    protected abstract void WriteTransposed(ClickHouseBinaryWriter writer, IColumn column, int start, int length);
+
+    /// <summary>
+    /// Rents a zeroed scratch buffer for the slice's plane-major body. Rented memory is dirty and the transpose
+    /// only ever sets bits, so the used region must be cleared first.
+    /// </summary>
+    /// <param name="length">The number of rows the slice covers.</param>
+    /// <param name="byteCount">The used size of the returned buffer.</param>
+    /// <returns>The rented buffer, zeroed over <paramref name="byteCount"/> bytes.</returns>
+    protected byte[] RentScratch(int length, out int byteCount)
+    {
+        byteCount = checked(BitWidth * length * BytesPerRow);
+        byte[] scratch = ArrayPool<byte>.Shared.Rent(byteCount);
+        Array.Clear(scratch, 0, byteCount);
+        return scratch;
+    }
+
+    /// <summary>
+    /// Validates one row's vector and returns it, blaming the row when it is null or the wrong length. A QBit row
+    /// is never null on the wire — <c>Nullable</c> carries that and substitutes the placeholder at a null
+    /// position — and the vector length is fixed by the type, so neither can be silently padded.
+    /// </summary>
+    /// <param name="vector">The row's vector.</param>
+    /// <param name="row">The row index, for the message.</param>
+    /// <returns>The validated vector.</returns>
+    /// <exception cref="ArgumentException">The vector is null or not <see cref="Dimension"/> elements.</exception>
+    protected T[] Validate<T>(T[] vector, int row)
+    {
+        if (vector is null)
+        {
+            throw new ArgumentException(
+                $"A {TypeName} column cannot hold a null vector (at row {row}); wrap the type in Nullable to write nulls.",
+                nameof(vector));
+        }
+
+        if (vector.Length != Dimension)
+        {
+            throw new ArgumentException(
+                $"A {TypeName} vector at row {row} has {vector.Length} element(s); every vector must have exactly {Dimension}.",
+                nameof(vector));
+        }
+
+        return vector;
+    }
+}
+
+/// <summary>
+/// The <c>QBit(Float32, N)</c> and <c>QBit(BFloat16, N)</c> codec. Both surface as <see cref="float"/>[]: a
+/// brain-float is the top 16 bits of an IEEE-754 <see cref="float"/>, so on write the low 16 bits are dropped —
+/// the same narrowing <see cref="BFloat16ColumnCodec"/> does for a plain <c>BFloat16</c> column.
+/// </summary>
+internal sealed class QBitFloatColumnCodec : QBitColumnCodec
+{
+    private float[] nullPlaceholder;
+
+    /// <summary>Initializes the single-precision codec.</summary>
+    /// <param name="typeName">The canonical type string.</param>
+    /// <param name="dimension">The vector length <c>N</c>.</param>
+    /// <param name="bitWidth">16 for <c>BFloat16</c>, 32 for <c>Float32</c>.</param>
+    public QBitFloatColumnCodec(string typeName, int dimension, int bitWidth)
+        : base(typeName, dimension, bitWidth)
+    {
+    }
+
+    /// <inheritdoc/>
+    public override Type ElementType => typeof(float[]);
+
+    /// <summary>
+    /// The placeholder for a null row is an all-zero vector, so the values stream stays aligned at a
+    /// <c>Nullable(QBit(T, N))</c> null position — the width every row occupies. Built on first use: a codec is
+    /// resolved per column per block, so a pure read would otherwise allocate a vector per block that only the
+    /// Nullable write path ever touches.
+    /// </summary>
+    public override object NullPlaceholder => nullPlaceholder ??= new float[Dimension];
+
+    /// <inheritdoc/>
+    public override bool CanWrite(IColumn column) => column is IColumn<float[]>;
+
+    /// <inheritdoc/>
+    protected override IColumn CreateColumn(string name, string typeName, byte[] blob, int rowCount, bool pooled)
+        => new QBitFloatColumn(name, typeName, Dimension, BitWidth, blob, rowCount, pooled);
+
+    /// <inheritdoc/>
+    protected override void WriteTransposed(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
+    {
+        var typed = (IColumn<float[]>)column;
+        byte[] scratch = RentScratch(length, out int byteCount);
+        try
+        {
+            for (int r = 0; r < length; r++)
+            {
+                float[] vector = Validate(typed[start + r], start + r);
+                for (int i = 0; i < vector.Length; i++)
+                {
+                    // A brain-float keeps only the float's high half, so shift it down to sit in bits 15..0.
+                    uint raw = BitConverter.SingleToUInt32Bits(vector[i]);
+                    uint stored = BitWidth == 16 ? raw >> 16 : raw;
+
+                    int slot = i >> 3;
+                    byte bit = (byte)(1 << (i & 7));
+                    for (int wireIndex = 0; wireIndex < BitWidth; wireIndex++)
+                    {
+                        if (((stored >> (BitWidth - 1 - wireIndex)) & 1) != 0)
+                        {
+                            scratch[((((wireIndex * length) + r) * BytesPerRow) + slot)] |= bit;
+                        }
+                    }
+                }
+            }
+
+            writer.WriteBytes(scratch.AsSpan(0, byteCount));
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(scratch);
+        }
+    }
+}
+
+/// <summary>The <c>QBit(Float64, N)</c> codec: 64 planes over each element's IEEE-754 double pattern.</summary>
+internal sealed class QBitDoubleColumnCodec : QBitColumnCodec
+{
+    private double[] nullPlaceholder;
+
+    /// <summary>Initializes the double-precision codec.</summary>
+    /// <param name="typeName">The canonical type string.</param>
+    /// <param name="dimension">The vector length <c>N</c>.</param>
+    public QBitDoubleColumnCodec(string typeName, int dimension)
+        : base(typeName, dimension, bitWidth: 64)
+    {
+    }
+
+    /// <inheritdoc/>
+    public override Type ElementType => typeof(double[]);
+
+    /// <summary>The all-zero placeholder vector; see <see cref="QBitFloatColumnCodec.NullPlaceholder"/>.</summary>
+    public override object NullPlaceholder => nullPlaceholder ??= new double[Dimension];
+
+    /// <inheritdoc/>
+    public override bool CanWrite(IColumn column) => column is IColumn<double[]>;
+
+    /// <inheritdoc/>
+    protected override IColumn CreateColumn(string name, string typeName, byte[] blob, int rowCount, bool pooled)
+        => new QBitDoubleColumn(name, typeName, Dimension, blob, rowCount, pooled);
+
+    /// <inheritdoc/>
+    protected override void WriteTransposed(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
+    {
+        var typed = (IColumn<double[]>)column;
+        byte[] scratch = RentScratch(length, out int byteCount);
+        try
+        {
+            for (int r = 0; r < length; r++)
+            {
+                double[] vector = Validate(typed[start + r], start + r);
+                for (int i = 0; i < vector.Length; i++)
+                {
+                    ulong stored = BitConverter.DoubleToUInt64Bits(vector[i]);
+                    int slot = i >> 3;
+                    byte bit = (byte)(1 << (i & 7));
+                    for (int wireIndex = 0; wireIndex < BitWidth; wireIndex++)
+                    {
+                        if (((stored >> (BitWidth - 1 - wireIndex)) & 1) != 0)
+                        {
+                            scratch[((((wireIndex * length) + r) * BytesPerRow) + slot)] |= bit;
+                        }
+                    }
+                }
+            }
+
+            writer.WriteBytes(scratch.AsSpan(0, byteCount));
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(scratch);
+        }
+    }
+}

--- a/ClickHouse.Driver.Tcp/Types/Codecs/QBitColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/QBitColumnCodec.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Buffers;
 using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
 using System.Threading;
 using System.Threading.Tasks;
 using ClickHouse.Driver.Tcp.Protocol;
@@ -15,9 +18,10 @@ namespace ClickHouse.Driver.Tcp.Types.Codecs;
 /// <para>
 /// The column carries no state prefix. Its body is <c>bits(T)</c> planes, ordered from the <b>most</b>
 /// significant bit of <c>T</c> down to bit 0; each plane holds one <c>ceil(N / 8)</c>-byte bitmap per row, rows
-/// contiguous within the plane, and element <c>i</c> sits at bit <c>i % 8</c> of byte <c>i / 8</c>
-/// (least-significant bit first). So the body is plane-major and exactly
-/// <c>bits(T) * num_rows * ceil(N / 8)</c> bytes — every row the same width.
+/// contiguous within the plane. Element <c>i</c> sits at bit <c>i % 8</c> of the bitmap byte
+/// <see cref="QBitLayout.ByteOfGroup"/> names — the bytes run in the reverse of the element order, so group 0 is
+/// the last byte. The body is plane-major and exactly <c>bits(T) * num_rows * ceil(N / 8)</c> bytes — every row
+/// the same width.
 /// </para>
 ///
 /// <para>
@@ -248,22 +252,35 @@ internal sealed class QBitFloatColumnCodec : QBitColumnCodec
         byte[] scratch = RentScratch(length, out int byteCount);
         try
         {
+            // Hoisted out of the row loop, as UuidColumnCodec does: the answer is the same for every row.
+            bool simd = Vector256.IsHardwareAccelerated;
+            int planeStride = length * BytesPerRow;
             for (int r = 0; r < length; r++)
             {
                 float[] vector = Validate(typed[start + r], start + r);
-                for (int i = 0; i < vector.Length; i++)
-                {
-                    // A brain-float keeps only the float's high half, so shift it down to sit in bits 15..0.
-                    uint raw = BitConverter.SingleToUInt32Bits(vector[i]);
-                    uint stored = BitWidth == 16 ? raw >> 16 : raw;
+                int rowBase = (r * BytesPerRow);
+                int whole = simd ? Dimension >> 3 : 0;
 
-                    int slot = i >> 3;
+                if (whole != 0)
+                {
+                    TransposeGroups(scratch, vector, whole, rowBase, planeStride);
+                }
+
+                // The elements past the last whole group of 8, and every element when there is no hardware
+                // acceleration. They occupy byte `whole` of the row, which the vector path never writes, so the
+                // two cannot collide.
+                for (int i = whole << 3; i < vector.Length; i++)
+                {
+                    uint raw = BitConverter.SingleToUInt32Bits(vector[i]);
+                    int slot = QBitLayout.ByteOfGroup(i >> 3, BytesPerRow);
                     byte bit = (byte)(1 << (i & 7));
                     for (int wireIndex = 0; wireIndex < BitWidth; wireIndex++)
                     {
-                        if (((stored >> (BitWidth - 1 - wireIndex)) & 1) != 0)
+                        // Plane `wireIndex` is bit 31 - wireIndex of the float, for a brain-float too: its 16
+                        // bits *are* the float's high half, so its planes are the float's top 16.
+                        if (((raw >> (31 - wireIndex)) & 1) != 0)
                         {
-                            scratch[((((wireIndex * length) + r) * BytesPerRow) + slot)] |= bit;
+                            scratch[(wireIndex * planeStride) + rowBase + slot] |= bit;
                         }
                     }
                 }
@@ -274,6 +291,33 @@ internal sealed class QBitFloatColumnCodec : QBitColumnCodec
         finally
         {
             ArrayPool<byte>.Shared.Return(scratch);
+        }
+    }
+
+    /// <summary>
+    /// Transposes the first <paramref name="whole"/> groups of 8 elements of one row.
+    /// <see cref="Vector256{T}.ExtractMostSignificantBits"/> gathers the top bit of 8 lanes into a byte, which
+    /// <em>is</em> one plane byte for 8 <see cref="float"/>s in the order the wire wants (element <c>i</c> at bit
+    /// <c>i</c>), so a plane costs one extract plus one shift rather than 8 test-and-sets. Walking the planes
+    /// most significant first is then just shifting the vector left one bit each step.
+    /// </summary>
+    /// <param name="scratch">The zeroed plane-major slice buffer.</param>
+    /// <param name="vector">The row's vector.</param>
+    /// <param name="whole">The number of complete 8-element groups.</param>
+    /// <param name="rowBase">The row's byte offset within a plane.</param>
+    /// <param name="planeStride">The bytes one plane occupies for the whole slice.</param>
+    private void TransposeGroups(byte[] scratch, float[] vector, int whole, int rowBase, int planeStride)
+    {
+        ref uint source = ref Unsafe.As<float, uint>(ref MemoryMarshal.GetArrayDataReference(vector));
+        for (int group = 0; group < whole; group++)
+        {
+            Vector256<uint> lanes = Vector256.LoadUnsafe(ref source, (nuint)(group << 3));
+            int slot = rowBase + QBitLayout.ByteOfGroup(group, BytesPerRow);
+            for (int wireIndex = 0; wireIndex < BitWidth; wireIndex++)
+            {
+                scratch[(wireIndex * planeStride) + slot] = (byte)lanes.ExtractMostSignificantBits();
+                lanes <<= 1;
+            }
         }
     }
 }
@@ -311,19 +355,29 @@ internal sealed class QBitDoubleColumnCodec : QBitColumnCodec
         byte[] scratch = RentScratch(length, out int byteCount);
         try
         {
+            bool simd = Vector256.IsHardwareAccelerated;
+            int planeStride = length * BytesPerRow;
             for (int r = 0; r < length; r++)
             {
                 double[] vector = Validate(typed[start + r], start + r);
-                for (int i = 0; i < vector.Length; i++)
+                int rowBase = r * BytesPerRow;
+                int whole = simd ? Dimension >> 3 : 0;
+
+                if (whole != 0)
                 {
-                    ulong stored = BitConverter.DoubleToUInt64Bits(vector[i]);
-                    int slot = i >> 3;
+                    TransposeGroups(scratch, vector, whole, rowBase, planeStride);
+                }
+
+                for (int i = whole << 3; i < vector.Length; i++)
+                {
+                    ulong raw = BitConverter.DoubleToUInt64Bits(vector[i]);
+                    int slot = QBitLayout.ByteOfGroup(i >> 3, BytesPerRow);
                     byte bit = (byte)(1 << (i & 7));
                     for (int wireIndex = 0; wireIndex < BitWidth; wireIndex++)
                     {
-                        if (((stored >> (BitWidth - 1 - wireIndex)) & 1) != 0)
+                        if (((raw >> (63 - wireIndex)) & 1) != 0)
                         {
-                            scratch[((((wireIndex * length) + r) * BytesPerRow) + slot)] |= bit;
+                            scratch[(wireIndex * planeStride) + rowBase + slot] |= bit;
                         }
                     }
                 }
@@ -334,6 +388,35 @@ internal sealed class QBitDoubleColumnCodec : QBitColumnCodec
         finally
         {
             ArrayPool<byte>.Shared.Return(scratch);
+        }
+    }
+
+    /// <summary>
+    /// Transposes the first <paramref name="whole"/> groups of 8 elements of one row. A
+    /// <see cref="Vector256{T}"/> of <see cref="double"/> holds only 4 lanes, so a plane byte takes two extracts
+    /// — the low group in bits 3..0 and the high group in bits 7..4 — against the single extract the
+    /// <see cref="float"/> path needs.
+    /// </summary>
+    /// <param name="scratch">The zeroed plane-major slice buffer.</param>
+    /// <param name="vector">The row's vector.</param>
+    /// <param name="whole">The number of complete 8-element groups.</param>
+    /// <param name="rowBase">The row's byte offset within a plane.</param>
+    /// <param name="planeStride">The bytes one plane occupies for the whole slice.</param>
+    private void TransposeGroups(byte[] scratch, double[] vector, int whole, int rowBase, int planeStride)
+    {
+        ref ulong source = ref Unsafe.As<double, ulong>(ref MemoryMarshal.GetArrayDataReference(vector));
+        for (int group = 0; group < whole; group++)
+        {
+            Vector256<ulong> low = Vector256.LoadUnsafe(ref source, (nuint)(group << 3));
+            Vector256<ulong> high = Vector256.LoadUnsafe(ref source, (nuint)((group << 3) + 4));
+            int slot = rowBase + QBitLayout.ByteOfGroup(group, BytesPerRow);
+            for (int wireIndex = 0; wireIndex < BitWidth; wireIndex++)
+            {
+                uint bits = low.ExtractMostSignificantBits() | (high.ExtractMostSignificantBits() << 4);
+                scratch[(wireIndex * planeStride) + slot] = (byte)bits;
+                low <<= 1;
+                high <<= 1;
+            }
         }
     }
 }

--- a/ClickHouse.Driver.Tcp/Types/Codecs/QBitColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/QBitColumnCodec.cs
@@ -25,9 +25,10 @@ namespace ClickHouse.Driver.Tcp.Types.Codecs;
 /// </para>
 ///
 /// <para>
-/// <c>T</c> is <c>BFloat16</c>, <c>Float32</c> or <c>Float64</c> only; the server rejects any other element
-/// type. Note this is the <c>Native</c> layout: over <c>RowBinary</c> the same type is a plain array, which is
-/// why the HTTP driver's <c>QBitType</c> reads a length-prefixed run of values instead.
+/// <c>T</c> is <c>Int8</c>, <c>BFloat16</c>, <c>Float32</c> or <c>Float64</c> only — <c>Int8</c> since 26.7 —
+/// and the server rejects any other element type. Note this is the <c>Native</c> layout: over <c>RowBinary</c>
+/// the same type is a plain array, which is why the HTTP driver's <c>QBitType</c> reads a length-prefixed run
+/// of values instead.
 /// </para>
 /// </summary>
 internal abstract class QBitColumnCodec : IColumnCodec
@@ -41,7 +42,7 @@ internal abstract class QBitColumnCodec : IColumnCodec
         TypeName = typeName;
         Dimension = dimension;
         BitWidth = bitWidth;
-        BytesPerRow = (dimension + 7) / 8;
+        BytesPerRow = QBitLayout.BytesPerRow(dimension);
     }
 
     /// <inheritdoc/>
@@ -62,13 +63,29 @@ internal abstract class QBitColumnCodec : IColumnCodec
     /// <summary>The bytes one row occupies within a single plane, <c>ceil(N / 8)</c>.</summary>
     protected int BytesPerRow { get; }
 
+    /// <summary>
+    /// The elements one group of planes covers. Always <see cref="Dimension"/>: the strided <c>QBit(T, N, stride)</c>
+    /// form is rejected in <see cref="Create"/>, so every column here is a single group.
+    /// </summary>
+    protected int Stride => Dimension;
+
     /// <summary>Builds a <c>QBit(T, N)</c> codec from its element type and dimension arguments.</summary>
     /// <param name="node">The parsed <c>QBit</c> type node.</param>
     /// <returns>The codec.</returns>
     /// <exception cref="FormatException">The type does not have exactly one element type and one positive integer dimension.</exception>
-    /// <exception cref="NotSupportedException">The element type is not one the server allows.</exception>
+    /// <exception cref="NotSupportedException">The element type is not one this client decodes, or the type is strided.</exception>
     public static QBitColumnCodec Create(TypeNode node)
     {
+        // ClickHouse 26.7 added an optional third argument, the stride, which splits a row into N / stride groups
+        // that each carry their own full set of planes. The server only prints it when stride != N, so a
+        // three-argument type is always a genuinely strided column, whose group-major body this client does not
+        // decode yet.
+        if (node.Arguments.Count == 3)
+        {
+            throw new NotSupportedException(
+                $"QBit type '{node}' is strided; this client does not support the strided QBit layout yet.");
+        }
+
         if (node.Arguments.Count != 2)
         {
             throw new FormatException(
@@ -85,15 +102,16 @@ internal abstract class QBitColumnCodec : IColumnCodec
                 $"QBit type '{node}' has an invalid vector length '{token}'; expected a positive integer.");
         }
 
-        // The same three the server allows; anything else is rejected at CREATE TABLE, so a column of one can
-        // only reach us from a server that has changed, not from a table a user could have made today.
+        // The same four the server allows: BFloat16/Float32/Float64 from the start, and Int8 from 26.7. Every one
+        // is stored the same way — bits(T) planes over the element's raw bit pattern, most significant first.
         return element switch
         {
+            "Int8" => new QBitSByteColumnCodec(typeName, dimension),
             "BFloat16" => new QBitFloatColumnCodec(typeName, dimension, bitWidth: 16),
             "Float32" => new QBitFloatColumnCodec(typeName, dimension, bitWidth: 32),
             "Float64" => new QBitDoubleColumnCodec(typeName, dimension),
             _ => throw new NotSupportedException(
-                $"QBit type '{node}' has element type '{element}'; only BFloat16, Float32 and Float64 are supported."),
+                $"QBit type '{node}' has element type '{element}'; only Int8, BFloat16, Float32 and Float64 are supported."),
         };
     }
 
@@ -132,7 +150,11 @@ internal abstract class QBitColumnCodec : IColumnCodec
         // straight back. One copy per plane rather than one for the whole range: the body is plane-major, so a
         // row range is contiguous *within* a plane but the planes themselves are strided by the source's own row
         // count, which is not this range's length unless the whole column is being written.
-        if (column is QBitColumn dense && dense.Dimension == Dimension && dense.BitWidth == BitWidth)
+        // The stride has to be compared too, not just the dimension and plane count: QBit(Float32, 16, 8) and
+        // QBit(Float32, 16) agree on both and even on total body size (2 groups x 32 planes x 1 byte against
+        // 32 planes x 2 bytes), so without this a strided source would blit a group-major body into an unstrided
+        // column with nothing to catch it. Always true today — no strided column resolves — and cheap to keep.
+        if (column is QBitColumn dense && dense.Dimension == Dimension && dense.BitWidth == BitWidth && dense.Stride == Stride)
         {
             for (int wireIndex = 0; wireIndex < BitWidth; wireIndex++)
             {
@@ -206,6 +228,78 @@ internal abstract class QBitColumnCodec : IColumnCodec
         }
 
         return vector;
+    }
+}
+
+/// <summary>
+/// The <c>QBit(Int8, N)</c> codec, added by ClickHouse 26.7: 8 planes over each element's raw two's-complement
+/// byte, most significant first, so plane 0 on the wire is the sign bit.
+///
+/// <para>
+/// Not vectorized yet. <c>Vector256&lt;byte&gt;.ExtractMostSignificantBits</c> would yield four plane bytes per
+/// extract against the <see cref="float"/> path's one, so the headroom is real; it wants a benchmark rather
+/// than a guess, and the follow-up is filed with the read-direction one.
+/// </para>
+/// </summary>
+internal sealed class QBitSByteColumnCodec : QBitColumnCodec
+{
+    private sbyte[] nullPlaceholder;
+
+    /// <summary>Initializes the 8-bit integer codec.</summary>
+    /// <param name="typeName">The canonical type string.</param>
+    /// <param name="dimension">The vector length <c>N</c>.</param>
+    public QBitSByteColumnCodec(string typeName, int dimension)
+        : base(typeName, dimension, bitWidth: 8)
+    {
+    }
+
+    /// <inheritdoc/>
+    public override Type ElementType => typeof(sbyte[]);
+
+    /// <summary>The all-zero placeholder vector; see <see cref="QBitFloatColumnCodec.NullPlaceholder"/>.</summary>
+    public override object NullPlaceholder => nullPlaceholder ??= new sbyte[Dimension];
+
+    /// <inheritdoc/>
+    public override bool CanWrite(IColumn column) => column is IColumn<sbyte[]>;
+
+    /// <inheritdoc/>
+    protected override IColumn CreateColumn(string name, string typeName, byte[] blob, int rowCount, bool pooled)
+        => new QBitSByteColumn(name, typeName, Dimension, blob, rowCount, pooled);
+
+    /// <inheritdoc/>
+    protected override void WriteTransposed(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
+    {
+        var typed = (IColumn<sbyte[]>)column;
+        byte[] scratch = RentScratch(length, out int byteCount);
+        try
+        {
+            int planeStride = length * BytesPerRow;
+            for (int r = 0; r < length; r++)
+            {
+                sbyte[] vector = Validate(typed[start + r], start + r);
+                int rowBase = r * BytesPerRow;
+                for (int i = 0; i < vector.Length; i++)
+                {
+                    // Reinterpreted, not converted: a negative element is its two's-complement byte.
+                    uint raw = unchecked((byte)vector[i]);
+                    int slot = QBitLayout.ByteOfGroup(i >> 3, BytesPerRow);
+                    byte bit = (byte)(1 << (i & 7));
+                    for (int wireIndex = 0; wireIndex < BitWidth; wireIndex++)
+                    {
+                        if (((raw >> (7 - wireIndex)) & 1) != 0)
+                        {
+                            scratch[(wireIndex * planeStride) + rowBase + slot] |= bit;
+                        }
+                    }
+                }
+            }
+
+            writer.WriteBytes(scratch.AsSpan(0, byteCount));
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(scratch);
+        }
     }
 }
 

--- a/ClickHouse.Driver.Tcp/Types/ColumnCodecRegistry.cs
+++ b/ClickHouse.Driver.Tcp/Types/ColumnCodecRegistry.cs
@@ -96,6 +96,10 @@ internal sealed class ColumnCodecRegistry
         // FixedString(N): N contiguous bytes per row, the length parsed from the type argument.
         AddFactory("FixedString", static (TypeNode node, in ResolveContext _, ColumnCodecRegistry _) => FixedStringColumnCodec.Create(node));
 
+        // QBit(T, N): an N-element vector stored as bits(T) transposed bit planes, most significant first, each
+        // plane holding one ceil(N/8)-byte bitmap per row. Fixed width per row, no state prefix.
+        AddFactory("QBit", static (TypeNode node, in ResolveContext _, ColumnCodecRegistry _) => QBitColumnCodec.Create(node));
+
         // Dates and times.
         AddConstant(DateColumnCodec.Instance);
         AddConstant(Date32ColumnCodec.Instance);

--- a/ClickHouse.Driver.Tcp/Types/ColumnCodecRegistry.cs
+++ b/ClickHouse.Driver.Tcp/Types/ColumnCodecRegistry.cs
@@ -97,7 +97,7 @@ internal sealed class ColumnCodecRegistry
         AddFactory("FixedString", static (TypeNode node, in ResolveContext _, ColumnCodecRegistry _) => FixedStringColumnCodec.Create(node));
 
         // QBit(T, N): an N-element vector stored as bits(T) transposed bit planes, most significant first, each
-        // plane holding one ceil(N/8)-byte bitmap per row. Fixed width per row, no state prefix.
+        // plane holding one big-endian ceil(N/8)-byte bitmap per row. Fixed width per row, no state prefix.
         AddFactory("QBit", static (TypeNode node, in ResolveContext _, ColumnCodecRegistry _) => QBitColumnCodec.Create(node));
 
         // Dates and times.

--- a/ClickHouse.Driver.Tcp/Types/ColumnCodecRegistry.cs
+++ b/ClickHouse.Driver.Tcp/Types/ColumnCodecRegistry.cs
@@ -96,8 +96,7 @@ internal sealed class ColumnCodecRegistry
         // FixedString(N): N contiguous bytes per row, the length parsed from the type argument.
         AddFactory("FixedString", static (TypeNode node, in ResolveContext _, ColumnCodecRegistry _) => FixedStringColumnCodec.Create(node));
 
-        // QBit(T, N): an N-element vector stored as bits(T) transposed bit planes, most significant first, each
-        // plane holding one big-endian ceil(N/8)-byte bitmap per row. Fixed width per row, no state prefix.
+        // QBit(T, N): no state prefix; most-significant-first planes containing one big-endian bitmap per row.
         AddFactory("QBit", static (TypeNode node, in ResolveContext _, ColumnCodecRegistry _) => QBitColumnCodec.Create(node));
 
         // Dates and times.

--- a/ClickHouse.Driver.Tcp/Types/IQBitColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/IQBitColumn.cs
@@ -1,0 +1,65 @@
+using System;
+
+namespace ClickHouse.Driver.Tcp.Types;
+
+/// <summary>
+/// The columnar read surface of a decoded <c>QBit(T, N)</c> column. A QBit row is an <c>N</c>-element vector
+/// stored with its <b>bit planes transposed</b>: rather than the elements of a row sitting together, the column
+/// holds one bitmap per bit position, and a bitmap carries that one bit of every element of every row. That is
+/// what lets a vector search read only the high-order planes and compute an approximate distance at reduced
+/// precision, which is how the server's <c>L2DistanceTransposed</c> / <c>cosineDistanceTransposed</c> work.
+///
+/// <para>
+/// The default <see cref="IColumn{T}"/> view undoes the transposition and hands back a per-row
+/// <see cref="float"/>[] (or <see cref="double"/>[] for <c>QBit(Float64, N)</c>), which is convenient but
+/// reverses the layout the type exists to provide. This interface exposes the planes as stored, so a caller
+/// computing a reduced-precision distance can read the few planes it needs without materializing any vector.
+/// </para>
+///
+/// <para>
+/// Obtain it by pattern-matching a column, e.g. <c>if (column is IQBitColumn qbit)</c>. It is not generic: the
+/// planes are raw bits, so plane access does not depend on whether the elements surface as
+/// <see cref="float"/> or <see cref="double"/>.
+/// </para>
+/// </summary>
+public interface IQBitColumn : IColumn
+{
+    /// <summary>The number of elements in each row's vector — the <c>N</c> of <c>QBit(T, N)</c>.</summary>
+    int Dimension { get; }
+
+    /// <summary>
+    /// The number of bit planes, which is the width of one element on the wire: 16 for <c>BFloat16</c>, 32 for
+    /// <c>Float32</c>, 64 for <c>Float64</c>.
+    /// </summary>
+    int BitWidth { get; }
+
+    /// <summary>
+    /// The bytes one row occupies within a single plane — <c>ceil(Dimension / 8)</c>. Element <c>i</c> of a row
+    /// sits at bit <c>i % 8</c> of byte <c>i / 8</c> of the row's slice, least-significant bit first. When
+    /// <see cref="Dimension"/> is not a multiple of 8 the high bits of the last byte are unused.
+    /// </summary>
+    int BytesPerRow { get; }
+
+    /// <summary>
+    /// One bit plane: the bit at position <paramref name="bit"/> of every element of every row, as
+    /// <see cref="IColumn.RowCount"/> consecutive <see cref="BytesPerRow"/>-byte bitmaps. Row <c>r</c>'s bitmap is
+    /// the slice <c>[r * BytesPerRow, (r + 1) * BytesPerRow)</c>.
+    ///
+    /// <para>
+    /// <paramref name="bit"/> is the bit's <em>significance</em> within the stored element, so
+    /// <c>BitWidth - 1</c> is the sign bit and 0 the least significant mantissa bit; the most significant planes
+    /// are the ones a reduced-precision distance wants. (The wire stores the planes in the opposite order, most
+    /// significant first — this accessor hides that.) For <c>QBit(BFloat16, N)</c> the positions are those of the
+    /// 16-bit brain-float, not of the widened <see cref="float"/> the values surface as.
+    /// </para>
+    ///
+    /// <para>
+    /// A borrowed span over the owning block's storage, valid only while the block is alive: read it in place and
+    /// copy out only what must outlive the block.
+    /// </para>
+    /// </summary>
+    /// <param name="bit">The bit position, from 0 (least significant) to <see cref="BitWidth"/> - 1 (the sign bit).</param>
+    /// <returns>The plane's bitmaps, <c>RowCount * BytesPerRow</c> bytes.</returns>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="bit"/> is outside [0, <see cref="BitWidth"/>).</exception>
+    ReadOnlySpan<byte> GetPlane(int bit);
+}

--- a/ClickHouse.Driver.Tcp/Types/IQBitColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/IQBitColumn.cs
@@ -3,119 +3,59 @@ using System;
 namespace ClickHouse.Driver.Tcp.Types;
 
 /// <summary>
-/// The columnar read surface of a decoded <c>QBit(T, N)</c> column. A QBit row is an <c>N</c>-element vector
-/// stored with its <b>bit planes transposed</b>: rather than the elements of a row sitting together, the column
-/// holds one bitmap per bit position, and a bitmap carries that one bit of every element of every row. That is
-/// what lets a vector search read only the high-order planes and compute an approximate distance at reduced
-/// precision, which is how the server's <c>L2DistanceTransposed</c> / <c>cosineDistanceTransposed</c> work.
-///
-/// <para>
-/// The default <see cref="IColumn{T}"/> view undoes the transposition and hands back a per-row
-/// <see cref="float"/>[] (<see cref="double"/>[] for <c>QBit(Float64, N)</c>, <see cref="sbyte"/>[] for
-/// <c>QBit(Int8, N)</c>), which is convenient but
-/// reverses the layout the type exists to provide. This interface exposes the planes as stored, so a caller
-/// computing a reduced-precision distance can read the few planes it needs without materializing any vector.
-/// </para>
-///
-/// <para>
-/// Obtain it by pattern-matching a column, e.g. <c>if (column is IQBitColumn qbit)</c>. It is not generic: the
-/// planes are raw bits, so plane access does not depend on which CLR type the elements surface as.
-/// </para>
+/// Exposes the transposed bit planes of a decoded <c>QBit(T, N)</c> column without materializing row vectors.
+/// The corresponding typed column exposes <see cref="float"/>[] for <c>BFloat16</c> and <c>Float32</c>,
+/// <see cref="double"/>[] for <c>Float64</c>, or <see cref="sbyte"/>[] for <c>Int8</c>.
 /// </summary>
 public interface IQBitColumn : IColumn
 {
-    /// <summary>The number of elements in each row's vector — the <c>N</c> of <c>QBit(T, N)</c>.</summary>
+    /// <summary>Gets the number of elements in each row.</summary>
     int Dimension { get; }
 
     /// <summary>
-    /// The number of bit planes, which is the width of one element on the wire: 8 for <c>Int8</c>, 16 for
-    /// <c>BFloat16</c>, 32 for <c>Float32</c>, 64 for <c>Float64</c>.
+    /// Gets the number of planes: 8 for <c>Int8</c>, 16 for <c>BFloat16</c>, 32 for <c>Float32</c>, or 64 for
+    /// <c>Float64</c>.
     /// </summary>
     int BitWidth { get; }
 
     /// <summary>
-    /// The elements one group of planes covers — the <c>stride</c> of <c>QBit(T, N, stride)</c>, and equal to
-    /// <see cref="Dimension"/> for the two-argument type, which is the only form this client decodes today.
-    ///
-    /// <para>
-    /// ClickHouse 26.7 added an optional stride that splits a row into <see cref="GroupCount"/> independent
-    /// groups of <c>stride</c> elements, each carrying its own full set of <see cref="BitWidth"/> planes. A
-    /// column of that shape currently fails to resolve, so <see cref="Stride"/> always reports
-    /// <see cref="Dimension"/> — it exists so a caller reading planes is written against the general layout
-    /// rather than against the single-group special case.
-    /// </para>
+    /// Gets the number of elements represented by each plane group. Columns decoded by this driver report
+    /// <see cref="Dimension"/> because strided <c>QBit(T, N, stride)</c> columns are unsupported.
     /// </summary>
     int Stride { get; }
 
-    /// <summary>
-    /// The number of plane groups a row is split into, <c>Dimension / Stride</c>. Always 1 today; see
-    /// <see cref="Stride"/>.
-    /// </summary>
+    /// <summary>Gets <c>Dimension / Stride</c>, the number of plane groups in each row.</summary>
     int GroupCount { get; }
 
     /// <summary>
-    /// The bytes one row occupies within a single plane of a single group — <c>ceil(Stride / 8)</c>, which is
-    /// <c>ceil(Dimension / 8)</c> while <see cref="GroupCount"/> is 1.
-    ///
-    /// <para>
-    /// Within group <c>g</c>, element <c>i</c> of a row sits at bit <c>i % 8</c> of byte
-    /// <c>BytesPerRow - 1 - i / 8</c>, counting <c>i</c> from the start of the group: the bits within a byte run
-    /// least significant first, but the bytes run in the <b>reverse</b> of the element order, so elements 0-7 are
-    /// in the <em>last</em> byte. Equivalently, the row's bitmap is the big-endian encoding of a
-    /// <c>BytesPerRow</c>-byte integer whose bit <c>i</c> is element <c>i</c>. When <see cref="Stride"/> is not a
-    /// multiple of 8 the unused bits are the high bits of byte 0.
-    /// </para>
+    /// Gets the size of one row bitmap, <c>ceil(Stride / 8)</c> bytes. Element <c>i</c> within a group is bit
+    /// <c>i % 8</c> of byte <c>BytesPerRow - 1 - i / 8</c>. Unused bits are the high bits of the first byte.
     /// </summary>
     int BytesPerRow { get; }
 
     /// <summary>
-    /// One bit plane: the bit at position <paramref name="bit"/> of every element of every row, as
-    /// <see cref="IColumn.RowCount"/> consecutive <see cref="BytesPerRow"/>-byte bitmaps. Row <c>r</c>'s bitmap is
-    /// the slice <c>[r * BytesPerRow, (r + 1) * BytesPerRow)</c>.
-    ///
-    /// <para>
-    /// Defined only for a single-group column, which is every column this client decodes today. On a strided
-    /// column a plane is <see cref="GroupCount"/> disjoint runs and no single span can be "the plane", so this
-    /// throws rather than quietly hand back one group's worth; use <see cref="GetPlane(int, int)"/> there.
-    /// </para>
-    ///
-    /// <para>
-    /// <paramref name="bit"/> is the bit's <em>significance</em> within the stored element, so
-    /// <c>BitWidth - 1</c> is the sign bit and 0 the least significant mantissa bit; the most significant planes
-    /// are the ones a reduced-precision distance wants. (The wire stores the planes in the opposite order, most
-    /// significant first — this accessor hides that.) For <c>QBit(BFloat16, N)</c> the positions are those of the
-    /// 16-bit brain-float, not of the widened <see cref="float"/> the values surface as.
-    /// </para>
-    ///
-    /// <para>
-    /// A borrowed span over the owning block's storage, valid only while the block is alive: read it in place and
-    /// copy out only what must outlive the block.
-    /// </para>
+    /// Gets one plane as consecutive row bitmaps. Row <c>r</c> occupies
+    /// <c>[r * BytesPerRow, (r + 1) * BytesPerRow)</c>. The bit number denotes significance, with 0 the least
+    /// significant stored bit and <c>BitWidth - 1</c> the sign bit. For <c>BFloat16</c>, it refers to the 16-bit
+    /// stored value rather than the widened <see cref="float"/>. The returned span borrows the column's storage
+    /// and is valid only for the owning block's lifetime.
     /// </summary>
-    /// <param name="bit">The bit position, from 0 (least significant) to <see cref="BitWidth"/> - 1 (the sign bit).</param>
-    /// <returns>The plane's bitmaps, <c>RowCount * BytesPerRow</c> bytes.</returns>
-    /// <exception cref="ArgumentOutOfRangeException"><paramref name="bit"/> is outside [0, <see cref="BitWidth"/>).</exception>
-    /// <exception cref="InvalidOperationException"><see cref="GroupCount"/> is not 1, so a plane is not one contiguous run.</exception>
+    /// <param name="bit">The bit position in the stored element.</param>
+    /// <returns><c>RowCount * BytesPerRow</c> bytes.</returns>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="bit"/> is outside
+    /// [0, <see cref="BitWidth"/>).</exception>
+    /// <exception cref="InvalidOperationException">The column contains more than one plane group.</exception>
     ReadOnlySpan<byte> GetPlane(int bit);
 
     /// <summary>
-    /// One bit plane of one group: the bit at position <paramref name="bit"/> of every element in group
-    /// <paramref name="group"/>, for every row, as <see cref="IColumn.RowCount"/> consecutive
-    /// <see cref="BytesPerRow"/>-byte bitmaps. Group <c>g</c> covers elements
-    /// <c>[g * Stride, (g + 1) * Stride)</c>.
-    ///
-    /// <para>
-    /// This is the general form; <see cref="GetPlane(int)"/> is the <see cref="GroupCount"/> == 1 shorthand for
-    /// it. Prefer this overload in code that should keep working when strided columns become readable.
-    /// </para>
-    ///
-    /// <para>
-    /// A borrowed span over the owning block's storage, valid only while the block is alive.
-    /// </para>
+    /// Gets one plane for one group as consecutive row bitmaps. Group <c>g</c> covers elements
+    /// <c>[g * Stride, (g + 1) * Stride)</c>. Bit numbering matches <see cref="GetPlane(int)"/>. The returned span
+    /// borrows the column's storage and is valid only for the owning block's lifetime.
     /// </summary>
-    /// <param name="bit">The bit position, from 0 (least significant) to <see cref="BitWidth"/> - 1 (the sign bit).</param>
-    /// <param name="group">The group index, from 0 to <see cref="GroupCount"/> - 1.</param>
-    /// <returns>The group's plane bitmaps, <c>RowCount * BytesPerRow</c> bytes.</returns>
-    /// <exception cref="ArgumentOutOfRangeException"><paramref name="bit"/> or <paramref name="group"/> is out of range.</exception>
+    /// <param name="bit">The bit position in the stored element.</param>
+    /// <param name="group">The zero-based group index.</param>
+    /// <returns><c>RowCount * BytesPerRow</c> bytes.</returns>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="bit"/> or <paramref name="group"/> is out
+    /// of range.</exception>
     ReadOnlySpan<byte> GetPlane(int bit, int group);
 }

--- a/ClickHouse.Driver.Tcp/Types/IQBitColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/IQBitColumn.cs
@@ -11,15 +11,15 @@ namespace ClickHouse.Driver.Tcp.Types;
 ///
 /// <para>
 /// The default <see cref="IColumn{T}"/> view undoes the transposition and hands back a per-row
-/// <see cref="float"/>[] (or <see cref="double"/>[] for <c>QBit(Float64, N)</c>), which is convenient but
+/// <see cref="float"/>[] (<see cref="double"/>[] for <c>QBit(Float64, N)</c>, <see cref="sbyte"/>[] for
+/// <c>QBit(Int8, N)</c>), which is convenient but
 /// reverses the layout the type exists to provide. This interface exposes the planes as stored, so a caller
 /// computing a reduced-precision distance can read the few planes it needs without materializing any vector.
 /// </para>
 ///
 /// <para>
 /// Obtain it by pattern-matching a column, e.g. <c>if (column is IQBitColumn qbit)</c>. It is not generic: the
-/// planes are raw bits, so plane access does not depend on whether the elements surface as
-/// <see cref="float"/> or <see cref="double"/>.
+/// planes are raw bits, so plane access does not depend on which CLR type the elements surface as.
 /// </para>
 /// </summary>
 public interface IQBitColumn : IColumn
@@ -28,20 +28,42 @@ public interface IQBitColumn : IColumn
     int Dimension { get; }
 
     /// <summary>
-    /// The number of bit planes, which is the width of one element on the wire: 16 for <c>BFloat16</c>, 32 for
-    /// <c>Float32</c>, 64 for <c>Float64</c>.
+    /// The number of bit planes, which is the width of one element on the wire: 8 for <c>Int8</c>, 16 for
+    /// <c>BFloat16</c>, 32 for <c>Float32</c>, 64 for <c>Float64</c>.
     /// </summary>
     int BitWidth { get; }
 
     /// <summary>
-    /// The bytes one row occupies within a single plane — <c>ceil(Dimension / 8)</c>.
+    /// The elements one group of planes covers — the <c>stride</c> of <c>QBit(T, N, stride)</c>, and equal to
+    /// <see cref="Dimension"/> for the two-argument type, which is the only form this client decodes today.
     ///
     /// <para>
-    /// Element <c>i</c> of a row sits at bit <c>i % 8</c> of byte <c>BytesPerRow - 1 - i / 8</c>: the bits within
-    /// a byte run least significant first, but the bytes run in the <b>reverse</b> of the element order, so
-    /// elements 0-7 are in the <em>last</em> byte. Equivalently, the row's bitmap is the big-endian encoding of a
-    /// <c>BytesPerRow</c>-byte integer whose bit <c>i</c> is element <c>i</c>. When <see cref="Dimension"/> is not
-    /// a multiple of 8 the unused bits are the high bits of byte 0.
+    /// ClickHouse 26.7 added an optional stride that splits a row into <see cref="GroupCount"/> independent
+    /// groups of <c>stride</c> elements, each carrying its own full set of <see cref="BitWidth"/> planes. A
+    /// column of that shape currently fails to resolve, so <see cref="Stride"/> always reports
+    /// <see cref="Dimension"/> — it exists so a caller reading planes is written against the general layout
+    /// rather than against the single-group special case.
+    /// </para>
+    /// </summary>
+    int Stride { get; }
+
+    /// <summary>
+    /// The number of plane groups a row is split into, <c>Dimension / Stride</c>. Always 1 today; see
+    /// <see cref="Stride"/>.
+    /// </summary>
+    int GroupCount { get; }
+
+    /// <summary>
+    /// The bytes one row occupies within a single plane of a single group — <c>ceil(Stride / 8)</c>, which is
+    /// <c>ceil(Dimension / 8)</c> while <see cref="GroupCount"/> is 1.
+    ///
+    /// <para>
+    /// Within group <c>g</c>, element <c>i</c> of a row sits at bit <c>i % 8</c> of byte
+    /// <c>BytesPerRow - 1 - i / 8</c>, counting <c>i</c> from the start of the group: the bits within a byte run
+    /// least significant first, but the bytes run in the <b>reverse</b> of the element order, so elements 0-7 are
+    /// in the <em>last</em> byte. Equivalently, the row's bitmap is the big-endian encoding of a
+    /// <c>BytesPerRow</c>-byte integer whose bit <c>i</c> is element <c>i</c>. When <see cref="Stride"/> is not a
+    /// multiple of 8 the unused bits are the high bits of byte 0.
     /// </para>
     /// </summary>
     int BytesPerRow { get; }
@@ -50,6 +72,12 @@ public interface IQBitColumn : IColumn
     /// One bit plane: the bit at position <paramref name="bit"/> of every element of every row, as
     /// <see cref="IColumn.RowCount"/> consecutive <see cref="BytesPerRow"/>-byte bitmaps. Row <c>r</c>'s bitmap is
     /// the slice <c>[r * BytesPerRow, (r + 1) * BytesPerRow)</c>.
+    ///
+    /// <para>
+    /// Defined only for a single-group column, which is every column this client decodes today. On a strided
+    /// column a plane is <see cref="GroupCount"/> disjoint runs and no single span can be "the plane", so this
+    /// throws rather than quietly hand back one group's worth; use <see cref="GetPlane(int, int)"/> there.
+    /// </para>
     ///
     /// <para>
     /// <paramref name="bit"/> is the bit's <em>significance</em> within the stored element, so
@@ -67,5 +95,27 @@ public interface IQBitColumn : IColumn
     /// <param name="bit">The bit position, from 0 (least significant) to <see cref="BitWidth"/> - 1 (the sign bit).</param>
     /// <returns>The plane's bitmaps, <c>RowCount * BytesPerRow</c> bytes.</returns>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="bit"/> is outside [0, <see cref="BitWidth"/>).</exception>
+    /// <exception cref="InvalidOperationException"><see cref="GroupCount"/> is not 1, so a plane is not one contiguous run.</exception>
     ReadOnlySpan<byte> GetPlane(int bit);
+
+    /// <summary>
+    /// One bit plane of one group: the bit at position <paramref name="bit"/> of every element in group
+    /// <paramref name="group"/>, for every row, as <see cref="IColumn.RowCount"/> consecutive
+    /// <see cref="BytesPerRow"/>-byte bitmaps. Group <c>g</c> covers elements
+    /// <c>[g * Stride, (g + 1) * Stride)</c>.
+    ///
+    /// <para>
+    /// This is the general form; <see cref="GetPlane(int)"/> is the <see cref="GroupCount"/> == 1 shorthand for
+    /// it. Prefer this overload in code that should keep working when strided columns become readable.
+    /// </para>
+    ///
+    /// <para>
+    /// A borrowed span over the owning block's storage, valid only while the block is alive.
+    /// </para>
+    /// </summary>
+    /// <param name="bit">The bit position, from 0 (least significant) to <see cref="BitWidth"/> - 1 (the sign bit).</param>
+    /// <param name="group">The group index, from 0 to <see cref="GroupCount"/> - 1.</param>
+    /// <returns>The group's plane bitmaps, <c>RowCount * BytesPerRow</c> bytes.</returns>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="bit"/> or <paramref name="group"/> is out of range.</exception>
+    ReadOnlySpan<byte> GetPlane(int bit, int group);
 }

--- a/ClickHouse.Driver.Tcp/Types/IQBitColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/IQBitColumn.cs
@@ -34,9 +34,15 @@ public interface IQBitColumn : IColumn
     int BitWidth { get; }
 
     /// <summary>
-    /// The bytes one row occupies within a single plane — <c>ceil(Dimension / 8)</c>. Element <c>i</c> of a row
-    /// sits at bit <c>i % 8</c> of byte <c>i / 8</c> of the row's slice, least-significant bit first. When
-    /// <see cref="Dimension"/> is not a multiple of 8 the high bits of the last byte are unused.
+    /// The bytes one row occupies within a single plane — <c>ceil(Dimension / 8)</c>.
+    ///
+    /// <para>
+    /// Element <c>i</c> of a row sits at bit <c>i % 8</c> of byte <c>BytesPerRow - 1 - i / 8</c>: the bits within
+    /// a byte run least significant first, but the bytes run in the <b>reverse</b> of the element order, so
+    /// elements 0-7 are in the <em>last</em> byte. Equivalently, the row's bitmap is the big-endian encoding of a
+    /// <c>BytesPerRow</c>-byte integer whose bit <c>i</c> is element <c>i</c>. When <see cref="Dimension"/> is not
+    /// a multiple of 8 the unused bits are the high bits of byte 0.
+    /// </para>
     /// </summary>
     int BytesPerRow { get; }
 

--- a/ClickHouse.Driver.Tcp/Types/QBitColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/QBitColumn.cs
@@ -5,6 +5,30 @@ using System.Runtime.InteropServices;
 namespace ClickHouse.Driver.Tcp.Types;
 
 /// <summary>
+/// Where an element sits inside one row's bitmap of a <c>QBit</c> plane. Shared by the read and write paths so
+/// the two cannot disagree about it.
+/// </summary>
+internal static class QBitLayout
+{
+    /// <summary>
+    /// The byte, within a row's <c>ceil(N / 8)</c>-byte bitmap, holding the group of 8 elements starting at
+    /// <c>group * 8</c>. The bytes run in the <b>reverse</b> of the element order — the row's bitmap is the
+    /// big-endian encoding of a <c>ceil(N / 8)</c>-byte integer whose bit <c>i</c> is element <c>i</c> — so group
+    /// 0 is the <em>last</em> byte. Verified against a 26.6 server with <c>QBit(Float32, 72)</c>: element 0 lands
+    /// in byte 8 and element 64 in byte 0.
+    ///
+    /// <para>
+    /// This is invisible whenever <c>N &lt;= 8</c>, where a row is a single byte — which is why the layout notes
+    /// in <c>native-format.md</c> describe it the other way round.
+    /// </para>
+    /// </summary>
+    /// <param name="group">The element's group index, <c>element / 8</c>.</param>
+    /// <param name="bytesPerRow">The row's bitmap width, <c>ceil(N / 8)</c>.</param>
+    /// <returns>The byte offset within the row's bitmap.</returns>
+    public static int ByteOfGroup(int group, int bytesPerRow) => bytesPerRow - 1 - group;
+}
+
+/// <summary>
 /// A decoded <c>QBit(T, N)</c> column: the bit-plane blob exactly as it arrived, plus the geometry needed to
 /// read it. The blob is <c>BitWidth</c> planes, each holding one <c>ceil(N / 8)</c>-byte bitmap per row, and the
 /// planes are stored most-significant first — so the plane for bit <c>b</c> is at wire index
@@ -261,7 +285,7 @@ internal sealed class QBitFloatColumn : QBitColumnBase<float>
             uint mask = 1u << (BitWidth - 1 - wireIndex);
             for (int i = 0; i < bits.Length; i++)
             {
-                if ((plane[i >> 3] & (1 << (i & 7))) != 0)
+                if ((plane[QBitLayout.ByteOfGroup(i >> 3, BytesPerRow)] & (1 << (i & 7))) != 0)
                 {
                     bits[i] |= mask;
                 }
@@ -309,7 +333,7 @@ internal sealed class QBitDoubleColumn : QBitColumnBase<double>
             ulong mask = 1UL << (BitWidth - 1 - wireIndex);
             for (int i = 0; i < bits.Length; i++)
             {
-                if ((plane[i >> 3] & (1 << (i & 7))) != 0)
+                if ((plane[QBitLayout.ByteOfGroup(i >> 3, BytesPerRow)] & (1 << (i & 7))) != 0)
                 {
                     bits[i] |= mask;
                 }

--- a/ClickHouse.Driver.Tcp/Types/QBitColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/QBitColumn.cs
@@ -5,60 +5,26 @@ using System.Runtime.InteropServices;
 namespace ClickHouse.Driver.Tcp.Types;
 
 /// <summary>
-/// Where an element sits inside one row's bitmap of a <c>QBit</c> plane. Shared by the read and write paths so
-/// the two cannot disagree about it.
+/// Maps elements to bytes within a <c>QBit</c> row bitmap.
 /// </summary>
 internal static class QBitLayout
 {
     /// <summary>
-    /// The byte, within a row's <c>ceil(N / 8)</c>-byte bitmap, holding the group of 8 elements starting at
-    /// <c>group * 8</c>. The bytes run in the <b>reverse</b> of the element order — the row's bitmap is the
-    /// big-endian encoding of a <c>ceil(N / 8)</c>-byte integer whose bit <c>i</c> is element <c>i</c> — so group
-    /// 0 is the <em>last</em> byte. Verified against a 26.6 server with <c>QBit(Float32, 72)</c>: element 0 lands
-    /// in byte 8 and element 64 in byte 0.
-    ///
-    /// <para>
-    /// This is invisible whenever <c>N &lt;= 8</c>, where a row is a single byte, so only a fixture wider than
-    /// that pins it.
-    /// </para>
+    /// Returns the byte containing an eight-element group. Row bitmaps are big-endian, so group 0 occupies the
+    /// last byte.
     /// </summary>
-    /// <param name="group">The element's group index, <c>element / 8</c>.</param>
-    /// <param name="bytesPerRow">The row's bitmap width, <c>ceil(N / 8)</c>.</param>
-    /// <returns>The byte offset within the row's bitmap.</returns>
     public static int ByteOfGroup(int group, int bytesPerRow) => bytesPerRow - 1 - group;
 
     /// <summary>
-    /// The bytes a row's bitmap occupies, <c>ceil(span / 8)</c>. Written as <c>(span - 1) / 8 + 1</c> rather than
-    /// the usual <c>(span + 7) / 8</c> so it cannot overflow for any positive <paramref name="span"/>.
+    /// Returns <c>ceil(span / 8)</c> without overflowing when <paramref name="span"/> is positive.
     /// </summary>
-    /// <param name="span">The number of elements the bitmap covers; must be positive.</param>
-    /// <returns>The bitmap width in bytes.</returns>
     public static int BytesPerRow(int span) => ((span - 1) / 8) + 1;
 }
 
 /// <summary>
-/// A decoded <c>QBit(T, N)</c> column: the bit-plane blob exactly as it arrived, plus the geometry needed to
-/// read it. The blob is <c>BitWidth</c> planes, each holding one <c>ceil(N / 8)</c>-byte bitmap per row, and the
-/// planes are stored most-significant first — so the plane for bit <c>b</c> is at wire index
-/// <c>BitWidth - 1 - b</c>. See <see cref="IQBitColumn"/> for the layout a caller sees.
-///
-/// <para>
-/// The blob is kept transposed rather than de-transposed on read, so a column read from the server and inserted
-/// straight back is a byte copy with no transposition at all — the common shape for a vector workload, where the
-/// distance is computed server-side and the client never looks at a vector. The per-row vector view is
-/// therefore materialized lazily by <see cref="QBitColumnBase{T}"/>, never eagerly.
-/// </para>
-///
-/// <para>
-/// This non-generic base carries everything that does not depend on which CLR type the elements surface as,
-/// which is what lets the codec's dense write path recognise a QBit column and copy its planes without knowing
-/// the element type.
-/// </para>
-///
-/// <para>
-/// The blob is rented from <see cref="ArrayPool{T}"/> and returned on <see cref="Dispose"/>; like every column,
-/// the bytes and any span returned by <see cref="GetPlane(int)"/> are borrowed for the block's lifetime.
-/// </para>
+/// Stores a decoded Native <c>QBit(T, N)</c> body in its transposed form. Planes are ordered most-significant
+/// first, and each plane contains one fixed-width bitmap per row. A rented body is returned on
+/// <see cref="Dispose"/>; plane spans borrow the body's storage. Typed row vectors are materialized lazily.
 /// </summary>
 internal abstract class QBitColumn : IQBitColumn
 {
@@ -66,14 +32,6 @@ internal abstract class QBitColumn : IQBitColumn
     private readonly bool pooled;
     private byte[] blob;
 
-    /// <summary>Initializes a column over a bit-plane blob.</summary>
-    /// <param name="name">The column name.</param>
-    /// <param name="typeName">The ClickHouse type string (e.g. <c>QBit(Float32, 4)</c>).</param>
-    /// <param name="dimension">The vector length <c>N</c>.</param>
-    /// <param name="bitWidth">The number of planes — the stored element's bit width.</param>
-    /// <param name="blob">The plane blob (may be longer than used).</param>
-    /// <param name="rowCount">The number of rows.</param>
-    /// <param name="pooled">Whether <paramref name="blob"/> was rented and should be returned on dispose.</param>
     protected QBitColumn(string name, string typeName, int dimension, int bitWidth, byte[] blob, int rowCount, bool pooled)
     {
         Name = name;
@@ -86,38 +44,24 @@ internal abstract class QBitColumn : IQBitColumn
         this.pooled = pooled;
     }
 
-    /// <inheritdoc/>
     public string Name { get; }
 
-    /// <inheritdoc/>
     public string TypeName { get; }
 
-    /// <inheritdoc/>
     public int RowCount => rowCount;
 
-    /// <inheritdoc/>
     public int Dimension { get; }
 
-    /// <inheritdoc/>
     public int BitWidth { get; }
 
-    /// <inheritdoc/>
     public int BytesPerRow { get; }
 
-    /// <summary>
-    /// Always <see cref="Dimension"/>: the strided <c>QBit(T, N, stride)</c> form that 26.7 added is rejected at
-    /// codec resolution, so every column that reaches here is a single group.
-    /// </summary>
     public int Stride => Dimension;
 
-    /// <summary>Always 1; see <see cref="Stride"/>.</summary>
     public int GroupCount => 1;
 
-    /// <inheritdoc/>
     public ReadOnlySpan<byte> GetPlane(int bit)
     {
-        // Unreachable while GroupCount is 1, and deliberately so: when the strided layout lands, a caller of this
-        // overload would otherwise get one group's bytes — a shorter span, silently misindexed — instead of an error.
         if (GroupCount != 1)
         {
             throw new InvalidOperationException(
@@ -127,7 +71,6 @@ internal abstract class QBitColumn : IQBitColumn
         return GetPlane(bit, group: 0);
     }
 
-    /// <inheritdoc/>
     public ReadOnlySpan<byte> GetPlane(int bit, int group)
     {
         if ((uint)bit >= (uint)BitWidth)
@@ -147,10 +90,8 @@ internal abstract class QBitColumn : IQBitColumn
         return WirePlane(((group * BitWidth) + BitWidth - 1 - bit), 0, rowCount);
     }
 
-    /// <inheritdoc/>
     public abstract object GetValue(int row);
 
-    /// <inheritdoc/>
     public virtual void Dispose()
     {
         if (pooled && blob.Length != 0)
@@ -162,20 +103,12 @@ internal abstract class QBitColumn : IQBitColumn
     }
 
     /// <summary>
-    /// The rows <c>[start, start + length)</c> of the plane at <paramref name="wireIndex"/> — plane order as
-    /// stored, most significant first — as a zero-copy slice of the blob. The write path emits planes in this
-    /// order, and a row range within one plane is contiguous, so a dense re-insert is one copy per plane.
+    /// Returns a zero-copy row range from a plane indexed in wire order, most-significant plane first.
     /// </summary>
-    /// <param name="wireIndex">The plane's index in stored order, 0 being the most significant bit.</param>
-    /// <param name="start">The zero-based first row of the range.</param>
-    /// <param name="length">The number of rows in the range.</param>
-    /// <returns>The range's bytes within that plane, <c>length * BytesPerRow</c> bytes.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">The range lies outside the column's rows.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">The requested range is outside the logical row count.</exception>
     internal ReadOnlySpan<byte> WirePlane(int wireIndex, int start, int length)
     {
-        // Bound the range against rowCount, not the blob: the blob is rented and may be longer, so slicing it
-        // directly would let an over-long range read a stale pooled region instead of failing fast. The products
-        // cannot overflow — the read path sized the blob with a checked total, and this range fits in it.
+        // Validate against the logical row count because a rented blob can contain unused trailing bytes.
         if (start < 0 || length < 0 || start + (long)length > rowCount)
         {
             throw new ArgumentOutOfRangeException(
@@ -186,15 +119,8 @@ internal abstract class QBitColumn : IQBitColumn
         return blob.AsSpan(((wireIndex * rowCount) + start) * BytesPerRow, length * BytesPerRow);
     }
 
-    /// <summary>The bitmap of one row within the plane at <paramref name="wireIndex"/>.</summary>
-    /// <param name="wireIndex">The plane's index in stored order, 0 being the most significant bit.</param>
-    /// <param name="row">The zero-based row index.</param>
-    /// <returns>The row's <c>BytesPerRow</c> bytes within that plane.</returns>
     protected ReadOnlySpan<byte> WirePlaneRow(int wireIndex, int row) => WirePlane(wireIndex, row, 1);
 
-    /// <summary>Bounds a row index against the column's rows.</summary>
-    /// <param name="row">The zero-based row index.</param>
-    /// <exception cref="IndexOutOfRangeException">The row lies outside the column.</exception>
     protected void CheckRow(int row)
     {
         if ((uint)row >= (uint)rowCount)
@@ -205,33 +131,21 @@ internal abstract class QBitColumn : IQBitColumn
 }
 
 /// <summary>
-/// The typed per-row view over a <see cref="QBitColumn"/>: each row's vector as a
-/// <typeparamref name="T"/>[], de-transposed on demand and cached.
+/// Provides lazily materialized <typeparamref name="T"/>[] rows over a transposed <see cref="QBitColumn"/>.
 /// </summary>
-/// <typeparam name="T">The CLR element type a row's vector surfaces as — <see cref="float"/>, <see cref="double"/> or <see cref="sbyte"/>.</typeparam>
 internal abstract class QBitColumnBase<T> : QBitColumn, IColumn<T[]>
     where T : struct
 {
     private T[][] cache;
 
-    /// <summary>Initializes the typed view.</summary>
-    /// <param name="name">The column name.</param>
-    /// <param name="typeName">The ClickHouse type string.</param>
-    /// <param name="dimension">The vector length <c>N</c>.</param>
-    /// <param name="bitWidth">The number of planes.</param>
-    /// <param name="blob">The plane blob.</param>
-    /// <param name="rowCount">The number of rows.</param>
-    /// <param name="pooled">Whether <paramref name="blob"/> was rented.</param>
     protected QBitColumnBase(string name, string typeName, int dimension, int bitWidth, byte[] blob, int rowCount, bool pooled)
         : base(name, typeName, dimension, bitWidth, blob, rowCount, pooled)
     {
     }
 
     /// <summary>
-    /// The rows as per-row vectors, materialized once and cached. Every row costs
-    /// <c>BitWidth * BytesPerRow</c> byte fetches to de-transpose — 4 KiB for a 1024-dimension
-    /// <c>Float32</c> embedding — so this is built on first use, not on read. Prefer
-    /// <see cref="QBitColumn.GetPlane(int)"/> where the planes themselves are what is wanted.
+    /// Gets row vectors, materializing and caching all rows on first access. Use <see cref="GetPlane(int)"/> to
+    /// inspect transposed data without this allocation.
     /// </summary>
     public ReadOnlySpan<T[]> Values
     {
@@ -239,13 +153,6 @@ internal abstract class QBitColumnBase<T> : QBitColumn, IColumn<T[]>
         {
             if (cache is null)
             {
-                // Rent rather than allocate: this is a convenience view consumers copy out of, so it only needs
-                // to live until Dispose returns it to the pool. Single-consumer per connection, so the lazy fill
-                // needs no synchronization. The rented buffer may be longer than RowCount; Values slices to it.
-                //
-                // De-transposed one whole row at a time, rather than one plane across all rows: a row's output
-                // vector then stays in cache for all BitWidth planes that write into it, where sweeping
-                // plane-by-plane would re-traverse the entire materialized output once per plane.
                 T[][] decoded = ArrayPool<T[]>.Shared.Rent(RowCount);
                 for (int i = 0; i < RowCount; i++)
                 {
@@ -259,63 +166,44 @@ internal abstract class QBitColumnBase<T> : QBitColumn, IColumn<T[]>
         }
     }
 
-    /// <inheritdoc/>
-    // The cache is rented and may be longer than RowCount, so slice before indexing to keep an out-of-range row
-    // failing fast rather than returning a stale slot; the uncached path is bounded by DetransposeRow.
+    // Slice to RowCount so indexing cannot reach unused entries in the pooled array.
     public T[] this[int row] => cache is not null ? cache.AsSpan(0, RowCount)[row] : DetransposeRow(row);
 
-    /// <inheritdoc/>
     public override object GetValue(int row) => this[row];
 
-    /// <inheritdoc/>
     public override void Dispose()
     {
         base.Dispose();
 
         if (cache is not null)
         {
-            // The elements are array references, so clear on return to avoid the pool pinning decoded rows.
+            // Clear references so the pool does not retain decoded row arrays.
             ArrayPool<T[]>.Shared.Return(cache, clearArray: true);
             cache = null;
         }
     }
 
-    /// <summary>Rebuilds one row's vector from the planes.</summary>
-    /// <param name="row">The zero-based row index.</param>
-    /// <returns>The row's <see cref="QBitColumn.Dimension"/>-element vector.</returns>
     protected abstract T[] DetransposeRow(int row);
 }
 
 /// <summary>
-/// A <c>QBit(Float32, N)</c> or <c>QBit(BFloat16, N)</c> column. Both surface as <see cref="float"/>: a
-/// brain-float is the top 16 bits of an IEEE-754 <see cref="float"/>, so its 16 planes rebuild the high half of
-/// the 32-bit pattern and the low half stays zero — the same widening <c>BFloat16ColumnCodec</c> does for a
-/// plain <c>BFloat16</c> column.
+/// Decodes <c>QBit(Float32, N)</c> and <c>QBit(BFloat16, N)</c> rows as <see cref="float"/> arrays. A
+/// <c>BFloat16</c> value fills the high 16 bits of the widened result.
 /// </summary>
 internal sealed class QBitFloatColumn : QBitColumnBase<float>
 {
-    /// <summary>Initializes a single-precision QBit column.</summary>
-    /// <param name="name">The column name.</param>
-    /// <param name="typeName">The ClickHouse type string.</param>
-    /// <param name="dimension">The vector length <c>N</c>.</param>
-    /// <param name="bitWidth">16 for <c>BFloat16</c>, 32 for <c>Float32</c>.</param>
-    /// <param name="blob">The plane blob.</param>
-    /// <param name="rowCount">The number of rows.</param>
-    /// <param name="pooled">Whether <paramref name="blob"/> was rented.</param>
     public QBitFloatColumn(string name, string typeName, int dimension, int bitWidth, byte[] blob, int rowCount, bool pooled)
         : base(name, typeName, dimension, bitWidth, blob, rowCount, pooled)
     {
     }
 
-    /// <inheritdoc/>
     protected override float[] DetransposeRow(int row)
     {
         CheckRow(row);
 
         var vector = new float[Dimension];
 
-        // Accumulate through the float's own storage rather than a separate integer scratch: the bits being
-        // gathered *are* the IEEE-754 pattern, so the vector holds the finished values once the last plane is in.
+        // Build each IEEE-754 pattern directly in the destination array.
         Span<uint> bits = MemoryMarshal.Cast<float, uint>(vector.AsSpan());
         for (int wireIndex = 0; wireIndex < BitWidth; wireIndex++)
         {
@@ -330,7 +218,7 @@ internal sealed class QBitFloatColumn : QBitColumnBase<float>
             }
         }
 
-        // A brain-float's 16 bits are the float's high half, so shift them up into it.
+        // BFloat16 occupies the high half of the widened float.
         if (BitWidth == 16)
         {
             for (int i = 0; i < bits.Length; i++)
@@ -344,31 +232,22 @@ internal sealed class QBitFloatColumn : QBitColumnBase<float>
 }
 
 /// <summary>
-/// A <c>QBit(Int8, N)</c> column: 8 planes rebuilding each element's raw two's-complement byte.
+/// Decodes <c>QBit(Int8, N)</c> rows from each element's two's-complement bit pattern.
 /// </summary>
 internal sealed class QBitSByteColumn : QBitColumnBase<sbyte>
 {
-    /// <summary>Initializes an 8-bit integer QBit column.</summary>
-    /// <param name="name">The column name.</param>
-    /// <param name="typeName">The ClickHouse type string.</param>
-    /// <param name="dimension">The vector length <c>N</c>.</param>
-    /// <param name="blob">The plane blob.</param>
-    /// <param name="rowCount">The number of rows.</param>
-    /// <param name="pooled">Whether <paramref name="blob"/> was rented.</param>
     public QBitSByteColumn(string name, string typeName, int dimension, byte[] blob, int rowCount, bool pooled)
         : base(name, typeName, dimension, bitWidth: 8, blob, rowCount, pooled)
     {
     }
 
-    /// <inheritdoc/>
     protected override sbyte[] DetransposeRow(int row)
     {
         CheckRow(row);
 
         var vector = new sbyte[Dimension];
 
-        // Gather through the unsigned view, as the float paths do: the bits being collected are the raw
-        // two's-complement pattern, so setting bit 7 gives the negative value without any signed cast.
+        // Use an unsigned view so the sign plane sets bit 7 without numeric conversion.
         Span<byte> bits = MemoryMarshal.Cast<sbyte, byte>(vector.AsSpan());
         for (int wireIndex = 0; wireIndex < BitWidth; wireIndex++)
         {
@@ -387,22 +266,14 @@ internal sealed class QBitSByteColumn : QBitColumnBase<sbyte>
     }
 }
 
-/// <summary>A <c>QBit(Float64, N)</c> column: 64 planes rebuilding each element's IEEE-754 double pattern.</summary>
+/// <summary>Decodes <c>QBit(Float64, N)</c> rows from each element's IEEE-754 bit pattern.</summary>
 internal sealed class QBitDoubleColumn : QBitColumnBase<double>
 {
-    /// <summary>Initializes a double-precision QBit column.</summary>
-    /// <param name="name">The column name.</param>
-    /// <param name="typeName">The ClickHouse type string.</param>
-    /// <param name="dimension">The vector length <c>N</c>.</param>
-    /// <param name="blob">The plane blob.</param>
-    /// <param name="rowCount">The number of rows.</param>
-    /// <param name="pooled">Whether <paramref name="blob"/> was rented.</param>
     public QBitDoubleColumn(string name, string typeName, int dimension, byte[] blob, int rowCount, bool pooled)
         : base(name, typeName, dimension, bitWidth: 64, blob, rowCount, pooled)
     {
     }
 
-    /// <inheritdoc/>
     protected override double[] DetransposeRow(int row)
     {
         CheckRow(row);

--- a/ClickHouse.Driver.Tcp/Types/QBitColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/QBitColumn.cs
@@ -1,0 +1,321 @@
+using System;
+using System.Buffers;
+using System.Runtime.InteropServices;
+
+namespace ClickHouse.Driver.Tcp.Types;
+
+/// <summary>
+/// A decoded <c>QBit(T, N)</c> column: the bit-plane blob exactly as it arrived, plus the geometry needed to
+/// read it. The blob is <c>BitWidth</c> planes, each holding one <c>ceil(N / 8)</c>-byte bitmap per row, and the
+/// planes are stored most-significant first — so the plane for bit <c>b</c> is at wire index
+/// <c>BitWidth - 1 - b</c>. See <see cref="IQBitColumn"/> for the layout a caller sees.
+///
+/// <para>
+/// The blob is kept transposed rather than de-transposed on read, so a column read from the server and inserted
+/// straight back is a byte copy with no transposition at all — the common shape for a vector workload, where the
+/// distance is computed server-side and the client never looks at a vector. The per-row vector view is
+/// therefore materialized lazily by <see cref="QBitColumnBase{T}"/>, never eagerly.
+/// </para>
+///
+/// <para>
+/// This non-generic base carries everything that does not depend on whether the elements surface as
+/// <see cref="float"/> or <see cref="double"/>, which is what lets the codec's dense write path recognise a
+/// QBit column and copy its planes without knowing the element type.
+/// </para>
+///
+/// <para>
+/// The blob is rented from <see cref="ArrayPool{T}"/> and returned on <see cref="Dispose"/>; like every column,
+/// the bytes and any span returned by <see cref="GetPlane"/> are borrowed for the block's lifetime.
+/// </para>
+/// </summary>
+internal abstract class QBitColumn : IQBitColumn
+{
+    private readonly int rowCount;
+    private readonly bool pooled;
+    private byte[] blob;
+
+    /// <summary>Initializes a column over a bit-plane blob.</summary>
+    /// <param name="name">The column name.</param>
+    /// <param name="typeName">The ClickHouse type string (e.g. <c>QBit(Float32, 4)</c>).</param>
+    /// <param name="dimension">The vector length <c>N</c>.</param>
+    /// <param name="bitWidth">The number of planes — the stored element's bit width.</param>
+    /// <param name="blob">The plane blob (may be longer than used).</param>
+    /// <param name="rowCount">The number of rows.</param>
+    /// <param name="pooled">Whether <paramref name="blob"/> was rented and should be returned on dispose.</param>
+    protected QBitColumn(string name, string typeName, int dimension, int bitWidth, byte[] blob, int rowCount, bool pooled)
+    {
+        Name = name;
+        TypeName = typeName;
+        Dimension = dimension;
+        BitWidth = bitWidth;
+        BytesPerRow = (dimension + 7) / 8;
+        this.blob = blob ?? throw new ArgumentNullException(nameof(blob));
+        this.rowCount = rowCount;
+        this.pooled = pooled;
+    }
+
+    /// <inheritdoc/>
+    public string Name { get; }
+
+    /// <inheritdoc/>
+    public string TypeName { get; }
+
+    /// <inheritdoc/>
+    public int RowCount => rowCount;
+
+    /// <inheritdoc/>
+    public int Dimension { get; }
+
+    /// <inheritdoc/>
+    public int BitWidth { get; }
+
+    /// <inheritdoc/>
+    public int BytesPerRow { get; }
+
+    /// <inheritdoc/>
+    public ReadOnlySpan<byte> GetPlane(int bit)
+    {
+        if ((uint)bit >= (uint)BitWidth)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(bit),
+                $"Bit {bit} is outside the {BitWidth} plane(s) of column '{Name}' ({TypeName}).");
+        }
+
+        return WirePlane(BitWidth - 1 - bit, 0, rowCount);
+    }
+
+    /// <inheritdoc/>
+    public abstract object GetValue(int row);
+
+    /// <inheritdoc/>
+    public virtual void Dispose()
+    {
+        if (pooled && blob.Length != 0)
+        {
+            ArrayPool<byte>.Shared.Return(blob);
+        }
+
+        blob = Array.Empty<byte>();
+    }
+
+    /// <summary>
+    /// The rows <c>[start, start + length)</c> of the plane at <paramref name="wireIndex"/> — plane order as
+    /// stored, most significant first — as a zero-copy slice of the blob. The write path emits planes in this
+    /// order, and a row range within one plane is contiguous, so a dense re-insert is one copy per plane.
+    /// </summary>
+    /// <param name="wireIndex">The plane's index in stored order, 0 being the most significant bit.</param>
+    /// <param name="start">The zero-based first row of the range.</param>
+    /// <param name="length">The number of rows in the range.</param>
+    /// <returns>The range's bytes within that plane, <c>length * BytesPerRow</c> bytes.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">The range lies outside the column's rows.</exception>
+    internal ReadOnlySpan<byte> WirePlane(int wireIndex, int start, int length)
+    {
+        // Bound the range against rowCount, not the blob: the blob is rented and may be longer, so slicing it
+        // directly would let an over-long range read a stale pooled region instead of failing fast. The products
+        // cannot overflow — the read path sized the blob with a checked total, and this range fits in it.
+        if (start < 0 || length < 0 || start + (long)length > rowCount)
+        {
+            throw new ArgumentOutOfRangeException(
+                length < 0 ? nameof(length) : nameof(start),
+                $"Rows [{start}, {start + (long)length}) lie outside the {rowCount} row(s) of column '{Name}'.");
+        }
+
+        return blob.AsSpan(((wireIndex * rowCount) + start) * BytesPerRow, length * BytesPerRow);
+    }
+
+    /// <summary>The bitmap of one row within the plane at <paramref name="wireIndex"/>.</summary>
+    /// <param name="wireIndex">The plane's index in stored order, 0 being the most significant bit.</param>
+    /// <param name="row">The zero-based row index.</param>
+    /// <returns>The row's <c>BytesPerRow</c> bytes within that plane.</returns>
+    protected ReadOnlySpan<byte> WirePlaneRow(int wireIndex, int row) => WirePlane(wireIndex, row, 1);
+
+    /// <summary>Bounds a row index against the column's rows.</summary>
+    /// <param name="row">The zero-based row index.</param>
+    /// <exception cref="IndexOutOfRangeException">The row lies outside the column.</exception>
+    protected void CheckRow(int row)
+    {
+        if ((uint)row >= (uint)rowCount)
+        {
+            throw new IndexOutOfRangeException();
+        }
+    }
+}
+
+/// <summary>
+/// The typed per-row view over a <see cref="QBitColumn"/>: each row's vector as a
+/// <typeparamref name="T"/>[], de-transposed on demand and cached.
+/// </summary>
+/// <typeparam name="T">The CLR element type a row's vector surfaces as — <see cref="float"/> or <see cref="double"/>.</typeparam>
+internal abstract class QBitColumnBase<T> : QBitColumn, IColumn<T[]>
+    where T : struct
+{
+    private T[][] cache;
+
+    /// <summary>Initializes the typed view.</summary>
+    /// <param name="name">The column name.</param>
+    /// <param name="typeName">The ClickHouse type string.</param>
+    /// <param name="dimension">The vector length <c>N</c>.</param>
+    /// <param name="bitWidth">The number of planes.</param>
+    /// <param name="blob">The plane blob.</param>
+    /// <param name="rowCount">The number of rows.</param>
+    /// <param name="pooled">Whether <paramref name="blob"/> was rented.</param>
+    protected QBitColumnBase(string name, string typeName, int dimension, int bitWidth, byte[] blob, int rowCount, bool pooled)
+        : base(name, typeName, dimension, bitWidth, blob, rowCount, pooled)
+    {
+    }
+
+    /// <summary>
+    /// The rows as per-row vectors, materialized once and cached. Every row costs
+    /// <c>BitWidth * BytesPerRow</c> byte fetches to de-transpose — 4 KiB for a 1024-dimension
+    /// <c>Float32</c> embedding — so this is built on first use, not on read. Prefer
+    /// <see cref="QBitColumn.GetPlane"/> where the planes themselves are what is wanted.
+    /// </summary>
+    public ReadOnlySpan<T[]> Values
+    {
+        get
+        {
+            if (cache is null)
+            {
+                // Rent rather than allocate: this is a convenience view consumers copy out of, so it only needs
+                // to live until Dispose returns it to the pool. Single-consumer per connection, so the lazy fill
+                // needs no synchronization. The rented buffer may be longer than RowCount; Values slices to it.
+                //
+                // De-transposed one whole row at a time, rather than one plane across all rows: a row's output
+                // vector then stays in cache for all BitWidth planes that write into it, where sweeping
+                // plane-by-plane would re-traverse the entire materialized output once per plane.
+                T[][] decoded = ArrayPool<T[]>.Shared.Rent(RowCount);
+                for (int i = 0; i < RowCount; i++)
+                {
+                    decoded[i] = DetransposeRow(i);
+                }
+
+                cache = decoded;
+            }
+
+            return cache.AsSpan(0, RowCount);
+        }
+    }
+
+    /// <inheritdoc/>
+    // The cache is rented and may be longer than RowCount, so slice before indexing to keep an out-of-range row
+    // failing fast rather than returning a stale slot; the uncached path is bounded by DetransposeRow.
+    public T[] this[int row] => cache is not null ? cache.AsSpan(0, RowCount)[row] : DetransposeRow(row);
+
+    /// <inheritdoc/>
+    public override object GetValue(int row) => this[row];
+
+    /// <inheritdoc/>
+    public override void Dispose()
+    {
+        base.Dispose();
+
+        if (cache is not null)
+        {
+            // The elements are array references, so clear on return to avoid the pool pinning decoded rows.
+            ArrayPool<T[]>.Shared.Return(cache, clearArray: true);
+            cache = null;
+        }
+    }
+
+    /// <summary>Rebuilds one row's vector from the planes.</summary>
+    /// <param name="row">The zero-based row index.</param>
+    /// <returns>The row's <see cref="QBitColumn.Dimension"/>-element vector.</returns>
+    protected abstract T[] DetransposeRow(int row);
+}
+
+/// <summary>
+/// A <c>QBit(Float32, N)</c> or <c>QBit(BFloat16, N)</c> column. Both surface as <see cref="float"/>: a
+/// brain-float is the top 16 bits of an IEEE-754 <see cref="float"/>, so its 16 planes rebuild the high half of
+/// the 32-bit pattern and the low half stays zero — the same widening <c>BFloat16ColumnCodec</c> does for a
+/// plain <c>BFloat16</c> column.
+/// </summary>
+internal sealed class QBitFloatColumn : QBitColumnBase<float>
+{
+    /// <summary>Initializes a single-precision QBit column.</summary>
+    /// <param name="name">The column name.</param>
+    /// <param name="typeName">The ClickHouse type string.</param>
+    /// <param name="dimension">The vector length <c>N</c>.</param>
+    /// <param name="bitWidth">16 for <c>BFloat16</c>, 32 for <c>Float32</c>.</param>
+    /// <param name="blob">The plane blob.</param>
+    /// <param name="rowCount">The number of rows.</param>
+    /// <param name="pooled">Whether <paramref name="blob"/> was rented.</param>
+    public QBitFloatColumn(string name, string typeName, int dimension, int bitWidth, byte[] blob, int rowCount, bool pooled)
+        : base(name, typeName, dimension, bitWidth, blob, rowCount, pooled)
+    {
+    }
+
+    /// <inheritdoc/>
+    protected override float[] DetransposeRow(int row)
+    {
+        CheckRow(row);
+
+        var vector = new float[Dimension];
+
+        // Accumulate through the float's own storage rather than a separate integer scratch: the bits being
+        // gathered *are* the IEEE-754 pattern, so the vector holds the finished values once the last plane is in.
+        Span<uint> bits = MemoryMarshal.Cast<float, uint>(vector.AsSpan());
+        for (int wireIndex = 0; wireIndex < BitWidth; wireIndex++)
+        {
+            ReadOnlySpan<byte> plane = WirePlaneRow(wireIndex, row);
+            uint mask = 1u << (BitWidth - 1 - wireIndex);
+            for (int i = 0; i < bits.Length; i++)
+            {
+                if ((plane[i >> 3] & (1 << (i & 7))) != 0)
+                {
+                    bits[i] |= mask;
+                }
+            }
+        }
+
+        // A brain-float's 16 bits are the float's high half, so shift them up into it.
+        if (BitWidth == 16)
+        {
+            for (int i = 0; i < bits.Length; i++)
+            {
+                bits[i] <<= 16;
+            }
+        }
+
+        return vector;
+    }
+}
+
+/// <summary>A <c>QBit(Float64, N)</c> column: 64 planes rebuilding each element's IEEE-754 double pattern.</summary>
+internal sealed class QBitDoubleColumn : QBitColumnBase<double>
+{
+    /// <summary>Initializes a double-precision QBit column.</summary>
+    /// <param name="name">The column name.</param>
+    /// <param name="typeName">The ClickHouse type string.</param>
+    /// <param name="dimension">The vector length <c>N</c>.</param>
+    /// <param name="blob">The plane blob.</param>
+    /// <param name="rowCount">The number of rows.</param>
+    /// <param name="pooled">Whether <paramref name="blob"/> was rented.</param>
+    public QBitDoubleColumn(string name, string typeName, int dimension, byte[] blob, int rowCount, bool pooled)
+        : base(name, typeName, dimension, bitWidth: 64, blob, rowCount, pooled)
+    {
+    }
+
+    /// <inheritdoc/>
+    protected override double[] DetransposeRow(int row)
+    {
+        CheckRow(row);
+
+        var vector = new double[Dimension];
+        Span<ulong> bits = MemoryMarshal.Cast<double, ulong>(vector.AsSpan());
+        for (int wireIndex = 0; wireIndex < BitWidth; wireIndex++)
+        {
+            ReadOnlySpan<byte> plane = WirePlaneRow(wireIndex, row);
+            ulong mask = 1UL << (BitWidth - 1 - wireIndex);
+            for (int i = 0; i < bits.Length; i++)
+            {
+                if ((plane[i >> 3] & (1 << (i & 7))) != 0)
+                {
+                    bits[i] |= mask;
+                }
+            }
+        }
+
+        return vector;
+    }
+}

--- a/ClickHouse.Driver.Tcp/Types/QBitColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/QBitColumn.cs
@@ -18,14 +18,22 @@ internal static class QBitLayout
     /// in byte 8 and element 64 in byte 0.
     ///
     /// <para>
-    /// This is invisible whenever <c>N &lt;= 8</c>, where a row is a single byte — which is why the layout notes
-    /// in <c>native-format.md</c> describe it the other way round.
+    /// This is invisible whenever <c>N &lt;= 8</c>, where a row is a single byte, so only a fixture wider than
+    /// that pins it.
     /// </para>
     /// </summary>
     /// <param name="group">The element's group index, <c>element / 8</c>.</param>
     /// <param name="bytesPerRow">The row's bitmap width, <c>ceil(N / 8)</c>.</param>
     /// <returns>The byte offset within the row's bitmap.</returns>
     public static int ByteOfGroup(int group, int bytesPerRow) => bytesPerRow - 1 - group;
+
+    /// <summary>
+    /// The bytes a row's bitmap occupies, <c>ceil(span / 8)</c>. Written as <c>(span - 1) / 8 + 1</c> rather than
+    /// the usual <c>(span + 7) / 8</c> so it cannot overflow for any positive <paramref name="span"/>.
+    /// </summary>
+    /// <param name="span">The number of elements the bitmap covers; must be positive.</param>
+    /// <returns>The bitmap width in bytes.</returns>
+    public static int BytesPerRow(int span) => ((span - 1) / 8) + 1;
 }
 
 /// <summary>
@@ -42,14 +50,14 @@ internal static class QBitLayout
 /// </para>
 ///
 /// <para>
-/// This non-generic base carries everything that does not depend on whether the elements surface as
-/// <see cref="float"/> or <see cref="double"/>, which is what lets the codec's dense write path recognise a
-/// QBit column and copy its planes without knowing the element type.
+/// This non-generic base carries everything that does not depend on which CLR type the elements surface as,
+/// which is what lets the codec's dense write path recognise a QBit column and copy its planes without knowing
+/// the element type.
 /// </para>
 ///
 /// <para>
 /// The blob is rented from <see cref="ArrayPool{T}"/> and returned on <see cref="Dispose"/>; like every column,
-/// the bytes and any span returned by <see cref="GetPlane"/> are borrowed for the block's lifetime.
+/// the bytes and any span returned by <see cref="GetPlane(int)"/> are borrowed for the block's lifetime.
 /// </para>
 /// </summary>
 internal abstract class QBitColumn : IQBitColumn
@@ -72,7 +80,7 @@ internal abstract class QBitColumn : IQBitColumn
         TypeName = typeName;
         Dimension = dimension;
         BitWidth = bitWidth;
-        BytesPerRow = (dimension + 7) / 8;
+        BytesPerRow = QBitLayout.BytesPerRow(dimension);
         this.blob = blob ?? throw new ArgumentNullException(nameof(blob));
         this.rowCount = rowCount;
         this.pooled = pooled;
@@ -96,8 +104,31 @@ internal abstract class QBitColumn : IQBitColumn
     /// <inheritdoc/>
     public int BytesPerRow { get; }
 
+    /// <summary>
+    /// Always <see cref="Dimension"/>: the strided <c>QBit(T, N, stride)</c> form that 26.7 added is rejected at
+    /// codec resolution, so every column that reaches here is a single group.
+    /// </summary>
+    public int Stride => Dimension;
+
+    /// <summary>Always 1; see <see cref="Stride"/>.</summary>
+    public int GroupCount => 1;
+
     /// <inheritdoc/>
     public ReadOnlySpan<byte> GetPlane(int bit)
+    {
+        // Unreachable while GroupCount is 1, and deliberately so: when the strided layout lands, a caller of this
+        // overload would otherwise get one group's bytes — a shorter span, silently misindexed — instead of an error.
+        if (GroupCount != 1)
+        {
+            throw new InvalidOperationException(
+                $"Column '{Name}' ({TypeName}) has {GroupCount} plane groups, so a plane is not one contiguous run; use GetPlane(bit, group).");
+        }
+
+        return GetPlane(bit, group: 0);
+    }
+
+    /// <inheritdoc/>
+    public ReadOnlySpan<byte> GetPlane(int bit, int group)
     {
         if ((uint)bit >= (uint)BitWidth)
         {
@@ -106,7 +137,14 @@ internal abstract class QBitColumn : IQBitColumn
                 $"Bit {bit} is outside the {BitWidth} plane(s) of column '{Name}' ({TypeName}).");
         }
 
-        return WirePlane(BitWidth - 1 - bit, 0, rowCount);
+        if ((uint)group >= (uint)GroupCount)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(group),
+                $"Group {group} is outside the {GroupCount} group(s) of column '{Name}' ({TypeName}).");
+        }
+
+        return WirePlane(((group * BitWidth) + BitWidth - 1 - bit), 0, rowCount);
     }
 
     /// <inheritdoc/>
@@ -170,7 +208,7 @@ internal abstract class QBitColumn : IQBitColumn
 /// The typed per-row view over a <see cref="QBitColumn"/>: each row's vector as a
 /// <typeparamref name="T"/>[], de-transposed on demand and cached.
 /// </summary>
-/// <typeparam name="T">The CLR element type a row's vector surfaces as — <see cref="float"/> or <see cref="double"/>.</typeparam>
+/// <typeparam name="T">The CLR element type a row's vector surfaces as — <see cref="float"/>, <see cref="double"/> or <see cref="sbyte"/>.</typeparam>
 internal abstract class QBitColumnBase<T> : QBitColumn, IColumn<T[]>
     where T : struct
 {
@@ -193,7 +231,7 @@ internal abstract class QBitColumnBase<T> : QBitColumn, IColumn<T[]>
     /// The rows as per-row vectors, materialized once and cached. Every row costs
     /// <c>BitWidth * BytesPerRow</c> byte fetches to de-transpose — 4 KiB for a 1024-dimension
     /// <c>Float32</c> embedding — so this is built on first use, not on read. Prefer
-    /// <see cref="QBitColumn.GetPlane"/> where the planes themselves are what is wanted.
+    /// <see cref="QBitColumn.GetPlane(int)"/> where the planes themselves are what is wanted.
     /// </summary>
     public ReadOnlySpan<T[]> Values
     {
@@ -298,6 +336,50 @@ internal sealed class QBitFloatColumn : QBitColumnBase<float>
             for (int i = 0; i < bits.Length; i++)
             {
                 bits[i] <<= 16;
+            }
+        }
+
+        return vector;
+    }
+}
+
+/// <summary>
+/// A <c>QBit(Int8, N)</c> column: 8 planes rebuilding each element's raw two's-complement byte.
+/// </summary>
+internal sealed class QBitSByteColumn : QBitColumnBase<sbyte>
+{
+    /// <summary>Initializes an 8-bit integer QBit column.</summary>
+    /// <param name="name">The column name.</param>
+    /// <param name="typeName">The ClickHouse type string.</param>
+    /// <param name="dimension">The vector length <c>N</c>.</param>
+    /// <param name="blob">The plane blob.</param>
+    /// <param name="rowCount">The number of rows.</param>
+    /// <param name="pooled">Whether <paramref name="blob"/> was rented.</param>
+    public QBitSByteColumn(string name, string typeName, int dimension, byte[] blob, int rowCount, bool pooled)
+        : base(name, typeName, dimension, bitWidth: 8, blob, rowCount, pooled)
+    {
+    }
+
+    /// <inheritdoc/>
+    protected override sbyte[] DetransposeRow(int row)
+    {
+        CheckRow(row);
+
+        var vector = new sbyte[Dimension];
+
+        // Gather through the unsigned view, as the float paths do: the bits being collected are the raw
+        // two's-complement pattern, so setting bit 7 gives the negative value without any signed cast.
+        Span<byte> bits = MemoryMarshal.Cast<sbyte, byte>(vector.AsSpan());
+        for (int wireIndex = 0; wireIndex < BitWidth; wireIndex++)
+        {
+            ReadOnlySpan<byte> plane = WirePlaneRow(wireIndex, row);
+            byte mask = (byte)(1 << (BitWidth - 1 - wireIndex));
+            for (int i = 0; i < bits.Length; i++)
+            {
+                if ((plane[QBitLayout.ByteOfGroup(i >> 3, BytesPerRow)] & (1 << (i & 7))) != 0)
+                {
+                    bits[i] |= mask;
+                }
             }
         }
 


### PR DESCRIPTION
Stacked on `tcp/epic-o-sessions` (#578). Implements **K5 `QBit(T, N)`** (read + write) for the native/TCP client — the last real codec in the type epic. Not an alias and not a refusal: it has a layout of its own that the client has to transpose in both directions.

## What QBit is

`QBit(T, N)` stores an `N`-element vector with its **bit planes transposed**, which is what lets a vector search read only the high-order planes and compute an approximate distance at reduced precision (`L2DistanceTransposed`, `cosineDistanceTransposed`). Before this, the type resolved to nothing and a `SELECT` returning one failed the whole query.

`T` is `BFloat16`, `Float32` or `Float64` only — the server rejects everything else. The three-argument stride form documented in the binary type encoding is rejected by 26.6 ("must have exactly two argument"), so only the two-argument form is built.

## Wire layout

No state prefix. The body is `bits(T)` planes, most significant bit first; each plane holds one `ceil(N/8)`-byte bitmap per row, rows contiguous **within** a plane. So the body is plane-major and exactly `bits(T) * num_rows * ceil(N/8)` bytes — every row the same width.

Within a row's bitmap the bits run LSB-first, but **the bytes run in the reverse of the element order**: element `i` is at bit `i % 8` of byte `ceil(N/8) - 1 - i / 8`. Equivalently the bitmap is the big-endian encoding of a `ceil(N/8)`-byte integer whose bit `i` is element `i`.

That byte order is the one thing here worth reviewing carefully — see below.

## CLR surface

`QBit(Float32, N)` and `QBit(BFloat16, N)` surface as `IColumn<float[]>`, `QBit(Float64, N)` as `IColumn<double[]>`. BFloat16 is widened to `float` and narrowed by dropping the low 16 bits, consistent with `BFloat16ColumnCodec` (G2).

The decoded column **keeps the blob transposed** rather than de-transposing on read, so a column read from the server and inserted straight back is a plane copy with no transposition at all. That is the common shape for a vector workload — the distance is computed server-side and the client never looks at a vector — so the per-row vector view is a lazily materialized pooled cache, never eager. De-transposing one row costs `bits × ceil(N/8)` byte fetches, 4 KiB for a 1024-dimension Float32 embedding.

`IQBitColumn` is **new public API**: `Dimension`, `BitWidth`, `BytesPerRow`, and `GetPlane(bit)`. It is indexed by bit *significance* (31 is the sign bit), not wire order, because the high planes are what a reduced-precision distance wants; the accessor hides the MSB-first storage. It is non-generic — planes are raw bits, so plane access does not depend on the element type.

## Write paths

- **Dense** (a `QBitColumn` of the same geometry): one copy per plane. Not one copy for the whole range — the body is plane-major, so a row range is contiguous within a plane but the planes are strided by the *source's* row count.
- **Ergonomic** (`IColumn<float[]>`): transposed into a rented scratch. Plane-major output cannot be streamed a row at a time, since plane 0 needs every row before plane 1 begins, so the scratch is the size of the slice's wire bytes. The dense path avoids it entirely.

## SIMD, write direction only

`Vector256<uint>.ExtractMostSignificantBits()` gathers the top bit of 8 lanes into a byte, which *is* one plane byte for 8 `Float32` elements in the order the wire wants. So a plane costs one extract plus one shift instead of 8 test-and-sets, and walking planes most significant first is just shifting the vector left. BFloat16 needs no narrowing on this path — its 16 planes are the float's top 16. Float64 takes two extracts per byte, since a `Vector256` holds only 4 lanes.

Guarded on `Vector256.IsHardwareAccelerated`, hoisted out of the row loop, with the scalar path as both the fallback and the handler for the sub-8 tail — the `UuidColumnCodec` (G9) shape. No `#if`: the project floors at net8.0.

Ad-hoc timing, 200 rows, Release, net9.0, AVX2 on vs off:

| dimension | scalar | vector | |
|---|---|---|---|
| 1024 | 85.9 ms | 7.3 ms | 11.7× |
| 768 | 55.1 ms | 3.3 ms | 16.5× |

**The read direction is deliberately left scalar.** Movemask has no cheap inverse before AVX-512, the portable sequence is only ~1.5× on op count, and by the type's own usage model the read path only runs when a caller materializes a vector — which most never do. Filed as a follow-up behind a real benchmark project rather than guessed at here.

## The byte order — and why the round-trip corpus could not catch it

The first commit had element `i` at byte `i / 8`, matching what the wire notes said. That is **wrong for `N > 8`**, and it is worth understanding how it survived: every earlier verification used `N = 4` or `N = 8`, where a row is a single byte and the order is unobservable.

An insert round-trip cannot catch it either. It writes and reads with the same client mapping, so a self-consistent layout error round-trips perfectly while putting bytes on the wire the server reads as a different vector. All the `QBit(Float32, 9)` and `QBit(Float32, 17)` corpus cases passed against a real server with the bug present.

What catches it is asymmetry — one side done by the client, the other by the server:

- `QBitIntegrationTests` inserts through the client and has the **server** render the value with `toString()`, then inserts through the server and has the **client** decode it.
- A unit fixture holds real server bytes for a 16-element vector, the narrowest that spans two bytes per row.

Reverting the fix fails exactly those three and none of the 65 symmetric cases.

The mapping was pinned with `QBit(Float32, 72)` (9 bytes per row) by making one element at a time negative and reading the sign plane: element 0 → byte 8 bit 0, element 8 → byte 7 bit 0, element 64 → byte 0 bit 0, element 71 → byte 0 bit 7. `native-format.md` is corrected to match.

## Tests

- **Corpus** (`InsertRoundTripCase`, gated on `TcpFeature.QBit`): Float32 at dimensions 4, 9 and 17; Float64 at 3 and 17; BFloat16 at 4; and `Nullable(QBit(Float32, 4))`, which is the only thing that reads the codec's all-zero placeholder. Dimensions 17 cross two whole 8-element groups plus a tail, so they reach the vector path; anything narrower than 9 is handled entirely by the scalar tail. Signed zero, infinity and NaN pin the sign and exponent planes.
- **Unit** (`QBitColumnCodecTests`): server-captured bytes for dimensions 4 and 16, the significance ordering of `GetPlane`, plane bounds, the row-slice write, the pooled `Values` cache, zero rows, BFloat16 narrowing, `CanWrite` rejections, and the resolution error paths.
- **Asymmetric integration** (`QBitIntegrationTests`): the two directions above, plus `GetPlane` against the server's own value.

3187 tests pass against a local 26.6.

## Notes for review

- No changelog fragment, per the convention for this epic stack.
- `ClickHouse.Driver.Tcp` has no `PublicAPI/*.txt`, so `IQBitColumn` is not analyzer-tracked yet; that lands with R1.
- The vector path's stores are scattered across the plane-major scratch and it manages only ~0.1 GB/s of plane output even so — dimension 1024 costs more per row than 768, which looks like a power-of-two stride conflict. Filed as a follow-up; blocking the rows should recover most of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)