### PR TITLE
Implement ClickHouseRawResult cancellation APIs

### DIFF
--- a/ClickHouse.Driver.Tests/ADO/ClickHouseRawResultDecompressionTests.cs
+++ b/ClickHouse.Driver.Tests/ADO/ClickHouseRawResultDecompressionTests.cs
@@ -4,6 +4,7 @@ using System.IO.Compression;
 using System.Net;
 using System.Net.Http;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using ClickHouse.Driver.ADO;
 using ClickHouse.Driver.Compression;
@@ -103,6 +104,31 @@ public class ClickHouseRawResultDecompressionTests
         var decompressed = await raw.ReadDecompressedStreamAsync();
 
         Assert.That(decompressed, Is.SameAs(contentStream), "nothing to decode, so nothing to wrap");
+    }
+    
+    [Test]
+    public async Task ReadDecompressedStreamAsync_WithCancellationToken_ReturnsTheRawContentStream()
+    {
+        using var cts = new CancellationTokenSource();
+        using var response = CreateResponse(Plaintext, contentEncoding: null);
+        using var raw = new ClickHouseRawResult(response);
+
+        var contentStream = await raw.ReadAsStreamAsync(cts.Token);
+        var decompressed = await raw.ReadDecompressedStreamAsync(cts.Token);
+
+        Assert.That(decompressed, Is.SameAs(contentStream), "nothing to decode, so nothing to wrap");
+    }
+    
+    [Test]
+    public async Task ReadDecompressedStreamAsync_WithCanceledToken_ThrowsOperationCanceledException()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        
+        using var response = CreateResponse(Plaintext, contentEncoding: null);
+        using var raw = new ClickHouseRawResult(response);
+        
+        Assert.CatchAsync<OperationCanceledException>(() => raw.ReadDecompressedStreamAsync(cts.Token));
     }
 
     [Test]

--- a/ClickHouse.Driver.Tests/ADO/RawResultReaderAsyncTests.cs
+++ b/ClickHouse.Driver.Tests/ADO/RawResultReaderAsyncTests.cs
@@ -1,7 +1,9 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using ClickHouse.Driver.ADO;
 using NUnit.Framework;
 
 namespace ClickHouse.Driver.Tests.ADO;
@@ -9,23 +11,36 @@ namespace ClickHouse.Driver.Tests.ADO;
 [Category("Cloud")]
 public class RawResultReaderAsyncTests : AbstractConnectionTestFixture
 {
-    [Test]
-    public async Task ShouldReadRawResultAsStream()
+    private async Task<ClickHouseRawResult> ExecuteRawResultAsync()
     {
-        using var command = connection.CreateCommand();
+        await using var command = connection.CreateCommand();
         command.CommandText = "SELECT 1,2,3 FORMAT TSV";
-        using var result = await command.ExecuteRawResultAsync(CancellationToken.None);
+        return await command.ExecuteRawResultAsync(CancellationToken.None);
+    }
+    
+    [Test]
+    public async Task ReadAsStreamAsync_WithoutCancellationToken_ReturnsStream()
+    {
+        using var result = await ExecuteRawResultAsync();
         using var stream = await result.ReadAsStreamAsync();
+        using var reader = new StreamReader(stream);
+        Assert.That(reader.ReadToEnd(), Is.EqualTo("1\t2\t3\n"));
+    }
+    
+    [Test]
+    public async Task ReadAsStreamAsync_WithCancellationToken_ReturnsStream()
+    {
+        using var cts = new CancellationTokenSource();
+        using var result = await ExecuteRawResultAsync();
+        using var stream = await result.ReadAsStreamAsync(cts.Token);
         using var reader = new StreamReader(stream);
         Assert.That(reader.ReadToEnd(), Is.EqualTo("1\t2\t3\n"));
     }
 
     [Test]
-    public async Task ShouldCopyRawResultToStream()
+    public async Task CopyToAsync_WithoutCancellationToken_ShouldCopyToStream()
     {
-        using var command = connection.CreateCommand();
-        command.CommandText = "SELECT 1,2,3 FORMAT TSV";
-        using var result = await command.ExecuteRawResultAsync(CancellationToken.None);
+        using var result = await ExecuteRawResultAsync();
         using var stream = new MemoryStream();
         await result.CopyToAsync(stream);
 
@@ -34,24 +49,83 @@ public class RawResultReaderAsyncTests : AbstractConnectionTestFixture
         using var reader = new StreamReader(stream);
         Assert.That(reader.ReadToEnd(), Is.EqualTo("1\t2\t3\n"));
     }
-
+    
     [Test]
-    public async Task ShouldReadRawResultAsArray()
+    public async Task CopyToAsync_WithCancellationToken_ShouldCopyToStream()
     {
-        using var command = connection.CreateCommand();
-        command.CommandText = "SELECT 1,2,3 FORMAT TSV";
-        using var result = await command.ExecuteRawResultAsync(CancellationToken.None);
+        using var cts = new CancellationTokenSource();
+        using var result = await ExecuteRawResultAsync();
+        using var stream = new MemoryStream();
+        await result.CopyToAsync(stream, cts.Token);
+
+        stream.Seek(0, SeekOrigin.Begin);
+
+        using var reader = new StreamReader(stream);
+        Assert.That(reader.ReadToEnd(), Is.EqualTo("1\t2\t3\n"));
+    }
+    
+    [Test]
+    public async Task CopyToAsync_WithCanceledToken_ThrowsOperationCanceledException()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        using var result = await ExecuteRawResultAsync();
+        using var stream = new MemoryStream();
+        Assert.CatchAsync<OperationCanceledException>(() => result.CopyToAsync(stream, cts.Token));
+    }
+    
+    [Test]
+    public async Task ReadAsByteArrayAsync_WithoutCancellationToken_ReturnsByteArray()
+    {
+        using var result = await ExecuteRawResultAsync();
         var array = await result.ReadAsByteArrayAsync();
         Assert.That(array, Is.EqualTo(Encoding.UTF8.GetBytes("1\t2\t3\n")));
     }
+    
+    [Test]
+    public async Task ReadAsByteArrayAsync_WithCancellationToken_ReturnsByteArray()
+    {
+        using var cts = new CancellationTokenSource();
+        using var result = await ExecuteRawResultAsync();
+        var array = await result.ReadAsByteArrayAsync(cts.Token);
+        Assert.That(array, Is.EqualTo(Encoding.UTF8.GetBytes("1\t2\t3\n")));
+    }
+    
+    [Test]
+    public async Task ReadAsByteArrayAsync_WithCanceledToken_ThrowsOperationCanceledException()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        using var result = await ExecuteRawResultAsync();
+        Assert.CatchAsync<OperationCanceledException>(() => result.ReadAsByteArrayAsync(cts.Token));
+    }
 
     [Test]
-    public async Task ShouldReadRawResultAsString()
+    public async Task ReadAsStringAsync_WithoutCancellationToken_ReturnsStrung()
     {
-        using var command = connection.CreateCommand();
-        command.CommandText = "SELECT 1,2,3 FORMAT TSV";
-        using var result = await command.ExecuteRawResultAsync(CancellationToken.None);
+        using var result = await ExecuteRawResultAsync();
         var @string = await result.ReadAsStringAsync();
         Assert.That(@string, Is.EqualTo("1\t2\t3\n"));
+    }
+    
+    [Test]
+    public async Task ReadAsStringAsync_WithCancellationToken_ReturnsStrung()
+    {
+        using var cts = new CancellationTokenSource();
+        using var result = await ExecuteRawResultAsync();
+        var @string = await result.ReadAsStringAsync(cts.Token);
+        Assert.That(@string, Is.EqualTo("1\t2\t3\n"));
+    }
+    
+    [Test]
+    public async Task ReadAsStringAsync_WithCanceledToken_ThrowsOperationCanceledException()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        
+        using var result = await ExecuteRawResultAsync();
+        Assert.CatchAsync<OperationCanceledException>(() => result.ReadAsStringAsync(cts.Token));
     }
 }

--- a/ClickHouse.Driver/ADO/Readers/ClickHouseRawResult.cs
+++ b/ClickHouse.Driver/ADO/Readers/ClickHouseRawResult.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using ClickHouse.Driver.Http;
 
@@ -72,7 +73,14 @@ public class ClickHouseRawResult : IDisposable
     /// Reads the response content as a stream.
     /// </summary>
     /// <returns>A task that resolves to the response content stream.</returns>
-    public Task<Stream> ReadAsStreamAsync() => response.Content.ReadAsStreamAsync();
+    public Task<Stream> ReadAsStreamAsync() => ReadAsStreamAsync(CancellationToken.None);
+
+    /// <summary>
+    /// Reads the response content as a stream.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that resolves to the response content stream.</returns>
+    public Task<Stream> ReadAsStreamAsync(CancellationToken cancellationToken) => response.Content.ReadAsStreamAsync(cancellationToken);
 
     /// <summary>
     /// Reads the response content as a stream, transparently decoding it when the response is
@@ -92,12 +100,33 @@ public class ClickHouseRawResult : IDisposable
     /// return the same stream rather than stacking a decoder over a partly-consumed body; not safe for
     /// concurrent use.
     /// </remarks>
-    public async Task<Stream> ReadDecompressedStreamAsync()
+    public Task<Stream> ReadDecompressedStreamAsync() => ReadDecompressedStreamAsync(CancellationToken.None);
+
+    /// <summary>
+    /// Reads the response content as a stream, transparently decoding it when the response is
+    /// transport-compressed — unlike <see cref="ReadAsStreamAsync"/>, which is a verbatim pass-through of
+    /// the raw bytes. The codec is taken from the response's <c>Content-Encoding</c>: absent or
+    /// <c>identity</c> returns the raw stream unchanged, and <c>lz4</c>, <c>zstd</c>, <c>gzip</c>,
+    /// <c>deflate</c> and <c>br</c> are decoded.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that resolves to a plaintext stream over the response content.</returns>
+    /// <exception cref="NotSupportedException">
+    /// The response uses a codec this client cannot decode (e.g. <c>snappy</c>); the message names it.
+    /// </exception>
+    /// <remarks>
+    /// Disposing this <see cref="ClickHouseRawResult"/> is always sufficient — it releases the response and
+    /// any decoder inserted here. Disposing the returned stream is safe too, but note that with nothing to
+    /// decode it <i>is</i> the content stream, so that ends the response body. Repeated sequential calls
+    /// return the same stream rather than stacking a decoder over a partly-consumed body; not safe for
+    /// concurrent use.
+    /// </remarks>
+    public async Task<Stream> ReadDecompressedStreamAsync(CancellationToken cancellationToken)
     {
         if (decompressedStream != null)
             return decompressedStream;
 
-        var rawStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+        var rawStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
 
         // Throws for a codec we cannot decode, before anything has been read — so the body is left intact
         // for a caller who wants to decode it themselves, through any read member. Nothing leaks either:
@@ -115,20 +144,42 @@ public class ClickHouseRawResult : IDisposable
     /// Reads the response content as a byte array.
     /// </summary>
     /// <returns>A task that resolves to the response content as bytes.</returns>
-    public Task<byte[]> ReadAsByteArrayAsync() => response.Content.ReadAsByteArrayAsync();
+    public Task<byte[]> ReadAsByteArrayAsync() => ReadAsByteArrayAsync(CancellationToken.None);
+
+    /// <summary>
+    /// Reads the response content as a byte array.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that resolves to the response content as bytes.</returns>
+    public Task<byte[]> ReadAsByteArrayAsync(CancellationToken cancellationToken) => response.Content.ReadAsByteArrayAsync(cancellationToken);
 
     /// <summary>
     /// Reads the response content as a string.
     /// </summary>
     /// <returns>A task that resolves to the response content as a string.</returns>
-    public Task<string> ReadAsStringAsync() => response.Content.ReadAsStringAsync();
+    public Task<string> ReadAsStringAsync() => ReadAsStringAsync(CancellationToken.None);
+
+    /// <summary>
+    /// Reads the response content as a string.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that resolves to the response content as a string.</returns>
+    public Task<string> ReadAsStringAsync(CancellationToken cancellationToken) => response.Content.ReadAsStringAsync(cancellationToken);
 
     /// <summary>
     /// Copies the response content to the specified stream.
     /// </summary>
     /// <param name="stream">The destination stream to copy the content to.</param>
     /// <returns>A task that completes when the copy operation is finished.</returns>
-    public Task CopyToAsync(Stream stream) => response.Content.CopyToAsync(stream);
+    public Task CopyToAsync(Stream stream) => CopyToAsync(stream, CancellationToken.None);
+
+    /// <summary>
+    /// Copies the response content to the specified stream.
+    /// </summary>
+    /// <param name="stream">The destination stream to copy the content to.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that completes when the copy operation is finished.</returns>
+    public Task CopyToAsync(Stream stream, CancellationToken cancellationToken) => response.Content.CopyToAsync(stream, cancellationToken);
 
     public void Dispose()
     {

--- a/ClickHouse.Driver/PublicAPI/PublicAPI.Unshipped.txt
+++ b/ClickHouse.Driver/PublicAPI/PublicAPI.Unshipped.txt
@@ -250,6 +250,11 @@ ClickHouse.Driver.ADO.ClickHouseClientSettings.AcceptEncoding.init -> void
 ClickHouse.Driver.ADO.ClickHouseConnectionStringBuilder.AcceptEncoding.get -> string
 ClickHouse.Driver.ADO.ClickHouseConnectionStringBuilder.AcceptEncoding.set -> void
 ClickHouse.Driver.ADO.ClickHouseRawResult.ReadDecompressedStreamAsync() -> System.Threading.Tasks.Task<System.IO.Stream>
+ClickHouse.Driver.ADO.ClickHouseRawResult.ReadDecompressedStreamAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.IO.Stream>
+ClickHouse.Driver.ADO.ClickHouseRawResult.ReadAsStreamAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.IO.Stream>
+ClickHouse.Driver.ADO.ClickHouseRawResult.ReadAsByteArrayAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<byte[]>
+ClickHouse.Driver.ADO.ClickHouseRawResult.ReadAsStringAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<string>
+ClickHouse.Driver.ADO.ClickHouseRawResult.CopyToAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
 ClickHouse.Driver.MapReadMode
 ClickHouse.Driver.MapReadMode.Dictionary = 0 -> ClickHouse.Driver.MapReadMode
 ClickHouse.Driver.MapReadMode.KeyValuePairs = 1 -> ClickHouse.Driver.MapReadMode

--- a/changelog.d/546-raw-result-reader-cancellation-api.improvements.md
+++ b/changelog.d/546-raw-result-reader-cancellation-api.improvements.md
@@ -1,0 +1,1 @@
+* Implement ClickHouseRawResult cancellation APIs (issue #546)


### PR DESCRIPTION
## Summary
Fixes #546 

Implement ClickHouseRawResult cancellation APIs

Warning: A test for passing a cancelled token to ReadAsStreamAsync was not added, as it is ignored in .NET. - [Link](https://github.com/dotnet/runtime/blob/75e7ab6483c9f921f64aabf221b0687fee3c7e9a/src/libraries/System.Net.Http/src/System/Net/Http/HttpContent.cs#L559)

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG