### PR TITLE
ci: publish to NuGet.org with trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,14 +176,15 @@ jobs:
       with:
         user: ${{ secrets.NUGET_USER }}
 
-    # The key reaches the script through the environment, so its value is never interpolated
-    # into the command line.
+    # The key goes through the environment because a ${{ }} expansion is substituted into the
+    # script text before the shell runs. PowerShell then passes the value as one argument
+    # whatever characters it holds, which cmd's %VAR% expansion does not guarantee.
     - name: Push package
       id: push
-      shell: cmd
+      shell: pwsh
       env:
         NUGET_API_KEY: ${{ steps.login.outputs.NUGET_API_KEY }}
-      run: dotnet nuget push ClickHouse.Driver.*.nupkg --skip-duplicate --api-key %NUGET_API_KEY% --source https://api.nuget.org/v3/index.json
+      run: dotnet nuget push ClickHouse.Driver.*.nupkg --skip-duplicate --api-key $env:NUGET_API_KEY --source https://api.nuget.org/v3/index.json
 
   github_release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,20 +152,38 @@ jobs:
         name: package
         path: ${{ github.workspace }}/package/ClickHouse.Driver.*nupkg
 
+  # Publishes with NuGet.org trusted publishing: GitHub issues an OIDC token for this job,
+  # NuGet.org matches it against a policy naming this owner, repository and workflow file, and
+  # returns an API key that is valid for one hour. No long-lived key is stored in the repository.
   push_nuget_org:
     runs-on: windows-latest
     needs: [sign]
     name: Upload to NuGet.org
+    permissions:
+      id-token: write # request the OIDC token that NuGet.org exchanges for an API key
+      contents: read
     steps:
     - name: Download Artifact
       uses: actions/download-artifact@v8
       with:
         name: package
-      
+
+    # NUGET_USER is the NuGet.org username of the account that created the trusted publishing
+    # policy, which is not necessarily the account that owns the packages.
+    - name: Get a short-lived NuGet API key
+      id: login
+      uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
+      with:
+        user: ${{ secrets.NUGET_USER }}
+
+    # The key reaches the script through the environment, so its value is never interpolated
+    # into the command line.
     - name: Push package
       id: push
       shell: cmd
-      run: dotnet nuget push ClickHouse.Driver.*.nupkg --skip-duplicate --api-key ${{ secrets.NUGET_TOKEN }} --source https://api.nuget.org/v3/index.json
+      env:
+        NUGET_API_KEY: ${{ steps.login.outputs.NUGET_API_KEY }}
+      run: dotnet nuget push ClickHouse.Driver.*.nupkg --skip-duplicate --api-key %NUGET_API_KEY% --source https://api.nuget.org/v3/index.json
 
   github_release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why

NuGet.org now caps new API keys at 30 days (from 2026-08-17), and keys created before that date stop working on 2026-11-01. The stored `NUGET_TOKEN` has already expired once; keeping it means rotating a secret every month forever.

[Trusted publishing](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing) replaces the stored key with an OIDC exchange: GitHub issues a signed token for the job, NuGet.org matches it against a policy naming the repository owner, the repository and this workflow file, and returns an API key valid for one hour.

## What changed

Only the `push_nuget_org` job in `.github/workflows/release.yml`:

- `permissions: {id-token: write, contents: read}` so the job can request the OIDC token.
- A `NuGet/login` step, SHA-pinned to `8d19675` (v1.2.0, the current target of the `v1` tag). `.github/zizmor.yml` requires a hash pin outside `actions/*`, `github/*` and `ClickHouse/*`; Dependabot's `github-actions` entry will keep it current.
- The push takes the short-lived key instead of `secrets.NUGET_TOKEN`, passed through `env:` rather than interpolated into the `run:` block.

Nothing else in the release path moves. Build, signing and the GitHub release are untouched.

## Setup needed before the next release

This PR alone does not make a release work. Two things have to exist first:

1. A trusted publishing policy on NuGet.org (account menu -> Trusted Publishing), owned by the ClickHouse organisation so it covers the organisation's packages. Repository Owner `ClickHouse`, Repository `clickhouse-cs`, Workflow File `release.yml`, Environment blank.
2. A `NUGET_USER` repository secret holding the NuGet.org **username of the account that created the policy** — not an email address, and not the organisation name.

`NUGET_TOKEN` should be deleted after the first release that publishes this way, not before.

## Notes

- No GitHub environment is used, so the policy is not tied to a branch. A backport release dispatched from a branch off an older tag keeps working.
- The policy is keyed on the literal filename `release.yml`. Renaming that file breaks publishing until the policy is updated.
- The repository is public, so the policy activates permanently on creation. The 7-day pending window applies only to private repositories.
- An organisation-owned policy goes inactive if its creator leaves the organisation, and returns when they rejoin.

## Verification

The zizmor gate runs on this PR because it touches `.github/workflows/**`. Audited against the merge tree with the repository config: zero findings, matching the `origin/main` baseline exactly.

The narrowed `GITHUB_TOKEN` scope is safe for the artifact download — the existing `github_release` job already does a same-run `actions/download-artifact@v8` under job-scoped `permissions: contents: write` with no `actions: read`.

The publish path itself cannot be exercised without a real release; the first release using it is the real test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)