### PR TITLE
fix: make ClickHouseDataReader.IsClosed reflect disposal

### DIFF
--- a/ClickHouse.Driver.Tests/ADO/DataReaderTests.cs
+++ b/ClickHouse.Driver.Tests/ADO/DataReaderTests.cs
@@ -21,6 +21,39 @@ public class DataReaderTests : AbstractConnectionTestFixture
     }
 
     [Test]
+    public async Task IsClosed_AfterClose_ReturnsTrue()
+    {
+        using var reader = await connection.ExecuteReaderAsync("SELECT 1 as value");
+        Assert.That(reader.IsClosed, Is.False);
+
+        reader.Close();
+
+        Assert.That(reader.IsClosed, Is.True);
+    }
+
+    [Test]
+    public async Task IsClosed_AfterDispose_ReturnsTrue()
+    {
+        using var reader = await connection.ExecuteReaderAsync("SELECT 1 as value");
+        Assert.That(reader.IsClosed, Is.False);
+
+        reader.Dispose();
+
+        Assert.That(reader.IsClosed, Is.True);
+    }
+
+    [Test]
+    public async Task IsClosed_AfterDisposeAsync_ReturnsTrue()
+    {
+        await using var reader = await connection.ExecuteReaderAsync("SELECT 1 as value");
+        Assert.That(reader.IsClosed, Is.False);
+
+        await reader.DisposeAsync();
+
+        Assert.That(reader.IsClosed, Is.True);
+    }
+
+    [Test]
     public async Task ShouldReadFieldByName()
     {
         using var reader = await connection.ExecuteReaderAsync("SELECT 1 as value");

--- a/ClickHouse.Driver/ADO/Readers/ClickHouseDataReader.cs
+++ b/ClickHouse.Driver/ADO/Readers/ClickHouseDataReader.cs
@@ -50,6 +50,7 @@ public class ClickHouseDataReader : DbDataReader, IEnumerator<IDataReader>, IEnu
     // NullReferenceException instead of the intended InvalidOperationException.
     private ColumnSlot[] slots;
     private bool hasCurrentRow;
+    private bool isClosed;
 
     private ClickHouseDataReader(HttpResponseMessage httpResponse, ExtendedBinaryReader reader, PooledReadBufferStream pooledReadBuffer, string[] names, ClickHouseType[] types, string[] rawTypeNames, PocoTypeRegistry pocoRegistry, ExceptionTagAwareStream exceptionTagStream = null, IReadValueConverter readValueConverter = null, Stream decompressor = null)
     {
@@ -197,7 +198,7 @@ public class ClickHouseDataReader : DbDataReader, IEnumerator<IDataReader>, IEnu
 
     public override int FieldCount => RawTypes?.Length ?? throw new InvalidOperationException();
 
-    public override bool IsClosed => false;
+    public override bool IsClosed => isClosed;
 
     public sealed override bool HasRows => true;
 
@@ -744,6 +745,8 @@ public class ClickHouseDataReader : DbDataReader, IEnumerator<IDataReader>, IEnu
 #pragma warning disable CA2215 // Dispose methods should call base class dispose
     protected override void Dispose(bool disposing)
     {
+        isClosed = true;
+
         if (disposing)
         {
             httpResponse?.Dispose();

--- a/changelog.d/fix-reader-isclosed.fixes.md
+++ b/changelog.d/fix-reader-isclosed.fixes.md
@@ -1,0 +1,1 @@
+* Fixed `ClickHouseDataReader.IsClosed` to report `true` after the reader is closed or disposed.


### PR DESCRIPTION
## Summary

`ClickHouseDataReader.IsClosed` always returned `false`, even after `Close()` or `Dispose()`.

- **Fix:** Track the closed state in `Dispose(bool)`.
- **Test:** Add a regression test for `Close()`.
- **Changelog:** Add a bug-fix fragment.

## Checklist

- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG