### PR TITLE
TCP T1/T2: native-client benchmarks, the transport comparison, and a working comparison job

### DIFF
--- a/.github/workflows/benchmark-compare.yml
+++ b/.github/workflows/benchmark-compare.yml
@@ -7,10 +7,18 @@ on:
         description: 'PR number to benchmark (leave empty if running on PR branch)'
         required: false
         type: string
+      baseline_ref:
+        description: 'Ref to compare against. Empty uses the PR base branch, so a stacked PR compares against its own base rather than main.'
+        required: false
+        type: string
+      categories:
+        description: 'BenchmarkDotNet categories, comma-separated. Empty selects them from the changed files. Pass "all" to run everything.'
+        required: false
+        type: string
 
 jobs:
   benchmark-compare:
-    name: Compare PR vs Main
+    name: Compare PR vs baseline
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -20,6 +28,7 @@ jobs:
         image: clickhouse/clickhouse-server:latest
         ports:
           - 8123:8123
+          - 9000:9000
         env:
           CLICKHOUSE_DB: test
           CLICKHOUSE_USER: test
@@ -32,12 +41,8 @@ jobs:
         with:
           ref: ${{ inputs.pr_number && format('refs/pull/{0}/head', inputs.pr_number) || '' }}
           path: pr
-
-      - name: Checkout main branch
-        uses: actions/checkout@v7
-        with:
-          ref: main
-          path: main
+          fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
@@ -52,55 +57,160 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-nuget-
 
-      # The input reaches the run script through the environment rather than being interpolated
-      # into it, so a workflow_dispatch input cannot inject shell.
-      - name: Get PR number
-        id: pr
-        run: |
-          PR_NUM="$INPUT_PR_NUMBER"
-          if [ -z "$PR_NUM" ]; then
-            cd pr
-            PR_NUM=$(gh pr view --json number -q .number 2>/dev/null || echo "local")
-            cd ..
-          fi
-          echo "number=$PR_NUM" >> $GITHUB_OUTPUT
+      - name: Resolve PR, baseline and categories
+        id: plan
+        working-directory: pr
         env:
           GH_TOKEN: ${{ github.token }}
           INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+          INPUT_BASELINE_REF: ${{ inputs.baseline_ref }}
+          INPUT_CATEGORIES: ${{ inputs.categories }}
+        run: |
+          set -euo pipefail
 
-      - name: Build main package
+          PR_NUM="$INPUT_PR_NUMBER"
+          if [ -z "$PR_NUM" ]; then
+            PR_NUM=$(gh pr view --json number -q .number 2>/dev/null || echo "local")
+          fi
+          echo "number=$PR_NUM" >> $GITHUB_OUTPUT
+
+          # A tcp/** PR sits on a stack whose base is not main, and its benchmarks can reference code
+          # main does not have. Comparing against the PR's own base keeps the baseline compilable.
+          BASELINE="$INPUT_BASELINE_REF"
+          if [ -z "$BASELINE" ] && [ "$PR_NUM" != "local" ]; then
+            BASELINE=$(gh pr view "$PR_NUM" --json baseRefName -q .baseRefName 2>/dev/null || true)
+          fi
+          BASELINE="${BASELINE:-main}"
+          echo "baseline=$BASELINE" >> $GITHUB_OUTPUT
+          echo "Baseline ref: $BASELINE"
+
+          CATEGORIES="$INPUT_CATEGORIES"
+          if [ "$CATEGORIES" = "all" ]; then
+            echo "categories=" >> $GITHUB_OUTPUT
+            echo "Running every benchmark."
+            exit 0
+          fi
+
+          if [ -n "$CATEGORIES" ]; then
+            echo "categories=$CATEGORIES" >> $GITHUB_OUTPUT
+            echo "Categories from input: $CATEGORIES"
+            exit 0
+          fi
+
+          # Select the benchmark set from what the PR touched, so a TCP-only change does not pay for
+          # the HTTP suite and the other way round.
+          if [ "$PR_NUM" != "local" ]; then
+            CHANGED=$(gh pr diff "$PR_NUM" --name-only)
+          else
+            git fetch --no-tags --depth=1 origin "$BASELINE"
+            CHANGED=$(git diff --name-only FETCH_HEAD...HEAD)
+          fi
+          echo "Changed files:"
+          echo "$CHANGED" | sed 's/^/  /'
+
+          SELECTED=""
+          add() { case " $SELECTED " in *" $1 "*) ;; *) SELECTED="$SELECTED $1" ;; esac; }
+
+          if echo "$CHANGED" | grep -q '^ClickHouse\.Driver\.Benchmark/'; then
+            # The harness itself moved, so no arm can be assumed unaffected.
+            echo "categories=" >> $GITHUB_OUTPUT
+            echo "Benchmark project changed; running every benchmark."
+            exit 0
+          fi
+
+          if echo "$CHANGED" | grep -q '^ClickHouse\.Driver\.Tcp/'; then
+            add tcp-regression
+          fi
+          if echo "$CHANGED" | grep -q '^ClickHouse\.Driver/'; then
+            add http-regression
+          fi
+          if echo "$CHANGED" | grep -q '^ClickHouse\.Driver\.Common/'; then
+            # Shared: the compression codecs and CityHash serve both transports.
+            add http-regression
+            add tcp-regression
+            add compression
+          fi
+          # The frame reader and writer live in the TCP project, and the regression sets only ever
+          # run the default codec.
+          if echo "$CHANGED" | grep -q '^ClickHouse\.Driver\.Tcp/Compression/'; then
+            add compression
+          fi
+
+          # Both transports moved together, which is the case where the cross-transport table says
+          # something the per-transport ones cannot.
+          case " $SELECTED " in
+            *" http-regression "*)
+              case " $SELECTED " in *" tcp-regression "*) add cross ;; esac
+              ;;
+          esac
+
+          if [ -z "$SELECTED" ]; then
+            SELECTED="http-regression tcp-regression"
+            echo "No driver sources changed; falling back to both regression sets."
+          fi
+
+          SELECTED=$(echo "$SELECTED" | xargs | tr ' ' ',')
+          echo "categories=$SELECTED" >> $GITHUB_OUTPUT
+          echo "Selected categories: $SELECTED"
+
+      - name: Checkout baseline branch
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ steps.plan.outputs.baseline }}
+          path: baseline
+          persist-credentials: false
+
+      - name: Build baseline package
         run: |
           mkdir -p pr/.nupkg
-          dotnet build main/ClickHouse.Driver/ClickHouse.Driver.csproj \
+          dotnet build baseline/ClickHouse.Driver/ClickHouse.Driver.csproj \
             --configuration Release \
-            /p:Version=0.0.0-main
-          cp main/ClickHouse.Driver/bin/Release/*.nupkg pr/.nupkg/
+            /p:Version=0.0.0-baseline
+          cp baseline/ClickHouse.Driver/bin/Release/*.nupkg pr/.nupkg/
 
       - name: Build PR package
+        env:
+          PR_NUMBER: ${{ steps.plan.outputs.number }}
         run: |
           dotnet build pr/ClickHouse.Driver/ClickHouse.Driver.csproj \
             --configuration Release \
-            /p:Version=0.0.0-pr.${{ steps.pr.outputs.number }}
+            "/p:Version=0.0.0-pr.${PR_NUMBER}"
           cp pr/ClickHouse.Driver/bin/Release/*.nupkg pr/.nupkg/
 
       - name: Run comparison benchmarks
         working-directory: pr
+        env:
+          CLICKHOUSE_CONNECTION: Host=localhost;Port=8123;Username=test;Password=test1234
+          CLICKHOUSE_TCP_CONNECTION_STRING: Host=localhost;Port=9000;Username=test;Password=test1234
+          BASELINE_VERSION: 0.0.0-baseline
+          PR_VERSION: 0.0.0-pr.${{ steps.plan.outputs.number }}
+          NUGET_SOURCE: ${{ github.workspace }}/pr/.nupkg
+          CATEGORIES: ${{ steps.plan.outputs.categories }}
         run: |
+          CATEGORY_ARG=""
+          if [ -n "$CATEGORIES" ]; then
+            CATEGORY_ARG="--anyCategories $(echo "$CATEGORIES" | tr ',' ' ')"
+          fi
+          # The outer build must resolve the same package the baseline job uses. Left unpinned it
+          # takes the ClickHouseDriverVersion default from Directory.Packages.props, restores that
+          # release from nuget.org, and fails to compile against any API added since it.
           dotnet run \
             --project ClickHouse.Driver.Benchmark/ClickHouse.Driver.Benchmark.csproj \
             --framework net10.0 \
             --configuration Release \
+            --no-launch-profile \
             -p:BenchmarkComparisonMode=true \
-            -- --join --filter "*" --artifacts .
-        env:
-          CLICKHOUSE_CONNECTION: Host=localhost;Port=8123;Username=test;Password=test1234
-          BASELINE_VERSION: 0.0.0-main
-          PR_VERSION: 0.0.0-pr.${{ steps.pr.outputs.number }}
-          NUGET_SOURCE: ${{ github.workspace }}/pr/.nupkg
+            -p:ClickHouseDriverVersion=$BASELINE_VERSION \
+            -p:RestoreAdditionalProjectSources=$NUGET_SOURCE \
+            -- --join --filter "*" $CATEGORY_ARG --artifacts .
 
       - name: Post results to PR
-        if: steps.pr.outputs.number != 'local'
+        if: steps.plan.outputs.number != 'local'
         uses: actions/github-script@v9
+        env:
+          BASELINE_REF: ${{ steps.plan.outputs.baseline }}
+          CATEGORIES: ${{ steps.plan.outputs.categories }}
+          PR_NUMBER: ${{ steps.plan.outputs.number }}
         with:
           script: |
             const fs = require('fs');
@@ -111,11 +221,12 @@ jobs:
               .filter(f => f.endsWith('-report-github.md'))
               .map(f => path.join(resultsDir, f));
 
-            const prNumber = parseInt('${{ steps.pr.outputs.number }}');
+            const prNumber = Number.parseInt(process.env.PR_NUMBER, 10);
 
             let body = '## Benchmark Comparison\n\n';
-            body += `**Baseline:** main branch\n`;
-            body += `**PR:** #${prNumber}\n\n`;
+            body += `**Baseline:** \`${process.env.BASELINE_REF}\`\n`;
+            body += `**PR:** #${prNumber}\n`;
+            body += `**Categories:** ${process.env.CATEGORIES || 'all'}\n\n`;
 
             for (const file of files) {
               const content = fs.readFileSync(file, 'utf8');

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,6 +6,17 @@ on:
     paths-ignore:
     - '**/*.md'
   workflow_dispatch:
+    inputs:
+      categories:
+        description: 'BenchmarkDotNet categories, comma-separated. Empty runs everything.'
+        required: false
+        type: string
+  workflow_call:
+    inputs:
+      categories:
+        description: 'BenchmarkDotNet categories, comma-separated. Empty runs everything.'
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -19,6 +30,7 @@ jobs:
         image: clickhouse/clickhouse-server:latest
         ports:
           - 8123:8123
+          - 9000:9000
         env:
           CLICKHOUSE_DB: test
           CLICKHOUSE_USER: test
@@ -28,7 +40,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7
       name: Checkout
-    
+
     - uses: actions/cache@v6
       name: Cache NuGet
       with:
@@ -44,9 +56,28 @@ jobs:
           10.x
 
     - name: Run
-      run: dotnet run --project ClickHouse.Driver.Benchmark/ClickHouse.Driver.Benchmark.csproj --framework net10.0 --configuration Release -- --join --filter "*" --artifacts .
       env:
         CLICKHOUSE_CONNECTION: Host=localhost;Port=8123;Username=test;Password=test1234
+        CLICKHOUSE_TCP_CONNECTION_STRING: Host=localhost;Port=9000;Username=test;Password=test1234
+        INPUT_CATEGORIES: ${{ inputs.categories }}
+        EVENT_NAME: ${{ github.event_name }}
+      run: |
+        # A push to main runs the regression sets. The whole suite runs nightly, where an hours-long
+        # job costs nothing; a dispatch or a nightly call with no categories also runs everything.
+        CATEGORIES="$INPUT_CATEGORIES"
+        if [ -z "$CATEGORIES" ] && [ "$EVENT_NAME" = "push" ]; then
+          CATEGORIES="http-regression,tcp-regression,cross"
+        fi
+        CATEGORY_ARG=""
+        if [ -n "$CATEGORIES" ]; then
+          CATEGORY_ARG="--anyCategories $(echo "$CATEGORIES" | tr ',' ' ')"
+        fi
+        echo "Categories: ${CATEGORIES:-all}"
+        dotnet run --project ClickHouse.Driver.Benchmark/ClickHouse.Driver.Benchmark.csproj \
+          --framework net10.0 \
+          --configuration Release \
+          --no-launch-profile \
+          -- --join --filter "*" $CATEGORY_ARG --artifacts .
 
     - name: Post results to summary
       run: cat results/*-report-github.md >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,6 +6,9 @@ on:
     - cron: '0 2 * * *'
   workflow_dispatch: # Allow manual triggering
 
+permissions:
+  contents: read
+
 jobs:
   test-head:
     name: Test against ClickHouse HEAD
@@ -15,3 +18,9 @@ jobs:
       clickhouse-version: head
     permissions:
       statuses: write
+
+  benchmark-full:
+    name: Full benchmark suite
+    uses: ./.github/workflows/benchmark.yml
+    with:
+      categories: ''

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,6 +21,6 @@ jobs:
 
   benchmark-full:
     name: Full benchmark suite
-    uses: ./.github/workflows/benchmark.yml
+    uses: $/.github/workflows/benchmark.yml
     with:
       categories: ''

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,16 +112,45 @@ ClickHouse.Driver.Tests/coverage.net9.0.opencover.xml
 
 ### Running benchmarks
 
-Benchmarks use BenchmarkDotNet and require a running ClickHouse instance:
+Benchmarks use BenchmarkDotNet and require a running ClickHouse instance. `CLICKHOUSE_CONNECTION`
+carries the HTTP connection string. `CLICKHOUSE_TCP_CONNECTION_STRING` carries the native one; with
+it unset, the native endpoint is derived from the HTTP string on port 9000.
 
 ```bash
 dotnet run --project ClickHouse.Driver.Benchmark/ClickHouse.Driver.Benchmark.csproj \
-  --framework net9.0 \
   --configuration Release \
-  -- --join --filter "*" --artifacts ./results --job Short
+  -- --join --filter "*" --artifacts ./results
 ```
 
 Results will be saved in the `results/` directory.
+
+Every benchmark class carries a category, and the CI runs select on them:
+
+| Category | Covers |
+| --- | --- |
+| `http-regression` | HTTP throughput and allocation |
+| `tcp-regression` | Native protocol throughput and allocation |
+| `cross` | The same workload over both transports |
+| `http-investigation`, `tcp-investigation` | One issue or one past optimization |
+| `compression` | Codecs and framing, shared by both transports |
+
+```bash
+dotnet run --project ClickHouse.Driver.Benchmark/ClickHouse.Driver.Benchmark.csproj \
+  --configuration Release \
+  -- --join --filter "*" --anyCategories tcp-regression cross --artifacts ./results
+```
+
+A pull request runs the categories its changed files select, in
+`.github/workflows/benchmark-compare.yml`. The nightly build runs all of them.
+
+The full iteration counts take hours. For a quick local pass, `BENCH_WARMUP`, `BENCH_ITERATIONS` and
+`BENCH_LAUNCHES` override them:
+
+```bash
+BENCH_WARMUP=1 BENCH_ITERATIONS=5 BENCH_LAUNCHES=1 \
+  dotnet run --project ClickHouse.Driver.Benchmark/ClickHouse.Driver.Benchmark.csproj \
+  --configuration Release -- --join --filter "*TcpReadTiers*" --artifacts ./results
+```
 
 ### Testing against different ClickHouse versions
 

--- a/ClickHouse.Driver.Benchmark/AdoReadPathBenchmark.cs
+++ b/ClickHouse.Driver.Benchmark/AdoReadPathBenchmark.cs
@@ -65,7 +65,7 @@ FROM system.numbers LIMIT {Count}";
     [GlobalCleanup]
     public void Cleanup() => connection?.Dispose();
 
-    [Benchmark(Baseline = true)]
+    [Benchmark(Baseline = BenchmarkModes.MethodBaseline)]
     public async Task UntypedAccessor()
     {
         using var reader = await connection.ExecuteReaderAsync(Sql);

--- a/ClickHouse.Driver.Benchmark/AdoReadPathBenchmark.cs
+++ b/ClickHouse.Driver.Benchmark/AdoReadPathBenchmark.cs
@@ -29,6 +29,7 @@ namespace ClickHouse.Driver.Benchmark;
 ///   punished hardest.</item>
 /// </list>
 /// </summary>
+[BenchmarkCategory(BenchmarkCategories.HttpInvestigation)]
 [Config(typeof(ComparisonConfig))]
 [MemoryDiagnoser(true)]
 public class AdoReadPathBenchmark

--- a/ClickHouse.Driver.Benchmark/ArrayInsertElementBoxing.cs
+++ b/ClickHouse.Driver.Benchmark/ArrayInsertElementBoxing.cs
@@ -23,6 +23,7 @@ namespace ClickHouse.Driver.Benchmark;
 /// </list>
 /// Inserts into <c>Null</c>-engine tables to isolate client serialization.
 /// </summary>
+[BenchmarkCategory(BenchmarkCategories.HttpInvestigation)]
 [Config(typeof(ComparisonConfig))]
 [MemoryDiagnoser(true)]
 public class ArrayInsertElementBoxing

--- a/ClickHouse.Driver.Benchmark/BatchQueryLineBenchmark.cs
+++ b/ClickHouse.Driver.Benchmark/BatchQueryLineBenchmark.cs
@@ -22,6 +22,7 @@ namespace ClickHouse.Driver.Benchmark;
 /// The table uses ENGINE Null so the server discards rows and the benchmark isolates client-side
 /// serialization cost rather than storage.
 /// </summary>
+[BenchmarkCategory(BenchmarkCategories.HttpInvestigation)]
 [Config(typeof(ComparisonConfig))]
 [MemoryDiagnoser(true)]
 public class BatchQueryLineBenchmark

--- a/ClickHouse.Driver.Benchmark/BenchmarkCategories.cs
+++ b/ClickHouse.Driver.Benchmark/BenchmarkCategories.cs
@@ -1,0 +1,38 @@
+namespace ClickHouse.Driver.Benchmark;
+
+/// <summary>
+/// The category names the CI workflows filter on with <c>--anyCategories</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>benchmark-compare.yml</c> picks the set from the files a PR changed: a change under
+/// <c>ClickHouse.Driver.Tcp/</c> selects <see cref="TcpRegression"/>, one under
+/// <c>ClickHouse.Driver/</c> selects <see cref="HttpRegression"/>, and one under
+/// <c>ClickHouse.Driver.Common/</c> selects both plus <see cref="Compression"/>. When both
+/// transports move, <see cref="Cross"/> is added.
+/// </para>
+/// <para>
+/// A benchmark class with no category matches no <c>--anyCategories</c> run, so it would appear
+/// only in the nightly full sweep. <c>Program</c> fails the run rather than let that pass silently.
+/// </para>
+/// </remarks>
+public static class BenchmarkCategories
+{
+    /// <summary>HTTP transport, standing throughput and allocation coverage.</summary>
+    public const string HttpRegression = "http-regression";
+
+    /// <summary>Native TCP transport, standing throughput and allocation coverage.</summary>
+    public const string TcpRegression = "tcp-regression";
+
+    /// <summary>Runs the same workload over both transports in one process.</summary>
+    public const string Cross = "cross";
+
+    /// <summary>HTTP, pinned to one issue or one past optimization.</summary>
+    public const string HttpInvestigation = "http-investigation";
+
+    /// <summary>Native TCP, pinned to one issue or one past optimization.</summary>
+    public const string TcpInvestigation = "tcp-investigation";
+
+    /// <summary>Compression codecs and framing, shared by both transports.</summary>
+    public const string Compression = "compression";
+}

--- a/ClickHouse.Driver.Benchmark/BenchmarkModes.cs
+++ b/ClickHouse.Driver.Benchmark/BenchmarkModes.cs
@@ -1,0 +1,30 @@
+namespace ClickHouse.Driver.Benchmark;
+
+/// <summary>
+/// Compile-time switches that differ between a local run and a CI comparison run.
+/// </summary>
+public static class BenchmarkModes
+{
+    /// <summary>
+    /// Whether a class that exists to compare two approaches should mark one of them as the
+    /// baseline: <c>true</c> locally and in the nightly sweep, <c>false</c> in comparison mode.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Use it in place of a literal: <c>[Benchmark(Baseline = BenchmarkModes.MethodBaseline)]</c>.
+    /// </para>
+    /// <para>
+    /// BenchmarkDotNet accepts a baseline method or a baseline job, not both. A single job runs
+    /// locally, so the method baseline is what gives those classes their point — POCO against
+    /// <c>GetValue</c>, blit against boxing. Comparison mode instead runs two jobs, one per package
+    /// version, and the question there is whether the PR moved each benchmark; a method baseline
+    /// answers a different question and, worse, wins over the job, leaving every other row's ratio a
+    /// mix of the two effects.
+    /// </para>
+    /// </remarks>
+#if BENCHMARK_COMPARISON
+    public const bool MethodBaseline = false;
+#else
+    public const bool MethodBaseline = true;
+#endif
+}

--- a/ClickHouse.Driver.Benchmark/BenchmarkServer.cs
+++ b/ClickHouse.Driver.Benchmark/BenchmarkServer.cs
@@ -1,0 +1,60 @@
+using System;
+using ClickHouse.Driver.ADO;
+using ClickHouse.Driver.Tcp;
+
+namespace ClickHouse.Driver.Benchmark;
+
+/// <summary>
+/// Resolves the server both transports dial, so a cross-transport benchmark cannot accidentally
+/// measure two different endpoints.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>CLICKHOUSE_CONNECTION</c> carries the HTTP connection string, as the existing benchmarks
+/// already expect. <c>CLICKHOUSE_TCP_CONNECTION_STRING</c> carries its native counterpart, named as
+/// in the examples project.
+/// </para>
+/// <para>
+/// With only the HTTP variable set, the native string is derived from it: same host, user, password
+/// and database, on the native port. That keeps a local run honest without asking for two variables.
+/// </para>
+/// </remarks>
+public static class BenchmarkServer
+{
+    private const int NativePort = 9000;
+
+    /// <summary>The HTTP connection string.</summary>
+    public static string Http { get; } = Env("CLICKHOUSE_CONNECTION") ?? "Host=localhost";
+
+    /// <summary>The native-protocol connection string.</summary>
+    public static string Tcp { get; } = Env("CLICKHOUSE_TCP_CONNECTION_STRING") ?? DeriveNativeFromHttp();
+
+    /// <summary>Creates a native client for the resolved endpoint. The caller owns it.</summary>
+    public static ClickHouseTcpClient CreateTcpClient() => new(Tcp);
+
+    /// <summary>Creates a native client with one option overridden. The caller owns it.</summary>
+    public static ClickHouseTcpClient CreateTcpClient(Func<ClickHouseTcpConnectionStringBuilder, ClickHouseTcpConnectionStringBuilder> configure)
+    {
+        var builder = configure(new ClickHouseTcpConnectionStringBuilder(Tcp));
+        return new ClickHouseTcpClient(builder.ToString());
+    }
+
+    private static string DeriveNativeFromHttp()
+    {
+        var http = new ClickHouseConnectionStringBuilder(Http);
+        return new ClickHouseTcpConnectionStringBuilder
+        {
+            Host = http.Host,
+            Port = NativePort,
+            Username = http.Username,
+            Password = http.Password,
+            Database = http.Database,
+        }.ToString();
+    }
+
+    private static string Env(string name)
+    {
+        var value = Environment.GetEnvironmentVariable(name);
+        return string.IsNullOrWhiteSpace(value) ? null : value;
+    }
+}

--- a/ClickHouse.Driver.Benchmark/BenchmarkServer.cs
+++ b/ClickHouse.Driver.Benchmark/BenchmarkServer.cs
@@ -29,8 +29,30 @@ public static class BenchmarkServer
     /// <summary>The native-protocol connection string.</summary>
     public static string Tcp { get; } = Env("CLICKHOUSE_TCP_CONNECTION_STRING") ?? DeriveNativeFromHttp();
 
+    /// <summary>
+    /// The HTTP connection string with compression off, for a cross-transport comparison.
+    /// </summary>
+    /// <remarks>
+    /// The two transports do not default to the same codec — HTTP to gzip/ZSTD, the native client to
+    /// LZ4 — so a comparison at their defaults reports the codec difference as a transport
+    /// difference. Over loopback a codec costs CPU and saves nothing, so the uncompressed pair is the
+    /// one that answers "which client does less work". Pair with
+    /// <see cref="CreateUncompressedTcpClient"/>, and see <see cref="TcpCompression"/> for the codec
+    /// axis itself.
+    /// </remarks>
+    public static string HttpUncompressed { get; } =
+        new ClickHouseConnectionStringBuilder(Http) { Compression = false }.ToString();
+
     /// <summary>Creates a native client for the resolved endpoint. The caller owns it.</summary>
     public static ClickHouseTcpClient CreateTcpClient() => new(Tcp);
+
+    /// <summary>Creates a native client with compression off, matching <see cref="HttpUncompressed"/>.</summary>
+    public static ClickHouseTcpClient CreateUncompressedTcpClient() =>
+        CreateTcpClient(builder =>
+        {
+            builder.Compression = "none";
+            return builder;
+        });
 
     /// <summary>Creates a native client with one option overridden. The caller owns it.</summary>
     public static ClickHouseTcpClient CreateTcpClient(Func<ClickHouseTcpConnectionStringBuilder, ClickHouseTcpConnectionStringBuilder> configure)

--- a/ClickHouse.Driver.Benchmark/BinaryInsertCompressionBenchmark.cs
+++ b/ClickHouse.Driver.Benchmark/BinaryInsertCompressionBenchmark.cs
@@ -24,6 +24,7 @@ namespace ClickHouse.Driver.Benchmark;
 /// The table uses ENGINE Null so the server discards rows and the benchmark isolates client-side
 /// serialization + compression + transport rather than storage.
 /// </summary>
+[BenchmarkCategory(BenchmarkCategories.Compression)]
 [Config(typeof(ComparisonConfig))]
 [MemoryDiagnoser(true)]
 public class BinaryInsertCompressionBenchmark

--- a/ClickHouse.Driver.Benchmark/BinaryInsertObjectArrayBenchmark.cs
+++ b/ClickHouse.Driver.Benchmark/BinaryInsertObjectArrayBenchmark.cs
@@ -20,6 +20,7 @@ namespace ClickHouse.Driver.Benchmark;
 /// The table uses ENGINE Null so the server discards rows and the benchmark isolates client-side
 /// batching/serialization cost rather than storage.
 /// </summary>
+[BenchmarkCategory(BenchmarkCategories.HttpInvestigation)]
 [Config(typeof(ComparisonConfig))]
 [MemoryDiagnoser(true)]
 public class BinaryInsertObjectArrayBenchmark

--- a/ClickHouse.Driver.Benchmark/BinaryInsertStreamingBenchmark.cs
+++ b/ClickHouse.Driver.Benchmark/BinaryInsertStreamingBenchmark.cs
@@ -22,6 +22,7 @@ namespace ClickHouse.Driver.Benchmark;
 /// Peak values are written to <c>streaming-peak-memory.txt</c> in the working directory so a
 /// before/after comparison survives across the two benchmark runs.
 /// </summary>
+[BenchmarkCategory(BenchmarkCategories.HttpInvestigation)]
 [Config(typeof(ComparisonConfig))]
 [MemoryDiagnoser(true)]
 public class BinaryInsertStreamingBenchmark
@@ -98,7 +99,7 @@ public class BinaryInsertStreamingBenchmark
         client?.Dispose();
     }
 
-    [Benchmark(Baseline = true)]
+    [Benchmark(Baseline = BenchmarkModes.MethodBaseline)]
     public async Task<long> ObjectArray()
     {
         var options = new InsertOptions { BatchSize = BatchRows, MaxDegreeOfParallelism = Degree };

--- a/ClickHouse.Driver.Benchmark/BulkInsertColumn.cs
+++ b/ClickHouse.Driver.Benchmark/BulkInsertColumn.cs
@@ -9,6 +9,7 @@ using ClickHouse.Driver.Utility;
 
 namespace ClickHouse.Driver.Benchmark;
 
+[BenchmarkCategory(BenchmarkCategories.HttpRegression)]
 [Config(typeof(ComparisonConfig))]
 [MemoryDiagnoser(true)]
 public class BulkInsertColumn

--- a/ClickHouse.Driver.Benchmark/ClickHouse.Driver.Benchmark.csproj
+++ b/ClickHouse.Driver.Benchmark/ClickHouse.Driver.Benchmark.csproj
@@ -7,6 +7,8 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <LangVersion>latest</LangVersion>
+    <!-- CHTCP0001: the native-TCP client is experimental; the benchmarks opt in to measuring it. -->
+    <NoWarn>$(NoWarn);CHTCP0001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -32,7 +34,17 @@
     <!-- Compression types (incl. LZ4) live in the bundled (PrivateAssets="all") Common assembly;
          reference it directly for local dev. In comparison mode the types come from Common.dll inside the package. -->
     <ProjectReference Include="..\ClickHouse.Driver.Common\ClickHouse.Driver.Common.csproj" />
+    <!-- The native client is bundled into the ClickHouse.Driver package the same way, so comparison
+         mode picks it up from Tcp.dll inside the package. -->
+    <ProjectReference Include="..\ClickHouse.Driver.Tcp\ClickHouse.Driver.Tcp.csproj" />
   </ItemGroup>
+  <!-- BenchmarkDotNet takes either a baseline method or a baseline job, not both: given both, the
+       method wins and every other row's ratio silently mixes the two effects. Comparison mode needs
+       the job to be the baseline, so BenchmarkModes.MethodBaseline turns the method baselines off
+       there. See BenchmarkModes. -->
+  <PropertyGroup Condition="'$(BenchmarkComparisonMode)' == 'true'">
+    <DefineConstants>$(DefineConstants);BENCHMARK_COMPARISON</DefineConstants>
+  </PropertyGroup>
   <ItemGroup Condition="'$(BenchmarkComparisonMode)' == 'true'">
     <PackageReference Include="ClickHouse.Driver" />
   </ItemGroup>

--- a/ClickHouse.Driver.Benchmark/ComparisonConfig.cs
+++ b/ClickHouse.Driver.Benchmark/ComparisonConfig.cs
@@ -55,6 +55,12 @@ public class ComparisonConfig : ManualConfig
             SummaryStyle = SummaryStyle.Default
                 .WithRatioStyle(RatioStyle.Percentage);
 
+            // Group each method's two jobs together, so the ratio reads pr-against-baseline for that
+            // method. Without this a class carrying [Benchmark(Baseline = true)] makes that one method
+            // the baseline for the whole table, and every other row's ratio mixes the transport change
+            // with the method difference — unreadable as a regression signal.
+            AddLogicalGroupRules(BenchmarkLogicalGroupRule.ByMethod);
+
             HideColumns(Column.Arguments);
             AddColumn(StatisticColumn.P95);
         }
@@ -63,6 +69,9 @@ public class ComparisonConfig : ManualConfig
         {
             AddJob(job.WithId("current"));
         }
+
+        // The CI runs filter on categories, so the report has to say which ones it covered.
+        AddColumn(CategoriesColumn.Default);
     }
 
     // Reads a non-negative integer from an env var, falling back to the default when unset/invalid.

--- a/ClickHouse.Driver.Benchmark/DynamicReadBenchmark.cs
+++ b/ClickHouse.Driver.Benchmark/DynamicReadBenchmark.cs
@@ -14,6 +14,7 @@ namespace ClickHouse.Driver.Benchmark;
 /// <c>ClickHouseType</c> per row; now stateless types return a shared singleton, so the residual
 /// per-row allocation should be just the boxed value.
 /// </summary>
+[BenchmarkCategory(BenchmarkCategories.HttpInvestigation)]
 [Config(typeof(ComparisonConfig))]
 [MemoryDiagnoser(true)]
 public class DynamicReadBenchmark
@@ -35,7 +36,7 @@ public class DynamicReadBenchmark
     public void Cleanup() => connection?.Dispose();
 
     // Int64 Dynamic: per-row header decodes to a (now shared) Int64Type.
-    [Benchmark(Baseline = true)]
+    [Benchmark(Baseline = BenchmarkModes.MethodBaseline)]
     public async Task Int64_Dynamic_GetValue()
     {
         using var reader = await connection.ExecuteReaderAsync(

--- a/ClickHouse.Driver.Benchmark/InsertCompressionBreakdownBenchmark.cs
+++ b/ClickHouse.Driver.Benchmark/InsertCompressionBreakdownBenchmark.cs
@@ -41,6 +41,7 @@ namespace ClickHouse.Driver.Benchmark;
 ///
 /// Run against both endpoints via CLICKHOUSE_CONNECTION; the payload sizes are printed at setup.
 /// </summary>
+[BenchmarkCategory(BenchmarkCategories.Compression)]
 [Config(typeof(ComparisonConfig))]
 [MemoryDiagnoser(true)]
 public class InsertCompressionBreakdownBenchmark

--- a/ClickHouse.Driver.Benchmark/MultidimArrayInsert.cs
+++ b/ClickHouse.Driver.Benchmark/MultidimArrayInsert.cs
@@ -17,6 +17,7 @@ namespace ClickHouse.Driver.Benchmark;
 /// <c>Leaf</c> also covers the wire-transparent wrappers of that primitive leaf (issue #553): they
 /// serialize identically to a bare one, so they have to reach the blit path too.
 /// </summary>
+[BenchmarkCategory(BenchmarkCategories.HttpInvestigation)]
 [Config(typeof(ComparisonConfig))]
 [MemoryDiagnoser(true)]
 public class MultidimArrayInsert
@@ -80,7 +81,7 @@ public class MultidimArrayInsert
         client?.Dispose();
     }
 
-    [Benchmark(Baseline = true)]
+    [Benchmark(Baseline = BenchmarkModes.MethodBaseline)]
     public async Task<long> JaggedBoxing() =>
         await client.InsertBinaryAsync(targetTable, new[] { "arr" }, jaggedRows);
 

--- a/ClickHouse.Driver.Benchmark/PocoInsertBenchmark.cs
+++ b/ClickHouse.Driver.Benchmark/PocoInsertBenchmark.cs
@@ -12,6 +12,7 @@ namespace ClickHouse.Driver.Benchmark;
 /// Both benchmarks insert the same data into an ENGINE Null table
 /// so the measurement is purely client-side serialization + network overhead.
 /// </summary>
+[BenchmarkCategory(BenchmarkCategories.HttpRegression)]
 [Config(typeof(ComparisonConfig))]
 [MemoryDiagnoser(true)]
 public class PocoInsertBenchmark
@@ -49,7 +50,7 @@ public class PocoInsertBenchmark
         client?.Dispose();
     }
 
-    [Benchmark(Baseline = true)]
+    [Benchmark(Baseline = BenchmarkModes.MethodBaseline)]
     public async Task<long> ObjectArray()
     {
         var columns = new[] { "Id", "Name", "Value" };

--- a/ClickHouse.Driver.Benchmark/PocoInsertColumn.cs
+++ b/ClickHouse.Driver.Benchmark/PocoInsertColumn.cs
@@ -6,6 +6,7 @@ using BenchmarkDotNet.Attributes;
 
 namespace ClickHouse.Driver.Benchmark;
 
+[BenchmarkCategory(BenchmarkCategories.HttpRegression)]
 [Config(typeof(ComparisonConfig))]
 [MemoryDiagnoser(true)]
 public class PocoInsertColumn

--- a/ClickHouse.Driver.Benchmark/PocoReadBenchmark.cs
+++ b/ClickHouse.Driver.Benchmark/PocoReadBenchmark.cs
@@ -11,6 +11,7 @@ namespace ClickHouse.Driver.Benchmark;
 /// <see cref="SensorReading"/> instance per row, isolating the per-row materialization overhead
 /// from any disk/network dependency on a user-created table.
 /// </summary>
+[BenchmarkCategory(BenchmarkCategories.HttpRegression)]
 [Config(typeof(ComparisonConfig))]
 [MemoryDiagnoser(true)]
 public class PocoReadBenchmark
@@ -44,7 +45,7 @@ public class PocoReadBenchmark
         client?.Dispose();
     }
 
-    [Benchmark(Baseline = true)]
+    [Benchmark(Baseline = BenchmarkModes.MethodBaseline)]
     public async Task<long> ManualGetValue()
     {
         long count = 0;

--- a/ClickHouse.Driver.Benchmark/Program.cs
+++ b/ClickHouse.Driver.Benchmark/Program.cs
@@ -1,8 +1,61 @@
-﻿using BenchmarkDotNet.Running;
+using System;
+using System.Linq;
+using System.Reflection;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Running;
 
 namespace ClickHouse.Driver.Benchmark;
 
 internal class Program
 {
-    public static void Main(string[] args) => BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+    public static int Main(string[] args)
+    {
+        var uncategorized = FindUncategorizedBenchmarks();
+        if (uncategorized.Length > 0)
+        {
+            Console.Error.WriteLine(
+                "These benchmark classes carry no [BenchmarkCategory], so every CI run that filters with " +
+                "--anyCategories skips them: " + string.Join(", ", uncategorized) +
+                ". Tag each one with a BenchmarkCategories constant.");
+            return 1;
+        }
+
+#if BENCHMARK_COMPARISON
+        var methodBaselines = FindMethodBaselines();
+        if (methodBaselines.Length > 0)
+        {
+            Console.Error.WriteLine(
+                "Comparison mode makes the job the baseline, and BenchmarkDotNet lets only one of the two " +
+                "win. These methods set Baseline = true anyway, which leaves the other rows' ratios mixing " +
+                "the package difference with the method difference: " + string.Join(", ", methodBaselines) +
+                ". Write [Benchmark(Baseline = BenchmarkModes.MethodBaseline)] instead.");
+            return 1;
+        }
+#endif
+
+        BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+        return 0;
+    }
+
+    private static string[] FindUncategorizedBenchmarks() =>
+        BenchmarkTypes()
+            .Where(t => t.GetCustomAttribute<BenchmarkCategoryAttribute>() == null)
+            .Select(t => t.Name)
+            .OrderBy(n => n, StringComparer.Ordinal)
+            .ToArray();
+
+#if BENCHMARK_COMPARISON
+    private static string[] FindMethodBaselines() =>
+        BenchmarkTypes()
+            .SelectMany(t => t.GetMethods().Select(m => (Type: t, Method: m)))
+            .Where(x => x.Method.GetCustomAttribute<BenchmarkAttribute>()?.Baseline == true)
+            .Select(x => x.Type.Name + "." + x.Method.Name)
+            .OrderBy(n => n, StringComparer.Ordinal)
+            .ToArray();
+#endif
+
+    private static Type[] BenchmarkTypes() =>
+        typeof(Program).Assembly.GetTypes()
+            .Where(t => t.GetMethods().Any(m => m.GetCustomAttribute<BenchmarkAttribute>() != null))
+            .ToArray();
 }

--- a/ClickHouse.Driver.Benchmark/ReadValueBenchmark.cs
+++ b/ClickHouse.Driver.Benchmark/ReadValueBenchmark.cs
@@ -39,6 +39,7 @@ internal sealed class DateTimeKindConverter : IReadValueConverter
     }
 }
 
+[BenchmarkCategory(BenchmarkCategories.HttpRegression)]
 [Config(typeof(ComparisonConfig))]
 [MemoryDiagnoser(true)]
 public class ReadValueBenchmark
@@ -84,7 +85,7 @@ public class ReadValueBenchmark
     // Int32 - GetValue (boxed)
     // ==========================================
 
-    [Benchmark(Baseline = true)]
+    [Benchmark(Baseline = BenchmarkModes.MethodBaseline)]
     public async Task Int32_GetValue_NoConverter()
     {
         using var reader = await noConverterConn.ExecuteReaderAsync($"SELECT toInt32(number) FROM system.numbers LIMIT {Count}");

--- a/ClickHouse.Driver.Benchmark/ResponseDecompressionBenchmark.cs
+++ b/ClickHouse.Driver.Benchmark/ResponseDecompressionBenchmark.cs
@@ -46,6 +46,7 @@ namespace ClickHouse.Driver.Benchmark;
 /// BENCH_WARMUP=1 BENCH_ITERATIONS=10 BENCH_LAUNCHES=1 dotnet run -c Release -- --filter *ResponseDecompression*
 /// </code>
 /// </summary>
+[BenchmarkCategory(BenchmarkCategories.Compression)]
 [Config(typeof(ComparisonConfig))]
 [MemoryDiagnoser(true)]
 public class ResponseDecompressionBenchmark

--- a/ClickHouse.Driver.Benchmark/SelectColumn.cs
+++ b/ClickHouse.Driver.Benchmark/SelectColumn.cs
@@ -6,6 +6,7 @@ using ClickHouse.Driver.Utility;
 
 namespace ClickHouse.Driver.Benchmark;
 
+[BenchmarkCategory(BenchmarkCategories.HttpRegression)]
 [Config(typeof(ComparisonConfig))]
 [MemoryDiagnoser(true)]
 public class SelectColumn

--- a/ClickHouse.Driver.Benchmark/TcpArrayWriteShape.cs
+++ b/ClickHouse.Driver.Benchmark/TcpArrayWriteShape.cs
@@ -1,0 +1,103 @@
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using ClickHouse.Driver.Tcp;
+
+namespace ClickHouse.Driver.Benchmark;
+
+/// <summary>
+/// Prices the two shapes an <c>Array(T)</c> insert accepts: the wire's flat elements plus offsets, and
+/// one array per row.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The dense shape is what a read hands back, so a read-transform-write pipeline can pass it straight
+/// through. The jagged shape is what a caller building rows in memory has, and the client has to
+/// flatten it: an array per row to walk and every element copied.
+/// </para>
+/// <para>
+/// <see cref="ElementsPerRow"/> is the axis that decides how much that flattening costs, so both a
+/// short and a long row are measured. The source data is built once in <see cref="Setup"/>; only the
+/// column wrappers are built per operation, as a caller does.
+/// </para>
+/// </remarks>
+[BenchmarkCategory(BenchmarkCategories.TcpRegression)]
+[Config(typeof(ComparisonConfig))]
+[MemoryDiagnoser(true)]
+public class TcpArrayWriteShape
+{
+    private const string TableName = "test.benchmark_tcp_array_write";
+    private const string Statement = "INSERT INTO " + TableName + " (id, readings) VALUES";
+
+    private ClickHouseTcpClient client;
+    private ulong[] ids;
+    private double[] flat;
+    private int[] offsets;
+    private double[][] jagged;
+
+    [Params(100_000)]
+    public int Count { get; set; }
+
+    [Params(4, 32)]
+    public int ElementsPerRow { get; set; }
+
+    [GlobalSetup]
+    public async Task Setup()
+    {
+        client = BenchmarkServer.CreateTcpClient();
+        await client.ExecuteAsync("CREATE DATABASE IF NOT EXISTS test");
+        await client.ExecuteAsync(
+            $"CREATE TABLE IF NOT EXISTS {TableName} (id UInt64, readings Array(Float64)) ENGINE Null");
+
+        ids = new ulong[Count];
+        flat = new double[(long)Count * ElementsPerRow];
+        offsets = new int[Count + 1];
+        jagged = new double[Count][];
+
+        for (int row = 0; row < Count; row++)
+        {
+            ids[row] = (ulong)row;
+            var elements = new double[ElementsPerRow];
+            for (int i = 0; i < ElementsPerRow; i++)
+            {
+                double value = (row + i) / 7.0;
+                elements[i] = value;
+                flat[(row * ElementsPerRow) + i] = value;
+            }
+
+            jagged[row] = elements;
+            offsets[row + 1] = (row + 1) * ElementsPerRow;
+        }
+    }
+
+    [GlobalCleanup]
+    public void Cleanup() => client?.Dispose();
+
+    /// <summary>The wire's own layout: flat elements plus offsets, nothing to flatten.</summary>
+    [Benchmark(Baseline = BenchmarkModes.MethodBaseline)]
+    public async Task Dense()
+    {
+        var columns = new IColumn[]
+        {
+            ClickHouseTcpColumn.Create("id", ids),
+            ClickHouseTcpColumn.CreateArray(
+                "readings",
+                ClickHouseTcpColumn.Create("readings", flat),
+                offsets),
+        };
+
+        await client.InsertAsync(Statement, columns);
+    }
+
+    /// <summary>One array per row, which the client walks and flattens.</summary>
+    [Benchmark]
+    public async Task Jagged()
+    {
+        var columns = new IColumn[]
+        {
+            ClickHouseTcpColumn.Create("id", ids),
+            ClickHouseTcpColumn.Create("readings", jagged),
+        };
+
+        await client.InsertAsync(Statement, columns);
+    }
+}

--- a/ClickHouse.Driver.Benchmark/TcpCompositeRead.cs
+++ b/ClickHouse.Driver.Benchmark/TcpCompositeRead.cs
@@ -1,0 +1,345 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using ClickHouse.Driver.Tcp;
+
+namespace ClickHouse.Driver.Benchmark;
+
+/// <summary>The composite type a read is measured on.</summary>
+public enum CompositeShape
+{
+    /// <summary><c>Array(Float64)</c>: flattened elements plus offsets.</summary>
+    Array,
+
+    /// <summary><c>Map(String, Int64)</c>: a key column, a value column and offsets.</summary>
+    Map,
+
+    /// <summary><c>Nullable(Float64)</c>: an inner column plus a null map.</summary>
+    Nullable,
+
+    /// <summary><c>LowCardinality(String)</c>: a dictionary plus integer keys.</summary>
+    LowCardinality,
+
+    /// <summary><c>Tuple(UInt64, String)</c>: one column per field.</summary>
+    Tuple,
+}
+
+/// <summary>
+/// Prices the four ways to read a composite column, which do not rank the same for every shape.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every composite stores its rows as flat columns plus an index, and the arms differ in how far from
+/// that storage they read: the composite interface walks it directly, the typed indexer converts one
+/// row per access, <c>Values</c> converts the whole column into a cache first, and the row tier boxes
+/// on top of that.
+/// </para>
+/// <para>
+/// Which arms differ depends on the shape. A row of <see cref="CompositeShape.Array"/> or
+/// <see cref="CompositeShape.Map"/> is itself a collection, so reading row values builds one array per
+/// row however it is reached. A row of <see cref="CompositeShape.Nullable"/>,
+/// <see cref="CompositeShape.LowCardinality"/> or <see cref="CompositeShape.Tuple"/> is a single value
+/// the indexer reads straight from the storage, so for those three the table separates the indexer's
+/// per-access cost from what <c>Values</c> pays to build its cache first.
+/// </para>
+/// <para>
+/// Each arm does the same arithmetic per element, so the difference is the access path and not the
+/// work. Where a shape holds strings, the borrowed arm takes a length from
+/// <see cref="IStringColumn.Offsets"/> and the others take <c>string.Length</c>: the values here are
+/// ASCII, so the two counts agree. <see cref="TcpStringRead"/> prices that difference on its own.
+/// </para>
+/// </remarks>
+[BenchmarkCategory(BenchmarkCategories.TcpRegression)]
+[Config(typeof(ComparisonConfig))]
+[MemoryDiagnoser(true)]
+public class TcpCompositeRead
+{
+    private ClickHouseTcpClient client;
+
+    [Params(500_000)]
+    public int Count { get; set; }
+
+    [ParamsAllValues]
+    public CompositeShape Shape { get; set; }
+
+    private string Sql => Shape switch
+    {
+        CompositeShape.Array =>
+            $"SELECT [toFloat64(number), toFloat64(number + 1)] AS v FROM system.numbers LIMIT {Count}",
+        CompositeShape.Map =>
+            "SELECT map('floor', toInt64(number % 5), 'zone', toInt64(number % 7)) AS v " +
+            $"FROM system.numbers LIMIT {Count}",
+        CompositeShape.Nullable =>
+            $"SELECT if(number % 4 = 0, NULL, toFloat64(number)) AS v FROM system.numbers LIMIT {Count}",
+        CompositeShape.LowCardinality =>
+            "SELECT toLowCardinality(concat('city', toString(number % 100))) AS v " +
+            $"FROM system.numbers LIMIT {Count}",
+        _ =>
+            "SELECT (toUInt64(number), concat('c', toString(number % 10))) AS v " +
+            $"FROM system.numbers LIMIT {Count}",
+    };
+
+    [GlobalSetup]
+    public void Setup() => client = BenchmarkServer.CreateTcpClient();
+
+    [GlobalCleanup]
+    public void Cleanup() => client?.Dispose();
+
+    /// <summary>The composite interface: the flattened storage, borrowed, with no row value built.</summary>
+    [Benchmark(Baseline = BenchmarkModes.MethodBaseline)]
+    public async Task<double> BorrowedStorage()
+    {
+        double total = 0;
+        await foreach (Block block in client.StreamAsync(Sql))
+        {
+            switch (Shape)
+            {
+                case CompositeShape.Array:
+                {
+                    var column = (IArrayColumn<double>)block[0];
+                    foreach (double value in column.InnerValues)
+                    {
+                        total += value;
+                    }
+
+                    break;
+                }
+
+                case CompositeShape.Map:
+                {
+                    var column = (IMapColumn<string, long>)block[0];
+                    var keyOffsets = ((IStringColumn)column.KeyColumn).Offsets;
+                    var values = column.ValueColumn.Values;
+                    for (int i = 0; i < values.Length; i++)
+                    {
+                        total += (keyOffsets[i + 1] - keyOffsets[i]) + values[i];
+                    }
+
+                    break;
+                }
+
+                case CompositeShape.Nullable:
+                {
+                    var column = (INullableColumn<double>)block[0];
+                    var nullMap = column.NullMap;
+                    var values = column.Inner.Values;
+                    for (int row = 0; row < nullMap.Length; row++)
+                    {
+                        total += nullMap[row] == 0 ? values[row] : 0;
+                    }
+
+                    break;
+                }
+
+                case CompositeShape.LowCardinality:
+                {
+                    var column = (ILowCardinalityColumn<string>)block[0];
+                    var dictionary = column.Dictionary.Values;
+                    foreach (int key in column.Keys)
+                    {
+                        total += dictionary[key].Length;
+                    }
+
+                    break;
+                }
+
+                default:
+                {
+                    var column = (ITupleColumn)block[0];
+                    var ids = ((IColumn<ulong>)column.Children[0]).Values;
+                    var labelOffsets = ((IStringColumn)column.Children[1]).Offsets;
+                    for (int row = 0; row < ids.Length; row++)
+                    {
+                        total += (double)ids[row] + (labelOffsets[row + 1] - labelOffsets[row]);
+                    }
+
+                    break;
+                }
+            }
+        }
+
+        return total;
+    }
+
+    /// <summary>The typed indexer: one row value per access, read from the storage.</summary>
+    [Benchmark]
+    public async Task<double> TypedIndexer()
+    {
+        double total = 0;
+        await foreach (Block block in client.StreamAsync(Sql))
+        {
+            switch (Shape)
+            {
+                case CompositeShape.Array:
+                {
+                    IColumn<double[]> column = block.Column<double[]>(0);
+                    for (int row = 0; row < block.RowCount; row++)
+                    {
+                        foreach (double value in column[row])
+                        {
+                            total += value;
+                        }
+                    }
+
+                    break;
+                }
+
+                case CompositeShape.Map:
+                {
+                    IColumn<KeyValuePair<string, long>[]> column =
+                        block.Column<KeyValuePair<string, long>[]>(0);
+                    for (int row = 0; row < block.RowCount; row++)
+                    {
+                        foreach (var pair in column[row])
+                        {
+                            total += pair.Key.Length + pair.Value;
+                        }
+                    }
+
+                    break;
+                }
+
+                case CompositeShape.Nullable:
+                {
+                    IColumn<double?> column = block.Column<double?>(0);
+                    for (int row = 0; row < block.RowCount; row++)
+                    {
+                        total += column[row] ?? 0;
+                    }
+
+                    break;
+                }
+
+                case CompositeShape.LowCardinality:
+                {
+                    IColumn<string> column = block.Column<string>(0);
+                    for (int row = 0; row < block.RowCount; row++)
+                    {
+                        total += column[row].Length;
+                    }
+
+                    break;
+                }
+
+                default:
+                {
+                    IColumn<(ulong Id, string Label)> column = block.Column<(ulong, string)>(0);
+                    for (int row = 0; row < block.RowCount; row++)
+                    {
+                        var value = column[row];
+                        total += (double)value.Id + value.Label.Length;
+                    }
+
+                    break;
+                }
+            }
+        }
+
+        return total;
+    }
+
+    /// <summary><c>Values</c>: the whole column converted into a cache before the first read.</summary>
+    [Benchmark]
+    public async Task<double> TypedValues()
+    {
+        double total = 0;
+        await foreach (Block block in client.StreamAsync(Sql))
+        {
+            switch (Shape)
+            {
+                case CompositeShape.Array:
+                    foreach (double[] values in block.Column<double[]>(0).Values)
+                    {
+                        foreach (double value in values)
+                        {
+                            total += value;
+                        }
+                    }
+
+                    break;
+
+                case CompositeShape.Map:
+                    foreach (var pairs in block.Column<KeyValuePair<string, long>[]>(0).Values)
+                    {
+                        foreach (var pair in pairs)
+                        {
+                            total += pair.Key.Length + pair.Value;
+                        }
+                    }
+
+                    break;
+
+                case CompositeShape.Nullable:
+                    foreach (double? value in block.Column<double?>(0).Values)
+                    {
+                        total += value ?? 0;
+                    }
+
+                    break;
+
+                case CompositeShape.LowCardinality:
+                    foreach (string value in block.Column<string>(0).Values)
+                    {
+                        total += value.Length;
+                    }
+
+                    break;
+
+                default:
+                    foreach (var value in block.Column<(ulong Id, string Label)>(0).Values)
+                    {
+                        total += (double)value.Id + value.Label.Length;
+                    }
+
+                    break;
+            }
+        }
+
+        return total;
+    }
+
+    /// <summary>The row tier: the same values arriving boxed in an <c>object[]</c>.</summary>
+    [Benchmark]
+    public async Task<double> RowTier()
+    {
+        double total = 0;
+        await foreach (object[] row in client.QueryAsync(Sql))
+        {
+            switch (Shape)
+            {
+                case CompositeShape.Array:
+                    foreach (double value in (double[])row[0])
+                    {
+                        total += value;
+                    }
+
+                    break;
+
+                case CompositeShape.Map:
+                    foreach (var pair in (KeyValuePair<string, long>[])row[0])
+                    {
+                        total += pair.Key.Length + pair.Value;
+                    }
+
+                    break;
+
+                case CompositeShape.Nullable:
+                    total += row[0] is null ? 0 : (double)row[0];
+                    break;
+
+                case CompositeShape.LowCardinality:
+                    total += ((string)row[0]).Length;
+                    break;
+
+                default:
+                {
+                    var value = ((ulong Id, string Label))row[0];
+                    total += (double)value.Id + value.Label.Length;
+                    break;
+                }
+            }
+        }
+
+        return total;
+    }
+}

--- a/ClickHouse.Driver.Benchmark/TcpCompression.cs
+++ b/ClickHouse.Driver.Benchmark/TcpCompression.cs
@@ -11,7 +11,10 @@ public enum CompressionShape
     /// <summary>One fixed-width column: little redundancy per byte, so the codec has least to work with.</summary>
     Narrow,
 
-    /// <summary>An integer, a repeating short string and a float: what a real result set looks like.</summary>
+    /// <summary>
+    /// An integer, a repeating short string and a float. Each column repeats far more than a
+    /// production column does, so a codec scores better here than on real data.
+    /// </summary>
     Wide,
 }
 

--- a/ClickHouse.Driver.Benchmark/TcpCompression.cs
+++ b/ClickHouse.Driver.Benchmark/TcpCompression.cs
@@ -1,0 +1,130 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using ClickHouse.Driver.Tcp;
+
+namespace ClickHouse.Driver.Benchmark;
+
+/// <summary>The payload shape a compression measurement runs on.</summary>
+public enum CompressionShape
+{
+    /// <summary>One fixed-width column: little redundancy per byte, so the codec has least to work with.</summary>
+    Narrow,
+
+    /// <summary>An integer, a repeating short string and a float: what a real result set looks like.</summary>
+    Wide,
+}
+
+/// <summary>
+/// Prices the native block codecs — none, LZ4 and Zstandard — on the read and the insert path.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>This measures the cost of compression, not its benefit.</b> Over loopback there is no bandwidth
+/// to save, so the wall clock here is compression CPU plus framing and checksum, with none of the
+/// transfer saving that motivates the feature. Do not read this table as a verdict on the default
+/// codec. Deciding that needs either a bandwidth-limited path or a real network, and it is tracked
+/// as T1a.
+/// </para>
+/// <para>
+/// What this table is good for: catching a codec or framing change that makes the client's own work
+/// slower or allocate more, which is a regression whatever the network looks like.
+/// </para>
+/// </remarks>
+[BenchmarkCategory(BenchmarkCategories.Compression)]
+[Config(typeof(ComparisonConfig))]
+[MemoryDiagnoser(true)]
+public class TcpCompression
+{
+    private const string TableName = "test.benchmark_tcp_compression";
+
+    private readonly Dictionary<string, ClickHouseTcpClient> clients = new();
+    private ulong[] ids;
+    private string[] cities;
+    private double[] temperatures;
+
+    [Params(200_000)]
+    public int Count { get; set; }
+
+    [Params("none", "lz4", "zstd")]
+    public string Codec { get; set; }
+
+    [ParamsAllValues]
+    public CompressionShape Shape { get; set; }
+
+    private ClickHouseTcpClient Client => clients[Codec];
+
+    private string ReadSql => Shape == CompressionShape.Narrow
+        ? $"SELECT toUInt64(number) AS id FROM system.numbers LIMIT {Count}"
+        : "SELECT toUInt64(number) AS id, concat('city', toString(number % 100)) AS city, " +
+          $"toFloat64(number) / 7 AS temperature FROM system.numbers LIMIT {Count}";
+
+    private string InsertStatement => Shape == CompressionShape.Narrow
+        ? $"INSERT INTO {TableName} (id) VALUES"
+        : $"INSERT INTO {TableName} (id, city, temperature) VALUES";
+
+    [GlobalSetup]
+    public async Task Setup()
+    {
+        foreach (string codec in new[] { "none", "lz4", "zstd" })
+        {
+            clients[codec] = BenchmarkServer.CreateTcpClient(builder =>
+            {
+                builder.Compression = codec;
+                return builder;
+            });
+        }
+
+        await Client.ExecuteAsync("CREATE DATABASE IF NOT EXISTS test");
+        await Client.ExecuteAsync(
+            $"CREATE TABLE IF NOT EXISTS {TableName} (id UInt64, city String, temperature Float64) ENGINE Null");
+
+        ids = new ulong[Count];
+        cities = new string[Count];
+        temperatures = new double[Count];
+        for (int i = 0; i < Count; i++)
+        {
+            ids[i] = (ulong)i;
+            cities[i] = "city" + (i % 100);
+            temperatures[i] = i / 7.0;
+        }
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        foreach (var client in clients.Values)
+        {
+            client.Dispose();
+        }
+
+        clients.Clear();
+    }
+
+    [Benchmark]
+    public async Task<long> Read()
+    {
+        long rows = 0;
+        await foreach (Block block in Client.StreamAsync(ReadSql))
+        {
+            rows += block.RowCount;
+        }
+
+        return rows;
+    }
+
+    [Benchmark]
+    public async Task Insert()
+    {
+        var columns = Shape == CompressionShape.Narrow
+            ? new IColumn[] { ClickHouseTcpColumn.Create("id", ids) }
+            : new IColumn[]
+            {
+                ClickHouseTcpColumn.Create("id", ids),
+                ClickHouseTcpColumn.Create("city", cities),
+                ClickHouseTcpColumn.Create("temperature", temperatures),
+            };
+
+        await Client.InsertAsync(InsertStatement, columns);
+    }
+}

--- a/ClickHouse.Driver.Benchmark/TcpConnectionCost.cs
+++ b/ClickHouse.Driver.Benchmark/TcpConnectionCost.cs
@@ -1,0 +1,82 @@
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using ClickHouse.Driver.Tcp;
+
+namespace ClickHouse.Driver.Benchmark;
+
+/// <summary>
+/// Separates what a native operation pays for the connection from what it pays for the query, so the
+/// value of holding one client is a number rather than advice.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The warm arms run on a client whose pool already holds a connection: they measure a checkout plus
+/// the round trips. The cold arm builds a client, uses it once and disposes it, so it also pays the
+/// dial, the TLS negotiation if enabled, and the protocol handshake.
+/// </para>
+/// <para>
+/// Each arm repeats its operation <see cref="Operations"/> times. One of these operations takes about
+/// a millisecond, which is small enough that a single-operation measurement would report the
+/// harness's own per-iteration cost alongside it.
+/// </para>
+/// <para>
+/// Over loopback the dial is close to free and the handshake is not, so the gap here is a floor for
+/// what a per-operation client costs on a real network, not an estimate of it.
+/// </para>
+/// </remarks>
+[BenchmarkCategory(BenchmarkCategories.TcpRegression)]
+[Config(typeof(ComparisonConfig))]
+[MemoryDiagnoser(true)]
+public class TcpConnectionCost
+{
+    private ClickHouseTcpClient warmClient;
+
+    [Params(100)]
+    public int Operations { get; set; }
+
+    [GlobalSetup]
+    public async Task Setup()
+    {
+        warmClient = BenchmarkServer.CreateTcpClient();
+
+        // Leaves a connection in the pool, so the warm arms never pay a dial.
+        await warmClient.PingAsync();
+    }
+
+    [GlobalCleanup]
+    public void Cleanup() => warmClient?.Dispose();
+
+    /// <summary>A pool checkout and one round trip, with no query to run.</summary>
+    [Benchmark(Baseline = BenchmarkModes.MethodBaseline)]
+    public async Task WarmPing()
+    {
+        for (int i = 0; i < Operations; i++)
+        {
+            await warmClient.PingAsync();
+        }
+    }
+
+    /// <summary>The same checkout, running the smallest query the server will answer.</summary>
+    [Benchmark]
+    public async Task<object> WarmScalar()
+    {
+        object last = null;
+        for (int i = 0; i < Operations; i++)
+        {
+            last = await warmClient.ExecuteScalarAsync("SELECT 1");
+        }
+
+        return last;
+    }
+
+    /// <summary>A client per operation: dial, handshake, one round trip, teardown.</summary>
+    [Benchmark]
+    public async Task ColdClientPing()
+    {
+        for (int i = 0; i < Operations; i++)
+        {
+            await using var client = BenchmarkServer.CreateTcpClient();
+            await client.PingAsync();
+        }
+    }
+}

--- a/ClickHouse.Driver.Benchmark/TcpInsertShapes.cs
+++ b/ClickHouse.Driver.Benchmark/TcpInsertShapes.cs
@@ -1,0 +1,98 @@
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using ClickHouse.Driver.Tcp;
+
+namespace ClickHouse.Driver.Benchmark;
+
+/// <summary>
+/// Prices the native client's three write tiers on one shape: columnar, <c>object[]</c> rows, and POCO rows.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The source data is built once in <see cref="Setup"/> and shared by all three arms, so the table
+/// reports the insert path and not the cost of generating rows. Column wrappers are still built per
+/// operation because <c>ClickHouseTcpColumn.Create</c> takes the array over rather than copying it,
+/// which is what a caller does.
+/// </para>
+/// <para>
+/// The target is an <c>ENGINE Null</c> table, so the server discards the rows and the measurement
+/// stays on the client's serialization plus the wire.
+/// </para>
+/// </remarks>
+[BenchmarkCategory(BenchmarkCategories.TcpRegression)]
+[Config(typeof(ComparisonConfig))]
+[MemoryDiagnoser(true)]
+public class TcpInsertShapes
+{
+    private const string TableName = "test.benchmark_tcp_insert_shapes";
+    private const string Statement = "INSERT INTO " + TableName + " (id, city, temperature) VALUES";
+
+    private ClickHouseTcpClient client;
+    private ulong[] ids;
+    private string[] cities;
+    private double[] temperatures;
+    private object[][] objectRows;
+    private Reading[] pocoRows;
+
+    [Params(500_000)]
+    public int Count { get; set; }
+
+    [GlobalSetup]
+    public async Task Setup()
+    {
+        client = BenchmarkServer.CreateTcpClient();
+        await client.ExecuteAsync("CREATE DATABASE IF NOT EXISTS test");
+        await client.ExecuteAsync(
+            $"CREATE TABLE IF NOT EXISTS {TableName} (id UInt64, city String, temperature Float64) ENGINE Null");
+
+        ids = new ulong[Count];
+        cities = new string[Count];
+        temperatures = new double[Count];
+        objectRows = new object[Count][];
+        pocoRows = new Reading[Count];
+
+        for (int i = 0; i < Count; i++)
+        {
+            ids[i] = (ulong)i;
+            cities[i] = "city" + (i % 100);
+            temperatures[i] = i / 7.0;
+
+            objectRows[i] = new object[] { ids[i], cities[i], temperatures[i] };
+            pocoRows[i] = new Reading { Id = ids[i], City = cities[i], Temperature = temperatures[i] };
+        }
+    }
+
+    [GlobalCleanup]
+    public void Cleanup() => client?.Dispose();
+
+    /// <summary>Columnar: data already grouped by column, nothing transposed and nothing boxed.</summary>
+    [Benchmark(Baseline = BenchmarkModes.MethodBaseline)]
+    public async Task Columnar()
+    {
+        var columns = new IColumn[]
+        {
+            ClickHouseTcpColumn.Create("id", ids),
+            ClickHouseTcpColumn.Create("city", cities),
+            ClickHouseTcpColumn.Create("temperature", temperatures),
+        };
+
+        await client.InsertAsync(Statement, columns);
+    }
+
+    /// <summary>Row tier: the client transposes rows into columns, reading through boxed values.</summary>
+    [Benchmark]
+    public async Task RowObjectArray() => await client.InsertRowsAsync(Statement, objectRows);
+
+    /// <summary>POCO tier: the same transpose, driven by compiled per-property accessors.</summary>
+    [Benchmark]
+    public async Task Poco() => await client.InsertRowsAsync(Statement, pocoRows);
+
+    private sealed class Reading
+    {
+        public ulong Id { get; set; }
+
+        public string City { get; set; }
+
+        public double Temperature { get; set; }
+    }
+}

--- a/ClickHouse.Driver.Benchmark/TcpPoolConcurrency.cs
+++ b/ClickHouse.Driver.Benchmark/TcpPoolConcurrency.cs
@@ -1,0 +1,75 @@
+using System.Linq;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using ClickHouse.Driver.Tcp;
+
+namespace ClickHouse.Driver.Benchmark;
+
+/// <summary>
+/// Runs a fixed set of queries through one client serially and at several widths, so the pool's
+/// throughput is measured rather than assumed.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Both arms issue <see cref="Queries"/> queries whatever <see cref="Degree"/> is, so every row does
+/// the same work and the ratio is the speedup at that width. The serial arm ignores
+/// <see cref="Degree"/>, which makes its rows a consistency check: they should all report the same
+/// time.
+/// </para>
+/// <para>
+/// The pool is sized to <see cref="Degree"/>, so waiting for a connection is not part of the
+/// measurement. The runner's core count caps the speedup well below <see cref="Degree"/> at the wider
+/// settings, on the client and on a local server alike.
+/// </para>
+/// </remarks>
+[BenchmarkCategory(BenchmarkCategories.TcpRegression)]
+[Config(typeof(ComparisonConfig))]
+[MemoryDiagnoser(true)]
+public class TcpPoolConcurrency
+{
+    private const string Sql = "SELECT sum(number) FROM numbers(2000000)";
+
+    private ClickHouseTcpClient client;
+
+    [Params(64)]
+    public int Queries { get; set; }
+
+    [Params(1, 8, 32)]
+    public int Degree { get; set; }
+
+    [GlobalSetup]
+    public async Task Setup()
+    {
+        client = BenchmarkServer.CreateTcpClient(builder =>
+        {
+            builder.MaxPoolSize = Degree;
+            return builder;
+        });
+
+        await client.PingAsync();
+    }
+
+    [GlobalCleanup]
+    public void Cleanup() => client?.Dispose();
+
+    /// <summary>One query at a time, reusing a single pooled connection.</summary>
+    [Benchmark(Baseline = BenchmarkModes.MethodBaseline)]
+    public async Task<object> Serial()
+    {
+        object last = null;
+        for (int i = 0; i < Queries; i++)
+        {
+            last = await client.ExecuteScalarAsync(Sql);
+        }
+
+        return last;
+    }
+
+    /// <summary>The same queries with <see cref="Degree"/> of them in flight throughout.</summary>
+    [Benchmark]
+    public async Task Concurrent() =>
+        await Parallel.ForEachAsync(
+            Enumerable.Range(0, Queries),
+            new ParallelOptions { MaxDegreeOfParallelism = Degree },
+            async (_, token) => await client.ExecuteScalarAsync(Sql, cancellationToken: token));
+}

--- a/ClickHouse.Driver.Benchmark/TcpProjectedRead.cs
+++ b/ClickHouse.Driver.Benchmark/TcpProjectedRead.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using ClickHouse.Driver.Tcp;
+
+namespace ClickHouse.Driver.Benchmark;
+
+/// <summary>The conversion a projected read is measured on.</summary>
+public enum ProjectionShape
+{
+    /// <summary><c>DateTime64(3)</c>, stored as <see cref="long"/>, read as <see cref="DateTimeOffset"/>.</summary>
+    DateTime64ToOffset,
+
+    /// <summary><c>Enum8</c>, stored as <see cref="sbyte"/>, read as its label.</summary>
+    Enum8ToLabel,
+
+    /// <summary><c>Array(DateTime)</c>, read element-wise into a <see cref="DateTimeOffset"/> array per row.</summary>
+    ArrayOfDateTimeToOffset,
+}
+
+/// <summary>
+/// Prices <c>Block.ReadAs&lt;T&gt;</c> against reading the column's own storage type, so the cost of
+/// asking for a convenient type is visible before it is paid per row.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The native arm reads the stored type and converts nothing, which is the floor. The two projected
+/// arms differ in one thing: the indexer runs the compiled reader per access, while <c>Values</c>
+/// converts the whole column once into an array it allocates.
+/// </para>
+/// <para>
+/// The array shape is the one where a projection cannot avoid allocating: the element conversion
+/// builds a new array per row, so it prices the composite path rather than a widening.
+/// </para>
+/// </remarks>
+[BenchmarkCategory(BenchmarkCategories.TcpRegression)]
+[Config(typeof(ComparisonConfig))]
+[MemoryDiagnoser(true)]
+public class TcpProjectedRead
+{
+    private ClickHouseTcpClient client;
+
+    [Params(500_000)]
+    public int Count { get; set; }
+
+    [ParamsAllValues]
+    public ProjectionShape Shape { get; set; }
+
+    private string Sql => Shape switch
+    {
+        ProjectionShape.DateTime64ToOffset =>
+            $"SELECT toDateTime64(number / 1000, 3, 'UTC') AS v FROM system.numbers LIMIT {Count}",
+        ProjectionShape.Enum8ToLabel =>
+            "SELECT CAST(number % 3 AS Enum8('red' = 0, 'green' = 1, 'blue' = 2)) AS v " +
+            $"FROM system.numbers LIMIT {Count}",
+        _ =>
+            "SELECT [toDateTime(number, 'UTC'), toDateTime(number + 1, 'UTC')] AS v " +
+            $"FROM system.numbers LIMIT {Count}",
+    };
+
+    [GlobalSetup]
+    public void Setup() => client = BenchmarkServer.CreateTcpClient();
+
+    [GlobalCleanup]
+    public void Cleanup() => client?.Dispose();
+
+    /// <summary>The stored type, borrowed: no conversion and no per-row call.</summary>
+    [Benchmark(Baseline = BenchmarkModes.MethodBaseline)]
+    public async Task<long> NativeSpan()
+    {
+        long total = 0;
+        await foreach (Block block in client.StreamAsync(Sql))
+        {
+            switch (Shape)
+            {
+                case ProjectionShape.DateTime64ToOffset:
+                    foreach (long value in block.Column<long>(0).Values)
+                    {
+                        total += value;
+                    }
+
+                    break;
+
+                case ProjectionShape.Enum8ToLabel:
+                    foreach (sbyte value in block.Column<sbyte>(0).Values)
+                    {
+                        total += value;
+                    }
+
+                    break;
+
+                default:
+                    foreach (uint value in ((IArrayColumn<uint>)block[0]).InnerValues)
+                    {
+                        total += value;
+                    }
+
+                    break;
+            }
+        }
+
+        return total;
+    }
+
+    /// <summary>The projected view's indexer: the compiled reader runs once per access.</summary>
+    [Benchmark]
+    public async Task<long> ProjectedIndexer()
+    {
+        long total = 0;
+        await foreach (Block block in client.StreamAsync(Sql))
+        {
+            switch (Shape)
+            {
+                case ProjectionShape.DateTime64ToOffset:
+                {
+                    IColumn<DateTimeOffset> values = block.ReadAs<DateTimeOffset>(0);
+                    for (int row = 0; row < block.RowCount; row++)
+                    {
+                        total += values[row].Ticks;
+                    }
+
+                    break;
+                }
+
+                case ProjectionShape.Enum8ToLabel:
+                {
+                    IColumn<string> labels = block.ReadAs<string>(0);
+                    for (int row = 0; row < block.RowCount; row++)
+                    {
+                        total += labels[row].Length;
+                    }
+
+                    break;
+                }
+
+                default:
+                {
+                    IColumn<DateTimeOffset[]> values = block.ReadAs<DateTimeOffset[]>(0);
+                    for (int row = 0; row < block.RowCount; row++)
+                    {
+                        foreach (DateTimeOffset value in values[row])
+                        {
+                            total += value.Ticks;
+                        }
+                    }
+
+                    break;
+                }
+            }
+        }
+
+        return total;
+    }
+
+    /// <summary>The projected view's <c>Values</c>: one conversion pass into an array it allocates.</summary>
+    [Benchmark]
+    public async Task<long> ProjectedValues()
+    {
+        long total = 0;
+        await foreach (Block block in client.StreamAsync(Sql))
+        {
+            switch (Shape)
+            {
+                case ProjectionShape.DateTime64ToOffset:
+                    foreach (DateTimeOffset value in block.ReadAs<DateTimeOffset>(0).Values)
+                    {
+                        total += value.Ticks;
+                    }
+
+                    break;
+
+                case ProjectionShape.Enum8ToLabel:
+                    foreach (string label in block.ReadAs<string>(0).Values)
+                    {
+                        total += label.Length;
+                    }
+
+                    break;
+
+                default:
+                    foreach (DateTimeOffset[] values in block.ReadAs<DateTimeOffset[]>(0).Values)
+                    {
+                        foreach (DateTimeOffset value in values)
+                        {
+                            total += value.Ticks;
+                        }
+                    }
+
+                    break;
+            }
+        }
+
+        return total;
+    }
+}

--- a/ClickHouse.Driver.Benchmark/TcpReadTiers.cs
+++ b/ClickHouse.Driver.Benchmark/TcpReadTiers.cs
@@ -1,0 +1,138 @@
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using ClickHouse.Driver.Tcp;
+
+namespace ClickHouse.Driver.Benchmark;
+
+/// <summary>
+/// Prices the native client's read tiers against one another on a single mixed shape, so the cost
+/// of choosing a tier is visible rather than inferred.
+/// </summary>
+/// <remarks>
+/// <para>
+/// All five arms read the same three columns and the same rows; only the accessor differs. The
+/// block-tier arms separate the borrowed span from the typed indexer and from the boxing
+/// <c>GetValue</c>, because those are three different costs behind one tier.
+/// </para>
+/// <para>
+/// <see cref="TcpSelectColumn"/> covers the decode with no materialization at all, which is the
+/// floor every arm here pays.
+/// </para>
+/// </remarks>
+[BenchmarkCategory(BenchmarkCategories.TcpRegression)]
+[Config(typeof(ComparisonConfig))]
+[MemoryDiagnoser(true)]
+public class TcpReadTiers
+{
+    private ClickHouseTcpClient client;
+
+    [Params(500_000)]
+    public int Count { get; set; }
+
+    private string Sql =>
+        "SELECT toUInt64(number) AS id, concat('city', toString(number % 100)) AS city, " +
+        $"toFloat64(number) / 7 AS temperature FROM system.numbers LIMIT {Count}";
+
+    [GlobalSetup]
+    public void Setup() => client = BenchmarkServer.CreateTcpClient();
+
+    [GlobalCleanup]
+    public void Cleanup() => client?.Dispose();
+
+    /// <summary>Borrowed columnar spans: no per-row call, no allocation per row.</summary>
+    [Benchmark(Baseline = BenchmarkModes.MethodBaseline)]
+    public async Task<double> BlockSpans()
+    {
+        double total = 0;
+        await foreach (Block block in client.StreamAsync(Sql))
+        {
+            var ids = block.Column<ulong>("id").Values;
+            var cities = block.Column<string>("city").Values;
+            var temperatures = block.Column<double>("temperature").Values;
+
+            for (int row = 0; row < block.RowCount; row++)
+            {
+                total += (double)ids[row] + cities[row].Length + temperatures[row];
+            }
+        }
+
+        return total;
+    }
+
+    /// <summary>The typed indexer: one interface call per value, still no boxing.</summary>
+    [Benchmark]
+    public async Task<double> BlockTypedIndexer()
+    {
+        double total = 0;
+        await foreach (Block block in client.StreamAsync(Sql))
+        {
+            IColumn<ulong> ids = block.Column<ulong>("id");
+            IColumn<string> cities = block.Column<string>("city");
+            IColumn<double> temperatures = block.Column<double>("temperature");
+
+            for (int row = 0; row < block.RowCount; row++)
+            {
+                total += (double)ids[row] + cities[row].Length + temperatures[row];
+            }
+        }
+
+        return total;
+    }
+
+    /// <summary>The untyped accessor: one boxed object per value.</summary>
+    [Benchmark]
+    public async Task<double> BlockBoxedGetValue()
+    {
+        double total = 0;
+        await foreach (Block block in client.StreamAsync(Sql))
+        {
+            IColumn ids = block[0];
+            IColumn cities = block[1];
+            IColumn temperatures = block[2];
+
+            for (int row = 0; row < block.RowCount; row++)
+            {
+                total += (double)(ulong)ids.GetValue(row);
+                total += ((string)cities.GetValue(row)).Length;
+                total += (double)temperatures.GetValue(row);
+            }
+        }
+
+        return total;
+    }
+
+    /// <summary>The row tier: one <c>object[]</c> per row, every value boxed.</summary>
+    [Benchmark]
+    public async Task<double> RowObjectArray()
+    {
+        double total = 0;
+        await foreach (object[] row in client.QueryAsync(Sql))
+        {
+            total += (double)(ulong)row[0] + ((string)row[1]).Length + (double)row[2];
+        }
+
+        return total;
+    }
+
+    /// <summary>The POCO tier: one object per row, values assigned through compiled setters.</summary>
+    [Benchmark]
+    public async Task<double> Poco()
+    {
+        double total = 0;
+        await foreach (Reading row in client.QueryAsync<Reading>(Sql))
+        {
+            total += (double)row.Id + row.City.Length + row.Temperature;
+        }
+
+        return total;
+    }
+
+    private sealed class Reading
+    {
+        public ulong Id { get; set; }
+
+        public string City { get; set; }
+
+        public double Temperature { get; set; }
+    }
+}

--- a/ClickHouse.Driver.Benchmark/TcpSelectColumn.cs
+++ b/ClickHouse.Driver.Benchmark/TcpSelectColumn.cs
@@ -1,0 +1,98 @@
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using ClickHouse.Driver.Tcp;
+
+namespace ClickHouse.Driver.Benchmark;
+
+/// <summary>
+/// The native-protocol counterpart to <see cref="SelectColumn"/>: the same expressions at the same
+/// row count, read as columnar blocks.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Both classes drain the result the cheapest way their API allows, which is not the same amount of
+/// work. HTTP's <c>Read()</c> decodes every column of the row into a reused <c>object[]</c>, so it
+/// boxes each value; the block reader decodes every column into typed storage and boxes nothing. A
+/// per-expression gap between the two classes therefore mixes the wire and decode difference with
+/// that materialization difference.
+/// </para>
+/// <para>
+/// <see cref="TransportRead"/> is the comparison whose arms consume every value on both sides, and
+/// <see cref="TcpReadTiers"/> prices the native materialization tiers against each other.
+/// </para>
+/// </remarks>
+[BenchmarkCategory(BenchmarkCategories.TcpRegression)]
+[Config(typeof(ComparisonConfig))]
+[MemoryDiagnoser(true)]
+public class TcpSelectColumn
+{
+    private ClickHouseTcpClient client;
+
+    [Params(500000)]
+    public int Count { get; set; }
+
+    [GlobalSetup]
+    public void Setup() => client = BenchmarkServer.CreateTcpClient();
+
+    [GlobalCleanup]
+    public void Cleanup() => client?.Dispose();
+
+    [Benchmark]
+    public Task<long> SelectInt32() => RunBlockBenchmark("toInt32(number)");
+
+    [Benchmark]
+    public Task<long> SelectUInt32() => RunBlockBenchmark("toUInt32(number)");
+
+    [Benchmark]
+    public Task<long> SelectInt64() => RunBlockBenchmark("toInt64(number)");
+
+    [Benchmark]
+    public Task<long> SelectUInt64() => RunBlockBenchmark("toUInt64(number)");
+
+    [Benchmark]
+    public Task<long> SelectFloat32() => RunBlockBenchmark("toFloat32(number)");
+
+    [Benchmark]
+    public Task<long> SelectFloat64() => RunBlockBenchmark("toFloat64(number)");
+
+    [Benchmark]
+    public Task<long> SelectDecimal64() => RunBlockBenchmark("toDecimal64(number,5)");
+
+    [Benchmark]
+    public Task<long> SelectDecimal128() => RunBlockBenchmark("toDecimal128(number,5)");
+
+    [Benchmark]
+    public Task<long> SelectDecimal256() => RunBlockBenchmark("toDecimal256(number,5)");
+
+    [Benchmark]
+    public Task<long> SelectDate() => RunBlockBenchmark("toDate(18942+number)");
+
+    [Benchmark]
+    public Task<long> SelectDate32() => RunBlockBenchmark("toDate32(18942+number)");
+
+    [Benchmark]
+    public Task<long> SelectDateTime() => RunBlockBenchmark("toDateTime(18942+number,'UTC')");
+
+    [Benchmark]
+    public Task<long> SelectString() => RunBlockBenchmark("concat('test',toString(number))");
+
+    [Benchmark]
+    public Task<long> SelectArray() => RunBlockBenchmark("array(1, number, 3)");
+
+    [Benchmark]
+    public Task<long> SelectNullableInt32() => RunBlockBenchmark("CAST(toInt32(number) AS Nullable(Int32))");
+
+    [Benchmark]
+    public Task<long> SelectTuple() => RunBlockBenchmark("tuple(number, toString(number))");
+
+    private async Task<long> RunBlockBenchmark(string expression)
+    {
+        long rows = 0;
+        await foreach (Block block in client.StreamAsync($"SELECT {expression} FROM system.numbers LIMIT {Count}"))
+        {
+            rows += block.RowCount;
+        }
+
+        return rows;
+    }
+}

--- a/ClickHouse.Driver.Benchmark/TcpStringRead.cs
+++ b/ClickHouse.Driver.Benchmark/TcpStringRead.cs
@@ -1,0 +1,91 @@
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using ClickHouse.Driver.Tcp;
+
+namespace ClickHouse.Driver.Benchmark;
+
+/// <summary>
+/// Prices the three readings of a <c>String</c> column, which is the column type where the choice
+/// costs the most.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A decoded <c>String</c> column holds every row's bytes in one blob with per-row offsets, and
+/// <see cref="IStringColumn"/> reads them in place. The typed surface decodes each row as UTF-8
+/// instead, which allocates one string per row and is what almost every caller wants — the point of
+/// this table is what that convenience costs, not to argue against it.
+/// </para>
+/// <para>
+/// The arms measure byte length against <c>string.Length</c>. The values are ASCII, so the two counts
+/// agree; on non-ASCII data they would not, and only the byte reading would be lossless.
+/// </para>
+/// </remarks>
+[BenchmarkCategory(BenchmarkCategories.TcpRegression)]
+[Config(typeof(ComparisonConfig))]
+[MemoryDiagnoser(true)]
+public class TcpStringRead
+{
+    private ClickHouseTcpClient client;
+
+    [Params(500_000)]
+    public int Count { get; set; }
+
+    private string Sql =>
+        $"SELECT concat('city', toString(number % 100000)) AS v FROM system.numbers LIMIT {Count}";
+
+    [GlobalSetup]
+    public void Setup() => client = BenchmarkServer.CreateTcpClient();
+
+    [GlobalCleanup]
+    public void Cleanup() => client?.Dispose();
+
+    /// <summary>The offsets alone: a length per row with nothing read and nothing decoded.</summary>
+    [Benchmark(Baseline = BenchmarkModes.MethodBaseline)]
+    public async Task<long> BorrowedOffsets()
+    {
+        long total = 0;
+        await foreach (Block block in client.StreamAsync(Sql))
+        {
+            var offsets = ((IStringColumn)block[0]).Offsets;
+            for (int row = 0; row < block.RowCount; row++)
+            {
+                total += offsets[row + 1] - offsets[row];
+            }
+        }
+
+        return total;
+    }
+
+    /// <summary>A borrowed byte slice per row, which is the undecoded reading of the same data.</summary>
+    [Benchmark]
+    public async Task<long> BorrowedBytes()
+    {
+        long total = 0;
+        await foreach (Block block in client.StreamAsync(Sql))
+        {
+            var column = (IStringColumn)block[0];
+            for (int row = 0; row < block.RowCount; row++)
+            {
+                total += column.GetBytes(row).Length;
+            }
+        }
+
+        return total;
+    }
+
+    /// <summary>The typed surface: one UTF-8 decode and one string per row.</summary>
+    [Benchmark]
+    public async Task<long> DecodedStrings()
+    {
+        long total = 0;
+        await foreach (Block block in client.StreamAsync(Sql))
+        {
+            foreach (string value in block.Column<string>(0).Values)
+            {
+                total += value.Length;
+            }
+        }
+
+        return total;
+    }
+}

--- a/ClickHouse.Driver.Benchmark/TransportInsert.cs
+++ b/ClickHouse.Driver.Benchmark/TransportInsert.cs
@@ -36,14 +36,21 @@ namespace ClickHouse.Driver.Benchmark;
 /// </para>
 /// <para>
 /// Each arm also sends its rows in one request: <c>InsertOptions.BatchSize</c> defaults to 100,000,
-/// so a 500k-row HTTP insert would otherwise pay whatever per-request cost the server charges five
-/// times over. <see cref="HttpRowsDefaultBatching"/> keeps the default for comparison.
+/// so this insert would otherwise go as fifty sequential requests.
+/// <see cref="HttpRowsDefaultBatching"/> keeps the default for comparison, and measures about 2.6 ms
+/// per extra request - the round trip, and little else once the server's buffering is off.
 /// </para>
 /// <para>
 /// The target is an <c>ENGINE Null</c> table, so the server discards the rows and the measurement
 /// stays on serialization plus the wire. The source data is built once in <see cref="Setup"/>. The
 /// column names match the POCO's property names, because the HTTP binary insert maps a property to
 /// the column of that name and ClickHouse column names are case-sensitive.
+/// </para>
+/// <para>
+/// <see cref="Count"/> is 5,000,000 because at 500,000 every arm ran under 60 ms, where the ratios
+/// carried a standard deviation of 0.16 to 0.76 and told a reader nothing. At this size they land at
+/// 0.04 to 0.11 and hold across the tenfold change. It costs about 1 GB of source rows held for the
+/// run, which is the reason to raise it no further.
 /// </para>
 /// </remarks>
 [BenchmarkCategory(BenchmarkCategories.Cross)]
@@ -67,7 +74,7 @@ public class TransportInsert
     private object[][] rows;
     private Reading[] pocoRows;
 
-    [Params(500_000)]
+    [Params(5_000_000)]
     public int Count { get; set; }
 
     private InsertOptions HttpOptions => new()

--- a/ClickHouse.Driver.Benchmark/TransportInsert.cs
+++ b/ClickHouse.Driver.Benchmark/TransportInsert.cs
@@ -77,6 +77,8 @@ public class TransportInsert
     [Params(5_000_000)]
     public int Count { get; set; }
 
+    // Compressor, not the connection string's Compression key: a binary insert does not consult that
+    // setting (see ClickHouseClientSettings.UseCompression), so this is what turns the codec off here.
     private InsertOptions HttpOptions => new()
     {
         BatchSize = Count,
@@ -89,13 +91,9 @@ public class TransportInsert
     [GlobalSetup]
     public async Task Setup()
     {
-        httpClient = new ClickHouseClient(BenchmarkServer.Http);
+        httpClient = new ClickHouseClient(BenchmarkServer.HttpUncompressed);
         httpClient.RegisterBinaryInsertType<Reading>();
-        tcpClient = BenchmarkServer.CreateTcpClient(builder =>
-        {
-            builder.Compression = "none";
-            return builder;
-        });
+        tcpClient = BenchmarkServer.CreateUncompressedTcpClient();
 
         await httpClient.ExecuteNonQueryAsync("CREATE DATABASE IF NOT EXISTS test");
 

--- a/ClickHouse.Driver.Benchmark/TransportInsert.cs
+++ b/ClickHouse.Driver.Benchmark/TransportInsert.cs
@@ -16,12 +16,23 @@ namespace ClickHouse.Driver.Benchmark;
 /// what a caller who can group data by column should reach for.
 /// </para>
 /// <para>
-/// Every arm sets <c>async_insert = 0</c>. A server with async inserts on buffers any insert that
-/// carries a client data block and, with <c>wait_for_async_insert</c>, holds the response until the
-/// buffer flushes — the adaptive wait starts at <c>async_insert_busy_timeout_min_ms</c>, 50 ms by
-/// default. Measured on 26.6.1.1193, that is 55 ms per HTTP insert against 1.9 ms with the setting
-/// off, and it lands on the two transports unequally. Leaving it on measures the server's buffering
-/// policy rather than the client.
+/// Two things that would otherwise dominate are turned off, because each lands on the transports
+/// unequally and would report itself as a protocol difference:
+/// </para>
+/// <para>
+/// <b>Server-side insert buffering.</b> Every arm sets <c>async_insert = 0</c>. A server with async
+/// inserts on buffers any insert that carries a client data block and, with
+/// <c>wait_for_async_insert</c>, holds the response until the buffer flushes — the adaptive wait
+/// starts at <c>async_insert_busy_timeout_min_ms</c>, 50 ms by default. Measured on 26.6.1.1193,
+/// that is 55 ms per HTTP insert against 1.9 ms with the setting off, and the native arms never paid
+/// it.
+/// </para>
+/// <para>
+/// <b>Request compression.</b> The two transports do not default to the same codec — HTTP to ZSTD,
+/// the native client to LZ4 — and on this payload the codec costs more than the serialization the
+/// arms exist to compare, so it hides the difference. Both sides run uncompressed here.
+/// <see cref="TcpCompression"/> owns the codec axis, and over loopback there is no bandwidth to
+/// save, so nothing of value is left out.
 /// </para>
 /// <para>
 /// Each arm also sends its rows in one request: <c>InsertOptions.BatchSize</c> defaults to 100,000,
@@ -62,6 +73,7 @@ public class TransportInsert
     private InsertOptions HttpOptions => new()
     {
         BatchSize = Count,
+        Compressor = null,
         CustomSettings = new Dictionary<string, object> { ["async_insert"] = 0 },
     };
 
@@ -72,7 +84,11 @@ public class TransportInsert
     {
         httpClient = new ClickHouseClient(BenchmarkServer.Http);
         httpClient.RegisterBinaryInsertType<Reading>();
-        tcpClient = BenchmarkServer.CreateTcpClient();
+        tcpClient = BenchmarkServer.CreateTcpClient(builder =>
+        {
+            builder.Compression = "none";
+            return builder;
+        });
 
         await httpClient.ExecuteNonQueryAsync("CREATE DATABASE IF NOT EXISTS test");
 
@@ -147,7 +163,11 @@ public class TransportInsert
             TableName,
             ColumnNames,
             rows,
-            new InsertOptions { CustomSettings = new Dictionary<string, object> { ["async_insert"] = 0 } });
+            new InsertOptions
+            {
+                Compressor = null,
+                CustomSettings = new Dictionary<string, object> { ["async_insert"] = 0 },
+            });
 
     public class Reading
     {

--- a/ClickHouse.Driver.Benchmark/TransportInsert.cs
+++ b/ClickHouse.Driver.Benchmark/TransportInsert.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using ClickHouse.Driver.Tcp;
@@ -13,6 +14,19 @@ namespace ClickHouse.Driver.Benchmark;
 /// Two pairs are directly comparable: the <c>object[]</c> rows, and the POCO rows. The columnar arm
 /// is the native protocol's own shape, which HTTP has no counterpart for; it is here because it is
 /// what a caller who can group data by column should reach for.
+/// </para>
+/// <para>
+/// Every arm sets <c>async_insert = 0</c>. A server with async inserts on buffers any insert that
+/// carries a client data block and, with <c>wait_for_async_insert</c>, holds the response until the
+/// buffer flushes — the adaptive wait starts at <c>async_insert_busy_timeout_min_ms</c>, 50 ms by
+/// default. Measured on 26.6.1.1193, that is 55 ms per HTTP insert against 1.9 ms with the setting
+/// off, and it lands on the two transports unequally. Leaving it on measures the server's buffering
+/// policy rather than the client.
+/// </para>
+/// <para>
+/// Each arm also sends its rows in one request: <c>InsertOptions.BatchSize</c> defaults to 100,000,
+/// so a 500k-row HTTP insert would otherwise pay whatever per-request cost the server charges five
+/// times over. <see cref="HttpRowsDefaultBatching"/> keeps the default for comparison.
 /// </para>
 /// <para>
 /// The target is an <c>ENGINE Null</c> table, so the server discards the rows and the measurement
@@ -31,6 +45,9 @@ public class TransportInsert
 
     private static readonly string[] ColumnNames = { "Id", "City", "Temperature" };
 
+    private static readonly IReadOnlyDictionary<string, string> TcpSettings =
+        new Dictionary<string, string> { ["async_insert"] = "0" };
+
     private ClickHouseClient httpClient;
     private ClickHouseTcpClient tcpClient;
     private ulong[] ids;
@@ -41,6 +58,14 @@ public class TransportInsert
 
     [Params(500_000)]
     public int Count { get; set; }
+
+    private InsertOptions HttpOptions => new()
+    {
+        BatchSize = Count,
+        CustomSettings = new Dictionary<string, object> { ["async_insert"] = 0 },
+    };
+
+    private ClickHouseTcpInsertOptions TcpOptions => new() { Settings = TcpSettings };
 
     [GlobalSetup]
     public async Task Setup()
@@ -82,34 +107,21 @@ public class TransportInsert
 
     /// <summary>HTTP, through the binary insert path: one <c>object[]</c> per row.</summary>
     [Benchmark(Baseline = BenchmarkModes.MethodBaseline)]
-    public async Task<long> HttpRows() => await httpClient.InsertBinaryAsync(TableName, ColumnNames, rows);
-
-    /// <summary>
-    /// The same rows in one request. <c>InsertOptions.BatchSize</c> defaults to 100,000, so
-    /// <see cref="HttpRows"/> sends five sequential requests where the native arms send one block.
-    /// This arm separates that batching from the protocol.
-    /// </summary>
-    [Benchmark]
-    public async Task<long> HttpRowsOneBatch() =>
-        await httpClient.InsertBinaryAsync(
-            TableName, ColumnNames, rows, new InsertOptions { BatchSize = Count });
+    public async Task<long> HttpRows() =>
+        await httpClient.InsertBinaryAsync(TableName, ColumnNames, rows, HttpOptions);
 
     /// <summary>Native protocol, the same rows through its row tier.</summary>
     [Benchmark]
-    public async Task TcpRows() => await tcpClient.InsertRowsAsync(Statement, rows);
+    public async Task TcpRows() => await tcpClient.InsertRowsAsync(Statement, rows, TcpOptions);
 
     /// <summary>HTTP, reading the values off the POCO's compiled property accessors.</summary>
     [Benchmark]
-    public async Task<long> HttpPoco() => await httpClient.InsertBinaryAsync(TableName, pocoRows);
-
-    /// <summary>The same POCOs in one request, for the same reason as <see cref="HttpRowsOneBatch"/>.</summary>
-    [Benchmark]
-    public async Task<long> HttpPocoOneBatch() =>
-        await httpClient.InsertBinaryAsync(TableName, pocoRows, new InsertOptions { BatchSize = Count });
+    public async Task<long> HttpPoco() =>
+        await httpClient.InsertBinaryAsync(TableName, pocoRows, HttpOptions);
 
     /// <summary>Native protocol, the same POCOs through its row tier.</summary>
     [Benchmark]
-    public async Task TcpPoco() => await tcpClient.InsertRowsAsync(Statement, pocoRows);
+    public async Task TcpPoco() => await tcpClient.InsertRowsAsync(Statement, pocoRows, TcpOptions);
 
     /// <summary>Native protocol, columnar: nothing transposed and nothing boxed.</summary>
     [Benchmark]
@@ -122,8 +134,20 @@ public class TransportInsert
             ClickHouseTcpColumn.Create("Temperature", temperatures),
         };
 
-        await tcpClient.InsertAsync(Statement, columns);
+        await tcpClient.InsertAsync(Statement, columns, TcpOptions);
     }
+
+    /// <summary>
+    /// The same rows at the default <c>BatchSize</c> of 100,000, so the table shows what the
+    /// batching costs on top of the protocol.
+    /// </summary>
+    [Benchmark]
+    public async Task<long> HttpRowsDefaultBatching() =>
+        await httpClient.InsertBinaryAsync(
+            TableName,
+            ColumnNames,
+            rows,
+            new InsertOptions { CustomSettings = new Dictionary<string, object> { ["async_insert"] = 0 } });
 
     public class Reading
     {

--- a/ClickHouse.Driver.Benchmark/TransportInsert.cs
+++ b/ClickHouse.Driver.Benchmark/TransportInsert.cs
@@ -1,0 +1,136 @@
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using ClickHouse.Driver.Tcp;
+
+namespace ClickHouse.Driver.Benchmark;
+
+/// <summary>
+/// Inserts the same rows over both transports, pairing each shape a caller can hand the client with
+/// its counterpart on the other transport.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Two pairs are directly comparable: the <c>object[]</c> rows, and the POCO rows. The columnar arm
+/// is the native protocol's own shape, which HTTP has no counterpart for; it is here because it is
+/// what a caller who can group data by column should reach for.
+/// </para>
+/// <para>
+/// The target is an <c>ENGINE Null</c> table, so the server discards the rows and the measurement
+/// stays on serialization plus the wire. The source data is built once in <see cref="Setup"/>. The
+/// column names match the POCO's property names, because the HTTP binary insert maps a property to
+/// the column of that name and ClickHouse column names are case-sensitive.
+/// </para>
+/// </remarks>
+[BenchmarkCategory(BenchmarkCategories.Cross)]
+[Config(typeof(ComparisonConfig))]
+[MemoryDiagnoser(true)]
+public class TransportInsert
+{
+    private const string TableName = "test.benchmark_transport_insert";
+    private const string Statement = "INSERT INTO " + TableName + " (Id, City, Temperature) VALUES";
+
+    private static readonly string[] ColumnNames = { "Id", "City", "Temperature" };
+
+    private ClickHouseClient httpClient;
+    private ClickHouseTcpClient tcpClient;
+    private ulong[] ids;
+    private string[] cities;
+    private double[] temperatures;
+    private object[][] rows;
+    private Reading[] pocoRows;
+
+    [Params(500_000)]
+    public int Count { get; set; }
+
+    [GlobalSetup]
+    public async Task Setup()
+    {
+        httpClient = new ClickHouseClient(BenchmarkServer.Http);
+        httpClient.RegisterBinaryInsertType<Reading>();
+        tcpClient = BenchmarkServer.CreateTcpClient();
+
+        await httpClient.ExecuteNonQueryAsync("CREATE DATABASE IF NOT EXISTS test");
+
+        // Dropped rather than created only if absent: the name is fixed, so a schema change here
+        // would otherwise keep using whatever an earlier revision left behind.
+        await httpClient.ExecuteNonQueryAsync($"DROP TABLE IF EXISTS {TableName}");
+        await httpClient.ExecuteNonQueryAsync(
+            $"CREATE TABLE {TableName} (Id UInt64, City String, Temperature Float64) ENGINE Null");
+
+        ids = new ulong[Count];
+        cities = new string[Count];
+        temperatures = new double[Count];
+        rows = new object[Count][];
+        pocoRows = new Reading[Count];
+
+        for (int i = 0; i < Count; i++)
+        {
+            ids[i] = (ulong)i;
+            cities[i] = "city" + (i % 100);
+            temperatures[i] = i / 7.0;
+            rows[i] = new object[] { ids[i], cities[i], temperatures[i] };
+            pocoRows[i] = new Reading { Id = ids[i], City = cities[i], Temperature = temperatures[i] };
+        }
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        httpClient?.Dispose();
+        tcpClient?.Dispose();
+    }
+
+    /// <summary>HTTP, through the binary insert path: one <c>object[]</c> per row.</summary>
+    [Benchmark(Baseline = BenchmarkModes.MethodBaseline)]
+    public async Task<long> HttpRows() => await httpClient.InsertBinaryAsync(TableName, ColumnNames, rows);
+
+    /// <summary>
+    /// The same rows in one request. <c>InsertOptions.BatchSize</c> defaults to 100,000, so
+    /// <see cref="HttpRows"/> sends five sequential requests where the native arms send one block.
+    /// This arm separates that batching from the protocol.
+    /// </summary>
+    [Benchmark]
+    public async Task<long> HttpRowsOneBatch() =>
+        await httpClient.InsertBinaryAsync(
+            TableName, ColumnNames, rows, new InsertOptions { BatchSize = Count });
+
+    /// <summary>Native protocol, the same rows through its row tier.</summary>
+    [Benchmark]
+    public async Task TcpRows() => await tcpClient.InsertRowsAsync(Statement, rows);
+
+    /// <summary>HTTP, reading the values off the POCO's compiled property accessors.</summary>
+    [Benchmark]
+    public async Task<long> HttpPoco() => await httpClient.InsertBinaryAsync(TableName, pocoRows);
+
+    /// <summary>The same POCOs in one request, for the same reason as <see cref="HttpRowsOneBatch"/>.</summary>
+    [Benchmark]
+    public async Task<long> HttpPocoOneBatch() =>
+        await httpClient.InsertBinaryAsync(TableName, pocoRows, new InsertOptions { BatchSize = Count });
+
+    /// <summary>Native protocol, the same POCOs through its row tier.</summary>
+    [Benchmark]
+    public async Task TcpPoco() => await tcpClient.InsertRowsAsync(Statement, pocoRows);
+
+    /// <summary>Native protocol, columnar: nothing transposed and nothing boxed.</summary>
+    [Benchmark]
+    public async Task TcpColumnar()
+    {
+        var columns = new IColumn[]
+        {
+            ClickHouseTcpColumn.Create("Id", ids),
+            ClickHouseTcpColumn.Create("City", cities),
+            ClickHouseTcpColumn.Create("Temperature", temperatures),
+        };
+
+        await tcpClient.InsertAsync(Statement, columns);
+    }
+
+    public class Reading
+    {
+        public ulong Id { get; set; }
+
+        public string City { get; set; }
+
+        public double Temperature { get; set; }
+    }
+}

--- a/ClickHouse.Driver.Benchmark/TransportLatency.cs
+++ b/ClickHouse.Driver.Benchmark/TransportLatency.cs
@@ -30,14 +30,14 @@ public class TransportLatency
     private ClickHouseClient httpClient;
     private ClickHouseTcpClient tcpClient;
 
-    [Params(100)]
+    [Params(500)]
     public int RoundTrips { get; set; }
 
     [GlobalSetup]
     public async Task Setup()
     {
-        httpClient = new ClickHouseClient(BenchmarkServer.Http);
-        tcpClient = BenchmarkServer.CreateTcpClient();
+        httpClient = new ClickHouseClient(BenchmarkServer.HttpUncompressed);
+        tcpClient = BenchmarkServer.CreateUncompressedTcpClient();
 
         await httpClient.ExecuteScalarAsync(Sql);
         await tcpClient.ExecuteScalarAsync(Sql);

--- a/ClickHouse.Driver.Benchmark/TransportLatency.cs
+++ b/ClickHouse.Driver.Benchmark/TransportLatency.cs
@@ -1,0 +1,78 @@
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using ClickHouse.Driver.Tcp;
+
+namespace ClickHouse.Driver.Benchmark;
+
+/// <summary>
+/// Runs many trivial queries over both transports, so per-request overhead is measured where nothing
+/// else can hide it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every other cross-transport class reads or writes enough rows that decoding dominates. Here the
+/// server does no work, so what is left is the request itself: HTTP headers and response framing
+/// against the native protocol's packets on an already-open connection.
+/// </para>
+/// <para>
+/// Both clients are warmed in <see cref="Setup"/>, so neither pays a dial inside the measurement.
+/// The queries run one after another: this is latency per request, not throughput under load —
+/// <see cref="TcpPoolConcurrency"/> covers the concurrent case.
+/// </para>
+/// </remarks>
+[BenchmarkCategory(BenchmarkCategories.Cross)]
+[Config(typeof(ComparisonConfig))]
+[MemoryDiagnoser(true)]
+public class TransportLatency
+{
+    private const string Sql = "SELECT 1";
+
+    private ClickHouseClient httpClient;
+    private ClickHouseTcpClient tcpClient;
+
+    [Params(100)]
+    public int RoundTrips { get; set; }
+
+    [GlobalSetup]
+    public async Task Setup()
+    {
+        httpClient = new ClickHouseClient(BenchmarkServer.Http);
+        tcpClient = BenchmarkServer.CreateTcpClient();
+
+        await httpClient.ExecuteScalarAsync(Sql);
+        await tcpClient.ExecuteScalarAsync(Sql);
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        httpClient?.Dispose();
+        tcpClient?.Dispose();
+    }
+
+    /// <summary>HTTP: one request and response per query, on a pooled socket.</summary>
+    [Benchmark(Baseline = BenchmarkModes.MethodBaseline)]
+    public async Task<object> Http()
+    {
+        object last = null;
+        for (int i = 0; i < RoundTrips; i++)
+        {
+            last = await httpClient.ExecuteScalarAsync(Sql);
+        }
+
+        return last;
+    }
+
+    /// <summary>Native protocol: query and data packets on a pooled connection.</summary>
+    [Benchmark]
+    public async Task<object> Tcp()
+    {
+        object last = null;
+        for (int i = 0; i < RoundTrips; i++)
+        {
+            last = await tcpClient.ExecuteScalarAsync(Sql);
+        }
+
+        return last;
+    }
+}

--- a/ClickHouse.Driver.Benchmark/TransportRead.cs
+++ b/ClickHouse.Driver.Benchmark/TransportRead.cs
@@ -25,9 +25,10 @@ public enum TransportReadShape
 /// </summary>
 /// <remarks>
 /// <para>
-/// Both clients run at their own defaults, which is what a caller gets: response compression is on
-/// for HTTP and LZ4 framing is on for the native protocol. The codecs differ, so this table answers
-/// "what do I get today", not "which codec is faster" — <see cref="TcpCompression"/> owns that axis.
+/// Both sides run uncompressed. The transports do not default to the same codec — HTTP to gzip/ZSTD,
+/// the native client to LZ4 — so at their defaults the codec difference reports itself as a transport
+/// difference, and over loopback a codec costs CPU while saving nothing. <see cref="TcpCompression"/>
+/// owns the codec axis; a comparison of the codecs' benefit needs a path with real bandwidth.
 /// </para>
 /// <para>
 /// Every arm consumes every value, because a transport that only decodes is not comparable with one
@@ -39,6 +40,10 @@ public enum TransportReadShape
 /// runner changes. The per-transport classes (<see cref="SelectColumn"/>,
 /// <see cref="TcpSelectColumn"/>) are what a PR comparison reads.
 /// </para>
+/// <para>
+/// Two million rows rather than five hundred thousand: at the smaller size the arms ran in tens of
+/// milliseconds with a relative standard deviation near 30%, which no reader can act on.
+/// </para>
 /// </remarks>
 [BenchmarkCategory(BenchmarkCategories.Cross)]
 [Config(typeof(ComparisonConfig))]
@@ -48,7 +53,7 @@ public class TransportRead
     private ClickHouseConnection httpConnection;
     private ClickHouseTcpClient tcpClient;
 
-    [Params(500_000)]
+    [Params(2_000_000)]
     public int Count { get; set; }
 
     [ParamsAllValues]
@@ -70,8 +75,8 @@ public class TransportRead
     [GlobalSetup]
     public void Setup()
     {
-        httpConnection = new ClickHouseConnection(BenchmarkServer.Http);
-        tcpClient = BenchmarkServer.CreateTcpClient();
+        httpConnection = new ClickHouseConnection(BenchmarkServer.HttpUncompressed);
+        tcpClient = BenchmarkServer.CreateUncompressedTcpClient();
     }
 
     [GlobalCleanup]

--- a/ClickHouse.Driver.Benchmark/TransportRead.cs
+++ b/ClickHouse.Driver.Benchmark/TransportRead.cs
@@ -1,0 +1,184 @@
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using ClickHouse.Driver.ADO;
+using ClickHouse.Driver.Tcp;
+using ClickHouse.Driver.Utility;
+
+namespace ClickHouse.Driver.Benchmark;
+
+/// <summary>The column shape a cross-transport read is measured on.</summary>
+public enum TransportReadShape
+{
+    /// <summary>One fixed-width column: the closest thing to raw decode throughput.</summary>
+    NarrowUInt64,
+
+    /// <summary>An integer, a short string and a float: the shape most result sets resemble.</summary>
+    MixedThreeColumn,
+
+    /// <summary>Three string columns, where variable-length decoding dominates.</summary>
+    StringHeavy,
+}
+
+/// <summary>
+/// Reads the same rows over both transports in one process, so the choice between them can be made
+/// from numbers rather than from the protocol's reputation.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Both clients run at their own defaults, which is what a caller gets: response compression is on
+/// for HTTP and LZ4 framing is on for the native protocol. The codecs differ, so this table answers
+/// "what do I get today", not "which codec is faster" — <see cref="TcpCompression"/> owns that axis.
+/// </para>
+/// <para>
+/// Every arm consumes every value, because a transport that only decodes is not comparable with one
+/// that also materializes. The per-row <c>switch</c> on <see cref="Shape"/> is identical in all three
+/// arms, so it cannot bias the comparison.
+/// </para>
+/// <para>
+/// This is characterization, not a regression net: both arms move together when the server or the
+/// runner changes. The per-transport classes (<see cref="SelectColumn"/>,
+/// <see cref="TcpSelectColumn"/>) are what a PR comparison reads.
+/// </para>
+/// </remarks>
+[BenchmarkCategory(BenchmarkCategories.Cross)]
+[Config(typeof(ComparisonConfig))]
+[MemoryDiagnoser(true)]
+public class TransportRead
+{
+    private ClickHouseConnection httpConnection;
+    private ClickHouseTcpClient tcpClient;
+
+    [Params(500_000)]
+    public int Count { get; set; }
+
+    [ParamsAllValues]
+    public TransportReadShape Shape { get; set; }
+
+    private string Sql => Shape switch
+    {
+        TransportReadShape.NarrowUInt64 =>
+            $"SELECT toUInt64(number) AS id FROM system.numbers LIMIT {Count}",
+        TransportReadShape.MixedThreeColumn =>
+            "SELECT toUInt64(number) AS id, concat('city', toString(number % 100)) AS city, " +
+            $"toFloat64(number) / 7 AS temperature FROM system.numbers LIMIT {Count}",
+        _ =>
+            "SELECT concat('city', toString(number % 100)) AS city, " +
+            "concat('region', toString(number % 7)) AS region, " +
+            $"toString(number) AS label FROM system.numbers LIMIT {Count}",
+    };
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        httpConnection = new ClickHouseConnection(BenchmarkServer.Http);
+        tcpClient = BenchmarkServer.CreateTcpClient();
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        httpConnection?.Dispose();
+        tcpClient?.Dispose();
+    }
+
+    /// <summary>HTTP, through the ADO reader's typed accessor.</summary>
+    [Benchmark(Baseline = BenchmarkModes.MethodBaseline)]
+    public async Task<double> Http()
+    {
+        double total = 0;
+        using var reader = await httpConnection.ExecuteReaderAsync(Sql);
+        while (reader.Read())
+        {
+            switch (Shape)
+            {
+                case TransportReadShape.NarrowUInt64:
+                    total += reader.GetFieldValue<ulong>(0);
+                    break;
+                case TransportReadShape.MixedThreeColumn:
+                    total += (double)reader.GetFieldValue<ulong>(0)
+                        + reader.GetFieldValue<string>(1).Length
+                        + reader.GetFieldValue<double>(2);
+                    break;
+                default:
+                    total += reader.GetFieldValue<string>(0).Length
+                        + reader.GetFieldValue<string>(1).Length
+                        + reader.GetFieldValue<string>(2).Length;
+                    break;
+            }
+        }
+
+        return total;
+    }
+
+    /// <summary>Native protocol, block tier: borrowed columnar spans.</summary>
+    [Benchmark]
+    public async Task<double> TcpBlocks()
+    {
+        double total = 0;
+        await foreach (Block block in tcpClient.StreamAsync(Sql))
+        {
+            switch (Shape)
+            {
+                case TransportReadShape.NarrowUInt64:
+                    foreach (ulong id in block.Column<ulong>(0).Values)
+                    {
+                        total += id;
+                    }
+
+                    break;
+
+                case TransportReadShape.MixedThreeColumn:
+                {
+                    var ids = block.Column<ulong>(0).Values;
+                    var cities = block.Column<string>(1).Values;
+                    var temperatures = block.Column<double>(2).Values;
+                    for (int row = 0; row < block.RowCount; row++)
+                    {
+                        total += (double)ids[row] + cities[row].Length + temperatures[row];
+                    }
+
+                    break;
+                }
+
+                default:
+                {
+                    var first = block.Column<string>(0).Values;
+                    var second = block.Column<string>(1).Values;
+                    var third = block.Column<string>(2).Values;
+                    for (int row = 0; row < block.RowCount; row++)
+                    {
+                        total += first[row].Length + second[row].Length + third[row].Length;
+                    }
+
+                    break;
+                }
+            }
+        }
+
+        return total;
+    }
+
+    /// <summary>Native protocol, row tier: one <c>object[]</c> per row, every value boxed.</summary>
+    [Benchmark]
+    public async Task<double> TcpRows()
+    {
+        double total = 0;
+        await foreach (object[] row in tcpClient.QueryAsync(Sql))
+        {
+            switch (Shape)
+            {
+                case TransportReadShape.NarrowUInt64:
+                    total += (ulong)row[0];
+                    break;
+                case TransportReadShape.MixedThreeColumn:
+                    total += (double)(ulong)row[0] + ((string)row[1]).Length + (double)row[2];
+                    break;
+                default:
+                    total += ((string)row[0]).Length + ((string)row[1]).Length + ((string)row[2]).Length;
+                    break;
+            }
+        }
+
+        return total;
+    }
+}

--- a/ClickHouse.Driver.Benchmark/TransportReadPoco.cs
+++ b/ClickHouse.Driver.Benchmark/TransportReadPoco.cs
@@ -1,0 +1,113 @@
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using ClickHouse.Driver.Tcp;
+
+namespace ClickHouse.Driver.Benchmark;
+
+/// <summary>
+/// Reads the same rows into the same objects over both transports, which is the question an
+/// application mapping results to types actually asks.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The third arm builds the same objects from the native block tier, so the table separates two
+/// choices that are easy to confuse: which transport to use, and whether to leave the row tier once
+/// on it.
+/// </para>
+/// <para>
+/// Both clients run at their own defaults, as in <see cref="TransportRead"/>. This is
+/// characterization: the arms move together when the server or the runner changes.
+/// </para>
+/// </remarks>
+[BenchmarkCategory(BenchmarkCategories.Cross)]
+[Config(typeof(ComparisonConfig))]
+[MemoryDiagnoser(true)]
+public class TransportReadPoco
+{
+    private ClickHouseClient httpClient;
+    private ClickHouseTcpClient tcpClient;
+
+    [Params(500_000)]
+    public int Count { get; set; }
+
+    private string Sql =>
+        "SELECT toUInt64(number) AS Id, concat('city', toString(number % 100)) AS City, " +
+        $"toFloat64(number) / 7 AS Temperature FROM system.numbers LIMIT {Count}";
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        httpClient = new ClickHouseClient(BenchmarkServer.Http);
+        httpClient.RegisterPocoType<Reading>();
+        tcpClient = BenchmarkServer.CreateTcpClient();
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        httpClient?.Dispose();
+        tcpClient?.Dispose();
+    }
+
+    /// <summary>HTTP, through the client's POCO reader.</summary>
+    [Benchmark(Baseline = BenchmarkModes.MethodBaseline)]
+    public async Task<double> Http()
+    {
+        double total = 0;
+        await foreach (Reading row in httpClient.QueryAsync<Reading>(Sql))
+        {
+            total += (double)row.Id + row.City.Length + row.Temperature;
+        }
+
+        return total;
+    }
+
+    /// <summary>Native protocol, through its POCO reader.</summary>
+    [Benchmark]
+    public async Task<double> TcpPoco()
+    {
+        double total = 0;
+        await foreach (Reading row in tcpClient.QueryAsync<Reading>(Sql))
+        {
+            total += (double)row.Id + row.City.Length + row.Temperature;
+        }
+
+        return total;
+    }
+
+    /// <summary>Native protocol, building the same objects from columnar spans.</summary>
+    [Benchmark]
+    public async Task<double> TcpBlocksToPoco()
+    {
+        double total = 0;
+        await foreach (Block block in tcpClient.StreamAsync(Sql))
+        {
+            var ids = block.Column<ulong>("Id").Values;
+            var cities = block.Column<string>("City").Values;
+            var temperatures = block.Column<double>("Temperature").Values;
+
+            for (int row = 0; row < block.RowCount; row++)
+            {
+                var reading = new Reading
+                {
+                    Id = ids[row],
+                    City = cities[row],
+                    Temperature = temperatures[row],
+                };
+
+                total += (double)reading.Id + reading.City.Length + reading.Temperature;
+            }
+        }
+
+        return total;
+    }
+
+    public class Reading
+    {
+        public ulong Id { get; set; }
+
+        public string City { get; set; }
+
+        public double Temperature { get; set; }
+    }
+}

--- a/ClickHouse.Driver.Benchmark/TransportReadPoco.cs
+++ b/ClickHouse.Driver.Benchmark/TransportReadPoco.cs
@@ -15,8 +15,9 @@ namespace ClickHouse.Driver.Benchmark;
 /// on it.
 /// </para>
 /// <para>
-/// Both clients run at their own defaults, as in <see cref="TransportRead"/>. This is
-/// characterization: the arms move together when the server or the runner changes.
+/// Both sides run uncompressed, as in <see cref="TransportRead"/> and for the same reason: the
+/// transports do not default to the same codec, and over loopback a codec costs CPU while saving
+/// nothing. This is characterization: the arms move together when the server or the runner changes.
 /// </para>
 /// </remarks>
 [BenchmarkCategory(BenchmarkCategories.Cross)]
@@ -27,7 +28,7 @@ public class TransportReadPoco
     private ClickHouseClient httpClient;
     private ClickHouseTcpClient tcpClient;
 
-    [Params(500_000)]
+    [Params(2_000_000)]
     public int Count { get; set; }
 
     private string Sql =>
@@ -37,9 +38,9 @@ public class TransportReadPoco
     [GlobalSetup]
     public void Setup()
     {
-        httpClient = new ClickHouseClient(BenchmarkServer.Http);
+        httpClient = new ClickHouseClient(BenchmarkServer.HttpUncompressed);
         httpClient.RegisterPocoType<Reading>();
-        tcpClient = BenchmarkServer.CreateTcpClient();
+        tcpClient = BenchmarkServer.CreateUncompressedTcpClient();
     }
 
     [GlobalCleanup]

--- a/ClickHouse.Driver.Benchmark/WideIntegerInsert.cs
+++ b/ClickHouse.Driver.Benchmark/WideIntegerInsert.cs
@@ -15,6 +15,7 @@ namespace ClickHouse.Driver.Benchmark;
 /// Inserts into a <c>Null</c>-engine table to isolate client serialization; the interesting
 /// columns are Allocated and Mean.
 /// </summary>
+[BenchmarkCategory(BenchmarkCategories.HttpInvestigation)]
 [Config(typeof(ComparisonConfig))]
 [MemoryDiagnoser(true)]
 public class WideIntegerInsert


### PR DESCRIPTION
Epic T1/T2: benchmarks for the native client, the cross-transport comparison, and the PR comparison job that runs them.

Ratios below are **time relative to HTTP, so lower is faster** — the same convention as BenchmarkDotNet's own `Ratio` column.

## What this adds

**Native-protocol benchmarks** (`tcp-regression`, 41 methods). Each class prices the tiers a caller chooses between, not one number per operation:

| Class | Compares |
| --- | --- |
| `TcpSelectColumn` | 16 expressions, block tier, mirroring `SelectColumn` |
| `TcpReadTiers` | block spans / typed indexer / boxed `GetValue` / `object[]` / POCO |
| `TcpProjectedRead` | stored type / `ReadAs<T>` indexer / `ReadAs<T>.Values` |
| `TcpCompositeRead` | composite interface / indexer / `Values` / row tier, over 5 composites |
| `TcpStringRead` | `IStringColumn.Offsets` / `GetBytes` / decoded strings |
| `TcpInsertShapes` | columnar / `object[]` / POCO |
| `TcpArrayWriteShape` | dense offsets against one array per row |
| `TcpConnectionCost` | warm ping / warm scalar / client-per-operation |
| `TcpPoolConcurrency` | 64 queries serially against widths 1, 8, 32 |
| `TcpCompression` | none / lz4 / zstd, read and insert |

**Cross-transport benchmarks** (`cross`, 14 methods): `TransportRead`, `TransportReadPoco`, `TransportInsert`, `TransportLatency`. Each pairs an HTTP arm with its native counterpart on identical data in one process, with the codec and the server's insert buffering equalised so that a ratio reports the transport and not a setting that lands on one side only.

**A working PR comparison job.** `benchmark-compare.yml` has been failing to compile since the Common assembly split: the outer `dotnet run` left `ClickHouseDriverVersion` unpinned, so it restored the default release from nuget.org and could not compile against any API added since. It now pins the version and source, publishes 9000, and defaults `baseline_ref` to the PR's own base branch — a `tcp/**` PR sits on a stack whose base is not `main`, so comparing against `main` cannot compile.

**Category selection from the diff.** A change under `ClickHouse.Driver.Tcp/` runs the native set, `ClickHouse.Driver/` the HTTP set, either `Compression/` directory the codec sweep, and the harness itself runs everything. Both transports moving adds the cross table. A push to `main` runs the regression sets; the nightly build runs all of them.

## TCP against HTTP

One ClickHouse 26.6.1.1193 container serving both 8123 and 9000, so both transports hit the same data and CPU budget. 3 warmup + 30 iterations × 2 launches, on 4 logical and 2 physical cores. Loopback, so this measures client and protocol work and none of the transfer saving that compression exists for. The read sections use 2M rows; the insert section uses 5M, for the reason given there.

**Every time below is the fastest of 120 iterations: 30 × 2 launches, run twice.** This host interferes in bursts, so an iteration can land far above its neighbours. Means and medians do not survive that; best-case iterations do, agreeing between the two runs to within **0.03% to 6.79%** on every one of the 18 cross-transport arms. Interference is additive, so the fastest iteration is the arm's own cost and the tail is the box. Allocation does not depend on this and is quoted as BenchmarkDotNet reports it.

**Every arm below runs uncompressed on both sides.** The transports do not default to the same
codec (HTTP gzip or ZSTD, native LZ4), so at their defaults the codec difference reports itself as a
transport difference, and over loopback a codec costs CPU while saving nothing. An earlier revision
of this PR ran the read arms at both clients' defaults; that inflated the native client's advantage,
and the corrected figures are below. What compression is actually worth is measured on a real
network further down.

**Everything on loopback was re-measured on 2026-09-11, at `bdf1cdb8`.** Two things make that worth saying rather than silently replacing numbers:

- **The driver changed underneath the branch.** The 2026-09-09 rebase pulled in `main` as of that date, which includes the box-free typed column slots of #499. That is a real change to the HTTP read path and it moves the allocation columns below by three orders of magnitude on fixed-width data. It is not noise, and the row-reads section says what it did.
- **The host is not the host the earlier figures came from.** The box was reconfigured between the two sessions. Allocation reproduces to three significant figures wherever the code did not change — every native arm, HTTP's string-heavy read, the whole insert allocation model — so the arms are doing the same work. Times are not stable across sessions: bulk arms run 15% to 86% slower than the 2026-08-30 session, while `TransportLatency` runs 13% to 31% *faster*. A single cause that slows bulk throughput and speeds up round trips is not obvious, and this re-run cannot identify one. Treat absolute times as this box on this day.

The WAN and compression figures further down are the one part not re-measured, because they need a Cloud service; they are attributed where they appear.

### Row reads — `TransportRead`

`Http` and `TcpRows` both consume every value; `TcpBlocks` is the columnar ceiling.

| Shape | HTTP | TCP rows | TCP blocks | HTTP alloc | TCP rows alloc | TCP blocks alloc |
| --- | --- | --- | --- | --- | --- | --- |
| 1 × UInt64 | 68.6 ms | 79.6 ms (1.16) | **11.7 ms (0.17)** | **15.5 KB** | 109,397 KB (7,051) | 22.2 KB (1.43) |
| UInt64+String+Float64 | 255.7 ms | 274.9 ms (1.07) | 172.4 ms (0.67) | 76,580 KB | 264,111 KB (3.45) | 76,611 KB (1.00) |
| 3 × String | 352.6 ms | 518.9 ms (1.47) | 521.2 ms (1.48) | 232,049 KB | 325,840 KB (1.40) | 232,080 KB (1.00) |

**Equalising the codec removed the native row tier's read advantage.** At the two clients' defaults an earlier revision of this PR measured `TcpRows` at 0.66 / 0.72 / 1.02; uncompressed it reads 1.16 / 1.07 / 1.47. HTTP had been paying ZSTD on the response body while the native side paid LZ4, and that gap was most of the earlier win. On this hardware the native row tier is not faster than the ADO reader.

**The block tier's time advantage is real and is where the value is:** 0.17 on fixed-width data, because nothing is boxed and nothing is copied.

**Its allocation advantage on fixed-width data is gone, and HTTP now wins it.** 15.5 KB against the block tier's 22.2 KB, where the earlier session measured HTTP at 46,890 KB. #499 gave `GetFieldValue<T>` typed column slots that return the value without boxing, so HTTP's reader no longer allocates per row on this shape — 2M rows cost it fixed buffers and nothing else. The same change shows up on the mixed shape, where HTTP drops from 170,330 KB to 76,580 KB and lands within 31 KB of the block tier: both sides now allocate the 2M strings and neither boxes the integer or the float. On three string columns nothing changed, because strings were never the boxing (232,048 KB then, 232,049 KB now). **So the block tier is now a time argument, not an allocation one.**

**The native row tier still allocates a fresh `object[]` per row** — 109,397 KB on the narrow shape in both sessions, 56 B/row. Against HTTP's fixed buffers that is 7,051×, where the earlier session read 2.33×; the multiple moved because HTTP's denominator collapsed, not because the row tier changed. `QueryAsync` yields a fresh `object[]` per row because a consumer is free to keep it, which is the row API's shape rather than the protocol's, and it is not fixable without changing the contract.

**On string-heavy data both TCP tiers are slower than HTTP**, 1.47 and 1.48. The block arm calls `.Values` on the string columns, materialising 6M strings, and pays worse GC for it (Gen1 7,000 per 1,000 ops against HTTP's zero, Gen2 zero on all three) because three 2M-element arrays live for the whole block and get promoted, while HTTP's per-row strings die in Gen0.

That is what `IStringColumn` is for. `TcpStringRead` reads the same strings for **33.5 ms and 12.17 KB against 46.1 ms and 19,538 KB**: 0.73 on time, and 1/1,600 of the allocation. So TCP's read advantage on strings depends entirely on whether the caller decodes them.

### POCO reads — `TransportReadPoco`

| Arm | Fastest | Ratio | Allocated | Alloc ratio |
| --- | --- | --- | --- | --- |
| HTTP `QueryAsync<T>` | 277.5 ms | 1.00 | 151.08 MB | 1.00 |
| TCP `QueryAsync<T>` | 235.0 ms | **0.85** | 151.11 MB | 1.00 |
| TCP blocks → POCO by hand | 198.8 ms | **0.72** | 151.11 MB | 1.00 |

**All three allocate within 1% of each other, and the figures are identical to the earlier session's** — 151.08 MB over 2M rows is 79 B/row, which is the POCO (40 B) plus one fresh string per row (~32 B) and essentially nothing else. The objects *are* the allocation and no transport can avoid them. Neither path boxes: `QueryAsync<T>` materialises straight from the stream on both transports.

**What the shared allocation floor does not do is equalise the time.** The earlier session put all three within 3% of each other and concluded the floor left nothing for a transport to win; re-measured, the native reader is 15% ahead and hand-building from blocks 28% ahead. The allocation is identical to the byte, so whatever moved did not change what these arms allocate, and the gap is far larger than anything the two runs within this session disagree about (0.16% to 4.28% per arm). Beyond that the cause is open: #499 does not reach `QueryAsync<T>`, but the rebase brought three weeks of `main` with it and this re-run cannot separate that from the host. **An earlier revision of this PR reported 0.70 here and the PR then withdrew it as a codec artefact; at an equalised codec it reads 0.72, so that withdrawal was wrong.** What is fair to say is that the ordering is stable and the margin is not: on this box a POCO consumer should expect the native transport to be somewhere between level and a quarter faster, and should not plan around a specific figure.

Hand-building from blocks remains the worst of the three on GC pressure — Gen1 4,000 per 1,000 ops against zero for both `QueryAsync<T>` arms — because the intermediate column arrays survive the block.

**A caller who wants materially better than this has to stop building objects**, which is what the 0.17 on narrow blocks shows.

### Latency — `TransportLatency`

500 sequential `SELECT 1` on warm connections: HTTP 572.7 ms (1.15 ms/query, 7.19 MB) against TCP 513.4 ms (**1.03 ms/query**, 4.64 MB), ratio **0.90**, allocation **0.65**. TCP saves about 0.12 ms of fixed per-request cost.

This is the section that moved most against the earlier run, and in the opposite direction to everything else: both arms are faster than they were (824.6 and 590.6 ms), so the native client's per-request advantage narrows from 0.72 to 0.90 while its allocation ratio holds at 0.65 against 0.66. The allocation figures rule out the arms having changed. Whatever this host did between the two sessions, it helped round trips and hurt bulk transfer, so **the size of the latency win is the least portable number in this document.**

### Inserts — `TransportInsert`

**5,000,000 rows,** because a smaller insert measures the fixed cost of an insert as much as the serialization the arms compare. Fitting both sizes gives each arm 4.7 to 8.6 ms of fixed cost, which is a fifth of a 500k-row measurement, so the ratios there compress toward 1 (`TcpColumnar` reads 0.65 at 500k against 0.60 at 5M, `TcpRows` 1.07 against 1.04, `TcpPoco` 0.91 against 0.94). 5M costs about 1 GB of source rows held for the run, which is the reason not to go further.

The native arms send this insert as **100 wire blocks of 50,000 rows**, which is `MaxRowsPerBlock` at its default, and convert rows to columns one block at a time.

Two things are turned off, because each lands on the transports unequally and would report itself as a protocol difference. **`async_insert = 0`**: a server with async inserts on holds an insert's response until its buffer flushes, waiting from `async_insert_busy_timeout_min_ms` (50 ms) upward, and the native arms never paid it. **No request compression**: the transports do not default to the same codec (HTTP ZSTD, native LZ4), and the codec costs more than the serialization the arms exist to compare. Over loopback there is no bandwidth to save and `TcpCompression` owns the codec axis, so nothing of value is dropped.

| Arm | Fastest | Ratio | ns/row | Allocated |
| --- | --- | --- | --- | --- |
| `HttpRows` | 385.8 ms | 1.00 | 75.8 | 30.1 KB |
| `TcpRows` | 400.6 ms | **1.04** | 78.4 | 519.9 KB |
| `HttpPoco` | 392.5 ms | 1.02 | 76.9 | 30.4 KB † |
| `TcpPoco` | 362.6 ms | **0.94** | 71.5 | 518.3 KB |
| `TcpColumnar` | 233.2 ms | **0.60** | 45.3 | 517.8 KB |
| `HttpRowsDefaultBatching` | 536.1 ms | 1.39 | 106.3 | 487.2 KB |

The `ns/row` column is the slope between the two sizes, so it excludes the fixed cost. † `HttpPoco`'s allocation does not hold still between runs; the lower of the two is quoted and the spread is below.

**The native protocol's insert advantage still needs the columnar shape to appear.** `TcpColumnar` is the fastest thing here at 0.60, and hand the same client rows and the advantage disappears — but it no longer reverses. The earlier session put `TcpRows` *behind* HTTP at 1.35; re-measured it is 1.04, which is parity, and `TcpPoco` holds at 0.94 exactly. **The claim that the row tier is slower than HTTP on inserts does not survive re-measurement; the claim that it gives up the columnar win does.**

The transpose is still what the row tiers pay, and the two sizes price it twice over: as totals, 400.6 − 233.2 = 167.4 ms for 15M values, or 11.2 ns per value; as slopes, 78.4 − 45.3 = 33.1 ns per row, which is the same 11.0 ns per value. HTTP's RowBinary is row-major, so it matches the input layout and encodes straight into the request body while sending; the native block format is column-major, so every column must be fully materialised before a byte of it goes out, and the transpose runs inside the `schema => …` callback, wedged between two round trips with nothing to overlap.

**The POCO tier beats the `object[]` tier on the native side**, 362.6 against 400.6 ms — 2.5 ns per value, where the earlier session measured 7.2 — because the compiled typed accessors read fields in place instead of unboxing scattered values. On HTTP the same swap is a wash on the clock (392.5 against 385.8 ms), as it was before. A probe in the earlier session tagging each insert with a `query_id` put the HTTP POCO path at 239 ms of client CPU against the `object[]` path's 297 ms; that probe was not repeated, and the wall-clock wash it explains still reproduces.

**Allocation is per unit of framing, and the transports frame differently — and the framing model is the part that reproduces to the digit.** A native insert allocates about 13 KB fixed plus **5.05 KB per wire block**, which the two sizes pin down: 10 blocks cost 63 to 65 KB and 100 cost 518 to 520 KB, against the earlier session's 13 KB and 5.1 KB per block. HTTP allocates about 20 KB fixed plus **9.3 KB per request**, so one request costs 30 KB and the fifty of `HttpRowsDefaultBatching` cost 487 KB. Neither figure includes row handling, because the source objects are built once in `GlobalSetup`, and no arm triggers a single GC collection. Neither HTTP path boxes during the operation: the POCO path uses the typed `Action<T, ExtendedBinaryWriter>` writers, and `InsertOptions.Format` defaults to `RowBinary`, so the boxed getters serve only `RowBinaryWithDefaults` and failure diagnostics.

`HttpPoco`'s allocation was the one arm the earlier session could not reproduce, at 30.9 KB in one run against 358.9 KB in the other. **The anomaly recurred, so it is not a one-off:** 95.41 KB in this session's first run against 30.36 KB in its second, while `HttpRows` beside it held at 30.29 and 30.12 KB. Smaller spread than before and the same shape — one arm, on the HTTP side, whose allocation jumps by a multiple between runs while its neighbour is stable to 0.6%. Still unexplained, and now twice observed rather than once.

**`InsertOptions.BatchSize`**: the default 100,000 sends fifty requests for 5M rows, costing 536.1 against 385.8 ms — about 3.1 ms per extra request, which is the round trip and little else — plus 16.2× the allocation in per-request buffers. An earlier revision of this PR reported a 4× time penalty here; that was fifty exposed `async_insert` waits and the claim stays withdrawn.

## Compression, and the columnar layout, on a real network

Loopback cannot answer whether a codec pays for itself, so this was measured against a ClickHouse Cloud service (26.4.1.2212): 500k rows, median of 3 after a warm-up, rows taken from ClickBench `hits` so the payload is not a compressor-friendly sequence. **This is characterisation from a one-off probe on 2026-08-30, not a committed benchmark, and it is the one section the 2026-09-11 re-run did not repeat** — it needs that service, and its arms run for 0.4 s to 30 s each on a path where transfer dominates client work by an order of magnitude, so nothing the client does moves them. The arms run sequentially over a WAN, so read differences under ~15% are noise.

Reads:

| Shape | HTTP | HTTP compressed | Native | Native LZ4 | Native ZSTD |
| --- | --- | --- | --- | --- | --- |
| 10 × hits, mixed | 30,203 ms | **3,103 ms (0.10)** | 26,776 ms | 5,863 ms (0.22) | 5,294 ms (0.20) |
| 10 × hits, numeric | 2,332 ms | **245 ms (0.10)** | 2,499 ms | 397 ms (0.16) | 506 ms (0.20) |
| 3 × synthetic | 2,004 ms | **692 ms (0.35)** | 2,792 ms | 1,303 ms (0.47) | 1,398 ms (0.50) |

Inserts:

| Shape | HTTP | HTTP gzip | HTTP ZSTD | Native | Native LZ4 | Native ZSTD |
| --- | --- | --- | --- | --- | --- | --- |
| 10 × hits, mixed | 19,279 ms | 3,772 ms (0.20) | **3,059 ms (0.16)** | 16,847 ms | 4,314 ms (0.26) | 3,348 ms (0.20) |
| 10 × hits, numeric | 1,865 ms | 830 ms (0.45) | 463 ms (0.25) | 2,784 ms | 687 ms (0.25) | **415 ms (0.15)** |
| 3 × synthetic | 2,458 ms | 802 ms (0.33) | 791 ms (0.32) | 1,953 ms | 1,208 ms (0.62) | **448 ms (0.23)** |

**Compression is the dominant factor and everything else is secondary.** It takes 0.10 to 0.26 of the uncompressed time. This is the number the loopback suite structurally cannot produce, and it settles the direction of T1a: compression on by default is right.

**ZSTD, not LZ4, is the better codec on this path** — it wins 4 of 6 arms, including both large payloads and every insert. LZ4 holds only on the two small, highly compressible reads. One WAN probe is not enough to change a shipped default, but it is evidence T1a did not have.

**HTTP's compressed reads beat the native client's on every shape, by 1.6× to 2.1×.** Uncompressed the two are level or favour the native client (0.89 on the mixed hits shape), so the gap is specific to the compressed read path, and it is not explained by bytes: the layout table below has the native format sending *fewer* bytes on this data. Compression improves HTTP's mixed-shape read by 9.7× against a 6.49× byte reduction, while it improves the native client's by only 5.1× against its own 7.05×. The native compressed read is the one arm whose speedup falls short of its byte reduction, so something in that path is not converting the saving. Per-block framing is the leading suspect — a codec context, a CityHash checksum and a frame header per block rather than once per response — but this is **unverified**, and it is worth a look before the client ships.

Inserts are near parity on real data: HTTP is 21% ahead on the mixed shape, the native client 10% ahead on the numeric one. The native client's large insert win shows up only on the synthetic shape.

### The columnar layout does not compress better than RowBinary on realistic data

An earlier revision of this PR claimed it did, on the strength of a synthetic shape, and that claim is withdrawn. Comparing `FORMAT RowBinary` against `FORMAT Native` for the same 1M rows under ZSTD-3, compressed in 1 MB frames so neither layout gets cross-block context the native protocol would never have:

| Shape | RowBinary | Native | Columnar sends |
| --- | --- | --- | --- |
| 1 × `WatchID` | 1.00× | 1.00× | 1.00× (incompressible control) |
| 10 × hits, mixed | 6.49× | 7.05× | 1.09× fewer bytes |
| 3 × hits `String` | 7.70× | 8.04× | 1.04× fewer bytes |
| 10 × hits, numeric | 30.09× | 24.39× | **1.23× more bytes** |
| 3 × synthetic | 4.91× | 10.73× | 2.19× fewer bytes |

These are server-side format sizes, so no client change can move them, and they are unaffected by the re-run.

The synthetic row is the outlier, and it is the one the withdrawn claim rested on. Its columns are `number`, `number % 100` and `number / 7`: three short-period sequences that compress far better once grouped by column. Real hits columns are high-cardinality — `WatchID` and `UserID` are near-random, `URL` and `Title` are varied text — so grouping them by column unlocks little the compressor was not already finding.

On ten narrow numeric columns row-major wins outright, for a reason that is a property of real traffic rather than of either format: many hits repeat an identical `(CounterID, RegionID, OS, UserAgent, Resolution*, Flash*, Net*)` tuple. Row-major keeps each duplicate row contiguous, so the compressor matches one long run per repeat; column-major scatters that tuple across ten distant regions and can only find per-column runs.

The frame size barely mattered — whole-stream compression reads 6.98× against the chunked 6.49× on the mixed shape — so the distortion in the withdrawn claim was the synthetic data, not the compression window.

### Per-type decode — `SelectColumn` against `TcpSelectColumn`

Same 16 expressions, 500k rows, both drained without touching a value. **These are no longer unequal work in the way the earlier revision of this section said they were.** That text had HTTP's `Read()` boxing every value into a reused `object[]`; #499 replaced that row buffer with typed column slots, so a drain that calls no accessor now allocates nothing on the fixed-width types — 17.5 KB for 500k rows, flat across all ten of them. The allocation columns are therefore comparable on those types and are given below.

| Type | HTTP | TCP | Ratio | HTTP alloc | TCP alloc |
| --- | --- | --- | --- | --- | --- |
| DateTime | 31.9 ms | 5.2 ms | 0.16 | 18.0 KB | 18.0 KB |
| UInt32 | 22.9 ms | 4.4 ms | 0.19 | 17.5 KB | 12.3 KB |
| Date32 | 22.5 ms | 4.5 ms | 0.20 | 17.5 KB | 13.8 KB |
| Int32 | 22.7 ms | 4.7 ms | 0.21 | 17.5 KB | 12.2 KB |
| Nullable(Int32) | 25.7 ms | 5.5 ms | 0.21 | 18.1 KB | 17.5 KB |
| Date | 22.0 ms | 4.7 ms | 0.21 | 17.5 KB | 16.9 KB |
| Float32 | 21.5 ms | 5.1 ms | 0.24 | 17.5 KB | 12.3 KB |
| Float64 | 35.7 ms | 10.3 ms | 0.29 | 17.5 KB | 12.3 KB |
| Int64 | 34.9 ms | 10.1 ms | 0.29 | 17.5 KB | 12.2 KB |
| UInt64 | 34.9 ms | 10.1 ms | 0.29 | 17.5 KB | 12.3 KB |
| Decimal256 | 70.4 ms | 20.5 ms | 0.29 | 14.62 MB | 31.2 KB |
| Array | 72.1 ms | 21.7 ms | 0.30 | 22.91 MB | 17.4 KB |
| Decimal64 | 47.5 ms | 16.0 ms | 0.34 | 14.62 MB | 20.0 KB |
| Tuple | 77.7 ms | 39.1 ms | 0.50 | 45.03 MB | 37.3 KB |
| String | 53.2 ms | 31.4 ms | 0.59 | 22.14 MB | 12.7 KB |
| **Decimal128** | **58.3 ms** | **128.6 ms** | **2.21** | **14.62 MB** | **170.37 MB** |

**This is the section whose ratios reproduce best.** Every absolute time is 20% to 40% above the earlier session's, and the ratios still land within 0.04 of it on 15 of 16 types — `String` 0.51 → 0.59 is the only one that moved further. `Decimal128` reproduces at 2.21 against 2.19.

TCP scales with width — `Int32` 4.7 ms to `Int64` 10.1 ms is 2.1× — which HTTP does not.

**On the variable-length types HTTP still allocates per value and TCP still does not**, but for different reasons on each side, and neither is a protocol win. HTTP's 14.62 MB on the decimals is one decimal object per row (30 B/row) built during `Read()`, which typed slots do not cover; TCP's flat 12 to 37 KB is the drain loop declining to materialise strings, arrays and tuples at all. `TransportRead` is still the honest allocation comparison, because there both sides consume every value.

## What these turned up

**`Decimal128` reads allocate ~357 B/row, and this reproduces exactly.** 128.6 ms and 170.37 MB over 500k rows, against its own `Decimal64` at 16.0 ms / 20.0 KB and `Decimal256` at 20.5 ms / 31.2 KB — the same 174,459 KB the earlier session measured, to the digit. `Gen0` is 6,000 per 1,000 ops where every other TCP type is zero. It is the one type in the sweep where TCP loses to HTTP, in both sessions. `ClickHouseTcpDecimal(Int128 mantissa, int scale)` (`Numerics/ClickHouseTcpDecimal.cs:39`) is documented as sign-extending to 256 bits but reaches `Int256` through `Int256.FromBigInteger(mantissa)`, and the implicit `Int128` → `BigInteger` conversion heap-allocates once per row. The `Int256(ulong, ulong, ulong, ulong)` constructor next to it costs nothing. **Not fixed here** — this PR only measures.

**#499's typed column slots reach the ADO reader and the per-type sweep, and stop there.** The three places this suite can see it are HTTP's fixed-width reads (46,890 KB → 15.5 KB on 2M rows), HTTP's mixed-shape read (170,330 KB → 76,580 KB, the integer and the float stopping boxing while the string stays) and the drain loop in `SelectColumn` (per-value → 17.5 KB flat). It does not touch `QueryAsync<T>`, which materialises POCOs straight from the stream and already allocated only the objects; `TransportReadPoco`'s 151.08 MB is identical across the two sessions. Nor does it touch the decimals, arrays, tuples or strings in the sweep, which still build one object per value.

**Not TCP, and not a defect: the HTTP insert cost is `async_insert`.** A server with `async_insert = 1` and `wait_for_async_insert = 1` holds an insert's response until its buffer flushes, waiting from `async_insert_busy_timeout_min_ms` (50 ms) upward. On 26.6.1.1193 a one-row HTTP insert costs 52 ms against 2.0 ms with the setting off, where an empty `SELECT 1` round trip is 2.2 ms. It reproduces with `curl`, on `Null`/`MergeTree`/`Memory` alike and for VALUES/`FORMAT CSV` alike, and a buffered `ExecuteNonQueryAsync` literal pays it too — so it is the server's policy, not the driver's path. `INSERT ... SELECT` costs 2.4 ms, which is the line it falls on: async inserts apply only when the data comes from the client. Worth documenting rather than fixing, since `BatchSize` multiplies it and `async_insert = 1` is the ClickHouse Cloud default. (Measured 2026-08-30; not repeated.)

**RowBinary costs the server about three times what the native block format does.** For the same 109 MiB, the same 5M rows and the same `ENGINE Null` target, the server burns 150 to 180 ms of CPU parsing RowBinary against 55 to 68 ms reading native blocks, and on the native path it spends most of its time waiting for the client rather than parsing. So HTTP has a server-side floor the client cannot get under, and the native protocol's insert advantage is partly the server's work, not only the client's. Measured by tagging every insert with a `query_id` and reading `query_duration_ms`, `ProfileEvents['UserTimeMicroseconds']` and `ProfileEvents['NetworkReceiveElapsedMicroseconds']` out of `system.query_log`. (Measured 2026-08-30; not repeated, and note that it predicts a *larger* native insert win than the re-measured `TcpRows` 1.04 shows.)

**Where the row tier's cost is, and where it is not.** The native row tier costs 11.2 ns per value above the columnar arm, 2.5 ns when the values come off POCO fields, and neither figure has a confirmed cause. Both are smaller than the earlier session's 14.4 and 7.2. Two candidates are ruled out:

- `Type.IsInstanceOfType`, called once per value in the gather that `UntypedRowColumns.CreateBuilder` compiles, is **not** it: removing it moved `TcpRows` by less than its standard deviation.
- Cache locality in the transpose is **not** it either, and that one was settled by a change rather than an experiment. #559 replaced the whole-insert gather with one that fills a 50,000-row window per wire block, which is what the locality argument asks for. Measured back to back in the 2026-08-30 session, the tip before that change and the tip with it agreed on every arm: `TcpRows` 356.4 against 347.5 ms, `TcpPoco` 263.5 against 241.2, `TcpColumnar` 129.4 against 131.1. Those are that session's numbers — the same arms read 400.6, 362.6 and 233.2 here — but the comparison was same-session and back-to-back, which is what makes it valid. At three columns the row array is walked three times either way, and a 50,000-row window is still 200,000 scattered heap objects, about 5 MB of them. Whether locality pays on wide rows is a question three columns cannot answer.

That change is visible in this suite only as allocation: 5.05 KB per wire block is unchanged by it, but the default block size moved, so the same 5M-row insert allocates 519 KB as 100 blocks where it allocated 40 KB as 5. Its real subject, the peak memory of the conversion buffers, is not something a timing table shows.

## Caveats

- **Loopback for everything committed.** Compression is priced at its cost with none of its benefit, so `TcpCompression` cannot rank codecs; its own docs say so. The Cloud figures above come from a one-off probe that is not part of the suite, and T1a still owns making that repeatable.
- **This host is not a measurement instrument, and the re-run shows it is not even a stable one.** Two physical cores run the client and the server together, and the host interferes in bursts. That is why the figures are best-case iterations, and why an arm's mean sits 15% to 40% above its best case. Within one session best-case iterations are tight: 0.03% to 6.79% across the 18 cross-transport arms. Across the two sessions they are not, and not uniformly — bulk arms 15% to 86% slower, latency 13% to 31% faster, with allocation identical wherever the code did not change.
- **Ratios are more portable than times, but they are not fixed either.** The per-type sweep holds within 0.04 on 14 of 16 types across sessions, and `TcpPoco`'s insert ratio held at 0.94 exactly. Three did not: `TcpRows` on inserts 1.35 → 1.04, `TcpBlocks` on string reads 1.79 → 1.48, and the POCO read arms 0.97 → 0.85 and 0.72. Read any single ratio here as good to about ±0.1 and only the large ones as load-bearing.
- **The comparison job reports, it does not gate.** Nothing decides which rows matter: on a 2-core runner the same code on both sides reads as −21% to +11% at 3 iterations. Filed as T5 — a row should be flagged only when the ratio's interval clears `RatioSD`, and the job should say how many rows it suppressed.
- `tcp-investigation` is defined and unused, kept as the slot symmetric with `http-investigation`.
- BenchmarkDotNet's `MinIterationTime` advisory fires on the sub-100 ms arms. Under `RunStrategy.Monitoring` there is no invocation amortisation to increase; the measurements are still five orders of magnitude above timer resolution.

## Verification

- **Both `Program` guards were failing on this branch, in both modes, and both are fixed.** The 2026-09-09 rebase brought three benchmark classes from `main` that predate this branch's conventions, and each guard caught one half of that:
  - *Categorization.* `AdoReadPathBenchmark` (#499), `ArrayInsertElementBoxing` (#571) and `WideIntegerInsert` (#572) arrived carrying no category, and the guard exits 1 rather than let them be silently skipped by every `--anyCategories` run — so the harness ran nothing at all, in either mode. All three pin one issue or one past optimization on the HTTP path and are now `http-investigation`.
  - *Method baseline.* `AdoReadPathBenchmark.UntypedAccessor` also arrived with a literal `[Benchmark(Baseline = true)]`, which the second guard rejects in comparison mode — so `benchmark-compare.yml`, the mode every PR actually runs, stayed broken after the categories were fixed. It now uses `BenchmarkModes.MethodBaseline`, keeping it the method baseline locally and standing aside for the job baseline in a comparison run. Reported by Cursor Bugbot.
- Verified by running `--list flat` both ways — local, and with `BENCHMARK_COMPARISON` defined: exit 0 and 120 benchmarks each time, neither guard reporting anything.
- Category counts, from `--list flat --anyCategories`: `http-regression` 40, `tcp-regression` 41, `cross` 14, `http-investigation` 17, `tcp-investigation` 0, `compression` 8. They sum to the 120 the flat list reports, so every benchmark is reachable from exactly one category.
- Every loopback figure above was re-measured on 2026-09-11 at `bdf1cdb8`, twice, at 30 × 2 launches per run. Best-case iterations agree between the two runs to within 0.03% to 6.79% on the 18 cross-transport arms, and to within 3% on the per-type sweep and the string tiers.
- The insert `ns/row` slopes and the allocation model come from fitting 500k against 5M. The native model reproduces the earlier session's to the digit: 5.05 KB per wire block against 5.1, ~13 KB fixed against 13, 10 blocks at 63 to 65 KB and 100 at 518 to 520 KB.
- Where a figure changed for a reason other than the host, the reason is named: #499 for HTTP's read allocation, and nothing else.
- Where the earlier session's claim did not survive, it is withdrawn in place rather than quietly replaced: the row tier being behind HTTP on inserts, the POCO arms being at parity, the block tier's allocation advantage on fixed-width reads, and the 0.70 POCO figure's attribution to the codec. `HttpPoco`'s unstable allocation went the other way — it recurred, so that caveat is kept and strengthened.
- The `async_insert` finding, the server-CPU comparison, the client-CPU `query_id` probe and the Cloud/WAN section are from the 2026-08-30 session and were not repeated; each is marked where it appears.
- The path-to-category mapping has 12 cases covering each project, the `Compression/` subdirectory rule, the harness escape hatch, and the docs/tests/examples fallbacks.
- Every new class ran end to end against a real server; three arms were reworked after their first results showed they measured something other than what their docs claimed.

Stacked on #595. Nothing here depends on the examples, so the diff to review is the commits on top of `tcp/epic-t3-examples`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
