### PR TITLE
Add RowIndex to ClickHouseBulkCopySerializationException

### DIFF
--- a/ClickHouse.Driver.Tests/BulkCopy/BulkCopyTests.cs
+++ b/ClickHouse.Driver.Tests/BulkCopy/BulkCopyTests.cs
@@ -413,6 +413,7 @@ public class BulkCopyTests : AbstractConnectionTestFixture
         await connection.ExecuteStatementAsync($"CREATE TABLE {targetTable} (value UInt8) ENGINE Memory");
 
         var rows = Enumerable.Range(250, 10).Select(n => new object[] { n }).ToArray();
+        var firstInvalidRowIndex = Array.FindIndex(rows, x=> (int)x[0] > 255);
 
         var bulkCopy = new ClickHouseBulkCopy(connection) { DestinationTableName = targetTable };
         try
@@ -423,6 +424,7 @@ public class BulkCopyTests : AbstractConnectionTestFixture
         catch (ClickHouseBulkCopySerializationException ex)
         {
             Assert.That(ex.Row, Is.EqualTo(new object[] { 256 }).AsCollection);
+            Assert.That(ex.RowIndex, Is.EqualTo(firstInvalidRowIndex));
             ClassicAssert.IsInstanceOf<OverflowException>(ex.InnerException);
         }
     }

--- a/ClickHouse.Driver.Tests/Copy/InsertBinaryPocoTests.cs
+++ b/ClickHouse.Driver.Tests/Copy/InsertBinaryPocoTests.cs
@@ -404,6 +404,7 @@ public class InsertBinaryPocoTests : AbstractConnectionTestFixture
             await client.InsertBinaryAsync(tableName, rows));
 
         Assert.That(ex.Row, Is.Not.Null);
+        Assert.That(ex.RowIndex, Is.EqualTo(0));
         Assert.That(ex.InnerException, Is.Not.Null);
     }
 

--- a/ClickHouse.Driver.Tests/Copy/SerializationErrorClassificationTests.cs
+++ b/ClickHouse.Driver.Tests/Copy/SerializationErrorClassificationTests.cs
@@ -118,6 +118,8 @@ public class SerializationErrorClassificationTests : AbstractConnectionTestFixtu
             .Append(new DateRow { Id = ulong.MaxValue, Value = OutOfRangeValue })
             .ToList();
 
+        var invalidRowIndex = rows.Count - 1;
+
         var ex = Assert.CatchAsync<ClickHouseBulkCopySerializationException>(
             () => InsertDateRowsAsync(client, path, table, rows, Uncompressed()));
 
@@ -129,6 +131,7 @@ public class SerializationErrorClassificationTests : AbstractConnectionTestFixtu
             Assert.That(ex.InnerException?.Message, Does.Contain("ClickHouse DateTime"));
             Assert.That(ex.Row, Is.Not.Null);
             Assert.That(ex.Row[1], Is.EqualTo(OutOfRangeValue));
+            Assert.That(ex.RowIndex, Is.EqualTo(invalidRowIndex));
         });
 
         // A truncated insert commits nothing, so none of the rows the server did receive land.

--- a/ClickHouse.Driver/Copy/Serializer/BatchSerializer.cs
+++ b/ClickHouse.Driver/Copy/Serializer/BatchSerializer.cs
@@ -33,6 +33,7 @@ internal class BatchSerializer : IBatchSerializer
         var writer = new ExtendedBinaryWriter(target, leaveOpen: false);
 
         object[] row = null;
+        int currentRowIndex = 0;
 
         // With the statement in the URL the body is rows alone: not even a newline may precede them,
         // as the server would read it as row data. Nothing can fail before the rows then, so the flag
@@ -49,9 +50,9 @@ internal class BatchSerializer : IBatchSerializer
 
             var rows = batch.Rows.AsSpan()[..batch.Size];
             var types = batch.Types;
-            for (int i = 0; i < rows.Length; i++)
+            for (; currentRowIndex < rows.Length; currentRowIndex++)
             {
-                row = rows[i];
+                row = rows[currentRowIndex];
                 rowSerializer.Serialize(row, types, writer);
             }
         }
@@ -63,7 +64,7 @@ internal class BatchSerializer : IBatchSerializer
             if (!serializingRows)
                 throw;
 
-            throw new ClickHouseBulkCopySerializationException(row, e);
+            throw new ClickHouseBulkCopySerializationException(currentRowIndex, row, e);
         }
 
         writer.Dispose();

--- a/ClickHouse.Driver/Copy/Serializer/ClickHouseBulkCopySerializationException.cs
+++ b/ClickHouse.Driver/Copy/Serializer/ClickHouseBulkCopySerializationException.cs
@@ -4,11 +4,24 @@ namespace ClickHouse.Driver.Copy;
 
 public class ClickHouseBulkCopySerializationException : Exception
 {
+    [Obsolete("This constructor does not populate RowIndex (it stays at 0 even for a later row). Use the overload that takes the row index so the failing row's position is reported; will be removed in a future version.")]
     public ClickHouseBulkCopySerializationException(object[] row, Exception innerException)
         : base("Error when serializing data", innerException)
     {
         Row = row;
     }
+
+    public ClickHouseBulkCopySerializationException(int rowIndex, object[] row, Exception innerException)
+        : base("Error when serializing data", innerException)
+    {
+        RowIndex = rowIndex;
+        Row = row;
+    }
+
+    /// <summary>
+    /// Gets row index at which exception happened
+    /// </summary>
+    public int RowIndex { get; }
 
     /// <summary>
     /// Gets row at which exception happened

--- a/ClickHouse.Driver/Copy/Serializer/PocoBatchSerializer.cs
+++ b/ClickHouse.Driver/Copy/Serializer/PocoBatchSerializer.cs
@@ -59,6 +59,7 @@ internal class PocoBatchSerializer
         var types = batch.Types;
 
         T current = default;
+        int currentRowIndex = 0;
 
         // See BatchSerializer.Serialize: in URL mode the body must start at the first row, so no
         // prologue is written and the row/prologue discriminator starts out set.
@@ -75,9 +76,9 @@ internal class PocoBatchSerializer
             if (writers != null)
             {
                 // RowBinary path
-                for (int i = 0; i < batch.Size; i++)
+                for (; currentRowIndex < batch.Size; currentRowIndex++)
                 {
-                    current = batch.Rows[i];
+                    current = batch.Rows[currentRowIndex];
                     for (int col = 0; col < writers.Length; col++)
                         writers[col](current, writer);
                 }
@@ -85,9 +86,9 @@ internal class PocoBatchSerializer
             else
             {
                 // RowBinaryWithDefaults path
-                for (int i = 0; i < batch.Size; i++)
+                for (; currentRowIndex < batch.Size; currentRowIndex++)
                 {
-                    current = batch.Rows[i];
+                    current = batch.Rows[currentRowIndex];
                     rowSerializer.Serialize(current, getters, types, writer);
                 }
             }
@@ -119,7 +120,7 @@ internal class PocoBatchSerializer
                 }
             }
 
-            throw new ClickHouseBulkCopySerializationException(failedRow, e);
+            throw new ClickHouseBulkCopySerializationException(currentRowIndex, failedRow, e);
         }
 
         writer.Dispose();

--- a/ClickHouse.Driver/PublicAPI/PublicAPI.Unshipped.txt
+++ b/ClickHouse.Driver/PublicAPI/PublicAPI.Unshipped.txt
@@ -268,3 +268,5 @@ ClickHouse.Driver.InsertOptions.QueryPlacement.init -> void
 ClickHouse.Driver.InsertQueryPlacement
 ClickHouse.Driver.InsertQueryPlacement.Body = 0 -> ClickHouse.Driver.InsertQueryPlacement
 ClickHouse.Driver.InsertQueryPlacement.Url = 1 -> ClickHouse.Driver.InsertQueryPlacement
+ClickHouse.Driver.Copy.ClickHouseBulkCopySerializationException.ClickHouseBulkCopySerializationException(int rowIndex, object[] row, System.Exception innerException) -> void
+ClickHouse.Driver.Copy.ClickHouseBulkCopySerializationException.RowIndex.get -> int

--- a/changelog.d/606-add-row-index-to-serialization-exception.improvements.md
+++ b/changelog.d/606-add-row-index-to-serialization-exception.improvements.md
@@ -1,0 +1,1 @@
+* Added `RowIndex` to `ClickHouseBulkCopySerializationException` so binary-insert failures report the zero-based index of the offending row within the batch, making it easy to locate bad data in large inserts. (#606)


### PR DESCRIPTION
## Summary
Fixes #606 

When a binary insert fails (e.g. a null in a non-nullable column), ClickHouseBulkCopySerializationException only carried the offending Row - with a large batch there was no way to know which row caused it.

This PR adds a RowIndex property (zero-based index within the batch) and populates it from both the object[] (BatchSerializer) and POCO (PocoBatchSerializer) insert paths.

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG