### PR TITLE
TCP TT: a test audit of the native client, and the defects it found

### DIFF
--- a/ClickHouse.Driver.Tcp.Tests/Client/ClickHouseTcpClientOptionsTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Client/ClickHouseTcpClientOptionsTests.cs
@@ -486,6 +486,9 @@ public class ClickHouseTcpClientOptionsTests
             IncludeSqlInActivityTags = true,
             StatementMaxLength = 42,
 
+            // Defaults to true, so false is the non-default value here.
+            SendJsonAndDynamicSerializationSettings = false,
+
             // Zstd rather than Lz4 so this stays non-default whichever codec the default becomes.
             Compressor = ZstdCompressor.Default,
         };

--- a/ClickHouse.Driver.Tcp.Tests/Client/ClickHouseTcpClientSettingsTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Client/ClickHouseTcpClientSettingsTests.cs
@@ -44,6 +44,40 @@ public class ClickHouseTcpClientSettingsTests
         Assert.That(merged[setting], Is.EqualTo("0"));
     }
 
+    // Sending either setting is a modification, which a readonly profile refuses outright, so a caller has to be
+    // able to send neither. Sending "0" is not the same thing: the server takes it as a no-op change from a
+    // full-rights user, and still refuses it from a readonly one.
+    [Test]
+    public void MergeSettings_SendSerializationSettingsOff_SendsNeither()
+    {
+        var merged = ClickHouseTcpClient.MergeSettings(
+            clientSettings: null, perQuerySettings: null, sendSerializationSettings: false);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(merged.ContainsKey(FlattenedSetting), Is.False);
+            Assert.That(merged.ContainsKey(JsonAsStringSetting), Is.False);
+        });
+    }
+
+    // The switch governs the injection only. A caller who names one of the settings themselves has asked for it,
+    // and a readonly user asking for it is their own error to see.
+    [TestCase(FlattenedSetting)]
+    [TestCase(JsonAsStringSetting)]
+    public void MergeSettings_SendSerializationSettingsOffAndCallerNamesOne_KeepsTheCallersOwn(string setting)
+    {
+        var perQuery = new Dictionary<string, string> { [setting] = "1" };
+
+        var merged = ClickHouseTcpClient.MergeSettings(
+            clientSettings: null, perQuery, sendSerializationSettings: false);
+
+        Assert.That(merged[setting], Is.EqualTo("1"));
+    }
+
+    [Test]
+    public void SendJsonAndDynamicSerializationSettings_NotSet_DefaultsToOn()
+        => Assert.That(new ClickHouseTcpClientOptions().SendJsonAndDynamicSerializationSettings, Is.True);
+
     [Test]
     public void MergeSettings_PerQueryOverridesClientLevelForSameKey()
     {

--- a/ClickHouse.Driver.Tcp.Tests/Client/ClickHouseTcpConnectionStringBuilderTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Client/ClickHouseTcpConnectionStringBuilderTests.cs
@@ -327,6 +327,24 @@ public class ClickHouseTcpConnectionStringBuilderTests
         });
     }
 
+    // A readonly user reaches this switch through a connection string more often than through options, since that
+    // is what a host application takes from configuration.
+    [Test]
+    public void ToOptions_SendJsonAndDynamicSerializationSettings_CarriesTheKeyAndDefaultsToOn()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                ClickHouseTcpClientOptions.FromConnectionString("Host=h;SendJsonAndDynamicSerializationSettings=false")
+                    .SendJsonAndDynamicSerializationSettings,
+                Is.False);
+            Assert.That(
+                ClickHouseTcpClientOptions.FromConnectionString("Host=h").SendJsonAndDynamicSerializationSettings,
+                Is.True,
+                "no key means the injection stays on");
+        });
+    }
+
     [Test]
     public void ToOptions_UseTlsWithNoPortKey_ResolvesToTheSecureNativePort()
     {

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpCancellationIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpCancellationIntegrationTests.cs
@@ -99,6 +99,57 @@ public class ClickHouseTcpCancellationIntegrationTests
         Assert.That(rows, Is.EqualTo(100));
     }
 
+    /// <summary>
+    /// The same one-second deadline against a query that sends nothing at all, which is what it takes to make it
+    /// fire. A <c>Progress</c> packet counts as the server speaking, and the server sends one every
+    /// <c>interactive_delay</c> microseconds (100 ms by default), so <c>sleep(3)</c> on its own finishes under a
+    /// one-second deadline — see the case below. Raising <c>interactive_delay</c> past the sleep buys the silence.
+    /// </summary>
+    [Test]
+    public async Task StreamAsync_ServerSilentForLongerThanReadTimeout_FailsWithTimeoutAndGivesThePoolSlotBack()
+    {
+        ClickHouseTcpClientOptions options = TcpServerFixture.Options() with
+        {
+            ReadTimeout = TimeSpan.FromSeconds(1),
+            MaxPoolSize = 1,
+        };
+        await using var client = new ClickHouseTcpClient(options);
+
+        var queryOptions = new ClickHouseTcpQueryOptions
+        {
+            Settings = new Dictionary<string, string>(StringComparer.Ordinal) { ["interactive_delay"] = "10000000" },
+        };
+
+        // TimeoutException comes from nowhere else, so the type alone proves the deadline fired. Asserted instead
+        // of the elapsed time, which would make this a race on a loaded machine.
+        var timeout = Assert.ThrowsAsync<TimeoutException>(
+            async () => await client.ExecuteScalarAsync("SELECT sleep(3)", queryOptions, None));
+
+        // The deadline unwinds a socket read that was genuinely blocked, and the cancel attempt on the way out
+        // must not block behind the same silence. A slot that never came back would fail here instead.
+        object next = await client.ExecuteScalarAsync("SELECT toUInt64(7)", cancellationToken: None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(timeout.Message, Does.Contain("ReadTimeout"), "the message has to name the option to change");
+            Assert.That(next, Is.EqualTo(7UL));
+        });
+    }
+
+    /// <summary>
+    /// The complement, and the reason the case above has to silence the server: three seconds of work that
+    /// produces no row until the end still survives a one-second deadline, because the periodic
+    /// <c>Progress</c> packets keep resetting it.
+    /// </summary>
+    [Test]
+    public async Task StreamAsync_QuerySilentApartFromProgressPackets_SurvivesAShorterReadTimeout()
+    {
+        ClickHouseTcpClientOptions options = TcpServerFixture.Options() with { ReadTimeout = TimeSpan.FromSeconds(1) };
+        await using var client = new ClickHouseTcpClient(options);
+
+        Assert.That(await client.ExecuteScalarAsync("SELECT sleep(3)", cancellationToken: None), Is.EqualTo((byte)0));
+    }
+
     // An unbounded query remains active when the client stops reading. Small, delayed blocks
     // allow the server to read Cancel between writes.
     private static IAsyncEnumerable<Block> Unbounded(ClickHouseTcpClient client, string queryId, CancellationToken cancellationToken)

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpConnectionInsertIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpConnectionInsertIntegrationTests.cs
@@ -535,6 +535,11 @@ public class ClickHouseTcpConnectionInsertIntegrationTests
     /// Such a column cannot use the dense shortcut, which pairs alternative <c>i</c> with alternative <c>i</c>, so
     /// it is scattered by each value's own type instead — and only a server can say where the values then landed.
     /// This is the case where the counts match, which is the one no arity check separates.
+    /// <para>
+    /// The alternative the value belongs to has to change index between the two types, or the shortcut reaches
+    /// the same answer and the test cannot fail: here the source's Int64 is alternative 0 and the target's is
+    /// alternative 1, so reusing the source discriminators would name Bool for every row.
+    /// </para>
     /// </summary>
     [Test]
     public async Task InsertAsync_DenseVariantOfAnotherVariantsAlternatives_LandsInTheAlternativeTheValueNames()
@@ -544,12 +549,14 @@ public class ClickHouseTcpConnectionInsertIntegrationTests
         string target = UniqueTableName();
         try
         {
-            await ExecuteAsync(connection, $"CREATE TABLE {source} (value Variant(Date, Int64)) ENGINE = Memory");
-            await ExecuteAsync(connection, $"CREATE TABLE {target} (value Variant(Date32, Int64)) ENGINE = Memory");
-            // toInt64: a bare 7 is UInt8, and a Variant takes only its own alternatives.
+            await ExecuteAsync(connection, $"CREATE TABLE {source} (value Variant(Int64, String)) ENGINE = Memory");
+            await ExecuteAsync(connection, $"CREATE TABLE {target} (value Variant(Bool, Int64)) ENGINE = Memory");
+            // toInt64: a bare 7 is UInt8, and a Variant takes only its own alternatives. Both rows are Int64 so
+            // that both fit the target, while the source column still declares the String alternative that makes
+            // the two alternative lists differ.
             await ExecuteAsync(
                 connection,
-                $"INSERT INTO {source} VALUES (CAST(toDate('2024-06-15') AS Variant(Date, Int64))), (CAST(toInt64(7) AS Variant(Date, Int64)))");
+                $"INSERT INTO {source} VALUES (CAST(toInt64(-3) AS Variant(Int64, String))), (CAST(toInt64(7) AS Variant(Int64, String)))");
 
             // Inside the loop: the block owns the column's pooled buffers, so it has to still be alive. The read
             // needs its own connection — one connection carries one in-flight operation.
@@ -575,7 +582,7 @@ public class ClickHouseTcpConnectionInsertIntegrationTests
 
             Assert.Multiple(() =>
             {
-                Assert.That(readBack, Is.EqualTo(new[] { "2024-06-15 as Date32", "7 as Int64" }));
+                Assert.That(readBack, Is.EqualTo(new[] { "-3 as Int64", "7 as Int64" }));
                 Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
             });
         }

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpConnectionInsertIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpConnectionInsertIntegrationTests.cs
@@ -530,6 +530,118 @@ public class ClickHouseTcpConnectionInsertIntegrationTests
         }
     }
 
+    /// <summary>
+    /// A dense <c>Variant</c> column read from one column and inserted into another whose alternatives differ.
+    /// Such a column cannot use the dense shortcut, which pairs alternative <c>i</c> with alternative <c>i</c>, so
+    /// it is scattered by each value's own type instead — and only a server can say where the values then landed.
+    /// This is the case where the counts match, which is the one no arity check separates.
+    /// </summary>
+    [Test]
+    public async Task InsertAsync_DenseVariantOfAnotherVariantsAlternatives_LandsInTheAlternativeTheValueNames()
+    {
+        await using var connection = await TcpServerFixture.ConnectAsync(None);
+        string source = UniqueTableName();
+        string target = UniqueTableName();
+        try
+        {
+            await ExecuteAsync(connection, $"CREATE TABLE {source} (value Variant(Date, Int64)) ENGINE = Memory");
+            await ExecuteAsync(connection, $"CREATE TABLE {target} (value Variant(Date32, Int64)) ENGINE = Memory");
+            // toInt64: a bare 7 is UInt8, and a Variant takes only its own alternatives.
+            await ExecuteAsync(
+                connection,
+                $"INSERT INTO {source} VALUES (CAST(toDate('2024-06-15') AS Variant(Date, Int64))), (CAST(toInt64(7) AS Variant(Date, Int64)))");
+
+            // Inside the loop: the block owns the column's pooled buffers, so it has to still be alive. The read
+            // needs its own connection — one connection carries one in-flight operation.
+            await using ClickHouseTcpConnection reader = await TcpServerFixture.ConnectAsync(None);
+            // No ORDER BY on the Variant itself: the server refuses one without allow_suspicious_types_in_order_by,
+            // and the read-back below sorts on a String expression instead.
+            await foreach (Block block in reader.QueryAsync($"SELECT value FROM {source}", cancellationToken: None))
+            {
+                await connection.InsertAsync($"INSERT INTO {target} (value) VALUES", new[] { block[0] }, cancellationToken: None);
+            }
+
+            // variantType names the alternative the row actually selected, which is the whole question here.
+            var readBack = new List<string>();
+            await foreach (Block block in connection.QueryAsync(
+                $"SELECT concat(toString(value), ' as ', toString(variantType(value))) FROM {target} ORDER BY toString(value)",
+                cancellationToken: None))
+            {
+                for (int row = 0; row < block[0].RowCount; row++)
+                {
+                    readBack.Add((string)block[0].GetValue(row));
+                }
+            }
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(readBack, Is.EqualTo(new[] { "2024-06-15 as Date32", "7 as Int64" }));
+                Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+            });
+        }
+        finally
+        {
+            // Its own connection: a write that fails terminates the one it failed on, and a DROP that then
+            // throws ObjectDisposedException would mask the failure under test.
+            await using ClickHouseTcpConnection cleanup = await TcpServerFixture.ConnectAsync(None);
+            await ExecuteAsync(cleanup, $"DROP TABLE IF EXISTS {source}");
+            await ExecuteAsync(cleanup, $"DROP TABLE IF EXISTS {target}");
+        }
+    }
+
+    /// <summary>
+    /// The same shortcut, where the value fits no alternative of the target at all. The refusal has to come
+    /// before any of the column reaches the wire: the discriminators are written first, so a failure discovered
+    /// in the body leaves a half-written column and costs the connection.
+    /// </summary>
+    [Test]
+    public async Task InsertAsync_DenseVariantWhoseValueNoTargetAlternativeAccepts_RefusesBeforeWritingAnything()
+    {
+        await using var connection = await TcpServerFixture.ConnectAsync(None);
+        string source = UniqueTableName();
+        string target = UniqueTableName();
+        try
+        {
+            await ExecuteAsync(connection, $"CREATE TABLE {source} (value Variant(Int64, String)) ENGINE = Memory");
+            await ExecuteAsync(connection, $"CREATE TABLE {target} (value Variant(Bool, Int64)) ENGINE = Memory");
+            await ExecuteAsync(connection, $"INSERT INTO {source} VALUES (CAST('abc' AS Variant(Int64, String)))");
+
+            ArgumentException refusal = null;
+            await using ClickHouseTcpConnection reader = await TcpServerFixture.ConnectAsync(None);
+            await foreach (Block block in reader.QueryAsync($"SELECT value FROM {source}", cancellationToken: None))
+            {
+                refusal = Assert.ThrowsAsync<ArgumentException>(
+                    async () => await connection.InsertAsync($"INSERT INTO {target} (value) VALUES", new[] { block[0] }, cancellationToken: None));
+            }
+
+            // A fresh connection to count with: the INSERT statement was already in flight when the column was
+            // refused, so the client cannot resume that connection and terminates it. That is the existing
+            // contract for an abandoned insert, not something this test is asserting about.
+            long rows = 0;
+            await using ClickHouseTcpConnection counter = await TcpServerFixture.ConnectAsync(None);
+            await foreach (Block block in counter.QueryAsync($"SELECT count() FROM {target}", cancellationToken: None))
+            {
+                rows = Convert.ToInt64(block[0].GetValue(0));
+            }
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(refusal, Is.Not.Null);
+                Assert.That(refusal.Message, Does.Contain("System.String"), "names the CLR type no alternative accepts");
+                Assert.That(refusal.Message, Does.Contain("Variant(Bool, Int64)"), "names the target type");
+                Assert.That(rows, Is.Zero, "nothing may land from a column that could not be written");
+            });
+        }
+        finally
+        {
+            // Its own connection: a write that fails terminates the one it failed on, and a DROP that then
+            // throws ObjectDisposedException would mask the failure under test.
+            await using ClickHouseTcpConnection cleanup = await TcpServerFixture.ConnectAsync(None);
+            await ExecuteAsync(cleanup, $"DROP TABLE IF EXISTS {source}");
+            await ExecuteAsync(cleanup, $"DROP TABLE IF EXISTS {target}");
+        }
+    }
+
     [Test]
     public async Task InsertAsync_DenseDynamicColumnSplitAcrossBlocks_RoundTripsEveryRow()
     {

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpConnectionMetadataIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpConnectionMetadataIntegrationTests.cs
@@ -13,9 +13,10 @@ namespace ClickHouse.Driver.Tcp.Tests.Integration;
 // leaving the connection unusable. What the packets carry, and the schema of the Log and ProfileEvents blocks,
 // belongs to ClickHouseTcpCallbackIntegrationTests.
 //
-// Not covered here: TableColumns (the server sends it for external-table/defaults scenarios that a plain query
-// does not create, and the client discards it anyway) and PartUUIDs (needs part-level query deduplication on a
-// replicated table). Both remain covered by the scripted-byte unit tests.
+// Not covered here: TableColumns, which a plain query does not produce — an insert under
+// input_format_defaults_for_omitted_fields = 1 does, and ComputedColumnInsertIntegrationTests covers it there —
+// and PartUUIDs, which needs part-level query deduplication on a replicated table and so remains covered by the
+// scripted-byte unit tests alone.
 [TestFixture]
 [Category("Integration")]
 public class ClickHouseTcpConnectionMetadataIntegrationTests

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpExceptionIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpExceptionIntegrationTests.cs
@@ -67,9 +67,9 @@ public class ClickHouseTcpExceptionIntegrationTests
     }
 
     // A column type the client cannot resolve arrives as a type name in the block header, so the refusal is a
-    // disagreement with the server and belongs under the same base as the rest. AggregateFunction is the one
-    // type a real server produces that the client deliberately declines, so it is the only way to reach this
-    // path without hand-building a block.
+    // disagreement with the server and belongs under the same base as the rest. AggregateFunction is one of the
+    // two types a real server produces that the client deliberately declines — the other is a wide Tuple, below
+    // — so between them this path is reachable without hand-building a block.
     [Test]
     public async Task QueryAsync_ColumnTypeTheClientCannotRead_ReportsAProtocolFailureKeepingTheHint()
     {
@@ -84,6 +84,29 @@ public class ClickHouseTcpExceptionIntegrationTests
             Assert.That(thrown.Message, Does.Contain("'s'"), "the failing column is named.");
             Assert.That(thrown.Message, Does.Contain("sumMerge(column)"), "the actionable hint survives the wrapping.");
             Assert.That(thrown.InnerException, Is.InstanceOf<NotSupportedException>());
+        });
+    }
+
+    // The typed TupleColumn shapes stop at seven elements, and a server will happily send more — a wide table
+    // selected as a tuple, or any tuple() of eight. Read on a pool of one, so the follow-up query is also the
+    // proof that declining a column type costs neither the connection nor its permit.
+    [Test]
+    public async Task QueryAsync_TupleWiderThanTheClientReads_ReportsAProtocolFailureAndKeepsThePoolUsable()
+    {
+        await using var client = new ClickHouseTcpClient(TcpServerFixture.Options() with { MaxPoolSize = 1 });
+
+        var thrown = Assert.ThrowsAsync<ClickHouseTcpProtocolException>(
+            async () => await client.QueryAsync("SELECT tuple(1, 2, 3, 4, 5, 6, 7, 8) AS t").ToListAsync());
+
+        object next = await client.ExecuteScalarAsync("SELECT toUInt64(7)", cancellationToken: None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(thrown, Is.InstanceOf<ClickHouseTcpException>());
+            Assert.That(thrown.Message, Does.Contain("'t'"), "the failing column is named.");
+            Assert.That(thrown.Message, Does.Contain("at most 7"), "and the limit, so a caller knows what it has to change.");
+            Assert.That(thrown.InnerException, Is.InstanceOf<NotSupportedException>());
+            Assert.That(next, Is.EqualTo(7UL), "the only pool slot came back.");
         });
     }
 

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpParameterIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpParameterIntegrationTests.cs
@@ -164,6 +164,11 @@ public class ClickHouseTcpParameterIntegrationTests
         yield return new TestCaseData("Time", new TimeSpan(1, 1, 1)).Returns("01:01:01").SetName("Time");
         yield return new TestCaseData("Time", 3723).Returns("01:02:03").SetName("Time from whole seconds");
         yield return new TestCaseData("Time64(3)", new TimeSpan(0, 1, 1, 1, 500)).Returns("01:01:01.500").SetName("Time64");
+
+        // The time-of-day type, which the shipped HTTP driver takes for both of these.
+        yield return new TestCaseData("Time", new TimeOnly(1, 1, 1)).Returns("01:01:01").SetName("Time from a TimeOnly");
+        yield return new TestCaseData("Time64(3)", new TimeOnly(1, 1, 1, 500)).Returns("01:01:01.500").SetName("Time64 from a TimeOnly");
+        yield return new TestCaseData("Time64(7)", TimeOnly.MaxValue).Returns("23:59:59.9999999").SetName("Time64 from the last tick of the day");
         yield return new TestCaseData("FixedString(3)", Encoding.UTF8.GetBytes("abc")).Returns("abc").SetName("FixedString from bytes");
         yield return new TestCaseData("String", Encoding.UTF8.GetBytes("abc")).Returns("abc").SetName("String from bytes");
         yield return new TestCaseData("IntervalDay", -3L).Returns("-3").SetName("IntervalDay negative");

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpParameterIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpParameterIntegrationTests.cs
@@ -55,6 +55,17 @@ public class ClickHouseTcpParameterIntegrationTests
         yield return new TestCaseData("Decimal256(4)", "12345678901234567890123456789012345.6789")
             .Returns("12345678901234567890123456789012345.6789").SetName("Decimal256 wider than a CLR decimal");
 
+        // The names a caller writes rather than the ones a header carries. The hint reaches the server verbatim,
+        // so these prove the server takes the same spellings the client resolves — including a two-word alias and
+        // one nested inside a composite.
+        yield return new TestCaseData("VARCHAR", "abc").Returns("abc").SetName("VARCHAR, an alias of String");
+        yield return new TestCaseData("BIGINT", -5L).Returns("-5").SetName("BIGINT, an alias of Int64");
+        yield return new TestCaseData("DOUBLE PRECISION", 1.5d).Returns("1.5").SetName("DOUBLE PRECISION, a two-word alias");
+        yield return new TestCaseData("Boolean", true).Returns("true").SetName("Boolean, an alias of Bool");
+        yield return new TestCaseData("datetime64(3)", new DateTime(2024, 1, 2, 3, 4, 5, 123, DateTimeKind.Unspecified))
+            .Returns("2024-01-02 03:04:05.123").SetName("A case variant of a case-insensitive family");
+        yield return new TestCaseData("Array(TINYINT UNSIGNED)", new byte[] { 1, 2 }).Returns("[1,2]").SetName("An alias inside a composite");
+
         // The server accepts .NET's NaN and Infinity spellings.
         yield return new TestCaseData("Float64", double.NaN).Returns("nan").SetName("Float64 NaN");
         yield return new TestCaseData("Float64", double.PositiveInfinity).Returns("inf").SetName("Float64 +Infinity");

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpParameterIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpParameterIntegrationTests.cs
@@ -258,6 +258,23 @@ public class ClickHouseTcpParameterIntegrationTests
         // A surrogate pair, which a formatter that walks chars rather than runes can split.
         yield return new TestCaseData("String", "a\U0001F600b").Returns("a\U0001F600b").SetName("String with an emoji");
 
+        // Three types whose name does not fix the value's layout, so the client writes the value's own text and the
+        // server's parse decides. Geometry is the ambiguous one — this ring is equally a LineString — and the text
+        // is the same either way.
+        yield return new TestCaseData("SimpleAggregateFunction(sum, UInt64)", 42UL)
+            .Returns("42").SetName("SimpleAggregateFunction as its inner type");
+        yield return new TestCaseData("SimpleAggregateFunction(groupArrayArray, Array(UInt64))", new ulong[] { 1, 2, 3 })
+            .Returns("[1,2,3]").SetName("SimpleAggregateFunction over an array inner");
+        yield return new TestCaseData("Dynamic", -7L).Returns("-7").SetName("Dynamic holding an integer");
+        yield return new TestCaseData("Dynamic", "x").Returns("x").SetName("Dynamic holding a string");
+        yield return new TestCaseData("Dynamic", new ulong[] { 1, 2, 3 }).Returns("[1,2,3]").SetName("Dynamic holding an array");
+        if (TcpServerFeatures.Has(TcpFeature.Geometry))
+        {
+            yield return new TestCaseData("Geometry", (10.0, 20.0)).Returns("(10,20)").SetName("Geometry as a point");
+            yield return new TestCaseData("Geometry", new[] { (0.0, 0.0), (1.0, 1.0), (0.0, 1.0) })
+                .Returns("[(0,0),(1,1),(0,1)]").SetName("Geometry as a ring");
+        }
+
         // A ValueTuple past 7 elements nests its tail in TRest, which ITuple flattens back out.
         yield return new TestCaseData("Tuple(Int32, Int32, Int32, Int32, Int32, Int32, Int32, String, String)",
             (1, 2, 3, 4, 5, 6, 7, "eight", "nine")).Returns("(1,2,3,4,5,6,7,'eight','nine')").SetName("Tuple of nine");

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpParameterIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpParameterIntegrationTests.cs
@@ -192,6 +192,15 @@ public class ClickHouseTcpParameterIntegrationTests
         yield return new TestCaseData("Variant(Array(LowCardinality(Nullable(String))), Int64)", new[] { "a", null })
             .Returns("['a',NULL]").SetName("Variant holding a low-cardinality array with a null element");
 
+        // A Variant holding Time: the value has to match that arm, not only a Time64 one. Matching nothing
+        // refuses the whole Variant rather than the one alternative, so a time value reached no Variant at all.
+        // The server renders a Time inside a Variant without the leading zero it gives a bare Time column, hence
+        // 1:01:01 here against 01:01:01 above.
+        yield return new TestCaseData("Variant(Time, String)", new TimeSpan(1, 1, 1))
+            .Returns("1:01:01").SetName("Variant picks the Time arm from a TimeSpan");
+        yield return new TestCaseData("Variant(Time, String)", new TimeOnly(1, 1, 1))
+            .Returns("1:01:01").SetName("Variant picks the Time arm from a TimeOnly");
+
         // Covers both JSON spellings and geo types backed by tuple/array shapes.
         yield return new TestCaseData("Json", "{\"a\":1}").Returns("{\"a\":1}").SetName("Json in the lowercase spelling");
         yield return new TestCaseData("JSON", "{\"a\":1}").Returns("{\"a\":1}").SetName("JSON in the uppercase spelling");

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpParameterIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpParameterIntegrationTests.cs
@@ -231,6 +231,11 @@ public class ClickHouseTcpParameterIntegrationTests
         // An Enum bound by its numeric value rather than its label. Neither transport had a case for it.
         yield return new TestCaseData("Enum8('a' = 1, 'b' = 2)", 2).Returns("b").SetName("Enum by number");
 
+        // A bare Enum, whose width the client has to pick before it can format the value. The hint reaches the
+        // server verbatim, so this is what shows the server reads the same spelling the client resolved.
+        yield return new TestCaseData("Enum('a' = 1, 'b' = 2)", "b").Returns("b").SetName("Enum with no width");
+        yield return new TestCaseData("Enum('a' = 1, 'b' = 200)", "b").Returns("b").SetName("Enum with no width, past the Int8 range");
+
         // A wide decimal past what a CLR decimal can hold, so the BigInteger path is the one under test.
         yield return new TestCaseData("Decimal128(0)", new string('1', 30)).Returns(new string('1', 30)).SetName("Decimal128 of 30 digits");
         yield return new TestCaseData("Decimal256(0)", new string('1', 50)).Returns(new string('1', 50)).SetName("Decimal256 of 50 digits");

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpParameterIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpParameterIntegrationTests.cs
@@ -192,6 +192,12 @@ public class ClickHouseTcpParameterIntegrationTests
         yield return new TestCaseData("Variant(Array(LowCardinality(Nullable(String))), Int64)", new[] { "a", null })
             .Returns("['a',NULL]").SetName("Variant holding a low-cardinality array with a null element");
 
+        // Picking the alternative is a separate match from formatting the value, and it reads the name as the
+        // caller wrote it. The server resolves both declarations to Variant(Int64, String).
+        yield return new TestCaseData("Variant(BIGINT, String)", 7L).Returns("7").SetName("An alias as a Variant alternative");
+        yield return new TestCaseData("Variant(Array(BIGINT), String)", new[] { 7L, 8L })
+            .Returns("[7,8]").SetName("An alias nested inside a Variant alternative");
+
         // A Variant holding Time: the value has to match that arm, not only a Time64 one. Matching nothing
         // refuses the whole Variant rather than the one alternative, so a time value reached no Variant at all.
         // The server renders a Time inside a Variant without the leading zero it gives a bare Time column, hence
@@ -451,6 +457,38 @@ public class ClickHouseTcpParameterIntegrationTests
             async () => await ScalarAsync(client, "SELECT toString({p:BFloat16})", options));
 
         Assert.That(exception.Message, Does.Contain("Pass a float"));
+    }
+
+    /// <summary>
+    /// A Map row comes back as <c>KeyValuePair&lt;K, V&gt;[]</c>, not as a dictionary, so that duplicate keys and
+    /// pair order survive. A <c>Dynamic</c> parameter names no layout, so the value's own type has to, and the
+    /// inference had no reading for a pair sequence: a value read from a Map column could not be sent back as
+    /// one at all.
+    /// <para>
+    /// The server holds a <c>Dynamic</c> parameter as a String whatever the text looks like — checked on 26.6,
+    /// where <c>{p:Dynamic}</c> reports <c>dynamicType</c> String for <c>42</c> as well. It does parse the text
+    /// first, which is why the map comes back with the pair separator normalized.
+    /// </para>
+    /// </summary>
+    [Test]
+    public async Task QueryAsync_MapReadBackSentAsADynamicParameter_IsParsedAsAMap()
+    {
+        await using var client = TcpServerFixture.CreateClient();
+
+        object pairs = await ScalarAsync(client, "SELECT map('a', toInt32(1), 'b', toInt32(2))", null);
+        Assert.That(pairs, Is.InstanceOf<KeyValuePair<string, int>[]>(), "the shape this test is about");
+
+        var options = new ClickHouseTcpQueryOptions
+        {
+            Parameters = new ClickHouseTcpParameterCollection { { "p", pairs } },
+        };
+
+        object read = await ScalarAsync(
+            client,
+            "SELECT concat(toString(dynamicType({p:Dynamic})), ' = ', toString({p:Dynamic}))",
+            options);
+
+        Assert.That(read, Is.EqualTo("String = {'a':1,'b':2}"));
     }
 
     [TestCase("limit")]

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpTypesIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpTypesIntegrationTests.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using ClickHouse.Driver.Tcp.Format;
+using ClickHouse.Driver.Tcp.Types;
 
 namespace ClickHouse.Driver.Tcp.Tests.Integration;
 
@@ -143,6 +144,63 @@ public class ClickHouseTcpTypesIntegrationTests
                 Assert.That(failure, Is.TypeOf<InvalidCastException>());
             }
         }
+    }
+
+    /// <summary>
+    /// <see cref="TypeAliases"/> is a copy of <c>system.data_type_families</c>, so this is the test that notices
+    /// when the server's copy changes: an alias added, an alias whose target moved, or a spelling mistyped in the
+    /// copy. Both directions are checked, and every disagreement is reported at once rather than one per run.
+    /// </summary>
+    [Test]
+    public async Task TypeAliases_TheTable_AgreesWithTheServersOwn()
+    {
+        await using var client = TcpServerFixture.CreateClient();
+
+        var serverFamilies = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        await foreach (Block block in client.StreamAsync(
+            "SELECT name, alias_to FROM system.data_type_families",
+            cancellationToken: None))
+        {
+            IColumn<string> names = block.ReadAs<string>("name");
+            IColumn<string> targets = block.ReadAs<string>("alias_to");
+            for (int row = 0; row < block.RowCount; row++)
+            {
+                serverFamilies[names[row]] = targets[row];
+            }
+        }
+
+        Assert.That(serverFamilies, Is.Not.Empty, "the server reported no type families");
+
+        var missing = new List<string>();
+        foreach (KeyValuePair<string, string> family in serverFamilies)
+        {
+            // Only the aliases whose target this client has a codec for: the server also aliases types the
+            // client does not support, and those are TT-14/TT-48 decisions rather than table entries.
+            if (family.Value.Length == 0 || !ColumnCodecRegistry.Default.KnowsTypeName(family.Value))
+            {
+                continue;
+            }
+
+            if (TypeAliases.Canonical(family.Key) != family.Value)
+            {
+                missing.Add($"the server aliases '{family.Key}' to '{family.Value}'; the table says '{TypeAliases.Canonical(family.Key)}'");
+            }
+        }
+
+        var unknown = new List<string>();
+        foreach (KeyValuePair<string, string> alias in TypeAliases.All())
+        {
+            if (!serverFamilies.ContainsKey(alias.Key))
+            {
+                unknown.Add($"the table has '{alias.Key}', which is not a family this server reports");
+            }
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(missing, Is.Empty, string.Join("; ", missing));
+            Assert.That(unknown, Is.Empty, string.Join("; ", unknown));
+        });
     }
 
     // The candidate CLR type has to be the sample's static type, so the column is built by a generic helper rather

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpTypesIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ClickHouseTcpTypesIntegrationTests.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using ClickHouse.Driver.Tcp.Format;
+using ClickHouse.Driver.Tcp.Tests.Utilities;
 using ClickHouse.Driver.Tcp.Types;
 
 namespace ClickHouse.Driver.Tcp.Tests.Integration;
@@ -177,6 +178,14 @@ public class ClickHouseTcpTypesIntegrationTests
             // Only the aliases whose target this client has a codec for: the server also aliases types the
             // client does not support, and those are TT-14/TT-48 decisions rather than table entries.
             if (family.Value.Length == 0 || !ColumnCodecRegistry.Default.KnowsTypeName(family.Value))
+            {
+                continue;
+            }
+
+            // 25.8 has the GEOMETRY alias but not the Geometry type, so it points the alias at String. The
+            // client's table names the type, which is right for every server that has one.
+            if (!TcpServerFeatures.Has(TcpFeature.Geometry)
+                && family.Key.Equals("GEOMETRY", StringComparison.OrdinalIgnoreCase))
             {
                 continue;
             }

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ColumnReadProjectionIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ColumnReadProjectionIntegrationTests.cs
@@ -101,6 +101,39 @@ public class ColumnReadProjectionIntegrationTests
     }
 
     /// <summary>
+    /// The server accepts and applies fixed offsets .NET cannot represent — on 26.6 both of these are past
+    /// <see cref="TimeZoneInfo"/>'s ±14 hours — and it is the server that decides what a header carries. The
+    /// seconds are the wire value and need no zone, so the read has to arrive; only a calendar value reports it.
+    /// </summary>
+    [TestCase("Fixed/UTC+19:00:00", "+19:00:00")]
+    [TestCase("Fixed/UTC-18:00:00", "-18:00:00")]
+    public async Task StreamAsync_DateTimeOffsetTimeZoneInfoCannotHold_ReadsTheSecondsAndReportsOnlyTheZone(string zone, string offset)
+    {
+        await using var client = TcpServerFixture.CreateClient();
+
+        uint canonical = 0;
+        FormatException fromTimeZone = null;
+        FormatException fromProjection = null;
+
+        await foreach (Block block in client.StreamAsync(
+            $"SELECT toDateTime(1700000000, '{zone}')",
+            cancellationToken: None))
+        {
+            IColumn column = block[0];
+            canonical = ((IColumn<uint>)column).Values[0];
+            fromTimeZone = Assert.Throws<FormatException>(() => _ = ((IDateTimeColumn)column).TimeZone);
+            fromProjection = Assert.Throws<FormatException>(() => ProjectRow<DateTime>(column, 0));
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(canonical, Is.EqualTo(1_700_000_000u));
+            Assert.That(fromTimeZone?.Message, Does.Contain(zone).And.Contain(offset));
+            Assert.That(fromProjection?.Message, Does.Contain(offset));
+        });
+    }
+
+    /// <summary>
     /// A daylight-saving date, where the offset differs from the zone's standard offset. A projection that used a
     /// fixed base offset instead of resolving it per instant would pass the winter case above and fail here.
     /// </summary>

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ColumnarReadSurfaceIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ColumnarReadSurfaceIntegrationTests.cs
@@ -29,6 +29,39 @@ public class ColumnarReadSurfaceIntegrationTests
 {
     private static readonly CancellationToken None = CancellationToken.None;
 
+    /// <summary>
+    /// A bare <c>NULL</c> literal is typed <c>Nullable(Nothing)</c>, whose layout — a null map plus one
+    /// placeholder byte per row — is otherwise read only from bytes a test wrote itself. The column selected
+    /// after it is what proves the placeholder run was the right length: reading too few or too many bytes leaves
+    /// the rest of the block mis-framed. <c>Nothing</c> is not writable, so this can only be a read.
+    /// </summary>
+    [Test]
+    public async Task StreamAsync_NullLiteral_ReadsAsNullableNothingAndLeavesTheBlockAligned()
+    {
+        await using var client = TcpServerFixture.CreateClient();
+
+        var nulls = new List<object>();
+        var following = new List<ulong>();
+        string typeName = null;
+        await foreach (Block block in client.StreamAsync(
+            "SELECT NULL AS n, toUInt64(number) + 1 AS following FROM numbers(3)", cancellationToken: None))
+        {
+            typeName = block[0].TypeName;
+            for (int row = 0; row < block.RowCount; row++)
+            {
+                nulls.Add(block[0].GetValue(row));
+                following.Add((ulong)block[1].GetValue(row));
+            }
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(typeName, Is.EqualTo("Nullable(Nothing)"));
+            Assert.That(nulls, Is.EqualTo(new object[] { null, null, null }));
+            Assert.That(following, Is.EqualTo(new ulong[] { 1, 2, 3 }), "the next column decodes, so the placeholder run was one byte per row");
+        });
+    }
+
     [Test]
     public async Task StreamAsync_NullableColumn_ExposesInnerAndNullMapThroughINullableColumn()
     {

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ComputedColumnInsertIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ComputedColumnInsertIntegrationTests.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Format;
+using ClickHouse.Driver.Tcp.Protocol;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Tests.Integration;
+
+/// <summary>
+/// Inserts into a table whose columns are not all insertable — <c>DEFAULT</c>, <c>MATERIALIZED</c> and
+/// <c>ALIAS</c> — which is the shape of most real schemas and the one the test tables elsewhere in this suite
+/// never have.
+///
+/// <para>
+/// Two things only a real server settles here. The insert schema block does not name every column, and which
+/// ones it omits decides whether a caller who built columns from the table definition can insert at all. And an
+/// insert under <c>input_format_defaults_for_omitted_fields = 1</c> makes the server send a
+/// <c>TableColumns</c> packet, whose body the client decodes only to stay aligned — a decoder reading the wrong
+/// number of bytes would leave the rest of the response mis-framed.
+/// </para>
+/// </summary>
+[TestFixture]
+[Category("Integration")]
+public class ComputedColumnInsertIntegrationTests
+{
+    private static readonly CancellationToken None = CancellationToken.None;
+
+    // What makes the server send the TableColumns packet before the insert schema block. Verified on 26.6: with
+    // this on the packet arrives (one per insert), with it off it does not.
+    private static readonly Dictionary<string, string> DefaultsForOmittedFields = new(StringComparer.Ordinal)
+    {
+        ["input_format_defaults_for_omitted_fields"] = "1",
+    };
+
+    private static string UniqueTableName() => $"tcp_computed_column_test_{Guid.NewGuid():N}";
+
+    private static async Task ExecuteAsync(ClickHouseTcpConnection connection, string sql)
+    {
+        await foreach (Block block in connection.QueryAsync(sql, cancellationToken: None))
+        {
+            block.Dispose();
+        }
+    }
+
+    // id, plain: insertable. withDefault: insertable, computed when omitted. materialized, aliased: never
+    // insertable, and absent from the insert schema block.
+    private static async Task<string> CreateTableAsync(ClickHouseTcpConnection connection)
+    {
+        string table = UniqueTableName();
+        await ExecuteAsync(connection, $@"CREATE TABLE {table} (
+            id UInt64,
+            plain String,
+            withDefault String DEFAULT concat('d', toString(id)),
+            materialized UInt64 MATERIALIZED id * 2,
+            aliased UInt64 ALIAS id + 1
+        ) ENGINE = MergeTree ORDER BY id");
+        return table;
+    }
+
+    private static IColumn[] IdAndPlain() =>
+    [
+        PrimitiveColumn<ulong>.FromValues("id", "UInt64", [1, 2]),
+        new ArrayColumn<string>("plain", "String", ["a", "b"]),
+    ];
+
+    private static async Task<List<string>> ReadEveryColumnAsync(ClickHouseTcpConnection connection, string table)
+    {
+        var rows = new List<string>();
+        await foreach (Block block in connection.QueryAsync(
+            $"SELECT id, plain, withDefault, materialized, aliased FROM {table} ORDER BY id", cancellationToken: None))
+        {
+            for (int row = 0; row < block.RowCount; row++)
+            {
+                rows.Add(string.Join(
+                    "/",
+                    block[0].GetValue(row),
+                    block[1].GetValue(row),
+                    block[2].GetValue(row),
+                    block[3].GetValue(row),
+                    block[4].GetValue(row)));
+            }
+        }
+
+        return rows;
+    }
+
+    /// <summary>
+    /// The <c>TableColumns</c> packet is discarded rather than surfaced, so this cannot assert that it arrived —
+    /// only that the response stays aligned around it, which is what a wrong byte count would break. Two inserts
+    /// on one connection, because the packet comes once per insert and a decoder that under-reads leaves the
+    /// leftovers for the next operation.
+    /// </summary>
+    [Test]
+    public async Task InsertAsync_UnderDefaultsForOmittedFields_StaysAlignedAroundTheTableColumnsPacket()
+    {
+        await using var connection = await TcpServerFixture.ConnectAsync(None);
+        string table = await CreateTableAsync(connection);
+        try
+        {
+            await connection.InsertAsync(
+                $"INSERT INTO {table} (id, plain) VALUES", IdAndPlain(), settings: DefaultsForOmittedFields, cancellationToken: None);
+            TcpConnectionState afterFirst = connection.State;
+
+            await connection.InsertAsync(
+                $"INSERT INTO {table} (id, plain) VALUES", IdAndPlain(), settings: DefaultsForOmittedFields, cancellationToken: None);
+
+            // On the same connection, so it reads whatever the two inserts left on the wire.
+            List<string> rows = await ReadEveryColumnAsync(connection, table);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(afterFirst, Is.EqualTo(TcpConnectionState.Ready), "the connection survives the packet");
+                Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+                Assert.That(rows, Has.Count.EqualTo(4), "both inserts landed");
+                Assert.That(rows[0], Is.EqualTo("1/a/d1/2/2"), "the server computed the DEFAULT, MATERIALIZED and ALIAS values");
+            });
+        }
+        finally
+        {
+            await using ClickHouseTcpConnection cleanup = await TcpServerFixture.ConnectAsync(None);
+            await ExecuteAsync(cleanup, $"DROP TABLE IF EXISTS {table}");
+        }
+    }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ComputedColumnInsertIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ComputedColumnInsertIntegrationTests.cs
@@ -123,4 +123,145 @@ public class ComputedColumnInsertIntegrationTests
             await ExecuteAsync(cleanup, $"DROP TABLE IF EXISTS {table}");
         }
     }
+
+    /// <summary>
+    /// An insert with no column list. The schema block names the three insertable columns and omits the
+    /// <c>MATERIALIZED</c> and <c>ALIAS</c> ones, so what a caller must supply is not the table's column list —
+    /// which is what makes building columns from the table definition go wrong.
+    /// </summary>
+    [Test]
+    public async Task InsertAsync_NoColumnList_SchemaBlockNamesTheInsertableColumnsOnly()
+    {
+        await using var connection = await TcpServerFixture.ConnectAsync(None);
+        string table = await CreateTableAsync(connection);
+        try
+        {
+            var schemaColumns = new List<string>();
+            await connection.InsertAsync(
+                $"INSERT INTO {table} VALUES",
+                rowCount: 2,
+                buildColumns: schema =>
+                {
+                    for (int i = 0; i < schema.ColumnCount; i++)
+                    {
+                        schemaColumns.Add(schema[i].Name);
+                    }
+
+                    return new FixedColumnSource(
+                    [
+                        PrimitiveColumn<ulong>.FromValues("id", "UInt64", [1, 2]),
+                        new ArrayColumn<string>("plain", "String", ["a", "b"]),
+                        new ArrayColumn<string>("withDefault", "String", ["given", "given"]),
+                    ]);
+                },
+                settings: null,
+                parameters: null,
+                queryId: null,
+                maxRowsPerBlock: null,
+                cancellationToken: None);
+
+            List<string> rows = await ReadEveryColumnAsync(connection, table);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(schemaColumns, Is.EqualTo(new[] { "id", "plain", "withDefault" }));
+                Assert.That(rows[0], Is.EqualTo("1/a/given/2/2"), "a supplied DEFAULT column keeps its value");
+            });
+        }
+        finally
+        {
+            await using ClickHouseTcpConnection cleanup = await TcpServerFixture.ConnectAsync(None);
+            await ExecuteAsync(cleanup, $"DROP TABLE IF EXISTS {table}");
+        }
+    }
+
+    /// <summary>
+    /// Supplying a <c>MATERIALIZED</c> column, the mistake a caller makes after reading the table definition.
+    /// The client refuses it against the schema block before writing anything, and names the column.
+    /// </summary>
+    [Test]
+    public async Task InsertAsync_SupplyingAMaterializedColumn_RefusesAndNamesTheColumn()
+    {
+        await using var connection = await TcpServerFixture.ConnectAsync(None);
+        string table = await CreateTableAsync(connection);
+        try
+        {
+            IColumn[] columns =
+            [
+                PrimitiveColumn<ulong>.FromValues("id", "UInt64", [1, 2]),
+                new ArrayColumn<string>("plain", "String", ["a", "b"]),
+                PrimitiveColumn<ulong>.FromValues("materialized", "UInt64", [9, 9]),
+            ];
+
+            var refusal = Assert.ThrowsAsync<ArgumentException>(
+                async () => await connection.InsertAsync($"INSERT INTO {table} (id, plain) VALUES", columns, cancellationToken: None));
+
+            // The mismatch writes no row block and closes the row stream cleanly, so the caller's mistake costs
+            // neither rows nor the connection. Counted on the same connection, which is the proof it survived.
+            long committed = 0;
+            await foreach (Block block in connection.QueryAsync($"SELECT count() FROM {table}", cancellationToken: None))
+            {
+                committed = Convert.ToInt64(block[0].GetValue(0));
+            }
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(refusal.Message, Does.Contain("materialized"), "the caller has to be told which column");
+                Assert.That(committed, Is.Zero);
+                Assert.That(connection.State, Is.EqualTo(TcpConnectionState.Ready));
+            });
+        }
+        finally
+        {
+            await using ClickHouseTcpConnection cleanup = await TcpServerFixture.ConnectAsync(None);
+            await ExecuteAsync(cleanup, $"DROP TABLE IF EXISTS {table}");
+        }
+    }
+
+    /// <summary>
+    /// Naming the <c>MATERIALIZED</c> column in the statement instead. Now it is the server's refusal, not the
+    /// client's, and it arrives before the schema block — so the two mistakes fail on different sides and a
+    /// caller sees a different exception type for each.
+    /// </summary>
+    [Test]
+    public async Task InsertAsync_StatementNamesAMaterializedColumn_IsRefusedByTheServer()
+    {
+        await using var connection = await TcpServerFixture.ConnectAsync(None);
+        string table = await CreateTableAsync(connection);
+        try
+        {
+            IColumn[] columns =
+            [
+                PrimitiveColumn<ulong>.FromValues("id", "UInt64", [1, 2]),
+                new ArrayColumn<string>("plain", "String", ["a", "b"]),
+                PrimitiveColumn<ulong>.FromValues("materialized", "UInt64", [9, 9]),
+            ];
+
+            var refusal = Assert.ThrowsAsync<ClickHouseTcpServerException>(
+                async () => await connection.InsertAsync(
+                    $"INSERT INTO {table} (id, plain, materialized) VALUES", columns, cancellationToken: None));
+
+            Assert.That(refusal.Message, Does.Contain("MATERIALIZED"));
+        }
+        finally
+        {
+            await using ClickHouseTcpConnection cleanup = await TcpServerFixture.ConnectAsync(None);
+            await ExecuteAsync(cleanup, $"DROP TABLE IF EXISTS {table}");
+        }
+    }
+
+    // A row-stream source over columns already built: the insert calls Gather per block, and these columns hold
+    // every row already, so there is nothing to gather.
+    private sealed class FixedColumnSource(IReadOnlyList<IColumn> columns) : IInsertColumnSource
+    {
+        public IReadOnlyList<IColumn> Columns { get; } = columns;
+
+        public void Gather(int start, int length)
+        {
+        }
+
+        public void Dispose()
+        {
+        }
+    }
 }

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ConnectionPoolIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ConnectionPoolIntegrationTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using ClickHouse.Driver.Tcp.Format;
+using ClickHouse.Driver.Tcp.Tests.Utilities;
 
 namespace ClickHouse.Driver.Tcp.Tests.Integration;
 
@@ -271,6 +272,71 @@ public class ConnectionPoolIntegrationTests
         });
     }
 
+    /// <summary>
+    /// Retiring a connection closes the socket on the server, not only in the client. <c>ConnectionPoolTests</c>
+    /// proves the pool calls <c>Close</c>, but against a double whose "closed" is a flag the test itself watches;
+    /// only the server's own connection count says the socket went away. A leak here is invisible until a
+    /// long-running process runs the server out of <c>max_connections</c>.
+    ///
+    /// <para>
+    /// A one-tick lifetime retires a connection the moment the operation using it ends, so every query below runs
+    /// on a connection of its own. How many that really was comes from the server too: <c>system.query_log</c>
+    /// records the client port each query arrived on, which is the connection's identity. Without that the
+    /// connection count could be flat because nothing was ever opened rather than because everything was closed.
+    /// </para>
+    ///
+    /// <para>
+    /// The count is read over a second client held open for the whole test, which therefore contributes one
+    /// connection to both readings. The tolerance is for the other framework suites, which share the server and
+    /// open connections of their own; forty leaked sockets sit far outside it.
+    /// </para>
+    /// </summary>
+    [Test]
+    public async Task Retirement_AfterChurningManyConnections_LeavesNoneOpenOnTheServer()
+    {
+        const int churns = 40;
+        const int tolerance = churns / 4;
+
+        await using ClickHouseTcpClient observer = CreateClient(maxPoolSize: 1);
+        long baseline = await ServerConnectionsAsync(observer);
+        Assert.That(baseline, Is.GreaterThan(0), "the observer's own connection must be in the count, or this is not the count");
+
+        string tag = $"tcp_churn_{Guid.NewGuid():N}";
+        await using (var churning = new ClickHouseTcpClient(TcpServerFixture.Options() with
+        {
+            MaxPoolSize = 1,
+            MaxConnectionLifetime = TimeSpan.FromTicks(1),
+        }))
+        {
+            for (int churn = 0; churn < churns; churn++)
+            {
+                await churning.ExecuteAsync(
+                    "SELECT 1",
+                    new ClickHouseTcpQueryOptions { QueryId = $"{tag}_{churn}" },
+                    None);
+            }
+        }
+
+        // HAVING, so the lookup matches no row until every record is flushed: uniqExact over a partial set would
+        // answer with a lower number and the retry would stop at it.
+        object ports = await QueryLog.ScalarAsync(
+            observer,
+            $"SELECT toUInt64(uniqExact(port)) FROM system.query_log WHERE query_id LIKE '{tag}%' AND type = 'QueryStart' HAVING count() = {churns}");
+        long open = await WaitForServerConnectionsAsync(observer, baseline + tolerance);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                Convert.ToInt64(ports),
+                Is.EqualTo(churns),
+                "the server must have seen each query on a client port of its own");
+            Assert.That(
+                open - baseline,
+                Is.LessThanOrEqualTo(tolerance),
+                $"connections the pool retired must not stay open on the server (baseline {baseline})");
+        });
+    }
+
     [Test]
     public async Task ExecuteAsync_UnparseableSetting_ReplacesClosedConnectionBeforeNextOperation()
     {
@@ -294,6 +360,40 @@ public class ConnectionPoolIntegrationTests
                 async () => await client.ExecuteAsync("SELECT 1", cancellationToken: None),
                 $"iteration {iteration + 1}: the valid statement must not inherit the closed connection");
         }
+    }
+
+    // How many native connections the server has open, this client's own among them.
+    private static async Task<long> ServerConnectionsAsync(ClickHouseTcpClient client)
+    {
+        long open = 0;
+        await foreach (ValueRow row in client.QueryAsync<ValueRow>(
+            "SELECT toUInt64(value) AS id FROM system.metrics WHERE metric = 'TCPConnection'",
+            cancellationToken: None))
+        {
+            open = (long)row.Id;
+        }
+
+        return open;
+    }
+
+    // Waits for the server's connection count to come down to a limit, and returns the last value read. A
+    // close is asynchronous on the server's side, and the count is shared with the other framework suites, so
+    // one reading taken right after the churn is not the answer.
+    private static async Task<long> WaitForServerConnectionsAsync(ClickHouseTcpClient client, long limit)
+    {
+        long open = 0;
+        for (int attempt = 0; attempt < 20; attempt++)
+        {
+            open = await ServerConnectionsAsync(client);
+            if (open <= limit)
+            {
+                return open;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(100));
+        }
+
+        return open;
     }
 
     private static async Task<ulong> TemporaryTableExistsAsync(

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ConnectionPoolIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ConnectionPoolIntegrationTests.cs
@@ -236,14 +236,29 @@ public class ConnectionPoolIntegrationTests
             Is.EqualTo(1UL),
             "the marker must exist to begin with, or the assertion below proves nothing");
 
-        // Four seconds against a one-second server timeout: the server notices an idle connection on its own
-        // schedule, and the suites for the other frameworks are on the same server.
-        await Task.Delay(TimeSpan.FromSeconds(4));
-
-        // Has to be asserted rather than thrown out of: the failure this defends against is the query failing,
-        // and the marker count then says whether the connection was replaced or kept.
+        // Polled, not slept: the server notices an idle connection on its own schedule, and the suites for the
+        // other frameworks share the server, so a fixed wait is a race this can lose. Each gap is longer than the
+        // one-second server timeout, so a poll that finds the connection alive resets the timer and still leaves
+        // the next gap long enough to expire it. The control has nothing to wait for and takes the first reading,
+        // after the same gap.
+        //
+        // Asserted rather than thrown out of: the failure this defends against is the query failing, and the
+        // marker count then says whether the connection was replaced or kept.
         ulong markerAfterwards = 0;
-        Assert.DoesNotThrowAsync(async () => markerAfterwards = await TemporaryTableExistsAsync(client, marker, options));
+        int attempts = serverIdleTimeout is null ? 1 : 12;
+        Assert.DoesNotThrowAsync(async () =>
+        {
+            for (int attempt = 0; attempt < attempts; attempt++)
+            {
+                await Task.Delay(TimeSpan.FromSeconds(3));
+                markerAfterwards = await TemporaryTableExistsAsync(client, marker, options);
+                if (markerAfterwards == markerAfterTheWait)
+                {
+                    return;
+                }
+            }
+        });
+
         Assert.That(markerAfterwards, Is.EqualTo(markerAfterTheWait));
     }
 

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ConnectionPoolIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ConnectionPoolIntegrationTests.cs
@@ -185,6 +185,53 @@ public class ConnectionPoolIntegrationTests
             "a connection left idle past the timeout must not be handed out again");
     }
 
+    /// <summary>
+    /// The other way a pooled connection dies: the server hangs up on it while the client still considers it
+    /// fresh. <c>idle_connection_timeout</c> makes a real server do that on request, which is the behaviour of
+    /// Cloud and of any load balancer with an idle cut, and the client's own timeouts are left at their defaults
+    /// so neither can be what retires the connection. The only thing between the caller and a dead socket is the
+    /// probe in <c>IsReusable</c>: with it disabled, the query below fails with a transport error saying the
+    /// server closed the connection before the response was complete.
+    ///
+    /// <para>
+    /// The <c>null</c> case is the control. The same wait against a server left at its default idle timeout keeps
+    /// the connection, so what retires it in the other case is the server hanging up and not the wait.
+    /// </para>
+    /// </summary>
+    /// <param name="serverIdleTimeout">Seconds for the server's <c>idle_connection_timeout</c>, or null to leave it.</param>
+    /// <param name="markerAfterTheWait">The marker count expected after the wait: 1 if the connection was kept, 0 if it was replaced.</param>
+    [TestCase("1", 0UL)]
+    [TestCase(null, 1UL)]
+    public async Task QueryAsync_AfterTheServerHungUpOnAnIdleConnection_RunsOnAFreshConnectionRatherThanFailing(
+        string serverIdleTimeout,
+        ulong markerAfterTheWait)
+    {
+        await using ClickHouseTcpClient client = CreateClient(maxPoolSize: 1);
+        ClickHouseTcpQueryOptions options = serverIdleTimeout is null
+            ? null
+            : new ClickHouseTcpQueryOptions
+            {
+                Settings = new Dictionary<string, string> { ["idle_connection_timeout"] = serverIdleTimeout },
+            };
+
+        string marker = UniqueTableName();
+        await client.ExecuteAsync($"CREATE TEMPORARY TABLE {marker} (id UInt64)", options, None);
+        Assert.That(
+            await TemporaryTableExistsAsync(client, marker, options),
+            Is.EqualTo(1UL),
+            "the marker must exist to begin with, or the assertion below proves nothing");
+
+        // Four seconds against a one-second server timeout: the server notices an idle connection on its own
+        // schedule, and the suites for the other frameworks are on the same server.
+        await Task.Delay(TimeSpan.FromSeconds(4));
+
+        // Has to be asserted rather than thrown out of: the failure this defends against is the query failing,
+        // and the marker count then says whether the connection was replaced or kept.
+        ulong markerAfterwards = 0;
+        Assert.DoesNotThrowAsync(async () => markerAfterwards = await TemporaryTableExistsAsync(client, marker, options));
+        Assert.That(markerAfterwards, Is.EqualTo(markerAfterTheWait));
+    }
+
     [Test]
     public async Task Return_AfterEachKindOfOperation_KeepsTheSameConnection()
     {
@@ -249,12 +296,16 @@ public class ConnectionPoolIntegrationTests
         }
     }
 
-    private static async Task<ulong> TemporaryTableExistsAsync(ClickHouseTcpClient client, string name)
+    private static async Task<ulong> TemporaryTableExistsAsync(
+        ClickHouseTcpClient client,
+        string name,
+        ClickHouseTcpQueryOptions options = null)
     {
         ulong exists = 0;
         await foreach (ValueRow row in client.QueryAsync<ValueRow>(
             $"SELECT toUInt64(count()) AS id FROM system.tables WHERE is_temporary AND name = '{name}'",
-            cancellationToken: None))
+            options,
+            None))
         {
             exists = row.Id;
         }

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ConnectionPoolIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ConnectionPoolIntegrationTests.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using ClickHouse.Driver.Tcp.Format;
 using ClickHouse.Driver.Tcp.Tests.Utilities;
+using ClickHouse.Driver.Tcp.Types;
 
 namespace ClickHouse.Driver.Tcp.Tests.Integration;
 
@@ -17,6 +18,19 @@ namespace ClickHouse.Driver.Tcp.Tests.Integration;
 public class ConnectionPoolIntegrationTests
 {
     private static readonly CancellationToken None = CancellationToken.None;
+
+    /// <summary>An operation that fails, one per place a failure can strike after the permit is taken.</summary>
+    public enum FailingOperation
+    {
+        /// <summary>A query the server refuses, so the failure arrives over the wire.</summary>
+        QueryTheServerRefuses,
+
+        /// <summary>An insert of a column the table has not, refused by the client against the schema block.</summary>
+        InsertOfAnUnknownColumn,
+
+        /// <summary>An insert whose columns disagree on row count, refused before the connection is used.</summary>
+        InsertOfRaggedColumns,
+    }
 
     private static string UniqueTableName() => $"tcp_pool_test_{Guid.NewGuid():N}";
 
@@ -359,6 +373,87 @@ public class ConnectionPoolIntegrationTests
             Assert.DoesNotThrowAsync(
                 async () => await client.ExecuteAsync("SELECT 1", cancellationToken: None),
                 $"iteration {iteration + 1}: the valid statement must not inherit the closed connection");
+        }
+    }
+
+    /// <summary>
+    /// A failed operation gives its pool permit back. The other error-path tests run at the default
+    /// <c>MaxPoolSize</c> of 20, where losing one permit per failure still leaves nineteen and every assertion
+    /// passes; at a pool of one the attempt after the first has nothing to run on. Three failures, then a
+    /// successful query on the same client.
+    ///
+    /// <para>
+    /// One case per place an operation can fail once it holds a permit: on the server, in the client against the
+    /// insert schema block, and in the client before the connection is touched at all. The fourth failure kind,
+    /// a setting the server refuses, is already repeated at a pool of one by
+    /// <see cref="ExecuteAsync_UnparseableSetting_ReplacesClosedConnectionBeforeNextOperation"/>.
+    /// </para>
+    /// </summary>
+    /// <param name="failing">The operation to repeat.</param>
+    /// <param name="expected">The exception it must fail with. A lost permit reports a pool timeout instead.</param>
+    [TestCase(FailingOperation.QueryTheServerRefuses, typeof(ClickHouseTcpServerException))]
+    [TestCase(FailingOperation.InsertOfAnUnknownColumn, typeof(ArgumentException))]
+    [TestCase(FailingOperation.InsertOfRaggedColumns, typeof(ArgumentException))]
+    public async Task Failure_RepeatedAtAPoolOfOne_ReturnsThePermitEveryTime(FailingOperation failing, Type expected)
+    {
+        const int attempts = 3;
+
+        // A lost permit makes the next attempt wait out PoolTimeout and report one, so the value is what this
+        // test costs when it fails. Five seconds is long enough not to be reported by a busy machine instead.
+        await using ClickHouseTcpClient client = CreateClient(maxPoolSize: 1, poolTimeout: TimeSpan.FromSeconds(5));
+        string table = UniqueTableName();
+        await client.ExecuteAsync($"CREATE TABLE {table} (id UInt64) ENGINE = MergeTree ORDER BY id", cancellationToken: None);
+        try
+        {
+            for (int attempt = 1; attempt <= attempts; attempt++)
+            {
+                Exception thrown = Assert.CatchAsync(async () => await FailAsync(client, failing, table));
+                Assert.That(thrown, Is.InstanceOf(expected), $"attempt {attempt}");
+            }
+
+            ulong rows = 0;
+            await foreach (ValueRow row in client.QueryAsync<ValueRow>(
+                $"SELECT toUInt64(count()) AS id FROM {table}", cancellationToken: None))
+            {
+                rows = row.Id;
+            }
+
+            Assert.That(rows, Is.Zero, "a refused insert must leave no row behind");
+        }
+        finally
+        {
+            await client.ExecuteAsync($"DROP TABLE IF EXISTS {table}", cancellationToken: None);
+        }
+    }
+
+    private static async Task FailAsync(ClickHouseTcpClient client, FailingOperation failing, string table)
+    {
+        switch (failing)
+        {
+            case FailingOperation.QueryTheServerRefuses:
+                await client.ExecuteAsync($"SELECT count() FROM {table}_absent", cancellationToken: None);
+                break;
+
+            case FailingOperation.InsertOfAnUnknownColumn:
+                IColumn[] unknown =
+                [
+                    PrimitiveColumn<ulong>.FromValues("id", "UInt64", [1, 2]),
+                    PrimitiveColumn<ulong>.FromValues("absent", "UInt64", [1, 2]),
+                ];
+                await client.InsertAsync($"INSERT INTO {table} (id) VALUES", unknown, cancellationToken: None);
+                break;
+
+            case FailingOperation.InsertOfRaggedColumns:
+                IColumn[] ragged =
+                [
+                    PrimitiveColumn<ulong>.FromValues("id", "UInt64", [1, 2]),
+                    PrimitiveColumn<ulong>.FromValues("second", "UInt64", [1, 2, 3]),
+                ];
+                await client.InsertAsync($"INSERT INTO {table} (id) VALUES", ragged, cancellationToken: None);
+                break;
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(failing), failing, "unhandled failure");
         }
     }
 

--- a/ClickHouse.Driver.Tcp.Tests/Integration/FloatSpecialValueIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/FloatSpecialValueIntegrationTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using ClickHouse.Driver.Tcp.Types;
@@ -6,13 +7,14 @@ using ClickHouse.Driver.Tcp.Types;
 namespace ClickHouse.Driver.Tcp.Tests.Integration;
 
 /// <summary>
-/// Signed zero, asserted against the server's rendering of what was stored.
+/// Signed zero, asserted against the bits the server stored.
 ///
 /// <para>
 /// The corpus carries <c>-0.0</c> in the float cases, but its comparison cannot see the sign: in .NET
-/// <c>(-0.0).Equals(0.0)</c> is true, so a write that dropped the sign bit would round-trip as equal. The
-/// server's text form distinguishes them, and it is the only oracle here that does. <c>NaN</c> and the
-/// infinities need no test of their own, being ordinary corpus values that compare unequal to everything else.
+/// <c>(-0.0).Equals(0.0)</c> is true, so a write that dropped the sign bit would round-trip as equal. The text
+/// form cannot be the oracle either — 25.8 renders a negative zero as <c>0</c> and 26.6 as <c>-0</c> — so the
+/// stored bits are, which is also the exact claim. <c>NaN</c> and the infinities need no test of their own,
+/// being ordinary corpus values that compare unequal to everything else.
 /// </para>
 /// </summary>
 [TestFixture]
@@ -22,19 +24,29 @@ public class FloatSpecialValueIntegrationTests
     private static readonly CancellationToken None = CancellationToken.None;
 
     /// <param name="columnType">The float column to write into.</param>
-    /// <param name="settings">Whether the type needs its experimental flag.</param>
-    [TestCase("Float32", false)]
-    [TestCase("Float64", false)]
-    [TestCase("BFloat16", true)]
-    public async Task InsertAsync_NegativeZero_KeepsItsSignOnTheServer(string columnType, bool experimental)
+    /// <param name="reinterpret">The function that reads the stored value back as its raw bits.</param>
+    /// <param name="negativeZeroBits">The bit pattern of a negative zero at that width.</param>
+    /// <param name="experimental">Whether the type needs its experimental flag.</param>
+    [TestCase("Float32", "reinterpretAsUInt32", 2147483648UL, false)]
+    [TestCase("Float64", "reinterpretAsUInt64", 9223372036854775808UL, false)]
+    [TestCase("BFloat16", "reinterpretAsUInt16", 32768UL, true)]
+    public async Task InsertAsync_NegativeZero_KeepsItsSignBitOnTheServer(
+        string columnType,
+        string reinterpret,
+        ulong negativeZeroBits,
+        bool experimental)
     {
         await using ClickHouseTcpClient client = TcpServerFixture.CreateClient();
-        var options = experimental
-            ? new ClickHouseTcpQueryOptions { Settings = new System.Collections.Generic.Dictionary<string, string>(StringComparer.Ordinal) { ["allow_experimental_bfloat16_type"] = "1" } }
+        IReadOnlyDictionary<string, string> settings = experimental
+            ? new Dictionary<string, string>(StringComparer.Ordinal) { ["allow_experimental_bfloat16_type"] = "1" }
             : null;
+        var options = settings is null ? null : new ClickHouseTcpQueryOptions { Settings = settings };
 
+        // Memory, not MergeTree: 25.8's part writer normalizes a negative zero away, a plain SQL insert included,
+        // so a MergeTree table would test the storage engine's rounding rather than what the client wrote. 26.6
+        // keeps it either way.
         string table = $"tcp_float_special_test_{Guid.NewGuid():N}";
-        await client.ExecuteAsync($"CREATE TABLE {table} (id UInt64, v {columnType}) ENGINE = MergeTree ORDER BY id", options, None);
+        await client.ExecuteAsync($"CREATE TABLE {table} (id UInt64, v {columnType}) ENGINE = Memory", options, None);
         try
         {
             IColumn[] columns =
@@ -48,19 +60,20 @@ public class FloatSpecialValueIntegrationTests
             await client.InsertAsync(
                 $"INSERT INTO {table} (id, v) VALUES",
                 columns,
-                new ClickHouseTcpInsertOptions { Settings = options?.Settings },
+                new ClickHouseTcpInsertOptions { Settings = settings },
                 None);
 
-            var rendered = new string[2];
-            await foreach (object[] row in client.QueryAsync($"SELECT id, toString(v) FROM {table} ORDER BY id", options, None))
+            var stored = new ulong[2];
+            await foreach (object[] row in client.QueryAsync(
+                $"SELECT id, {reinterpret}(v) FROM {table} ORDER BY id", options, None))
             {
-                rendered[Convert.ToInt32(row[0]) - 1] = (string)row[1];
+                stored[Convert.ToInt32(row[0]) - 1] = Convert.ToUInt64(row[1]);
             }
 
             Assert.Multiple(() =>
             {
-                Assert.That(rendered[0], Is.EqualTo("-0"), "the sign bit of a zero has to survive the write");
-                Assert.That(rendered[1], Is.EqualTo("0"), "and the positive zero must not acquire one");
+                Assert.That(stored[0], Is.EqualTo(negativeZeroBits), "the sign bit of a zero has to survive the write");
+                Assert.That(stored[1], Is.Zero, "and the positive zero must not acquire one");
             });
         }
         finally

--- a/ClickHouse.Driver.Tcp.Tests/Integration/FloatSpecialValueIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/FloatSpecialValueIntegrationTests.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Tests.Integration;
+
+/// <summary>
+/// Signed zero, asserted against the server's rendering of what was stored.
+///
+/// <para>
+/// The corpus carries <c>-0.0</c> in the float cases, but its comparison cannot see the sign: in .NET
+/// <c>(-0.0).Equals(0.0)</c> is true, so a write that dropped the sign bit would round-trip as equal. The
+/// server's text form distinguishes them, and it is the only oracle here that does. <c>NaN</c> and the
+/// infinities need no test of their own, being ordinary corpus values that compare unequal to everything else.
+/// </para>
+/// </summary>
+[TestFixture]
+[Category("Integration")]
+public class FloatSpecialValueIntegrationTests
+{
+    private static readonly CancellationToken None = CancellationToken.None;
+
+    /// <param name="columnType">The float column to write into.</param>
+    /// <param name="settings">Whether the type needs its experimental flag.</param>
+    [TestCase("Float32", false)]
+    [TestCase("Float64", false)]
+    [TestCase("BFloat16", true)]
+    public async Task InsertAsync_NegativeZero_KeepsItsSignOnTheServer(string columnType, bool experimental)
+    {
+        await using ClickHouseTcpClient client = TcpServerFixture.CreateClient();
+        var options = experimental
+            ? new ClickHouseTcpQueryOptions { Settings = new System.Collections.Generic.Dictionary<string, string>(StringComparer.Ordinal) { ["allow_experimental_bfloat16_type"] = "1" } }
+            : null;
+
+        string table = $"tcp_float_special_test_{Guid.NewGuid():N}";
+        await client.ExecuteAsync($"CREATE TABLE {table} (id UInt64, v {columnType}) ENGINE = MergeTree ORDER BY id", options, None);
+        try
+        {
+            IColumn[] columns =
+            [
+                PrimitiveColumn<ulong>.FromValues("id", "UInt64", [1, 2]),
+                columnType == "Float64"
+                    ? new ArrayColumn<double>("v", columnType, [-0d, 0d])
+                    : new ArrayColumn<float>("v", columnType, [-0f, 0f]),
+            ];
+
+            await client.InsertAsync(
+                $"INSERT INTO {table} (id, v) VALUES",
+                columns,
+                new ClickHouseTcpInsertOptions { Settings = options?.Settings },
+                None);
+
+            var rendered = new string[2];
+            await foreach (object[] row in client.QueryAsync($"SELECT id, toString(v) FROM {table} ORDER BY id", options, None))
+            {
+                rendered[Convert.ToInt32(row[0]) - 1] = (string)row[1];
+            }
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(rendered[0], Is.EqualTo("-0"), "the sign bit of a zero has to survive the write");
+                Assert.That(rendered[1], Is.EqualTo("0"), "and the positive zero must not acquire one");
+            });
+        }
+        finally
+        {
+            await client.ExecuteAsync($"DROP TABLE IF EXISTS {table}", cancellationToken: None);
+        }
+    }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Integration/InsertInterruptionIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/InsertInterruptionIntegrationTests.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ClickHouse.Driver.Tcp.Tests.Integration;
+
+/// <summary>
+/// An INSERT whose data phase does not finish, either because the caller cancelled it or because the server
+/// rejected an early block while later ones were still going out. An insert writes every block before reading
+/// anything, so both cases leave blocks the socket has already taken, and the question a caller needs answered
+/// is whether any of those rows land.
+///
+/// <para>
+/// The row phase is also the one stretch where the client cannot send a Cancel packet — appended to a truncated
+/// Data packet it would be read as more block bytes — so an interrupted insert is expressed by dropping the
+/// connection. That makes "the pool slot comes back" a separate claim from "the connection survives", and both
+/// are asserted here on a pool one connection wide.
+/// </para>
+/// </summary>
+[TestFixture]
+[Category("Integration")]
+public class InsertInterruptionIntegrationTests
+{
+    private const int RowsPerBlock = 100;
+
+    private static readonly CancellationToken None = CancellationToken.None;
+
+    private static string UniqueTableName() => $"tcp_insert_interrupt_test_{Guid.NewGuid():N}";
+
+    private static object[][] Ids(int count) => Enumerable.Range(0, count).Select(i => new object[] { (ulong)i }).ToArray();
+
+    [Test]
+    public async Task InsertRowsAsync_CancelledPartWayThroughTheDataPhase_CommitsNothingAndGivesThePoolSlotBack()
+    {
+        await using var client = new ClickHouseTcpClient(TcpServerFixture.Options() with { MaxPoolSize = 1 });
+        string table = UniqueTableName();
+        try
+        {
+            await client.ExecuteAsync($"CREATE TABLE {table} (id UInt64) ENGINE = MergeTree ORDER BY id", cancellationToken: None);
+
+            // OnBlockWritten runs after the block's flush, so cancelling from it puts the cancellation squarely
+            // inside the data phase with one block already on the socket. Waiting on a timer instead would land
+            // anywhere, including before the phase starts.
+            using var cancellation = new CancellationTokenSource();
+            var blocksWritten = new List<int>();
+            var options = new ClickHouseTcpInsertOptions
+            {
+                MaxRowsPerBlock = RowsPerBlock,
+                Callbacks = new ClickHouseTcpQueryCallbacks
+                {
+                    OnBlockWritten = block =>
+                    {
+                        blocksWritten.Add(block.RowCount);
+                        if (block.BlockIndex == 0)
+                        {
+                            cancellation.Cancel();
+                        }
+                    },
+                },
+            };
+
+            Assert.That(
+                async () => await client.InsertRowsAsync($"INSERT INTO {table} (id) VALUES", Ids(5 * RowsPerBlock), options, cancellation.Token),
+                Throws.InstanceOf<OperationCanceledException>());
+
+            object committed = await client.ExecuteScalarAsync($"SELECT count() FROM {table}", cancellationToken: None);
+            object next = await client.ExecuteScalarAsync("SELECT toUInt64(7)", cancellationToken: None);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(blocksWritten, Is.EqualTo(new[] { RowsPerBlock }), "one block out, then the cancel");
+                Assert.That(committed, Is.EqualTo(0UL), "an insert the server never saw the end of commits nothing");
+                Assert.That(next, Is.EqualTo(7UL), "the only pool slot came back");
+            });
+        }
+        finally
+        {
+            await client.ExecuteAsync($"DROP TABLE IF EXISTS {table}", cancellationToken: None);
+        }
+    }
+
+    /// <summary>
+    /// The server rejects the second block while the client is still writing the rest. Nothing reads the error
+    /// until every block has gone out, so this pins that the write phase finishes and reports the server's error
+    /// rather than stalling against a peer that stopped reading.
+    /// </summary>
+    [TestCase(5, TestName = "{m}(five blocks)")]
+    [TestCase(200, TestName = "{m}(two hundred blocks)")]
+    public async Task InsertRowsAsync_ServerRejectsAnEarlyBlockWhileLaterOnesAreStillGoingOut_ReportsTheError(int blocks)
+    {
+        await using var client = new ClickHouseTcpClient(TcpServerFixture.Options() with { MaxPoolSize = 1 });
+        string table = UniqueTableName();
+        try
+        {
+            // The constraint passes for the first block's ids and fails for every one after it.
+            await client.ExecuteAsync(
+                $"CREATE TABLE {table} (id UInt64, CONSTRAINT first_block_only CHECK id < {RowsPerBlock}) ENGINE = MergeTree ORDER BY id",
+                cancellationToken: None);
+
+            var options = new ClickHouseTcpInsertOptions { MaxRowsPerBlock = RowsPerBlock };
+
+            var refusal = Assert.ThrowsAsync<ClickHouseTcpServerException>(
+                async () => await client.InsertRowsAsync($"INSERT INTO {table} (id) VALUES", Ids(blocks * RowsPerBlock), options, None));
+
+            object committed = await client.ExecuteScalarAsync($"SELECT count() FROM {table}", cancellationToken: None);
+            object next = await client.ExecuteScalarAsync("SELECT toUInt64(7)", cancellationToken: None);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(refusal.Message, Does.Contain("first_block_only"), "the server names the constraint");
+                Assert.That(committed, Is.EqualTo(0UL), "not even the block that satisfied the constraint");
+                Assert.That(next, Is.EqualTo(7UL), "the only pool slot came back");
+            });
+        }
+        finally
+        {
+            await client.ExecuteAsync($"DROP TABLE IF EXISTS {table}", cancellationToken: None);
+        }
+    }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Integration/MidStreamFailureIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/MidStreamFailureIntegrationTests.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Compression;
+using ClickHouse.Driver.Tcp.Format;
+
+namespace ClickHouse.Driver.Tcp.Tests.Integration;
+
+/// <summary>
+/// A server error raised part-way through a result, after rows have already been handed to the caller. The other
+/// integration error cases all fail at submit time, before any data block, and the mid-stream case was covered
+/// only by scripted bytes — which proves the reader agrees with our own idea of the packet order, not the
+/// server's.
+///
+/// <para>
+/// Compression is what makes this worth running per codec. The <c>Exception</c> packet body is <b>not</b> framed
+/// while the data blocks around it are, so it is read straight from the raw reader; routing it through the frame
+/// reader instead would read the error text as a frame header and lose the error. That also means the framed
+/// bodies before it must have been consumed to the byte, or the raw reader starts the error text in the wrong
+/// place. The connection is retired either way, so the damage would be a wrong or missing exception rather than
+/// a corrupted next query.
+/// </para>
+/// </summary>
+[TestFixture]
+[Category("Integration")]
+public class MidStreamFailureIntegrationTests
+{
+    private static readonly CancellationToken None = CancellationToken.None;
+
+    // 395 is FUNCTION_THROW_IF_VALUE_IS_NON_ZERO. ClickHouseErrorCode names a subset of the server's codes, so
+    // this one arrives as Unknown with the raw number intact; the raw number is the part that is a contract.
+    private const int ThrowIfValueIsNonZero = 395;
+
+    private static IEnumerable<TestCaseData> Codecs()
+    {
+        yield return new TestCaseData(null).SetName("{m}(uncompressed)");
+        yield return new TestCaseData(Lz4Compressor.Default).SetName("{m}(LZ4)");
+        yield return new TestCaseData(ZstdCompressor.Default).SetName("{m}(ZSTD)");
+    }
+
+    [TestCaseSource(nameof(Codecs))]
+    public async Task StreamAsync_ServerThrowsPartWayThroughTheResult_ReportsTheErrorAfterTheRowsThatArrived(
+        IClickHouseCompressor codec)
+    {
+        // One connection, so the queries after the failure can only run on what the failed one left behind.
+        await using var client = new ClickHouseTcpClient(
+            TcpServerFixture.Options() with { Compressor = codec, MaxPoolSize = 1 });
+
+        // A temporary table is scoped to the connection, so it answers "retired or pooled?" without reaching
+        // into the pool: a pooled connection still has it, a retired one is replaced by a dial to a server that
+        // never saw it.
+        string marker = $"tcp_mid_stream_{Guid.NewGuid():N}";
+        await client.ExecuteAsync($"CREATE TEMPORARY TABLE {marker} (value UInt64)", cancellationToken: None);
+        Assert.That(
+            await client.ExecuteScalarAsync($"SELECT count() FROM {marker}", cancellationToken: None),
+            Is.EqualTo(0UL),
+            "the marker must survive an ordinary query, or it cannot testify about the failing one");
+
+        int blocks = 0;
+        long rows = 0;
+        var failure = Assert.ThrowsAsync<ClickHouseTcpServerException>(async () =>
+        {
+            await foreach (Block block in client.StreamAsync(
+                "SELECT number, throwIf(number = 50000) FROM system.numbers SETTINGS max_block_size = 100",
+                cancellationToken: None))
+            {
+                blocks++;
+                rows += block.RowCount;
+            }
+        });
+
+        // How many rows arrive is not fixed — the server drops whatever output it had not flushed when it threw —
+        // but the packet order is, so rows cannot arrive after the error.
+        Assert.Multiple(() =>
+        {
+            Assert.That(blocks, Is.GreaterThan(1), "the error must arrive mid-stream, not at submit time");
+            Assert.That(rows, Is.GreaterThan(1000));
+            Assert.That(failure.RawCode, Is.EqualTo(ThrowIfValueIsNonZero));
+            Assert.That(failure.Message, Does.Contain("throwIf"), "the error text survives an unframed body");
+        });
+
+        // Retired, not pooled. This is the uniform policy for a server exception rather than anything specific to
+        // failing mid-stream: only end-of-stream marks a connection reusable.
+        Assert.That(
+            async () => await client.ExecuteScalarAsync($"SELECT count() FROM {marker}", cancellationToken: None),
+            Throws.TypeOf<ClickHouseTcpServerException>(),
+            "a connection that failed mid-stream must not go back to the pool");
+
+        // And the pool got its one permit back, so the replacement is dialled rather than waited for.
+        Assert.That(
+            await client.ExecuteScalarAsync("SELECT toUInt64(7)", cancellationToken: None),
+            Is.EqualTo(7UL));
+    }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Integration/MultiBlockStateIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/MultiBlockStateIntegrationTests.cs
@@ -1,0 +1,234 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Format;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Tests.Integration;
+
+/// <summary>
+/// Reads of columns that carry per-block serialization state, split across more than one block. A column whose
+/// body cannot be decoded without state read ahead of it — a <c>LowCardinality</c> dictionary, a <c>Dynamic</c>
+/// runtime type list, a version word — puts that state in a per-block prefix, and
+/// <c>BlockReader</c> reads one prefix per block whose row count is greater than zero. If that placement were
+/// wrong, the first block would still decode and the second would desync: the reader would take body bytes for
+/// a prefix, or a stale dictionary for the current one. So a single-block read proves nothing here, and every
+/// case below asserts across at least two blocks.
+///
+/// <para>
+/// Only a real server settles it. Reading back what this client wrote agrees with the client's own model of
+/// where the prefix goes, whether or not the server shares it.
+/// </para>
+/// </summary>
+[TestFixture]
+[Category("Integration")]
+public class MultiBlockStateIntegrationTests
+{
+    private const int Rows = 9;
+
+    private static readonly CancellationToken None = CancellationToken.None;
+
+    // max_block_size = 2 over 9 rows splits the result into blocks of 2,2,2,2,1, and max_threads = 1 keeps
+    // system.numbers on one stream so the split points and the block order are both deterministic. The two
+    // experimental flags let the Dynamic and Variant cases run and are inert for the others.
+    private static readonly Dictionary<string, string> SplitSettings = new(StringComparer.Ordinal)
+    {
+        ["max_block_size"] = "2",
+        ["max_threads"] = "1",
+        ["allow_experimental_dynamic_type"] = "1",
+        ["allow_experimental_variant_type"] = "1",
+    };
+
+    private static IEnumerable<TestCaseData> StatefulColumns()
+    {
+        // Cycling '% 3' through 2-row blocks means consecutive blocks hold different distinct sets, so a
+        // dictionary held over from the previous block decodes to a wrong value instead of failing outright.
+        yield return new TestCaseData(
+                "toLowCardinality(concat('v', toString(number % 3)))",
+                NineRows(i => "v" + (i % 3)))
+            .SetName("{m}(LowCardinality(String))");
+
+        // Nullable moves every dictionary key up by one reserved slot, so it decodes the prefix differently.
+        yield return new TestCaseData(
+                "toLowCardinality(if(number % 3 = 0, NULL, concat('v', toString(number)))::Nullable(String))",
+                NineRows(i => i % 3 == 0 ? null : "v" + i))
+            .SetName("{m}(LowCardinality(Nullable(String)))");
+
+        // Nested one level down, where the prefix belongs to the inner column and not to the one named in the
+        // block header.
+        yield return new TestCaseData(
+                "[toLowCardinality(concat('v', toString(number)))]",
+                NineRows(i => new[] { "v" + i }))
+            .SetName("{m}(Array(LowCardinality(String)))");
+
+        yield return new TestCaseData(
+                "map(toLowCardinality(concat('k', toString(number))), toUInt8(number))",
+                NineRows(i => new[] { new KeyValuePair<string, byte>("k" + i, (byte)i) }))
+            .SetName("{m}(Map(LowCardinality(String), UInt8))");
+
+        // Two dictionary-bearing children in one column: the prefixes are consecutive, so reading one too few or
+        // too many bytes for the first mis-frames the second.
+        yield return new TestCaseData(
+                "tuple(toLowCardinality(concat('a', toString(number))), toLowCardinality(concat('b', toString(number))))",
+                NineRows(i => ("a" + i, "b" + i)))
+            .SetName("{m}(Tuple of two LowCardinality(String))");
+
+        // A Dynamic whose runtime type changes twice down the result, so the type list a block declares differs
+        // from the one before it. StreamAsync_DynamicSplitAcrossBlocks... asserts those lists directly.
+        yield return new TestCaseData(
+                "CAST(if(number < 3, CAST(toInt64(number), 'Dynamic'), if(number < 6, CAST(concat('s', toString(number)), 'Dynamic'), CAST(toFloat64(number), 'Dynamic'))), 'Dynamic')",
+                NineRows(i => i < 3 ? (long)i : i < 6 ? "s" + i : (double)i))
+            .SetName("{m}(Dynamic whose runtime type list differs per block)");
+
+        // NULL in a Dynamic is the discriminator one past the last runtime type, so it moves with the per-block
+        // list rather than sitting at a fixed sentinel.
+        yield return new TestCaseData(
+                "CAST(if(number % 3 = 1, CAST(NULL, 'Dynamic'), CAST(toInt64(number), 'Dynamic')), 'Dynamic')",
+                NineRows(i => i % 3 == 1 ? null : (long)i))
+            .SetName("{m}(Dynamic holding NULLs)");
+
+        yield return new TestCaseData(
+                "if(number % 2 = 0, CAST(toInt64(number), 'Variant(Int64, String)'), CAST(concat('s', toString(number)), 'Variant(Int64, String)'))",
+                NineRows(i => i % 2 == 0 ? (long)i : "s" + i))
+            .SetName("{m}(Variant(Int64, String))");
+
+        yield return new TestCaseData(
+                "CAST(concat('{\"a\":', toString(number), '}'), 'JSON')",
+                NineRows(i => "{\"a\":" + i.ToString(CultureInfo.InvariantCulture) + "}"))
+            .SetName("{m}(JSON)");
+    }
+
+    [TestCaseSource(nameof(StatefulColumns))]
+    public async Task StreamAsync_StatefulColumnSplitAcrossBlocks_ReadsEveryRowInOrder(string expression, object[] expected)
+    {
+        await using var client = TcpServerFixture.CreateClient();
+        var options = new ClickHouseTcpQueryOptions { Settings = SplitSettings };
+
+        int blocks = 0;
+        var readBack = new List<object>(Rows);
+        await foreach (Block block in client.StreamAsync(
+            $"SELECT {expression} FROM system.numbers LIMIT {Rows}", options, cancellationToken: None))
+        {
+            blocks++;
+            for (int row = 0; row < block.RowCount; row++)
+            {
+                readBack.Add(block[0].GetValue(row));
+            }
+        }
+
+        Assert.Multiple(() =>
+        {
+            // The precondition, asserted rather than assumed: a server that returned one block would make the
+            // row comparison below pass while proving nothing about the second prefix.
+            Assert.That(blocks, Is.GreaterThan(1), "max_block_size = 2 must split the result");
+            Assert.That(readBack, Is.EqualTo(expected));
+        });
+    }
+
+    /// <summary>
+    /// The dictionary belongs to the block, not to the column: the same key means a different value in a
+    /// different block. Cycling three values through 2-row blocks makes the keys identical block to block
+    /// (<c>[1, 2]</c>) while the values behind them move, so a dictionary read once and reused would decode
+    /// every block to block one's values and no length would look wrong.
+    /// </summary>
+    [Test]
+    public async Task StreamAsync_LowCardinalitySplitAcrossBlocks_ResolvesEachBlockAgainstItsOwnDictionary()
+    {
+        await using var client = TcpServerFixture.CreateClient();
+        var options = new ClickHouseTcpQueryOptions { Settings = SplitSettings };
+
+        var dictionaries = new List<string[]>();
+        var keys = new List<int[]>();
+        var readBack = new List<object>(Rows);
+        await foreach (Block block in client.StreamAsync(
+            $"SELECT toLowCardinality(concat('v', toString(number % 3))) FROM system.numbers LIMIT {Rows}",
+            options,
+            cancellationToken: None))
+        {
+            var lowCardinality = (ILowCardinalityColumn<string>)block[0];
+
+            // Copied out of the borrowed block, and past the reserved leading slot so only the distinct data
+            // values are compared.
+            var distinct = new string[lowCardinality.Dictionary.RowCount - lowCardinality.ReservedSlotCount];
+            for (int slot = 0; slot < distinct.Length; slot++)
+            {
+                distinct[slot] = lowCardinality.Dictionary[slot + lowCardinality.ReservedSlotCount];
+            }
+
+            dictionaries.Add(distinct);
+            keys.Add(lowCardinality.Keys.ToArray());
+            for (int row = 0; row < block.RowCount; row++)
+            {
+                readBack.Add(block[0].GetValue(row));
+            }
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(dictionaries, Has.Count.EqualTo(5));
+            Assert.That(dictionaries[0], Is.EqualTo(new[] { "v0", "v1" }));
+            Assert.That(dictionaries[1], Is.EqualTo(new[] { "v2", "v0" }), "its own dictionary, in its own order");
+            Assert.That(dictionaries[2], Is.EqualTo(new[] { "v1", "v2" }));
+            Assert.That(keys[0], Is.EqualTo(keys[1]), "identical keys, so only the per-block dictionary tells the values apart");
+            Assert.That(readBack, Is.EqualTo(NineRows(i => "v" + (i % 3))));
+        });
+    }
+
+    /// <summary>
+    /// A <c>Dynamic</c> column's runtime type list is discovered per block, so a block declares only the types
+    /// its own rows use: the list grows, shrinks, and here changes to a type no earlier block named. Every row
+    /// still decodes, which is what pins the list to the block.
+    /// </summary>
+    [Test]
+    public async Task StreamAsync_DynamicSplitAcrossBlocks_DeclaresEachBlocksOwnRuntimeTypeList()
+    {
+        await using var client = TcpServerFixture.CreateClient();
+        var options = new ClickHouseTcpQueryOptions { Settings = SplitSettings };
+
+        var typeLists = new List<string[]>();
+        var readBack = new List<object>(Rows);
+        await foreach (Block block in client.StreamAsync(
+            $"""
+            SELECT CAST(if(number < 3, CAST(toInt64(number), 'Dynamic'),
+                           if(number < 6, CAST(concat('s', toString(number)), 'Dynamic'),
+                                          CAST(toFloat64(number), 'Dynamic'))), 'Dynamic')
+            FROM system.numbers LIMIT {Rows}
+            """,
+            options,
+            cancellationToken: None))
+        {
+            typeLists.Add(((IDynamicColumn)block[0]).TypeNames.ToArray());
+            for (int row = 0; row < block.RowCount; row++)
+            {
+                readBack.Add(block[0].GetValue(row));
+            }
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(typeLists, Has.Count.EqualTo(5));
+
+            // Rows 0-1, then 2-3 straddling the Int64/String change, then 4-5, then the Float64 rows.
+            Assert.That(typeLists[0], Is.EquivalentTo(new[] { "Int64" }));
+            Assert.That(typeLists[1], Is.EquivalentTo(new[] { "Int64", "String" }), "two types where the block before named one");
+            Assert.That(typeLists[2], Is.EquivalentTo(new[] { "String" }), "and back to one");
+            Assert.That(typeLists[3], Is.EquivalentTo(new[] { "Float64" }), "a type no earlier block named");
+            Assert.That(typeLists[4], Is.EquivalentTo(new[] { "Float64" }));
+            Assert.That(readBack, Is.EqualTo(NineRows(i => i < 3 ? (long)i : i < 6 ? "s" + i : (double)i)));
+        });
+    }
+
+    private static object[] NineRows(Func<int, object> value)
+    {
+        var expected = new object[Rows];
+        for (int i = 0; i < Rows; i++)
+        {
+            expected[i] = value(i);
+        }
+
+        return expected;
+    }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ReadonlyUserIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ReadonlyUserIntegrationTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using ClickHouse.Driver.Tcp.Format;
+using ClickHouse.Driver.Tcp.Types;
 
 namespace ClickHouse.Driver.Tcp.Tests.Integration;
 
@@ -81,8 +82,13 @@ public class ReadonlyUserIntegrationTests
 
     /// <summary>
     /// Turning the injection off costs exactly one thing, and this is it: a JSON column may arrive in a
-    /// serialization this client does not read. The test asserts the cost is paid by JSON alone — an ordinary
-    /// column in the same session is unaffected — so anyone weighing the switch can see its price.
+    /// serialization this client does not read. The test asserts the cost is paid by JSON alone — ordinary
+    /// columns in the same session are unaffected — so anyone weighing the switch can see its price.
+    /// <para>
+    /// The columns arrive as themselves rather than as one <c>toString</c> expression, and are read through the
+    /// typed accessors. A server-computed string would come back through the String decoder alone, so the test
+    /// would pass with the DateTime, Array and LowCardinality codecs broken and could not support its name.
+    /// </para>
     /// </summary>
     [Test]
     public async Task QueryAsync_SerializationSettingsOff_LeavesEveryTypeButJsonAndDynamicWorking()
@@ -93,10 +99,29 @@ public class ReadonlyUserIntegrationTests
 
         await using var client = new ClickHouseTcpClient(options);
 
-        var readBack = (string)await client.ExecuteScalarAsync(
-            "SELECT concat(toString(toDateTime('2024-06-15 12:00:00', 'UTC')), '/', toString([1, 2]))",
-            cancellationToken: None);
+        DateTimeOffset instant = default;
+        int[] numbers = null;
+        string label = null;
+        decimal amount = 0;
+        await foreach (Block block in client.StreamAsync(
+            @"SELECT toDateTime('2024-06-15 12:00:00', 'UTC') AS instant,
+                     [toInt32(1), toInt32(2)] AS numbers,
+                     toLowCardinality('lc') AS label,
+                     toDecimal64(1.25, 2) AS amount",
+            cancellationToken: None))
+        {
+            instant = ((IDateTimeColumn)block["instant"]).GetDateTimeOffset(0);
+            numbers = (int[])block["numbers"].GetValue(0);
+            label = (string)block["label"].GetValue(0);
+            amount = (decimal)block["amount"].GetValue(0);
+        }
 
-        Assert.That(readBack, Is.EqualTo("2024-06-15 12:00:00/[1,2]"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(instant, Is.EqualTo(new DateTimeOffset(2024, 6, 15, 12, 0, 0, TimeSpan.Zero)));
+            Assert.That(numbers, Is.EqualTo(new[] { 1, 2 }));
+            Assert.That(label, Is.EqualTo("lc"));
+            Assert.That(amount, Is.EqualTo(1.25m));
+        });
     }
 }

--- a/ClickHouse.Driver.Tcp.Tests/Integration/ReadonlyUserIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/ReadonlyUserIntegrationTests.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Format;
+
+namespace ClickHouse.Driver.Tcp.Tests.Integration;
+
+/// <summary>
+/// A user under a readonly profile, which is the one caller the high-level client used to refuse outright. Only a
+/// real server can show this: the refusal is the server's (<c>Code: 164 … Cannot modify … in readonly mode</c>),
+/// raised because the client sends two <c>output_format_native_*</c> settings whose server defaults are <c>0</c>,
+/// which makes every operation a setting modification.
+/// </summary>
+[TestFixture]
+[Category("Integration")]
+public class ReadonlyUserIntegrationTests
+{
+    private static readonly CancellationToken None = CancellationToken.None;
+
+    private string user;
+
+    [OneTimeSetUp]
+    public async Task CreateReadonlyUser()
+    {
+        // Unique, because the framework suites run at once against one server and a user is server-wide.
+        user = $"tcp_ro_{Guid.NewGuid():N}";
+        await using var admin = TcpServerFixture.CreateClient();
+        await admin.ExecuteAsync($"CREATE USER {user} IDENTIFIED WITH no_password SETTINGS readonly = 1", cancellationToken: None);
+        await admin.ExecuteAsync($"GRANT SELECT ON *.* TO {user}", cancellationToken: None);
+    }
+
+    [OneTimeTearDown]
+    public async Task DropReadonlyUser()
+    {
+        await using var admin = TcpServerFixture.CreateClient();
+        await admin.ExecuteAsync($"DROP USER IF EXISTS {user}", cancellationToken: None);
+    }
+
+    [Test]
+    public async Task QueryAsync_ReadonlyUserWithTheSerializationSettingsOff_ReturnsRows()
+    {
+        ClickHouseTcpClientOptions options = TcpServerFixture.Options(user, string.Empty)
+            with
+            { SendJsonAndDynamicSerializationSettings = false };
+
+        await using var client = new ClickHouseTcpClient(options);
+
+        long value = 0;
+        await foreach (Block block in client.StreamAsync("SELECT 1", cancellationToken: None))
+        {
+            value = Convert.ToInt64(block[0].GetValue(0));
+        }
+
+        Assert.That(value, Is.EqualTo(1));
+    }
+
+    /// <summary>
+    /// The same user with the injection left on, which is what the switch exists to avoid. Pinned so that the
+    /// reason the switch exists stays visible, and so a server that one day allows the modification is noticed
+    /// here rather than by a caller.
+    /// </summary>
+    [Test]
+    public async Task QueryAsync_ReadonlyUserWithTheSerializationSettingsOn_IsRefusedByTheServer()
+    {
+        await using var client = TcpServerFixture.CreateClient(user, string.Empty);
+
+        var refusal = Assert.ThrowsAsync<ClickHouseTcpServerException>(async () =>
+        {
+            await foreach (Block block in client.StreamAsync("SELECT 1", cancellationToken: None))
+            {
+                _ = block;
+            }
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(refusal.Code, Is.EqualTo(ClickHouseErrorCode.ReadOnly));
+            Assert.That(refusal.Message, Does.Contain("readonly mode"));
+        });
+    }
+
+    /// <summary>
+    /// Turning the injection off costs exactly one thing, and this is it: a JSON column may arrive in a
+    /// serialization this client does not read. The test asserts the cost is paid by JSON alone — an ordinary
+    /// column in the same session is unaffected — so anyone weighing the switch can see its price.
+    /// </summary>
+    [Test]
+    public async Task QueryAsync_SerializationSettingsOff_LeavesEveryTypeButJsonAndDynamicWorking()
+    {
+        ClickHouseTcpClientOptions options = TcpServerFixture.Options(user, string.Empty)
+            with
+            { SendJsonAndDynamicSerializationSettings = false };
+
+        await using var client = new ClickHouseTcpClient(options);
+
+        var readBack = (string)await client.ExecuteScalarAsync(
+            "SELECT concat(toString(toDateTime('2024-06-15 12:00:00', 'UTC')), '/', toString([1, 2]))",
+            cancellationToken: None);
+
+        Assert.That(readBack, Is.EqualTo("2024-06-15 12:00:00/[1,2]"));
+    }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Integration/TcpServerFixture.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/TcpServerFixture.cs
@@ -50,6 +50,11 @@ public sealed class TcpServerFixture
         container = new ClickHouseBuilder($"clickhouse/clickhouse-server:{tag}")
             .WithUsername(Username)
             .WithPassword(Password)
+
+            // The image gives the user it creates no access management, so CREATE USER and GRANT are refused.
+            // A fixture that cannot make a second user can only ever test what a superuser sees, and
+            // ReadonlyUserIntegrationTests needs a user that is not this one.
+            .WithEnvironment("CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT", "1")
             .Build();
 
         await container.StartAsync();

--- a/ClickHouse.Driver.Tcp.Tests/Integration/TimezoneColumnIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/TimezoneColumnIntegrationTests.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Types;
+
+namespace ClickHouse.Driver.Tcp.Tests.Integration;
+
+/// <summary>
+/// A wall clock written into a column whose timezone is not UTC, checked against the server's own rendering of
+/// what was stored.
+///
+/// <para>
+/// Every other timezone-carrying integration column is <c>'UTC'</c>, and the corpus compares the read-back with
+/// an expected value produced by the same conversion the write used — so an inverted direction, or a tzdata
+/// disagreement between this machine and the server, cancels out and the assertion holds anyway. Here the oracle
+/// is the server: <c>toString(c)</c> renders the stored instant in the column's zone, and
+/// <c>toString(c, 'UTC')</c> shows which offset the client applied. Neither value passes through the code under
+/// test.
+/// </para>
+/// </summary>
+[TestFixture]
+[Category("Integration")]
+public class TimezoneColumnIntegrationTests
+{
+    private static readonly CancellationToken None = CancellationToken.None;
+
+    /// <param name="columnType">The column to create, carrying its own timezone.</param>
+    /// <param name="wallClock">The value to write, and the rendering the server must give it in that zone.</param>
+    /// <param name="inUtc">The same instant in UTC, which is the offset the client had to apply.</param>
+    [TestCase("DateTime('Europe/Amsterdam')", "2024-07-15 14:30:00", "2024-07-15 12:30:00")]
+    [TestCase("DateTime('Europe/Amsterdam')", "2024-01-15 14:30:00", "2024-01-15 13:30:00")]
+    [TestCase("DateTime('Europe/Amsterdam')", "2024-10-27 02:30:00", "2024-10-27 00:30:00")]
+    [TestCase("DateTime64(3, 'America/New_York')", "2024-07-15 14:30:00.000", "2024-07-15 18:30:00.000")]
+    [TestCase("DateTime64(3, 'America/New_York')", "2024-01-15 14:30:00.000", "2024-01-15 19:30:00.000")]
+    public async Task InsertAsync_UnspecifiedWallClockIntoANonUtcColumn_StoresTheInstantThatZoneNames(
+        string columnType,
+        string wallClock,
+        string inUtc)
+    {
+        await using ClickHouseTcpClient client = TcpServerFixture.CreateClient();
+        string table = $"tcp_timezone_test_{Guid.NewGuid():N}";
+
+        await client.ExecuteAsync($"CREATE TABLE {table} (c {columnType}) ENGINE = MergeTree ORDER BY tuple()", cancellationToken: None);
+        try
+        {
+            DateTime value = DateTime.Parse(wallClock, CultureInfo.InvariantCulture, DateTimeStyles.None);
+            Assert.That(value.Kind, Is.EqualTo(DateTimeKind.Unspecified), "the whole case is a value that names no offset of its own");
+
+            IColumn[] columns = [new ArrayColumn<DateTime>("c", columnType, [value])];
+            await client.InsertAsync($"INSERT INTO {table} (c) VALUES", columns, cancellationToken: None);
+
+            string inZone = null;
+            string inUniversal = null;
+            await foreach (object[] row in client.QueryAsync(
+                $"SELECT toString(c), toString(c, 'UTC') FROM {table}", cancellationToken: None))
+            {
+                inZone = (string)row[0];
+                inUniversal = (string)row[1];
+            }
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(inZone, Is.EqualTo(wallClock), "the server must render back the wall clock that was written");
+                Assert.That(inUniversal, Is.EqualTo(inUtc), "and the offset applied has to be the zone's for that date");
+            });
+        }
+        finally
+        {
+            await client.ExecuteAsync($"DROP TABLE IF EXISTS {table}", cancellationToken: None);
+        }
+    }
+}

--- a/ClickHouse.Driver.Tcp.Tests/Integration/TimezoneColumnIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/TimezoneColumnIntegrationTests.cs
@@ -70,4 +70,39 @@ public class TimezoneColumnIntegrationTests
             await client.ExecuteAsync($"DROP TABLE IF EXISTS {table}", cancellationToken: None);
         }
     }
+
+    /// <summary>
+    /// A column may declare an offset <see cref="TimeZoneInfo"/> cannot hold — 26.6 takes
+    /// <c>Fixed/UTC+19:00:00</c>, past .NET's ±14 hours — and a value that already names an instant does not need
+    /// that zone. So the write has to land, and only the calendar readings may report the zone.
+    /// </summary>
+    [TestCase("DateTime('Fixed/UTC+19:00:00')", "2024-01-15 10:30:00")]
+    [TestCase("DateTime64(3, 'Fixed/UTC+19:00:00')", "2024-01-15 10:30:00.000")]
+    public async Task InsertAsync_UtcDateTimeIntoAZoneTimeZoneInfoCannotHold_StoresTheInstant(
+        string columnType,
+        string inUtc)
+    {
+        await using ClickHouseTcpClient client = TcpServerFixture.CreateClient();
+        string table = $"tcp_timezone_test_{Guid.NewGuid():N}";
+
+        await client.ExecuteAsync($"CREATE TABLE {table} (c {columnType}) ENGINE = MergeTree ORDER BY tuple()", cancellationToken: None);
+        try
+        {
+            var value = new DateTime(2024, 1, 15, 10, 30, 0, DateTimeKind.Utc);
+            IColumn[] columns = [new ArrayColumn<DateTime>("c", columnType, [value])];
+            await client.InsertAsync($"INSERT INTO {table} (c) VALUES", columns, cancellationToken: None);
+
+            object stored = null;
+            await foreach (object[] row in client.QueryAsync($"SELECT toString(c, 'UTC') FROM {table}", cancellationToken: None))
+            {
+                stored = row[0];
+            }
+
+            Assert.That(stored, Is.EqualTo(inUtc));
+        }
+        finally
+        {
+            await client.ExecuteAsync($"DROP TABLE IF EXISTS {table}", cancellationToken: None);
+        }
+    }
 }

--- a/ClickHouse.Driver.Tcp.Tests/Integration/TlsTransportIntegrationTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Integration/TlsTransportIntegrationTests.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickHouse.Driver.Tcp.Tests.Utilities;
+
+namespace ClickHouse.Driver.Tcp.Tests.Integration;
+
+/// <summary>
+/// The native protocol inside a TLS tunnel, against the suite's own server. <c>TcpConnectionFactoryTests</c>
+/// covers the handshake and every certificate-validation outcome, but against a listener that answers with a
+/// canned Hello and nothing else, so no test in the default suite has ever run a query, a block or an insert
+/// through an <c>SslStream</c>. The <c>Cloud/</c> fixture does, and is skipped unless a service is configured.
+///
+/// <para>
+/// <see cref="TlsTerminatingProxy"/> supplies the tunnel, so what is under test is the client's side of it: a
+/// real handshake, then results large enough to span many TLS records, an insert, and a pooled connection used
+/// again. The server's own TLS implementation is not covered here, and is not the driver's to cover.
+/// </para>
+/// </summary>
+[TestFixture]
+[Category("Integration")]
+public class TlsTransportIntegrationTests
+{
+    // The name the proxy's certificate carries, not the loopback address the client dials, so TlsServerName is
+    // what the certificate is matched against.
+    private const string CertificateName = "clickhouse.tls.test.invalid";
+
+    private static readonly CancellationToken None = CancellationToken.None;
+
+    private X509Certificate2 authority;
+    private X509Certificate2 serverCertificate;
+    private TlsTerminatingProxy proxy;
+    private string authorityPath;
+
+    [OneTimeSetUp]
+    public void StartProxy()
+    {
+        authority = TestCertificates.CreateAuthority();
+        serverCertificate = TestCertificates.IssueServerCertificate(authority, CertificateName);
+        authorityPath = TestCertificates.WritePemFile(authority);
+        proxy = new TlsTerminatingProxy(TcpServerFixture.Host, TcpServerFixture.Port, serverCertificate);
+    }
+
+    [OneTimeTearDown]
+    public async Task StopProxyAsync()
+    {
+        await proxy.DisposeAsync();
+        serverCertificate.Dispose();
+        authority.Dispose();
+        TestCertificates.DeleteTemporaryFiles();
+    }
+
+    /// <summary>
+    /// The handshake, and that the server answering inside the tunnel is the real one: the version it reports
+    /// has to be the version the same server reports over plaintext. A fake server could pass everything else.
+    /// </summary>
+    [Test]
+    public async Task PingAsync_OverTls_HandshakesWithTheServerTheSuiteAlreadyUses()
+    {
+        await using ClickHouseTcpClient plaintext = TcpServerFixture.CreateClient();
+        await using ClickHouseTcpClient tunnelled = CreateClient();
+
+        // The shortest exchange that needs the tunnel to carry packets both ways.
+        await tunnelled.PingAsync(None);
+
+        object overTls = await tunnelled.ExecuteScalarAsync("SELECT version()", cancellationToken: None);
+        object direct = await plaintext.ExecuteScalarAsync("SELECT version()", cancellationToken: None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(overTls, Is.InstanceOf<string>().And.Not.Empty);
+            Assert.That(overTls, Is.EqualTo(direct));
+        });
+    }
+
+    /// <summary>
+    /// A result far larger than the 16 KB a TLS record holds, so the read path refills across record boundaries
+    /// rather than finding each block whole. Compression is on by default, so the blocks are compressed as well.
+    /// </summary>
+    [Test]
+    public async Task QueryAsync_OverTls_ReturnsEveryRowAcrossManyTlsRecords()
+    {
+        await using ClickHouseTcpClient client = CreateClient();
+
+        var numbers = new List<ulong>();
+        await foreach (object[] row in client.QueryAsync(
+            "SELECT number FROM system.numbers LIMIT 50000", cancellationToken: None))
+        {
+            numbers.Add((ulong)row[0]);
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(numbers, Has.Count.EqualTo(50000));
+            Assert.That(numbers[0], Is.EqualTo(0UL));
+            Assert.That(numbers[^1], Is.EqualTo(49999UL));
+        });
+    }
+
+    /// <summary>
+    /// The write path through the tunnel, on a pool of one and into a temporary table. A native connection is the
+    /// session that holds that table, so the read-back succeeds only if the same <c>SslStream</c> connection came
+    /// back out of the pool for each of the three operations.
+    /// </summary>
+    [Test]
+    public async Task InsertRowsAsync_OverTls_RoundTripsOnTheOnePooledTlsConnection()
+    {
+        await using ClickHouseTcpClient client = CreateClient(maxPoolSize: 1);
+        string temporary = $"tcp_tls_test_{Guid.NewGuid():N}";
+
+        await client.ExecuteAsync($"CREATE TEMPORARY TABLE {temporary} (id UInt64, name String)", cancellationToken: None);
+        await client.InsertRowsAsync(
+            $"INSERT INTO {temporary} (id, name) VALUES",
+            Enumerable.Range(0, 1000).Select(i => new object[] { (ulong)i, $"row-{i}" }).ToArray(),
+            cancellationToken: None);
+
+        var rows = new List<(ulong Id, string Name)>();
+        await foreach (object[] row in client.QueryAsync($"SELECT id, name FROM {temporary} ORDER BY id", cancellationToken: None))
+        {
+            rows.Add(((ulong)row[0], (string)row[1]));
+        }
+
+        // No DROP: the table goes when the session does, which is what the read-back above relies on.
+        Assert.Multiple(() =>
+        {
+            Assert.That(rows, Has.Count.EqualTo(1000));
+            Assert.That(rows[0], Is.EqualTo((0UL, "row-0")));
+            Assert.That(rows[^1], Is.EqualTo((999UL, "row-999")));
+        });
+    }
+
+    private ClickHouseTcpClient CreateClient(int maxPoolSize = 4)
+        => new(TcpServerFixture.Options() with
+        {
+            Host = "127.0.0.1",
+            Port = proxy.Port,
+            UseTls = true,
+            TlsServerName = CertificateName,
+            TlsCaCertificatePath = authorityPath,
+            MaxPoolSize = maxPoolSize,
+        });
+}

--- a/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterEdgeCaseTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterEdgeCaseTests.cs
@@ -14,20 +14,21 @@ public class TcpParameterFormatterEdgeCaseTests
     private static string Format(object value, string typeName)
         => TcpParameterFormatter.FormatSqlText(value, typeName, "p");
 
-    // A type hint the shipped HTTP driver accepts, a case variant, and two names no ClickHouse version has. All
-    // of them reach the same arm as a value that simply does not fit, and blaming the value there sends a caller
-    // to inspect a value that was never the problem.
-    [TestCase("VARCHAR", TestName = "An alias the HTTP driver accepts")]
-    [TestCase("BIGINT", TestName = "An alias whose spelling is SQL's")]
-    [TestCase("string", TestName = "A case variant the server rejects too")]
-    [TestCase("Boolean", TestName = "A name no version has, spelled like one that does")]
+    // Names the server does not have either (26.6 answers "Unknown data type family" for all four). They reach
+    // the same arm as a value that simply does not fit, and blaming the value there sends a caller to inspect a
+    // value that was never the problem.
+    [TestCase("MultiPoint", TestName = "A geo name no version has")]
+    [TestCase("Object", TestName = "A name a past version had")]
+    [TestCase("string", TestName = "A case variant of a case-sensitive family")]
+    [TestCase("array(uint8)", TestName = "A case variant with arguments")]
     public void FormatSqlText_TypeNameThisClientDoesNotKnow_SaysSoRatherThanBlamingTheValue(string typeName)
     {
         var exception = Assert.Throws<ArgumentException>(() => Format("abc", typeName));
 
         Assert.Multiple(() =>
         {
-            Assert.That(exception.Message, Does.Contain($"'{typeName}' is not a ClickHouse type name this client knows"));
+            Assert.That(exception.Message, Does.Contain("is not a ClickHouse type name this client knows"));
+            Assert.That(exception.Message, Does.Contain(typeName), "shows the type as it was written");
             Assert.That(exception.Message, Does.Contain("toTypeName"), "says how to find the name to write");
             Assert.That(exception.Message, Does.Contain("case-sensitive"), "says why a spelling that looks right can fail");
             Assert.That(exception.Message, Does.Not.Contain("Cannot convert value"), "the value is not the problem");

--- a/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterEdgeCaseTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterEdgeCaseTests.cs
@@ -14,6 +14,67 @@ public class TcpParameterFormatterEdgeCaseTests
     private static string Format(object value, string typeName)
         => TcpParameterFormatter.FormatSqlText(value, typeName, "p");
 
+    // A type hint the shipped HTTP driver accepts, a case variant, and two names no ClickHouse version has. All
+    // of them reach the same arm as a value that simply does not fit, and blaming the value there sends a caller
+    // to inspect a value that was never the problem.
+    [TestCase("VARCHAR", TestName = "An alias the HTTP driver accepts")]
+    [TestCase("BIGINT", TestName = "An alias whose spelling is SQL's")]
+    [TestCase("string", TestName = "A case variant the server rejects too")]
+    [TestCase("Boolean", TestName = "A name no version has, spelled like one that does")]
+    public void FormatSqlText_TypeNameThisClientDoesNotKnow_SaysSoRatherThanBlamingTheValue(string typeName)
+    {
+        var exception = Assert.Throws<ArgumentException>(() => Format("abc", typeName));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(exception.Message, Does.Contain($"'{typeName}' is not a ClickHouse type name this client knows"));
+            Assert.That(exception.Message, Does.Contain("toTypeName"), "says how to find the name to write");
+            Assert.That(exception.Message, Does.Contain("case-sensitive"), "says why a spelling that looks right can fail");
+            Assert.That(exception.Message, Does.Not.Contain("Cannot convert value"), "the value is not the problem");
+            Assert.That(exception.Message, Does.Contain("Parameter 'p'"), "names the parameter");
+        });
+    }
+
+    [Test]
+    public void FormatSqlText_KnownTypeAValueDoesNotFit_BlamesTheValue()
+    {
+        // The other half of the pair above: Array is a type this client knows, and an int is not a list, so here
+        // the value is exactly what is wrong.
+        var exception = Assert.Throws<ArgumentException>(() => Format(5, "Array(String)"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(exception.Message, Does.Contain("Cannot convert value of type 'System.Int32' (5)"));
+            Assert.That(exception.Message, Does.Contain("Array(String)"));
+        });
+    }
+
+    [Test]
+    public void FormatSqlText_AggregateFunction_SaysNoValueSpellsAState()
+    {
+        // The server rejects a parameter of this type as well (Code 33 on 26.6), so there is nothing to write.
+        var exception = Assert.Throws<ArgumentException>(() => Format("abc", "AggregateFunction(sum, UInt64)"));
+
+        Assert.That(exception.Message, Does.Contain("serialized aggregate states").And.Contain("the server rejects one too"));
+    }
+
+    // The server does accept a text value for each of these, so the refusal is this client's own and must not
+    // read like the type does not exist.
+    [TestCase("Dynamic", TestName = "Dynamic, where the value would have to name its own type")]
+    [TestCase("Geometry", TestName = "Geometry, where an array of points is two different shapes")]
+    [TestCase("SimpleAggregateFunction(sum, UInt64)", TestName = "SimpleAggregateFunction, which the codec reads as its inner type")]
+    public void FormatSqlText_TypeTheServerTakesAndThisClientCannotWrite_SaysWhoseLimitItIs(string typeName)
+    {
+        var exception = Assert.Throws<ArgumentException>(() => Format(5, typeName));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(exception.Message, Does.Contain("This client cannot format a parameter value"));
+            Assert.That(exception.Message, Does.Contain("Name the concrete type of the value instead"));
+            Assert.That(exception.Message, Does.Not.Contain("is not a ClickHouse type name"));
+        });
+    }
+
     [Test]
     public void FormatSqlText_NothingType_ProducesTheNullMarker()
     {

--- a/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterEdgeCaseTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterEdgeCaseTests.cs
@@ -14,13 +14,11 @@ public class TcpParameterFormatterEdgeCaseTests
     private static string Format(object value, string typeName)
         => TcpParameterFormatter.FormatSqlText(value, typeName, "p");
 
-    // Names the server does not have either (26.6 answers "Unknown data type family" for all four). They reach
-    // the same arm as a value that simply does not fit, and blaming the value there sends a caller to inspect a
+    // Names the server does not have either (26.6 answers "Unknown data type family" for both). They reach the
+    // same arm as a value that simply does not fit, and blaming the value there sends a caller to inspect a
     // value that was never the problem.
     [TestCase("MultiPoint", TestName = "A geo name no version has")]
     [TestCase("Object", TestName = "A name a past version had")]
-    [TestCase("string", TestName = "A case variant of a case-sensitive family")]
-    [TestCase("array(uint8)", TestName = "A case variant with arguments")]
     public void FormatSqlText_TypeNameThisClientDoesNotKnow_SaysSoRatherThanBlamingTheValue(string typeName)
     {
         var exception = Assert.Throws<ArgumentException>(() => Format("abc", typeName));
@@ -30,9 +28,21 @@ public class TcpParameterFormatterEdgeCaseTests
             Assert.That(exception.Message, Does.Contain("is not a ClickHouse type name this client knows"));
             Assert.That(exception.Message, Does.Contain(typeName), "shows the type as it was written");
             Assert.That(exception.Message, Does.Contain("toTypeName"), "says how to find the name to write");
-            Assert.That(exception.Message, Does.Contain("case-sensitive"), "says why a spelling that looks right can fail");
             Assert.That(exception.Message, Does.Not.Contain("Cannot convert value"), "the value is not the problem");
             Assert.That(exception.Message, Does.Contain("Parameter 'p'"), "names the parameter");
+        });
+    }
+
+    // A name in a case the server may or may not take is not this client's to refuse: it formats the value, the
+    // hint reaches the server verbatim, and the server answers for its own spelling rules.
+    [Test]
+    public void FormatSqlText_TypeNameInAnyCase_FormatsRatherThanRefusing()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(Format("abc", "string"), Is.EqualTo("abc"));
+            Assert.That(Format(new[] { "abc" }, "array(string)"), Is.EqualTo("['abc']"));
+            Assert.That(Format(1L, "bigint"), Is.EqualTo("1"));
         });
     }
 

--- a/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterEdgeCaseTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterEdgeCaseTests.cs
@@ -69,21 +69,25 @@ public class TcpParameterFormatterEdgeCaseTests
         Assert.That(exception.Message, Does.Contain("serialized aggregate states").And.Contain("the server rejects one too"));
     }
 
-    // The server does accept a text value for each of these, so the refusal is this client's own and must not
-    // read like the type does not exist.
-    [TestCase("Dynamic", TestName = "Dynamic, where the value would have to name its own type")]
-    [TestCase("Geometry", TestName = "Geometry, where an array of points is two different shapes")]
-    [TestCase("SimpleAggregateFunction(sum, UInt64)", TestName = "SimpleAggregateFunction, which the codec reads as its inner type")]
-    public void FormatSqlText_TypeTheServerTakesAndThisClientCannotWrite_SaysWhoseLimitItIs(string typeName)
-    {
-        var exception = Assert.Throws<ArgumentException>(() => Format(5, typeName));
+    // Three types whose name does not fix the value's layout on its own. SimpleAggregateFunction writes as its
+    // inner type; Dynamic and Geometry write as the value's own type, and the server's parse is what decides
+    // whether that text fits. A Geometry is ambiguous by construction — the ring below is equally a LineString —
+    // and the text is the same either way, which is why the ambiguity costs nothing here.
+    [TestCase("SimpleAggregateFunction(sum, UInt64)", 5, ExpectedResult = "5", TestName = "SimpleAggregateFunction writes as its inner type")]
+    [TestCase("Dynamic", 5, ExpectedResult = "5", TestName = "Dynamic writes an integer")]
+    [TestCase("Dynamic", "x", ExpectedResult = "x", TestName = "Dynamic writes a string")]
+    [TestCase("Geometry", null, ExpectedResult = "(10,20)", TestName = "Geometry writes a point")]
+    public string FormatSqlText_TypeThatTakesItsLayoutFromTheValue_WritesTheValuesOwnText(string typeName, object value)
+        => Format(value ?? (10.0, 20.0), typeName);
 
-        Assert.Multiple(() =>
-        {
-            Assert.That(exception.Message, Does.Contain("This client cannot format a parameter value"));
-            Assert.That(exception.Message, Does.Contain("Name the concrete type of the value instead"));
-            Assert.That(exception.Message, Does.Not.Contain("is not a ClickHouse type name"));
-        });
+    [Test]
+    public void FormatSqlText_GeometryHoldingAnArrayOfPoints_WritesTheShapeTextTheServerParses()
+    {
+        // Both the Ring and the LineString reading of this value produce this text, so the client does not have to
+        // choose between them.
+        Assert.That(
+            Format(new[] { (0.0, 0.0), (1.0, 1.0), (0.0, 1.0) }, "Geometry"),
+            Is.EqualTo("[(0,0),(1,1),(0,1)]"));
     }
 
     [Test]

--- a/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterEdgeCaseTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterEdgeCaseTests.cs
@@ -138,14 +138,23 @@ public class TcpParameterFormatterEdgeCaseTests
         });
     }
 
-    // A TimeOnly reaches a different arm than a TimeSpan, and the whole day is what a time of day spans: the
-    // last representable tick is 23:59:59.9999999, which scale 7 prints in full and a coarser scale rounds up
-    // into the next hour rather than clamping.
+    // A TimeOnly reaches a different arm than a TimeSpan, but both print as one clock reading.
     [TestCase("Time", ExpectedResult = "1:02:03", TestName = "Time from a TimeOnly")]
     [TestCase("Time64(3)", ExpectedResult = "1:02:03.123", TestName = "Time64 from a TimeOnly")]
-    [TestCase("Time64(1)", ExpectedResult = "1:02:03.1", TestName = "Time64 from a TimeOnly, truncated to the scale")]
     public string FormatSqlText_TimeFromATimeOnly_UsesTheClockReading(string typeName)
         => Format(new TimeOnly(1, 2, 3, 123), typeName);
+
+    // A value coarser than the declared scale is rounded to it, not truncated, and to even. That is what the
+    // shipped HTTP driver does with the same value, and the two clients have to agree on the text they send.
+    // The binary insert path truncates instead, so the same CLR value can land one unit apart depending on
+    // which path carried it; tracked in the TCP TODO rather than settled here.
+    [TestCase("Time64(1)", 150, ExpectedResult = "1:02:03.2", TestName = "A midpoint rounds to even, upward")]
+    [TestCase("Time64(1)", 250, ExpectedResult = "1:02:03.2", TestName = "A midpoint rounds to even, downward")]
+    [TestCase("Time64(1)", 149, ExpectedResult = "1:02:03.1", TestName = "Below the midpoint")]
+    [TestCase("Time64(2)", 999, ExpectedResult = "1:02:04.00", TestName = "Rounding carries into the second")]
+    [TestCase("Time", 600, ExpectedResult = "1:02:04", TestName = "Rounding carries into the second at scale 0")]
+    public string FormatSqlText_TimeOnlyFinerThanTheScale_IsRoundedToIt(string typeName, int milliseconds)
+        => Format(new TimeOnly(1, 2, 3, milliseconds), typeName);
 
     [Test]
     public void FormatSqlText_TimeOnlyAtTheEndOfTheDay_KeepsEveryTick()
@@ -155,9 +164,48 @@ public class TcpParameterFormatterEdgeCaseTests
             Assert.That(Format(TimeOnly.MaxValue, "Time64(7)"), Is.EqualTo("23:59:59.9999999"));
             Assert.That(Format(TimeOnly.MaxValue, "Time64(9)"), Is.EqualTo("23:59:59.999999900"));
             Assert.That(Format(TimeOnly.MinValue, "Time64(3)"), Is.EqualTo("0:00:00.000"));
+
+            // The last half-second of the day rounds past it. The server reads 24:00:00 as 86400 seconds, which
+            // is a legal Time value but no longer a time of day, so it does not read back as a TimeOnly. Pinned
+            // because it is what the shipped HTTP driver sends for the same value.
             Assert.That(Format(TimeOnly.MaxValue, "Time"), Is.EqualTo("24:00:00"), "rounded, not clamped to the day");
+            Assert.That(Format(TimeOnly.MaxValue, "Time64(3)"), Is.EqualTo("23:59:60.000"));
         });
     }
+
+    // Accepts picks the Variant alternative, and it sees the name as the caller wrote it. Canonicalizing only at
+    // the formatter's dispatch left every alias and every case variant unusable as an alternative, although the
+    // server resolves Variant(BIGINT, String) to Variant(Int64, String) and accepts the value.
+    [TestCase("Variant(BIGINT, String)", ExpectedResult = "7", TestName = "An alias alternative")]
+    [TestCase("Variant(bigint, String)", ExpectedResult = "7", TestName = "An alias alternative in another case")]
+    [TestCase("Variant(int64, String)", ExpectedResult = "7", TestName = "A canonical alternative in another case")]
+    [TestCase("Variant(String, BIGINT)", ExpectedResult = "7", TestName = "An alias alternative, second")]
+    public string FormatSqlText_VariantAlternativeSpelledAsAnAlias_TakesTheValue(string typeName)
+        => Format(7L, typeName);
+
+    [Test]
+    public void FormatSqlText_VariantAlternativeWithAnAliasInsideAComposite_TakesTheValue()
+        => Assert.That(Format(new[] { 7L, 8L }, "Variant(Array(BIGINT), String)"), Is.EqualTo("[7,8]"));
+
+    // Resolving the alias must not make every alternative match: an Int64 still fits neither of these.
+    [Test]
+    public void FormatSqlText_VariantWhoseAliasedAlternativesRefuseTheValue_IsStillRefused()
+        => Assert.Throws<ArgumentException>(() => Format(7L, "Variant(INET4, String)"));
+
+    // The shape this client reads a Map column back as. Infer had no arm for it, so it fell to the Array arm,
+    // whose element inference has no reading for a KeyValuePair: a row read from a Map column could not be sent
+    // back as a Dynamic parameter at all.
+    [Test]
+    public void FormatSqlText_DynamicFromTheMapReadShape_FormatsAMapLiteral()
+    {
+        var pairs = new[] { new KeyValuePair<string, int>("a", 1), new KeyValuePair<string, int>("b", 2) };
+
+        Assert.That(Format(pairs, "Dynamic"), Is.EqualTo("{'a' : 1,'b' : 2}"));
+    }
+
+    [Test]
+    public void FormatSqlText_DynamicFromAnEmptyPairSequence_FormatsAnEmptyMap()
+        => Assert.That(Format(Array.Empty<KeyValuePair<string, int>>(), "Dynamic"), Is.EqualTo("{}"));
 
     [Test]
     public void FormatSqlText_NestedSingleRow_FormatsAsOneTuple()

--- a/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterEdgeCaseTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterEdgeCaseTests.cs
@@ -124,6 +124,27 @@ public class TcpParameterFormatterEdgeCaseTests
         });
     }
 
+    // A TimeOnly reaches a different arm than a TimeSpan, and the whole day is what a time of day spans: the
+    // last representable tick is 23:59:59.9999999, which scale 7 prints in full and a coarser scale rounds up
+    // into the next hour rather than clamping.
+    [TestCase("Time", ExpectedResult = "1:02:03", TestName = "Time from a TimeOnly")]
+    [TestCase("Time64(3)", ExpectedResult = "1:02:03.123", TestName = "Time64 from a TimeOnly")]
+    [TestCase("Time64(1)", ExpectedResult = "1:02:03.1", TestName = "Time64 from a TimeOnly, truncated to the scale")]
+    public string FormatSqlText_TimeFromATimeOnly_UsesTheClockReading(string typeName)
+        => Format(new TimeOnly(1, 2, 3, 123), typeName);
+
+    [Test]
+    public void FormatSqlText_TimeOnlyAtTheEndOfTheDay_KeepsEveryTick()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(Format(TimeOnly.MaxValue, "Time64(7)"), Is.EqualTo("23:59:59.9999999"));
+            Assert.That(Format(TimeOnly.MaxValue, "Time64(9)"), Is.EqualTo("23:59:59.999999900"));
+            Assert.That(Format(TimeOnly.MinValue, "Time64(3)"), Is.EqualTo("0:00:00.000"));
+            Assert.That(Format(TimeOnly.MaxValue, "Time"), Is.EqualTo("24:00:00"), "rounded, not clamped to the day");
+        });
+    }
+
     [Test]
     public void FormatSqlText_NestedSingleRow_FormatsAsOneTuple()
     {
@@ -643,6 +664,7 @@ public class ParameterTypeInferenceTests
         yield return new TestCaseData(Guid.Empty).Returns("UUID").SetName("Guid");
         yield return new TestCaseData(new DateOnly(2024, 1, 2)).Returns("Date").SetName("DateOnly");
         yield return new TestCaseData(TimeSpan.Zero).Returns("Time64(9)").SetName("TimeSpan");
+        yield return new TestCaseData(new TimeOnly(1, 2, 3)).Returns("Time64(9)").SetName("TimeOnly");
         yield return new TestCaseData(new DateTime(2024, 1, 2)).Returns("DateTime64(7, 'UTC')").SetName("DateTime");
         yield return new TestCaseData(IPAddress.Parse("1.2.3.4")).Returns("IPv4").SetName("IPv4 address");
         yield return new TestCaseData(IPAddress.Parse("::1")).Returns("IPv6").SetName("IPv6 address");

--- a/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterEdgeCaseTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Parameters/TcpParameterFormatterEdgeCaseTests.cs
@@ -450,6 +450,33 @@ public class TcpParameterFormatterEdgeCaseTests
     }
 
     [Test]
+    public void FormatSqlText_VariantWithATimeAlternative_PicksIt()
+    {
+        // A time value matched no alternative at all, and a Variant with nothing matching is refused whole rather
+        // than by the arm, so no Variant took a time value in either spelling.
+        Assert.Multiple(() =>
+        {
+            Assert.That(Format(new TimeSpan(1, 1, 1), "Variant(Time, String)"), Is.EqualTo("1:01:01"));
+            Assert.That(Format(new TimeOnly(1, 1, 1), "Variant(Time, String)"), Is.EqualTo("1:01:01"));
+        });
+    }
+
+    [Test]
+    public void FormatSqlText_VariantOfTwoTimeAlternatives_PicksTheFirstThatAccepts()
+    {
+        // Both arms accept a time value, so the order decides and a sub-second value lands on the
+        // second-resolution one, rounded. The instant types behave the same way, which is the second assertion:
+        // first-match, not best-match, is the matcher's rule throughout.
+        Assert.Multiple(() =>
+        {
+            Assert.That(Format(new TimeSpan(0, 1, 1, 1, 500), "Variant(Time, Time64(3))"), Is.EqualTo("1:01:02"));
+            Assert.That(
+                Format(new DateTime(2024, 1, 2, 3, 4, 5, DateTimeKind.Utc), "Variant(Date, DateTime64(3))"),
+                Is.EqualTo("2024-01-02"));
+        });
+    }
+
+    [Test]
     public void FormatSqlText_VariantWhereNoArrayElementTypeFits_Throws()
     {
         var exception = Assert.Throws<ArgumentException>(

--- a/ClickHouse.Driver.Tcp.Tests/Types/ClickHouseTcpTypesTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/ClickHouseTcpTypesTests.cs
@@ -37,6 +37,20 @@ public class ClickHouseTcpTypesTests
     }
 
     [Test]
+    public void CanReadAndCanWrite_AnAliasOrACaseVariant_AnswerForTheTypeItNames()
+    {
+        // A caller asking about a type writes it the way their query does, and the server takes any of these.
+        Assert.Multiple(() =>
+        {
+            Assert.That(ClickHouseTcpTypes.CanWrite("VARCHAR", typeof(string)), Is.True);
+            Assert.That(ClickHouseTcpTypes.CanRead("BIGINT", typeof(long)), Is.True);
+            Assert.That(ClickHouseTcpTypes.CanRead("datetime64(3)", typeof(long)), Is.True);
+            Assert.That(ClickHouseTcpTypes.CanWrite("Array(TINYINT UNSIGNED)", typeof(byte[])), Is.True);
+            Assert.That(ClickHouseTcpTypes.CanWrite("VARCHAR", typeof(int)), Is.False, "the alias does not change what fits");
+        });
+    }
+
+    [Test]
     public void CanReadAndCanWrite_NullArgument_Throws()
     {
         Assert.Multiple(() =>

--- a/ClickHouse.Driver.Tcp.Tests/Types/ClickHouseTcpTypesTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/ClickHouseTcpTypesTests.cs
@@ -77,4 +77,21 @@ public class ClickHouseTcpTypesTests
             Assert.Throws<NotSupportedException>(() => ClickHouseTcpTypes.CanRead("NoSuchType", typeof(int)));
         });
     }
+
+    /// <summary>
+    /// A zone this platform cannot represent is a property of the value, not of the type: the type does offer the
+    /// calendar readings, and only a row actually projected needs the zone. So the answer is yes, and the read is
+    /// where the zone is reported. Asking is also how the POCO tier discovers a mapping, so a throw here would
+    /// fail a mapping that never asked for a calendar value.
+    /// </summary>
+    [TestCase("DateTime('Fixed/UTC+19:00:00')")]
+    [TestCase("DateTime64(3, 'Fixed/UTC+05:30:15')")]
+    public void CanRead_ACalendarReadingOfAZoneTimeZoneInfoCannotHold_AnswersYes(string clickHouseType)
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(ClickHouseTcpTypes.CanRead(clickHouseType, typeof(DateTimeOffset)), Is.True);
+            Assert.That(ClickHouseTcpTypes.CanRead(clickHouseType, typeof(DateTime)), Is.True);
+        });
+    }
 }

--- a/ClickHouse.Driver.Tcp.Tests/Types/ColumnCodecRegistryTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/ColumnCodecRegistryTests.cs
@@ -219,4 +219,41 @@ public class ColumnCodecRegistryTests
     [Test]
     public void Resolve_AggregateFunctionNamingNoFunction_ThrowsFormat()
         => Assert.Throws<FormatException>(() => ColumnCodecRegistry.Default.Resolve("AggregateFunction()", default));
+
+    // A bare Enum names no width, so the client has to pick the one the server would. Verified on 26.6: Enum8
+    // while every ordinal is in the Int8 range, Enum16 otherwise, and the column is reported under the width
+    // chosen. No round trip can check this — the server normalizes the name away — so the codec's own name is
+    // the only place the choice is visible.
+    [TestCase("Enum('A' = 1, 'B' = 2)", "Enum8('A' = 1, 'B' = 2)")]
+    [TestCase("Enum('A' = -128, 'B' = 127)", "Enum8('A' = -128, 'B' = 127)")]
+    [TestCase("Enum('A' = 1, 'B' = 200)", "Enum16('A' = 1, 'B' = 200)")]
+    [TestCase("Enum('A' = -129)", "Enum16('A' = -129)")]
+    [TestCase("enum('a' = 1)", "Enum8('a' = 1)")]
+    public void Resolve_BareEnum_PicksTheWidthTheServerWould(string written, string expectedTypeName)
+        => Assert.That(ColumnCodecRegistry.Default.Resolve(written, ResolveContext.ForWrite).TypeName, Is.EqualTo(expectedTypeName));
+
+    [Test]
+    public void Resolve_BareEnumDeclaringNoMembers_ThrowsFormat()
+        => Assert.Throws<FormatException>(() => ColumnCodecRegistry.Default.Resolve("Enum()", ResolveContext.ForWrite));
+
+    /// <summary>
+    /// Forms a real server accepts and this client refuses on purpose. Each one either has no generator — no
+    /// header carries it and no tool writes it, so accepting it would only hide a typo in a hand-written type —
+    /// or needs grammar this client has no caller for. The assertion is the refusal *type*, because that is what
+    /// separates "malformed" from "not supported" for anyone catching them.
+    /// </summary>
+    [TestCase("Enum8('a', 'b')", typeof(FormatException), TestName = "Enum members with implicit ordinals")]
+    [TestCase("DateTime64", typeof(FormatException), TestName = "DateTime64 with no scale, which the server defaults to 3")]
+    [TestCase("Decimal", typeof(FormatException), TestName = "Decimal with no precision, which the server defaults to (10, 0)")]
+    [TestCase("Decimal(4)", typeof(FormatException), TestName = "Decimal with no scale, which the server defaults to 0")]
+    [TestCase("Tuple(UInt8,)", typeof(FormatException), TestName = "A trailing comma")]
+    [TestCase("Array(/* c */ String)", typeof(NotSupportedException), TestName = "A comment inside a type")]
+    [TestCase("`Int64`", typeof(NotSupportedException), TestName = "A backticked type name")]
+    [TestCase("\"String\"", typeof(NotSupportedException), TestName = "A double-quoted type name")]
+    [TestCase("INT(10) UNSIGNED", typeof(FormatException), TestName = "A trailing word after the arguments")]
+    public void Resolve_FormTheServerAcceptsAndThisClientDoesNot_RefusesWithTheTypeThatSaysWhy(string written, Type refusal)
+        => Assert.That(
+            Assert.Throws(refusal, () => ColumnCodecRegistry.Default.Resolve(written, ResolveContext.ForWrite)).Message,
+            Does.Contain(written),
+            "a refusal that does not quote what was written leaves the caller nothing to search for");
 }

--- a/ClickHouse.Driver.Tcp.Tests/Types/ColumnCodecRegistryTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/ColumnCodecRegistryTests.cs
@@ -132,16 +132,16 @@ public class ColumnCodecRegistryTests
     [Test]
     public void Resolve_UnsupportedChildType_NamesTheOuterTypeAsWell()
     {
-        // The refusal comes from the child, and 'Boolean' on its own sends a caller searching their code for a
-        // name they never wrote (the server spells the type Bool). No "yet" either: Object('json') was removed
-        // from ClickHouse and MultiPoint never existed, so some of what lands here is not coming.
+        // The refusal comes from the child, and 'MultiPoint' on its own sends a caller searching their code for
+        // it. No "yet" either: MultiPoint is in no version's system.data_type_families (26.6 answers "Unknown
+        // data type family") and Object('json') was removed, so some of what lands here is not coming.
         var exception = Assert.Throws<NotSupportedException>(
-            () => ColumnCodecRegistry.Default.Resolve("Map(String, Array(Boolean))", default));
+            () => ColumnCodecRegistry.Default.Resolve("Map(String, Array(MultiPoint))", default));
 
         Assert.Multiple(() =>
         {
-            Assert.That(exception.Message, Does.Contain("'Boolean'"));
-            Assert.That(exception.Message, Does.Contain("'Map(String, Array(Boolean))'"));
+            Assert.That(exception.Message, Does.Contain("'MultiPoint'"));
+            Assert.That(exception.Message, Does.Contain("'Map(String, Array(MultiPoint))'"));
             Assert.That(exception.Message, Does.Not.Contain("yet"));
             Assert.That(exception.InnerException, Is.TypeOf<NotSupportedException>(), "the child's own refusal is kept");
         });
@@ -151,14 +151,70 @@ public class ColumnCodecRegistryTests
     public void Resolve_UnsupportedTopLevelType_NamesItOnce()
     {
         // The type the caller wrote is the type that failed, so there is no outer type to add.
-        var exception = Assert.Throws<NotSupportedException>(() => ColumnCodecRegistry.Default.Resolve("Boolean", default));
+        var exception = Assert.Throws<NotSupportedException>(() => ColumnCodecRegistry.Default.Resolve("MultiPoint", default));
 
         Assert.Multiple(() =>
         {
-            Assert.That(exception.Message, Does.Contain("'Boolean'").And.Not.Contain("inside"));
+            Assert.That(exception.Message, Does.Contain("'MultiPoint'").And.Not.Contain("inside"));
             Assert.That(exception.InnerException, Is.Null);
         });
     }
+
+    // system.data_type_families on 26.6, as the names a caller writes rather than as a header ever carries them.
+    // The canonical name is what the codec is stamped with, so DEC(4, 2) reports itself as Decimal(4, 2).
+    [TestCase("VARCHAR", "String")]
+    [TestCase("nchar varying(456)", "String")]
+    [TestCase("BIGINT", "Int64")]
+    [TestCase("TINYINT UNSIGNED", "UInt8")]
+    [TestCase("DOUBLE PRECISION", "Float64")]
+    [TestCase("BINARY(10)", "FixedString(10)")]
+    [TestCase("DEC(4, 2)", "Decimal(4, 2)")]
+    [TestCase("TIMESTAMP", "DateTime")]
+    [TestCase("INET4", "IPv4")]
+    [TestCase("Boolean", "Bool")]
+    [TestCase("GEOMETRY", "Geometry")]
+    [TestCase("DateTime32", "DateTime")]
+    [TestCase("datetime64(3)", "DateTime64(3)")]
+    [TestCase("json", "JSON")]
+    [TestCase("DATE", "Date")]
+    [TestCase("time64(9)", "Time64(9)")]
+    public void Resolve_AliasOrCaseVariant_ResolvesToTheCanonicalType(string written, string canonical)
+        => Assert.That(ColumnCodecRegistry.Default.Resolve(written, ResolveContext.ForWrite).TypeName, Is.EqualTo(canonical));
+
+    [Test]
+    public void Resolve_AliasInsideAComposite_ResolvesThroughTheChildNodes()
+    {
+        // Child nodes resolve through the same registry, so one table covers a composite. Checked on 26.6: a
+        // column created as Array(Map(String, Tuple(Int32, BIGINT))) reports the Int64 spelling.
+        IColumnCodec written = ColumnCodecRegistry.Default.Resolve(
+            "Array(Map(String, Tuple(Int32, BIGINT)))",
+            ResolveContext.ForWrite);
+        IColumnCodec canonical = ColumnCodecRegistry.Default.Resolve(
+            "Array(Map(String, Tuple(Int32, Int64)))",
+            ResolveContext.ForWrite);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(written.ElementType, Is.EqualTo(canonical.ElementType));
+
+            // Only the node whose own name is the alias is rewritten, so a composite keeps the spelling it was
+            // given in its type name. Canonicalizing the whole tree would mean walking it on every resolve,
+            // which is the read path, to tidy a name no header ever carries.
+            Assert.That(written.TypeName, Is.EqualTo("Array(Map(String, Tuple(Int32, BIGINT)))"));
+        });
+    }
+
+    // Case is per family. The server marks these case_insensitive = 0, so it answers "Unknown data type family"
+    // for every spelling here — matching them would accept what the server rejects.
+    [TestCase("string")]
+    [TestCase("int64")]
+    [TestCase("array(uint8)")]
+    [TestCase("nullable(string)")]
+    [TestCase("tuple(uint8)")]
+    [TestCase("geometry")]
+    [TestCase("variant(int64, string)")]
+    public void Resolve_CaseVariantOfACaseSensitiveFamily_ThrowsNotSupported(string written)
+        => Assert.Throws<NotSupportedException>(() => ColumnCodecRegistry.Default.Resolve(written, ResolveContext.ForWrite));
 
     [Test]
     public void Resolve_AggregateFunctionNamingNoFunction_ThrowsFormat()

--- a/ClickHouse.Driver.Tcp.Tests/Types/ColumnCodecRegistryTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/ColumnCodecRegistryTests.cs
@@ -204,17 +204,22 @@ public class ColumnCodecRegistryTests
         });
     }
 
-    // Case is per family. The server marks these case_insensitive = 0, so it answers "Unknown data type family"
-    // for every spelling here — matching them would accept what the server rejects.
-    [TestCase("string")]
-    [TestCase("int64")]
-    [TestCase("array(uint8)")]
-    [TestCase("nullable(string)")]
-    [TestCase("tuple(uint8)")]
-    [TestCase("geometry")]
-    [TestCase("variant(int64, string)")]
-    public void Resolve_CaseVariantOfACaseSensitiveFamily_ThrowsNotSupported(string written)
-        => Assert.Throws<NotSupportedException>(() => ColumnCodecRegistry.Default.Resolve(written, ResolveContext.ForWrite));
+    // The server marks only some families case_insensitive, and this client does not copy that rule: which
+    // spellings a server takes is its own business, it changes between versions and settings, and it reports a
+    // name it rejects far better than a stale copy of the rule here could. So any case resolves, and the codec
+    // is stamped with the registered spelling.
+    // As with an alias, only the node whose own name was rewritten reports the registered spelling: a child
+    // keeps what the caller wrote, because canonicalizing a whole tree would mean walking it on every resolve.
+    [TestCase("string", "String")]
+    [TestCase("int64", "Int64")]
+    [TestCase("array(uint8)", "Array(uint8)")]
+    [TestCase("nullable(string)", "Nullable(string)")]
+    [TestCase("geometry", "Geometry")]
+    [TestCase("VARIANT(Int64, String)", "Variant(Int64, String)")]
+    public void Resolve_AnyCaseOfAKnownName_Resolves(string written, string expectedTypeName)
+        => Assert.That(
+            ColumnCodecRegistry.Default.Resolve(written, ResolveContext.ForWrite).TypeName,
+            Is.EqualTo(expectedTypeName));
 
     [Test]
     public void Resolve_AggregateFunctionNamingNoFunction_ThrowsFormat()

--- a/ClickHouse.Driver.Tcp.Tests/Types/ColumnCodecRegistryTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/ColumnCodecRegistryTests.cs
@@ -130,6 +130,37 @@ public class ColumnCodecRegistryTests
     }
 
     [Test]
+    public void Resolve_UnsupportedChildType_NamesTheOuterTypeAsWell()
+    {
+        // The refusal comes from the child, and 'Boolean' on its own sends a caller searching their code for a
+        // name they never wrote (the server spells the type Bool). No "yet" either: Object('json') was removed
+        // from ClickHouse and MultiPoint never existed, so some of what lands here is not coming.
+        var exception = Assert.Throws<NotSupportedException>(
+            () => ColumnCodecRegistry.Default.Resolve("Map(String, Array(Boolean))", default));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(exception.Message, Does.Contain("'Boolean'"));
+            Assert.That(exception.Message, Does.Contain("'Map(String, Array(Boolean))'"));
+            Assert.That(exception.Message, Does.Not.Contain("yet"));
+            Assert.That(exception.InnerException, Is.TypeOf<NotSupportedException>(), "the child's own refusal is kept");
+        });
+    }
+
+    [Test]
+    public void Resolve_UnsupportedTopLevelType_NamesItOnce()
+    {
+        // The type the caller wrote is the type that failed, so there is no outer type to add.
+        var exception = Assert.Throws<NotSupportedException>(() => ColumnCodecRegistry.Default.Resolve("Boolean", default));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(exception.Message, Does.Contain("'Boolean'").And.Not.Contain("inside"));
+            Assert.That(exception.InnerException, Is.Null);
+        });
+    }
+
+    [Test]
     public void Resolve_AggregateFunctionNamingNoFunction_ThrowsFormat()
         => Assert.Throws<FormatException>(() => ColumnCodecRegistry.Default.Resolve("AggregateFunction()", default));
 }

--- a/ClickHouse.Driver.Tcp.Tests/Types/ColumnCodecRegistryTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/ColumnCodecRegistryTests.cs
@@ -103,12 +103,30 @@ public class ColumnCodecRegistryTests
     // be a query that actually runs: the combinator attaches to the bare name, and a parameterized function keeps its
     // parameters in their own list ahead of the column. "quantiles(0.5, 0.9)Merge" is not a function, and a bare
     // "quantilesMerge(column)" is rejected by the server for wanting its parameters — verified on 26.6.
+    // A leading integer is a serialization version rather than a function: 26.6 reports sumMapState(...) as
+    // AggregateFunction(1, sumMap, Array(UInt64), Array(UInt64)), and sumMapMerge / sumMapFilteredMerge([1, 2])
+    // are the queries that run — both verified on 26.6.
     [TestCase("AggregateFunction(sum, UInt64)", "sumMerge(column)")]
     [TestCase("AggregateFunction(quantiles(0.5, 0.9), UInt64)", "quantilesMerge(0.5, 0.9)(column)")]
+    [TestCase("AggregateFunction(1, sumMap, Array(UInt64), Array(UInt64))", "sumMapMerge(column)")]
+    [TestCase("AggregateFunction(1, sumMapFiltered([1, 2]), Array(UInt64), Array(UInt64))", "sumMapFilteredMerge([1, 2])(column)")]
     public void Resolve_AggregateFunction_ThrowsSuggestingAMergeQueryThatRuns(string type, string expectedHint)
     {
         var exception = Assert.Throws<NotSupportedException>(() => ColumnCodecRegistry.Default.Resolve(type, default));
         Assert.That(exception.Message, Does.Contain(expectedHint));
+    }
+
+    [Test]
+    public void Resolve_AggregateFunctionWithASerializationVersion_NamesTheFunctionAndNotTheVersion()
+    {
+        var exception = Assert.Throws<NotSupportedException>(
+            () => ColumnCodecRegistry.Default.Resolve("AggregateFunction(1, sumMap, Array(UInt64), Array(UInt64))", default));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(exception.Message, Does.Contain("'sumMap' aggregate function"));
+            Assert.That(exception.Message, Does.Not.Contain("'1' aggregate function"));
+        });
     }
 
     [Test]

--- a/ClickHouse.Driver.Tcp.Tests/Types/ColumnReadProjectionTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/ColumnReadProjectionTests.cs
@@ -183,8 +183,8 @@ public class ColumnReadProjectionTests
             Assert.That(
                 Codec("DateTime64(3, 'UTC')").ReadableElementTypes,
                 Is.EqualTo(new[] { typeof(long), typeof(DateTimeOffset), typeof(DateTime) }));
-            Assert.That(Codec("Time").ReadableElementTypes, Is.EqualTo(new[] { typeof(int), typeof(TimeSpan) }));
-            Assert.That(Codec("Time64(3)").ReadableElementTypes, Is.EqualTo(new[] { typeof(long), typeof(TimeSpan) }));
+            Assert.That(Codec("Time").ReadableElementTypes, Is.EqualTo(new[] { typeof(int), typeof(TimeSpan), typeof(TimeOnly) }));
+            Assert.That(Codec("Time64(3)").ReadableElementTypes, Is.EqualTo(new[] { typeof(long), typeof(TimeSpan), typeof(TimeOnly) }));
         });
     }
 
@@ -352,6 +352,48 @@ public class ColumnReadProjectionTests
         Func<long, TimeSpan> project = Project<long, TimeSpan>(Codec($"Time64({scale})"));
 
         Assert.That(project(count), Is.EqualTo(TimeSpan.Parse(expected)));
+    }
+
+    [Test]
+    public void TryProjectRead_TimeToTimeOnly_IsTheTimeOfDay()
+    {
+        Func<int, TimeOnly> project = Project<int, TimeOnly>(Codec("Time"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(project(3661), Is.EqualTo(new TimeOnly(1, 1, 1)));
+            Assert.That(project(0), Is.EqualTo(TimeOnly.MinValue));
+            Assert.That(project((23 * 3600) + (59 * 60) + 59), Is.EqualTo(new TimeOnly(23, 59, 59)));
+        });
+    }
+
+    [Test]
+    [TestCase(3, 3_661_500L, "01:01:01.5000000")]
+    [TestCase(9, 3_661_000_000_000L, "01:01:01")]
+    public void TryProjectRead_Time64ToTimeOnly_HonorsTheColumnScale(int scale, long count, string expected)
+    {
+        Func<long, TimeOnly> project = Project<long, TimeOnly>(Codec($"Time64({scale})"));
+
+        Assert.That(project(count), Is.EqualTo(TimeOnly.Parse(expected)));
+    }
+
+    // The one narrowing in the read surface: a Time column holds a signed duration of up to 999 hours, and the
+    // part of that range outside a day has no TimeOnly. Refused, not reduced modulo a day, which would be a
+    // different value presented as the stored one.
+    [TestCase(-1, TestName = "A negative duration")]
+    [TestCase(24 * 3600, TestName = "Exactly 24 hours")]
+    [TestCase(100 * 3600, TestName = "A duration of 100 hours")]
+    public void TryProjectRead_TimeToTimeOnlyOfAValueThatIsNoTimeOfDay_Throws(int seconds)
+    {
+        Func<int, TimeOnly> project = Project<int, TimeOnly>(Codec("Time"));
+
+        var thrown = Assert.Throws<InvalidOperationException>(() => project(seconds));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(thrown.Message, Does.Contain("is not a time of day"));
+            Assert.That(thrown.Message, Does.Contain("TimeSpan"), "the message has to name the reading that does work");
+        });
     }
 
     [Test]

--- a/ClickHouse.Driver.Tcp.Tests/Types/ColumnReadProjectionTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/ColumnReadProjectionTests.cs
@@ -219,6 +219,37 @@ public class ColumnReadProjectionTests
         });
     }
 
+    /// <summary>
+    /// Where an unrepresentable zone is reported, and where it is not. Building the projection must succeed:
+    /// <c>CanRead</c> and the POCO tier's mapping discovery both come through here with no row in hand, so a
+    /// throw at build time refuses the reading rather than the value. The row is what needs the zone.
+    /// </summary>
+    [TestCase("DateTime('Fixed/UTC+19:00:00')", "+19:00:00")]
+    [TestCase("DateTime('Fixed/UTC+05:30:15')", "+05:30:15")]
+    public void TryProjectRead_ACalendarTargetOfAZoneTimeZoneInfoCannotHold_BuildsAndThrowsOnTheRow(
+        string columnType,
+        string offset)
+    {
+        Func<uint, DateTimeOffset> project = Project<uint, DateTimeOffset>(Codec(columnType));
+
+        var thrown = Assert.Throws<FormatException>(() => project(1_700_000_000));
+
+        Assert.That(thrown.Message, Does.Contain(offset));
+    }
+
+    [TestCase("DateTime64(3, 'Fixed/UTC+19:00:00')", "+19:00:00")]
+    [TestCase("DateTime64(9, 'Fixed/UTC+05:30:15')", "+05:30:15")]
+    public void TryProjectRead_ADateTime64CalendarTargetOfAZoneTimeZoneInfoCannotHold_BuildsAndThrowsOnTheRow(
+        string columnType,
+        string offset)
+    {
+        Func<long, DateTimeOffset> project = Project<long, DateTimeOffset>(Codec(columnType));
+
+        var thrown = Assert.Throws<FormatException>(() => project(1_700_000_000_000));
+
+        Assert.That(thrown.Message, Does.Contain(offset));
+    }
+
     [Test]
     public void TryProjectRead_DateTimeToDateTime_UtcColumnYieldsUtcKind()
     {

--- a/ClickHouse.Driver.Tcp.Tests/Types/ColumnReadProjectionTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/ColumnReadProjectionTests.cs
@@ -396,6 +396,43 @@ public class ColumnReadProjectionTests
         });
     }
 
+    // The Time64 refusal is on the raw count, not on the TimeSpan it shifts to: at scale 8 and 9 the shift to
+    // 100 ns ticks truncates toward zero, so every count from -1 to -99 at scale 9 reaches TimeSpan.Zero and a
+    // check made after it reads a negative value as midnight.
+    [TestCase(9, -1L, TestName = "A nanosecond before midnight, scale 9")]
+    [TestCase(9, -99L, TestName = "The last count scale 9 truncates to zero")]
+    [TestCase(9, -100L, TestName = "One tick before midnight, scale 9")]
+    [TestCase(8, -1L, TestName = "Ten nanoseconds before midnight, scale 8")]
+    [TestCase(8, -9L, TestName = "The last count scale 8 truncates to zero")]
+    [TestCase(3, -1L, TestName = "A millisecond before midnight, scale 3")]
+    [TestCase(3, 86_400_000L, TestName = "Exactly 24 hours, scale 3")]
+    [TestCase(0, 86_400L, TestName = "Exactly 24 hours, scale 0")]
+    [TestCase(0, 100 * 3600L, TestName = "A duration of 100 hours, scale 0")]
+    public void TryProjectRead_Time64ToTimeOnlyOfAValueThatIsNoTimeOfDay_Throws(int scale, long count)
+    {
+        Func<long, TimeOnly> project = Project<long, TimeOnly>(Codec($"Time64({scale})"));
+
+        var thrown = Assert.Throws<InvalidOperationException>(() => project(count));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(thrown.Message, Does.Contain("is not a time of day"));
+            Assert.That(thrown.Message, Does.Contain("TimeSpan"));
+        });
+    }
+
+    // The bounds on the accepting side of the same check, so it cannot pass by refusing everything.
+    [TestCase(9, 0L, "00:00:00")]
+    [TestCase(9, 86_399_999_999_999L, "23:59:59.9999999")]
+    [TestCase(3, 86_399_999L, "23:59:59.999")]
+    [TestCase(0, 86_399L, "23:59:59")]
+    public void TryProjectRead_Time64ToTimeOnlyAtTheEndsOfTheDay_IsAccepted(int scale, long count, string expected)
+    {
+        Func<long, TimeOnly> project = Project<long, TimeOnly>(Codec($"Time64({scale})"));
+
+        Assert.That(project(count), Is.EqualTo(TimeOnly.Parse(expected)));
+    }
+
     [Test]
     public void ReadableElementTypes_NullableOfProjectingInner_LiftsEveryInnerType()
     {

--- a/ClickHouse.Driver.Tcp.Tests/Types/DateTime64ColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/DateTime64ColumnCodecTests.cs
@@ -253,6 +253,19 @@ public class DateTime64ColumnCodecTests
         });
     }
 
+    // The write side of the same rule. A Utc DateTime names an instant, so the zone the column declares is not
+    // needed and must not be resolved: this codec's own scaling is what has to run.
+    [Test]
+    public async Task WriteColumn_UtcDateTimeIntoAZoneTimeZoneInfoCannotHold_WritesTheInstant()
+    {
+        const string type = "DateTime64(3, 'Fixed/UTC+19:00:00')";
+        var value = new DateTime(2024, 1, 15, 10, 30, 0, DateTimeKind.Utc);
+
+        byte[] bytes = await WriteAsync(w => Codec(type).WriteColumn(w, new ArrayColumn<DateTime>("c", type, new[] { value })));
+
+        Assert.That(BitConverter.ToInt64(bytes, 0), Is.EqualTo(1_705_314_600_000L));
+    }
+
     // DateTime64 shares DateTimeColumnCodec.ToUtc; covered here too because a refactor could separate them.
     [Test]
     public void WriteColumn_UnspecifiedKindInDaylightSavingGap_ThrowsNamingTheZone()

--- a/ClickHouse.Driver.Tcp.Tests/Types/DateTime64ColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/DateTime64ColumnCodecTests.cs
@@ -214,6 +214,26 @@ public class DateTime64ColumnCodecTests
         Assert.That(BitConverter.ToInt64(bytes), Is.EqualTo(expectedMillis));
     }
 
+    [Test]
+    public async Task ReadColumn_FixedUtcOffsetTimeZoneInfoCannotHold_ReadsTheCountsAndReportsOnlyTheZone()
+    {
+        // The counts are the wire value and need no zone, so a zone TimeZoneInfo cannot hold (26.6 applies
+        // Fixed/UTC+05:30:15, which is not a whole number of minutes) must not fail the read. DateTime64 carries
+        // its own zone field and projection, so it is not covered by the DateTime codec's case.
+        const string type = "DateTime64(3, 'Fixed/UTC+05:30:15')";
+        byte[] bytes = await WriteAsync(w => w.WriteInt64(1_700_000_000_123));
+        using var reader = ReaderOver(bytes);
+
+        using var column = (DateTime64Column)await Codec(type).ReadColumnAsync(reader, "c", type, 1, None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(column[0], Is.EqualTo(1_700_000_000_123L));
+            Assert.That(Assert.Throws<FormatException>(() => _ = column.TimeZone).Message, Does.Contain("+05:30:15"));
+            Assert.Throws<FormatException>(() => column.GetDateTimeOffset(0));
+        });
+    }
+
     // DateTime64 shares DateTimeColumnCodec.ToUtc; covered here too because a refactor could separate them.
     [Test]
     public void WriteColumn_UnspecifiedKindInDaylightSavingGap_ThrowsNamingTheZone()

--- a/ClickHouse.Driver.Tcp.Tests/Types/DateTime64ColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/DateTime64ColumnCodecTests.cs
@@ -74,6 +74,25 @@ public class DateTime64ColumnCodecTests
         Assert.ThrowsAsync<ArgumentException>(async () => await WriteAsync(w => codec.WriteColumn(w, column)));
     }
 
+    [Test]
+    public void WriteColumn_DateTimeOffsetPastTheScalesRange_ThrowsNamingTheValueAndTheColumn()
+    {
+        // A fine scale reaches a nearer instant than .NET does: at scale 9 the Int64 nanosecond count stops at
+        // 2262-04-11, well inside DateTimeOffset's range, so a 2300 instant has to be refused. The message has to
+        // carry the value and the type, which is what an OverflowException out of the multiply does not.
+        const string type = "DateTime64(9)";
+        DateTime64ColumnCodec codec = Codec(type, "UTC");
+        var column = new ArrayColumn<DateTimeOffset>("c", type, new[] { new DateTimeOffset(2300, 1, 1, 0, 0, 0, TimeSpan.Zero) });
+
+        var thrown = Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await WriteAsync(w => codec.WriteColumn(w, column)));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(thrown.Message, Does.Contain("2300-01-01"));
+            Assert.That(thrown.Message, Does.Contain(type));
+        });
+    }
+
     // Scale 8 sets one digit finer than a .NET tick, scale 9 two. The raw count keeps them; the DateTimeOffset
     // view truncates toward zero, it does not round.
     [TestCase("DateTime64(8)", 170_000_000_012_345_678L)]

--- a/ClickHouse.Driver.Tcp.Tests/Types/DateTimeColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/DateTimeColumnCodecTests.cs
@@ -282,9 +282,26 @@ public class DateTimeColumnCodecTests
         });
     }
 
-    [Test]
-    public void Create_UnknownTimezone_Throws()
-        => Assert.Throws<FormatException>(() => Codec("DateTime('Not/AZone')"));
+    [TestCase("DateTime('Not/AZone')", "Not/AZone")]
+    [TestCase("DateTime('Fixed/UTC+19:00:00')", "+19:00:00")]
+    public async Task ReadColumn_TimezoneThisPlatformCannotResolve_ReadsTheSecondsAndReportsOnlyTheZone(string type, string named)
+    {
+        // Neither a zone with no tzdata here nor an offset TimeZoneInfo cannot hold (26.6 accepts and applies
+        // Fixed/UTC+19:00:00, past its ±14 hours) may fail the read: the seconds are the wire value and need no
+        // zone. Only a calendar value does, so only a calendar value reports it.
+        byte[] bytes = await WriteAsync(w => w.WriteUInt32(1_700_000_000));
+        using var reader = ReaderOver(bytes);
+
+        using var column = (DateTimeColumn)await Codec(type).ReadColumnAsync(reader, "c", type, 1, None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(column[0], Is.EqualTo(1_700_000_000u));
+            Assert.That(Assert.Throws<FormatException>(() => _ = column.TimeZone).Message, Does.Contain(named));
+            Assert.Throws<FormatException>(() => column.GetDateTimeOffset(0));
+            Assert.Throws<FormatException>(() => column.ToDateTimeOffsets());
+        });
+    }
 
     [TestCase("Fixed/UTC+05:30:00", 5, 30)]
     [TestCase("Fixed/UTC-08:00:00", -8, 0)]
@@ -319,8 +336,15 @@ public class DateTimeColumnCodecTests
     }
 
     [Test]
-    public void Create_FixedUtcOffsetOutOfRange_Throws()
-        => Assert.Throws<FormatException>(() => Codec("DateTime('Fixed/UTC+15:00:00')"));
+    public void WriteColumn_DateTimeIntoAZoneTimeZoneInfoCannotHold_ThrowsNamingTheZone()
+    {
+        // An Unspecified DateTime is a wall clock, so writing one needs the zone the raw seconds did not.
+        DateTimeColumnCodec codec = Codec("DateTime('Fixed/UTC+19:00:00')");
+        var values = new ArrayColumn<DateTime>("c", "DateTime", new[] { new DateTime(2024, 1, 15, 10, 30, 0, DateTimeKind.Unspecified) });
+
+        FormatException thrown = Assert.ThrowsAsync<FormatException>(() => WriteAsync(w => codec.WriteColumn(w, values)));
+        Assert.That(thrown.Message, Does.Contain("Fixed/UTC+19:00:00"));
+    }
 
     [Test]
     public void CanWrite_AcceptsRawSecondsDateTimeAndDateTimeOffset_RejectsOthers()

--- a/ClickHouse.Driver.Tcp.Tests/Types/DateTimeColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/DateTimeColumnCodecTests.cs
@@ -346,6 +346,54 @@ public class DateTimeColumnCodecTests
         Assert.That(thrown.Message, Does.Contain("Fixed/UTC+19:00:00"));
     }
 
+    // The other side of the same rule: a Utc DateTime already names an instant, so the zone the column declares
+    // is irrelevant to it and asking for one must not be what fails the write.
+    [Test]
+    public async Task WriteColumn_UtcDateTimeIntoAZoneTimeZoneInfoCannotHold_WritesTheInstant()
+    {
+        var value = new DateTime(2024, 1, 15, 10, 30, 0, DateTimeKind.Utc);
+        DateTimeColumnCodec codec = Codec("DateTime('Fixed/UTC+19:00:00')");
+
+        byte[] bytes = await WriteAsync(w => codec.WriteColumn(
+            w,
+            new ArrayColumn<DateTime>("c", "DateTime('Fixed/UTC+19:00:00')", new[] { value })));
+
+        Assert.That(BitConverter.ToUInt32(bytes, 0), Is.EqualTo(1_705_314_600U));
+    }
+
+    // A Local value names an instant too. Compared against the same conversion, since a literal would pin the
+    // machine's own zone; what this asserts is that the column's zone is not consulted, not the arithmetic.
+    [Test]
+    public async Task WriteColumn_LocalDateTimeIntoAZoneTimeZoneInfoCannotHold_WritesTheInstant()
+    {
+        var value = new DateTime(2024, 1, 15, 10, 30, 0, DateTimeKind.Local);
+        DateTimeColumnCodec codec = Codec("DateTime('Fixed/UTC+19:00:00')");
+
+        byte[] bytes = await WriteAsync(w => codec.WriteColumn(
+            w,
+            new ArrayColumn<DateTime>("c", "DateTime('Fixed/UTC+19:00:00')", new[] { value })));
+
+        Assert.That(
+            BitConverter.ToUInt32(bytes, 0),
+            Is.EqualTo((uint)new DateTimeOffset(value.ToUniversalTime(), TimeSpan.Zero).ToUnixTimeSeconds()));
+    }
+
+    // The null placeholder is DateTime.UnixEpoch, whose Kind is Utc, so a null row must not need the zone either.
+    [Test]
+    public async Task WriteColumn_NullableNullIntoAZoneTimeZoneInfoCannotHold_WritesThePlaceholder()
+    {
+        const string type = "Nullable(DateTime('Fixed/UTC+19:00:00'))";
+        IColumnCodec codec = ColumnCodecRegistry.Default.Resolve(type, ResolveContext.ForWrite);
+
+        byte[] bytes = await WriteAsync(w => codec.WriteColumn(w, new ArrayColumn<DateTime?>("c", type, new DateTime?[] { null })));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(bytes[0], Is.EqualTo(1), "the null map marks the row absent");
+            Assert.That(BitConverter.ToUInt32(bytes, 1), Is.EqualTo(0U), "the placeholder is the epoch");
+        });
+    }
+
     [Test]
     public void CanWrite_AcceptsRawSecondsDateTimeAndDateTimeOffset_RejectsOthers()
     {

--- a/ClickHouse.Driver.Tcp.Tests/Types/DateTimeZonesTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/DateTimeZonesTests.cs
@@ -6,34 +6,90 @@ namespace ClickHouse.Driver.Tcp.Tests.Types;
 /// <summary>
 /// Timezone fallback for the <c>DateTime</c> / <c>DateTime64</c> codecs: the type string's zone, then the session's,
 /// then UTC. The codecs' own tests always supply one of the first two, so the UTC step is pinned here.
+///
+/// <para>
+/// Resolution itself never throws. A name this platform cannot represent is reported by
+/// <c>ResolvedTimeZone.Value</c>, which only a caller asking for a calendar value reaches, so the counts a column
+/// carries still read.
+/// </para>
 /// </summary>
 [TestFixture]
 public class DateTimeZonesTests
 {
     [Test]
     public void Resolve_NoExplicitAndNoServerTimezone_ReturnsUtc()
-        => Assert.That(DateTimeZones.Resolve(explicitTimezone: null, serverTimezone: null), Is.EqualTo(TimeZoneInfo.Utc));
+        => Assert.That(DateTimeZones.Resolve(explicitTimezone: null, serverTimezone: null).Value, Is.EqualTo(TimeZoneInfo.Utc));
 
     // Empty means absent, not a zone id: an unset session timezone can arrive empty rather than null.
     [TestCase("", "")]
     [TestCase(null, "")]
     [TestCase("", null)]
     public void Resolve_EmptyTimezones_ReturnsUtc(string explicitTimezone, string serverTimezone)
-        => Assert.That(DateTimeZones.Resolve(explicitTimezone, serverTimezone), Is.EqualTo(TimeZoneInfo.Utc));
+        => Assert.That(DateTimeZones.Resolve(explicitTimezone, serverTimezone).Value, Is.EqualTo(TimeZoneInfo.Utc));
 
     [Test]
     public void Resolve_NoExplicitTimezone_UsesTheServerTimezone()
         => Assert.That(
-            DateTimeZones.Resolve(explicitTimezone: null, serverTimezone: "Asia/Kolkata").BaseUtcOffset,
+            DateTimeZones.Resolve(explicitTimezone: null, serverTimezone: "Asia/Kolkata").Value.BaseUtcOffset,
             Is.EqualTo(new TimeSpan(5, 30, 0)));
 
     [Test]
     public void Resolve_ExplicitTimezone_TakesPrecedenceOverTheServerTimezone()
         => Assert.That(
-            DateTimeZones.Resolve(explicitTimezone: "Asia/Kolkata", serverTimezone: "America/New_York").BaseUtcOffset,
+            DateTimeZones.Resolve(explicitTimezone: "Asia/Kolkata", serverTimezone: "America/New_York").Value.BaseUtcOffset,
             Is.EqualTo(new TimeSpan(5, 30, 0)));
 
     [Test]
-    public void Resolve_UnknownTimezone_ThrowsFormat()
-        => Assert.Throws<FormatException>(() => DateTimeZones.Resolve("Not/AZone", serverTimezone: null));
+    public void Resolve_UnknownTimezone_IsUnresolvedAndThrowsWhenUsed()
+    {
+        ResolvedTimeZone zone = DateTimeZones.Resolve("Not/AZone", serverTimezone: null);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(zone.IsResolved, Is.False);
+            Assert.That(Assert.Throws<FormatException>(() => _ = zone.Value).Message, Does.Contain("Not/AZone"));
+        });
+    }
+
+    // The synthetic fixed-offset name is not an IANA id, so it is parsed rather than looked up. The three
+    // components are summed as written, which is what the server does: 26.6 applies Fixed/UTC+05:00:60 as
+    // +05:01:00 and Fixed/UTC+05:70:00 as +06:10:00, keeping the name it was given.
+    [TestCase("Fixed/UTC+00:00:00", 0, 0)]
+    [TestCase("Fixed/UTC+05:30:00", 5, 30)]
+    [TestCase("Fixed/UTC-07:00:00", -7, 0)]
+    [TestCase("Fixed/UTC+14:00:00", 14, 0)]
+    [TestCase("Fixed/UTC+05:00:60", 5, 1)]
+    [TestCase("Fixed/UTC+05:70:00", 6, 10)]
+    [TestCase("Fixed/UTC+13:60:00", 14, 0)]
+    public void Resolve_FixedOffsetName_IsTheSumOfItsComponents(string id, int hours, int minutes)
+        => Assert.That(
+            DateTimeZones.Resolve(id, serverTimezone: null).Value.BaseUtcOffset,
+            Is.EqualTo(new TimeSpan(hours, minutes, 0)));
+
+    // Offsets the server accepts and applies (checked on 26.6) that TimeZoneInfo cannot hold: past ±14 hours, or
+    // not a whole number of minutes. The message has to name the offset, since the name alone does not say which
+    // rule it breaks.
+    [TestCase("Fixed/UTC+19:00:00", "+19:00:00")]
+    [TestCase("Fixed/UTC-18:00:00", "-18:00:00")]
+    [TestCase("Fixed/UTC+05:30:15", "+05:30:15")]
+    [TestCase("Fixed/UTC-00:00:01", "-00:00:01")]
+    public void Resolve_OffsetTimeZoneInfoCannotHold_IsUnresolvedAndNamesTheOffset(string id, string offset)
+    {
+        ResolvedTimeZone zone = DateTimeZones.Resolve(id, serverTimezone: null);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(zone.IsResolved, Is.False);
+            Assert.That(
+                Assert.Throws<FormatException>(() => _ = zone.Value).Message,
+                Does.Contain(id).And.Contain(offset));
+        });
+    }
+
+    // A name that looks synthetic but is not one of the server's: three components is the only shape it emits.
+    [TestCase("Fixed/UTC+05:30")]
+    [TestCase("Fixed/UTC+5:30:00")]
+    [TestCase("Fixed/UTC 05:30:00")]
+    public void Resolve_MalformedFixedOffsetName_FallsThroughToTheLookupAndIsUnresolved(string id)
+        => Assert.That(DateTimeZones.Resolve(id, serverTimezone: null).IsResolved, Is.False);
 }

--- a/ClickHouse.Driver.Tcp.Tests/Types/EnumColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/EnumColumnCodecTests.cs
@@ -43,11 +43,22 @@ public class EnumColumnCodecTests
     public void Create_DuplicateOrdinal_Throws()
         => Assert.Throws<FormatException>(() => Enum8ColumnCodec.Create(TypeParser.Parse("Enum8('a' = 1, 'b' = 1)")));
 
-    [Test]
-    public void Create_LabelWithEscapedQuote_IsUnescaped()
+    [TestCase(@"'a\'b' = 1", "a'b")]
+    [TestCase(@"'a\\b' = 1", @"a\b")]
+    [TestCase(@"'a\nb' = 1", "a\nb")]
+    [TestCase(@"'a\tb' = 1", "a\tb")]
+    [TestCase(@"'a\0b' = 1", "a\0b")]
+    [TestCase(@"'a\x41b' = 1", "aAb")]
+    [TestCase(@"'a\zb' = 1", @"a\zb")]
+    [TestCase("'a''b' = 1", "a'b")]
+    [TestCase("'' = 1", "")]
+    public void Create_LabelWithAnEscape_DecodesItLikeTheServer(string member, string expected)
     {
-        var codec = (EnumColumnCodec<sbyte>)Enum8ColumnCodec.Create(TypeParser.Parse(@"Enum8('a\'b' = 1)"));
-        Assert.That(codec.OrdinalToLabel[(sbyte)1], Is.EqualTo("a'b"));
+        // The label in a header carries the server's escaping, and the label a caller reads or writes is the
+        // decoded one. Checked against 26.6: hex('\a') is 07 … hex('\x41') is 41, an escape the server does not
+        // define keeps both characters (hex('\z') is 5C7A), and a doubled quote is one quote.
+        var codec = (EnumColumnCodec<sbyte>)Enum8ColumnCodec.Create(TypeParser.Parse($"Enum8({member})"));
+        Assert.That(codec.OrdinalToLabel[(sbyte)1], Is.EqualTo(expected));
     }
 
     [Test]

--- a/ClickHouse.Driver.Tcp.Tests/Types/NestedColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/NestedColumnCodecTests.cs
@@ -228,6 +228,28 @@ public class NestedColumnCodecTests
     public void Resolve_Nested_StampsFullTypeNameWithFieldNames()
         => Assert.That(Resolve("Nested(a UInt8, b String)").TypeName, Is.EqualTo("Nested(a UInt8, b String)"));
 
+    [Test]
+    public async Task ReadColumn_BacktickedFieldName_DecodesTheNameAndKeepsTheTypeName()
+    {
+        // A field name needing quotes arrives backticked in the header, so the split has to happen at the closing
+        // backtick. The name is decoded for the caller; the type name keeps the wire spelling.
+        const string type = "Nested(`a b` UInt8, `c,d` String)";
+        IColumnCodec codec = Resolve(type);
+        NestedColumn column = Nested(
+            type,
+            new[] { "a b", "c,d" },
+            new[] { Field<byte>("UInt8", 1, 2), Field<string>("String", "x", "y") },
+            new[] { 0, 1, 2 });
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, type, column.RowCount);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(codec.TypeName, Is.EqualTo(type));
+            Assert.That(((NestedColumn)read).FieldNames, Is.EqualTo(new[] { "a b", "c,d" }));
+        });
+    }
+
     [TestCase("Nested")]  // no parens: zero fields reaches the codec's own guard
     [TestCase("Nested()")] // empty parens: rejected by the parser before the codec
     public void Resolve_NoFields_ThrowsFormat(string type)

--- a/ClickHouse.Driver.Tcp.Tests/Types/TupleColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/TupleColumnCodecTests.cs
@@ -214,6 +214,25 @@ public class TupleColumnCodecTests
         Assert.That(codec.ElementType, Is.EqualTo(typeof((int, string))));
     }
 
+    [TestCase("Tuple(`a b` Int32, `c,d` String)", new[] { "a b", "c,d" })]
+    [TestCase(@"Tuple(`a\`b` Int32, `x\ny` String)", new[] { "a`b", "x\ny" })]
+    public async Task ReadColumn_BacktickedElementNames_DecodeToTheNameTheServerHolds(string type, string[] expectedNames)
+    {
+        // A quoted field name is split off at the closing backtick, not at the first space inside it, and its
+        // escapes are decoded: on 26.6 a column created as Tuple(`a``b` Int8) reports Tuple(`a\`b` Int8). The type
+        // name keeps the wire spelling, since it is what an insert header echoes.
+        IColumnCodec codec = Resolve(type);
+        var column = new TupleColumn<int, string>("c", type, new (int, string)[] { (1, "a") });
+
+        using IColumn read = await CodecTestHarness.RoundTripAsync(codec, column, type, 1);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(codec.TypeName, Is.EqualTo(type));
+            Assert.That(((TupleColumnBase)read).FieldNames, Is.EqualTo(expectedNames));
+        });
+    }
+
     [Test]
     public void CanWrite_NonWritableElement_IsFalse()
     {

--- a/ClickHouse.Driver.Tcp.Tests/Types/TypeParserTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/TypeParserTests.cs
@@ -62,6 +62,78 @@ public class TypeParserTests
         });
     }
 
+    [TestCase(",")]
+    [TestCase("(")]
+    [TestCase(")")]
+    [TestCase(" ")]
+    public void Parse_BacktickedIdentifierWithBreakCharacter_IsOneArgument(string inside)
+    {
+        // A backticked identifier is opaque, like a quoted label. The server emits these itself — a JSON typed
+        // path, a Tuple or Nested field name — and normalizes a double-quoted name into a backticked one, so a
+        // header carrying one must parse or the whole read fails before a row decodes.
+        TypeNode node = TypeParser.Parse($"JSON(`a{inside}b` Int64)");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(node.Name, Is.EqualTo("JSON"));
+            Assert.That(node.Arguments.Select(a => a.Name), Is.EqualTo(new[] { $"`a{inside}b` Int64" }));
+        });
+    }
+
+    [TestCase("JSON(`a,b` Int64)")]
+    [TestCase("Tuple(`a b` Int64, c String)")]
+    [TestCase("Nested(`a(b` UInt8)")]
+    [TestCase(@"Tuple(`a\`b` Int8)")]
+    [TestCase(@"Tuple(`a\nb` Int8)")]
+    public void Parse_BacktickedIdentifier_RoundTripsThroughToString(string type)
+    {
+        // ToString rebuilds from the tokens, so a name split across tokens would come back respelled — and the
+        // type name is what an insert header echoes. The last two are the server's own printed spelling for a
+        // backtick and a newline inside a name (verified on 26.6).
+        Assert.That(TypeParser.Parse(type).ToString(), Is.EqualTo(type));
+    }
+
+    [Test]
+    public void Parse_DoubledBacktick_ClosesAtTheFinalBacktick()
+    {
+        // The server accepts the doubled form on input, though it prints the backslash form.
+        TypeNode node = TypeParser.Parse("Tuple(`a``b` Int8)");
+        Assert.That(node.Arguments.Single().Name, Is.EqualTo("`a``b` Int8"));
+    }
+
+    [Test]
+    public void Parse_EmptyQuotedLabel_ClosesTheSpan()
+    {
+        // Enum8('' = 1) is a legal type. The two quotes are an empty label, not one escaped quote, so the span
+        // must close at the second one rather than swallow the rest of the type.
+        TypeNode node = TypeParser.Parse("Enum8('' = 1)");
+        Assert.That(node.Arguments.Single().Name, Is.EqualTo("'' = 1"));
+    }
+
+    [TestCase("Array( Array(Int32) )", "Array(Array(Int32))")]
+    [TestCase("Tuple(a UInt8, b Tuple(c UInt8) )", "Tuple(a UInt8, b Tuple(c UInt8))")]
+    [TestCase("Map( String , UInt64 )", "Map(String, UInt64)")]
+    [TestCase("Array(Int32) ", "Array(Int32)")]
+    public void Parse_WhitespaceBetweenStructuralCharacters_ParsesLikeTheCompactSpelling(string type, string expected)
+    {
+        // A run of only whitespace is no token at all. Whitespace after a closing paren is how a person
+        // pretty-prints a nested type, and it reaches the parser through a parameter type hint.
+        Assert.That(TypeParser.Parse(type).ToString(), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void Parse_SpacedEmptyArgumentList_IsTheZeroElementNode()
+    {
+        TypeNode node = TypeParser.Parse("Tuple( )");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(node.Arguments, Is.Empty);
+            Assert.That(node.HasArgumentList, Is.True);
+            Assert.That(node.ToString(), Is.EqualTo("Tuple()"));
+        });
+    }
+
     [Test]
     public void Parse_NestedType_DoesNotSplitInsideNestedParens()
     {
@@ -154,6 +226,8 @@ public class TypeParserTests
     [TestCase("Array(String)junk")]
     [TestCase("Enum8('a")]
     [TestCase("DateTime('UTC")]
+    [TestCase("Tuple(`a b Int64)")]
+    [TestCase("Tuple( , )")]
     public void Parse_Malformed_ThrowsFormat(string type)
         => Assert.Throws<FormatException>(() => TypeParser.Parse(type));
 }

--- a/ClickHouse.Driver.Tcp.Tests/Types/VariantColumnCodecTests.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Types/VariantColumnCodecTests.cs
@@ -199,6 +199,70 @@ public class VariantColumnCodecTests
         Assert.That(bytes, Is.Not.Empty);
     }
 
+    // The dense path pairs the column's alternative i with the codec's alternative i and reuses the column's own
+    // discriminators, so it is only correct when the two lists are the same list. The gate compared the counts
+    // alone, which let a column of one two-alternative Variant be written as another: every discriminator then
+    // named the wrong type, and the failure came from inside the body, after the discriminators had gone out.
+    [Test]
+    public async Task WriteColumn_DenseColumnOfAnotherVariant_WritesThisCodecsDiscriminatorsAndNotTheColumnsOwn()
+    {
+        IColumnCodec codec = Resolve(StringUInt64);
+        using var numbers = new ArrayColumn<ulong>("v", "UInt64", new ulong[] { 42 });
+        using var text = new ArrayColumn<string>("v", "String", new[] { "hi" });
+
+        // As a column read from a Variant(UInt64, String) arrives: its alternative 0 is UInt64, where this codec's
+        // alternative 0 is String. Row 0 selected UInt64, row 1 String.
+        using var dense = new VariantColumn(
+            "v", "Variant(UInt64, String)", new byte[] { 0, 1 }, new IColumn[] { numbers, text },
+            rowCount: 2, pooledDiscriminators: false, ownsColumns: false);
+
+        byte[] bytes = await CodecTestHarness.WriteAsync(w =>
+        {
+            codec.WriteStatePrefix(w, dense);
+            codec.WriteColumn(w, dense);
+        });
+
+        Assert.That(bytes, Is.EqualTo(new byte[]
+        {
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // state prefix: discriminators mode = 0 (BASIC)
+            0x01, 0x00,                                     // row 0 is the UInt64 (1 here), row 1 the String (0)
+            0x02, 0x68, 0x69,                               // String run: len = 2, "hi"
+            0x2A, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // UInt64 run: 42
+        }));
+    }
+
+    // The other side of that gate: a column whose alternatives *are* this codec's must still take the dense path.
+    // Where the two paths differ is a value whose CLR type several alternatives share — the dense column already
+    // records which alternative each row selected, while scattering the same values by runtime type cannot choose.
+    // A check that rejected a column it should accept would silently downgrade every such insert to a refusal.
+    [Test]
+    public void WriteColumn_DenseColumnOfThisVariant_WritesWhereScatteringTheSameValuesCouldNotChoose()
+    {
+        const string type = "Variant(JSON, String, UInt64)";
+        IColumnCodec codec = Resolve(type);
+        using var json = new ArrayColumn<string>("v", "JSON", Array.Empty<string>());
+        using var text = new ArrayColumn<string>("v", "String", new[] { "hi" });
+        using var numbers = new ArrayColumn<ulong>("v", "UInt64", Array.Empty<ulong>());
+        using var dense = new VariantColumn(
+            "v", type, new byte[] { 1 }, new IColumn[] { json, text, numbers },
+            rowCount: 1, pooledDiscriminators: false, ownsColumns: false);
+
+        var boxed = new ArrayColumn<object>("v", type, new object[] { "hi" });
+
+        Assert.Multiple(() =>
+        {
+            Assert.DoesNotThrowAsync(async () => await CodecTestHarness.WriteAsync(w =>
+            {
+                codec.WriteStatePrefix(w, dense);
+                codec.WriteColumn(w, dense);
+            }));
+
+            Assert.ThrowsAsync<ArgumentException>(
+                async () => await CodecTestHarness.WriteAsync(w => codec.WriteColumn(w, boxed)),
+                "the same value boxed is ambiguous between JSON and String, which is what makes the dense path observable");
+        });
+    }
+
     private static IEnumerable<TestCaseData> AmbiguousAlternativeCases()
     {
         yield return new TestCaseData("Variant(JSON, String, UInt64)", (object)"{}", new[] { "JSON", "String" })

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
@@ -245,6 +245,25 @@ public sealed class InsertRoundTripCase
         // inserted values are the exact wire values, returned verbatim.
         yield return TimeSeconds("Time", TimeSettings, 0, (12 * 3600) + (34 * 60) + 56, -((1 * 3600) + (2 * 60) + 3));
         yield return Time64Counts("Time64(3)", TimeSettings, 0L, (((1 * 3600) + (2 * 60) + 3) * 1000L) + 456, -((((1 * 3600) + (2 * 60) + 3) * 1000L) + 456));
+
+        // A TimeOnly is the time-of-day spelling of the same column, the counterpart of DateOnly for Date. The
+        // read-back is the raw count either way, so the two columns differ. TimeOnly.MaxValue is 23:59:59.9999999,
+        // which truncates toward zero at scale 3 exactly as a TimeSpan does.
+        var timesOfDay = new[] { new TimeOnly(0, 0, 0), new TimeOnly(12, 34, 56), new TimeOnly(23, 59, 59) };
+        yield return new InsertRoundTripCase(
+            "Time <- TimeOnly",
+            "Time",
+            name => new ArrayColumn<TimeOnly>(name, "Time", timesOfDay),
+            name => new ArrayColumn<int>(name, "Time", new[] { 0, (12 * 3600) + (34 * 60) + 56, (23 * 3600) + (59 * 60) + 59 }),
+            TimeSettings);
+
+        var timesOfDay64 = new[] { new TimeOnly(0, 0, 0), new TimeOnly(1, 2, 3, 456), TimeOnly.MaxValue };
+        yield return new InsertRoundTripCase(
+            "Time64(3) <- TimeOnly",
+            "Time64(3)",
+            name => new ArrayColumn<TimeOnly>(name, "Time64(3)", timesOfDay64),
+            name => new ArrayColumn<long>(name, "Time64(3)", new[] { 0L, (((1 * 3600) + (2 * 60) + 3) * 1000L) + 456, 86_399_999L }),
+            TimeSettings);
         yield return Time64Counts("Time64(9)", TimeSettings, 0L, 3_723_123_456_789L, -3_723_123_456_789L);
 
         // Time/Time64 also accept a TimeSpan on write, truncating toward zero at the column's scale. The read-back
@@ -359,6 +378,23 @@ public sealed class InsertRoundTripCase
         yield return NullableValues<float>("BFloat16", BFloat16Settings, 0f, null, 1f, -2f, float.NaN, null, float.PositiveInfinity);
         yield return NullableValues<int>("Time", TimeSettings, 0, null, (12 * 3600) + (34 * 60) + 56);
         yield return NullableValues<long>("Time64(3)", TimeSettings, 0L, null, (((1 * 3600) + (2 * 60) + 3) * 1000L) + 456);
+
+        // The TimeOnly spelling through the null wrapper, where the placeholder a null row contributes has to be
+        // one the inner codec offers for that write type.
+        var nullableTimesOfDay = new TimeOnly?[] { new TimeOnly(1, 2, 3), null, new TimeOnly(0, 0, 0) };
+        yield return new InsertRoundTripCase(
+            "Nullable(Time) <- TimeOnly?",
+            "Nullable(Time)",
+            name => new ArrayColumn<TimeOnly?>(name, "Nullable(Time)", nullableTimesOfDay),
+            name => new ArrayColumn<int?>(name, "Nullable(Time)", new int?[] { (1 * 3600) + (2 * 60) + 3, null, 0 }),
+            TimeSettings);
+
+        yield return new InsertRoundTripCase(
+            "Nullable(Time64(3)) <- TimeOnly?",
+            "Nullable(Time64(3))",
+            name => new ArrayColumn<TimeOnly?>(name, "Nullable(Time64(3))", nullableTimesOfDay),
+            name => new ArrayColumn<long?>(name, "Nullable(Time64(3))", new long?[] { (((1 * 3600) + (2 * 60) + 3) * 1000L), null, 0L }),
+            TimeSettings);
 
         yield return NullableStrings("hello", null, "world", string.Empty);
         yield return NullableStrings(null, null); // every row null

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
@@ -121,17 +121,22 @@ public sealed class InsertRoundTripCase
 
         // DateTime reads back as the raw UInt32 epoch seconds. Insert as DateTime (UTC) and expect the epoch
         // seconds of the same instants, regardless of the timezone the server presents.
+        // 2100 is past the signed-32-bit second count that a narrowing cast would wrap, and the last value is the
+        // largest a DateTime column holds: 2106-02-07 06:28:15 UTC, uint.MaxValue seconds.
         yield return DateTimes(
             "DateTime",
             new DateTime(1988, 8, 28, 11, 22, 33, DateTimeKind.Utc),
             new DateTime(2024, 1, 15, 10, 30, 0, DateTimeKind.Utc),
-            DateTime.UnixEpoch);
+            DateTime.UnixEpoch,
+            new DateTime(2100, 6, 15, 12, 0, 0, DateTimeKind.Utc),
+            DateTime.UnixEpoch.AddSeconds(uint.MaxValue));
 
         // A DateTimeOffset with a non-UTC offset survives as the same instant (i.e. the same epoch seconds).
         var dateTimeOffsets = new[]
         {
             new DateTimeOffset(2024, 1, 15, 10, 30, 0, TimeSpan.FromHours(5)),
             new DateTimeOffset(1988, 8, 28, 11, 22, 33, TimeSpan.FromHours(-8)),
+            new DateTimeOffset(2100, 6, 15, 12, 0, 0, TimeSpan.FromHours(5)),
         };
         yield return new InsertRoundTripCase(
             "DateTime <- DateTimeOffset",
@@ -143,7 +148,10 @@ public sealed class InsertRoundTripCase
         // DateTime64 surfaces as the raw Int64 count at the column's scale, so it retains the exact wire value at
         // any scale. Scale 9 (nanoseconds) is finer than a .NET tick, proving precision no DateTimeOffset can hold.
         yield return DateTime64s("DateTime64(3)", 0L, 1_700_000_000_123L, -6_000_000_000_000L);
-        yield return DateTime64s("DateTime64(9)", 0L, 1_700_000_000_123_456_789L, -1_000_000_001L);
+
+        // Both Int64 ends, which at scale 9 are the instants the type stops at (2262-04-11 23:47:16.854775807 and
+        // its negative mirror). The count is the wire value, so these pin the limbs of the widest column value.
+        yield return DateTime64s("DateTime64(9)", 0L, 1_700_000_000_123_456_789L, -1_000_000_001L, long.MaxValue, long.MinValue);
 
         // DateTime64 also accepts a DateTimeOffset on write, converting the instant to the column's scale; the
         // read-back is still the raw count, so at scale 3 the expected column carries epoch milliseconds. The
@@ -152,12 +160,25 @@ public sealed class InsertRoundTripCase
         {
             DateTimeOffset.FromUnixTimeMilliseconds(1_700_000_000_123),
             new DateTimeOffset(2024, 1, 15, 10, 30, 0, TimeSpan.FromHours(5)),
+            new DateTimeOffset(2299, 12, 31, 23, 59, 59, TimeSpan.Zero),
         };
         yield return new InsertRoundTripCase(
             "DateTime64(3) <- DateTimeOffset",
             "DateTime64(3)",
             name => new ArrayColumn<DateTimeOffset>(name, "DateTime64(3)", dateTime64Offsets),
             name => new ArrayColumn<long>(name, "DateTime64(3)", Array.ConvertAll(dateTime64Offsets, o => o.ToUnixTimeMilliseconds())),
+            settings: null);
+
+        // The last instant a scale-9 column can take from a DateTimeOffset: .NET ticks are 100 ns, so the finest
+        // value expressible is 2262-04-11 23:47:16.8547758, and scaling it up lands 7 nanoseconds short of
+        // Int64.MaxValue. The expected count is written out rather than computed, so the multiply under test is not
+        // also the oracle. One tick more overflows, which DateTime64ColumnCodecTests covers.
+        var dateTime64NanosecondOffsets = new[] { new DateTimeOffset(2262, 4, 11, 23, 47, 16, TimeSpan.Zero).AddTicks(8_547_758) };
+        yield return new InsertRoundTripCase(
+            "DateTime64(9) <- DateTimeOffset [latest instant]",
+            "DateTime64(9)",
+            name => new ArrayColumn<DateTimeOffset>(name, "DateTime64(9)", dateTime64NanosecondOffsets),
+            name => new ArrayColumn<long>(name, "DateTime64(9)", new[] { 9_223_372_036_854_775_800L }),
             settings: null);
 
         yield return Uuids("UUID", Guid.Empty, new Guid("00112233-4455-6677-8899-aabbccddeeff"), new Guid("ffffffff-ffff-ffff-ffff-ffffffffffff"));
@@ -244,9 +265,10 @@ public sealed class InsertRoundTripCase
         yield return NullableDateTimes(
             new DateTimeOffset(2024, 1, 15, 10, 30, 0, TimeSpan.Zero),
             null,
-            new DateTimeOffset(1988, 8, 28, 11, 22, 33, TimeSpan.Zero));
+            new DateTimeOffset(1988, 8, 28, 11, 22, 33, TimeSpan.Zero),
+            DateTimeOffset.UnixEpoch.AddSeconds(uint.MaxValue));
         yield return NullableDateTime64s(3, 0L, null, 1_700_000_000_123L, null);
-        yield return NullableDateTime64s(9, 1_700_000_000_123_456_789L, null, -1_000_000_001L);
+        yield return NullableDateTime64s(9, 1_700_000_000_123_456_789L, null, -1_000_000_001L, long.MaxValue);
 
         // Nullable re-offers every CLR write spelling the bare inner accepts, each with its own-typed null
         // placeholder — so Nullable(DateTime) takes DateTimeOffset? or DateTime?, and Nullable(DateTime64) takes
@@ -325,9 +347,9 @@ public sealed class InsertRoundTripCase
 
         // Array(DateTime) reads back raw uint epoch seconds; Array(DateTime64) raw long counts at the column scale.
         // The shared corpus uses canonical CLR types; lifted types have focused coverage.
-        yield return Arrays<uint>("DateTime", new uint[] { 1_700_000_000, 0 }, Array.Empty<uint>());
+        yield return Arrays<uint>("DateTime", new uint[] { 1_700_000_000, 0, uint.MaxValue }, Array.Empty<uint>());
         yield return Arrays<long>("DateTime64(3)", new[] { 0L, 1_700_000_000_123L });
-        yield return Arrays<long>("DateTime64(9)", new[] { 1_700_000_000_123_456_789L }, Array.Empty<long>());
+        yield return Arrays<long>("DateTime64(9)", new[] { 1_700_000_000_123_456_789L, long.MaxValue, long.MinValue }, Array.Empty<long>());
 
         // The dense shape built by a caller rather than received from a read: flat elements plus per-row offsets,
         // which is what the codec writes with no rebuilding. Same rows as the jagged Array(UInt32) case above.

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
@@ -108,6 +108,11 @@ public sealed class InsertRoundTripCase
         // so the label a caller writes has to be the decoded one, and only a server proves the two agree.
         yield return EnumLabels(@"Enum8('a\nb' = 1, 't\tab' = 2)", new sbyte[] { 1, 2 }, "a\nb", "t\tab");
 
+        // Labels holding the grammar's own separators: a comma, an escaped quote, and an equals sign. The member
+        // splitter must not cut on the comma or end the token at the quote, and ToString() has to re-emit the raw
+        // spelling into the insert header while ToOrdinal looks the decoded label up.
+        yield return EnumLabels(@"Enum8('a,b' = 1, 'c\'d' = 2, 'e = f' = 3)", new sbyte[] { 1, 2, 3 }, "a,b", "c'd", "e = f");
+
         // And through the wrappers, where the shape has to survive composition: the nullable substitute needs a
         // placeholder label for its null rows, and the array path flattens the labels before the enum sees them.
         yield return NullableEnumLabels("Enum8('a' = -1, 'b' = 127)", new sbyte?[] { -1, null, 127 }, "a", null, "b");

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
@@ -87,6 +87,10 @@ public sealed class InsertRoundTripCase
         yield return EnumLabels("Enum8('a' = -1, 'b' = 127)", new sbyte[] { -1, 127 }, "a", "b");
         yield return EnumLabels("Enum16('x' = -32768, 'y' = 32767)", new short[] { -32768, 32767 }, "x", "y");
 
+        // A label carrying an escape. The header spells it 'a\nb' — on 26.6 the label's stored bytes are 61 0A 62 —
+        // so the label a caller writes has to be the decoded one, and only a server proves the two agree.
+        yield return EnumLabels(@"Enum8('a\nb' = 1, 't\tab' = 2)", new sbyte[] { 1, 2 }, "a\nb", "t\tab");
+
         // And through the wrappers, where the shape has to survive composition: the nullable substitute needs a
         // placeholder label for its null rows, and the array path flattens the labels before the enum sees them.
         yield return NullableEnumLabels("Enum8('a' = -1, 'b' = 127)", new sbyte?[] { -1, null, 127 }, "a", null, "b");

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
@@ -294,16 +294,19 @@ public sealed class InsertRoundTripCase
         // project the inner column before the state-prefix phase: the tuple builds its write state there and
         // needs a column of (byte, string), not of (byte, string)?. A null row beside a row of inner defaults
         // keeps the two distinguishable.
-        yield return Same(
-            "Nullable(Tuple(UInt8, String))",
-            "Nullable(Tuple(UInt8, String))",
-            name => new ArrayColumn<(byte, string)?>(name, "Nullable(Tuple(UInt8, String))", new (byte, string)?[]
-            {
-                ((byte)7, "x"),
-                null,
-                ((byte)0, string.Empty),
-            }),
-            NullableTupleSettings);
+        if (TcpServerFeatures.Has(TcpFeature.NullableTuple))
+        {
+            yield return Same(
+                "Nullable(Tuple(UInt8, String))",
+                "Nullable(Tuple(UInt8, String))",
+                name => new ArrayColumn<(byte, string)?>(name, "Nullable(Tuple(UInt8, String))", new (byte, string)?[]
+                {
+                    ((byte)7, "x"),
+                    null,
+                    ((byte)0, string.Empty),
+                }),
+                NullableTupleSettings);
+        }
         yield return NullableValues<sbyte>("Enum8('a' = -1, 'b' = 127)", -1, null, 127);
         yield return NullableValues<short>("Enum16('x' = -32768, 'y' = 32767)", -32768, null, 32767);
         yield return NullableValues<DateOnly>("Date", new DateOnly(1970, 1, 1), null, new DateOnly(2149, 6, 6));
@@ -1595,16 +1598,19 @@ public sealed class InsertRoundTripCase
         // Nullable over an alias for a tuple: the null map sits outside, and the inner tuple is still resolved
         // from the alias name. The bare Nullable(Tuple(...)) case is in the nullable section above; this one adds
         // the alias.
-        yield return Same(
-            "Nullable(Point)",
-            "Nullable(Point)",
-            name => new ArrayColumn<(double, double)?>(name, "Nullable(Point)", new (double, double)?[]
-            {
-                (1.5d, -2.5d),
-                null,
-                (0d, 0d),
-            }),
-            NullableTupleSettings);
+        if (TcpServerFeatures.Has(TcpFeature.NullableTuple))
+        {
+            yield return Same(
+                "Nullable(Point)",
+                "Nullable(Point)",
+                name => new ArrayColumn<(double, double)?>(name, "Nullable(Point)", new (double, double)?[]
+                {
+                    (1.5d, -2.5d),
+                    null,
+                    (0d, 0d),
+                }),
+                NullableTupleSettings);
+        }
 
         // Geometry is a Variant over the six aliases, and the column header carries only "Geometry", so the client
         // expands it and picks the discriminator order itself. A row against each of the six discriminators, plus a

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
@@ -289,6 +289,21 @@ public sealed class InsertRoundTripCase
         yield return NullableValues<float>("Float32", 0f, null, -1.5f, float.MaxValue, float.NaN, null, float.PositiveInfinity, -0f);
         yield return NullableValues<double>("Float64", 1.5, null, -1.5e100, null, double.NaN, double.NegativeInfinity, -0d);
         yield return NullableValues<bool>("Bool", true, null, false);
+
+        // Nullable over a composite, which the server allows for Tuple behind a setting. The write path has to
+        // project the inner column before the state-prefix phase: the tuple builds its write state there and
+        // needs a column of (byte, string), not of (byte, string)?. A null row beside a row of inner defaults
+        // keeps the two distinguishable.
+        yield return Same(
+            "Nullable(Tuple(UInt8, String))",
+            "Nullable(Tuple(UInt8, String))",
+            name => new ArrayColumn<(byte, string)?>(name, "Nullable(Tuple(UInt8, String))", new (byte, string)?[]
+            {
+                ((byte)7, "x"),
+                null,
+                ((byte)0, string.Empty),
+            }),
+            NullableTupleSettings);
         yield return NullableValues<sbyte>("Enum8('a' = -1, 'b' = 127)", -1, null, 127);
         yield return NullableValues<short>("Enum16('x' = -32768, 'y' = 32767)", -32768, null, 32767);
         yield return NullableValues<DateOnly>("Date", new DateOnly(1970, 1, 1), null, new DateOnly(2149, 6, 6));
@@ -1514,8 +1529,8 @@ public sealed class InsertRoundTripCase
         // The geo aliases name structures already covered above — Point is Tuple(Float64, Float64) and the rest
         // are arrays over it — so what these cases prove is not the layout but that the alias resolves to it: the
         // server puts "Point"/"Ring"/… in the column header, and the client has to accept that name in both
-        // directions. Like Array and Tuple, they take no Nullable case: Nullable(Point) needs
-        // enable_nullable_tuple_type and the server rejects a Nullable array outright.
+        // directions. Nullable(Point) is covered below, behind enable_nullable_tuple_type; the array-shaped
+        // aliases take no Nullable case, the server rejecting a Nullable array outright.
         // Supplied as a flat column of tuples rather than a dense TupleColumn: that column's convenience
         // constructor derives its children's types by re-parsing its own type name, which an alias is not. The
         // dense shape is still covered — the read comes back as one, and the dense-readback case re-inserts it.
@@ -1577,11 +1592,19 @@ public sealed class InsertRoundTripCase
         // whole column type.
         yield return Arrays("Point", new[] { (0d, 0d), (1d, 2d) }, Array.Empty<(double, double)>());
 
-        // No Nullable(Point) case, though the server accepts the type behind enable_nullable_tuple_type and this
-        // client reads it correctly. Writing it hits a pre-existing defect that has nothing to do with geo:
-        // NullableColumnCodec forwards the *outer* column to the inner's state-prefix phase, and TupleColumnCodec
-        // builds its write state there, so it is handed a column of (double, double)? where it needs
-        // (double, double). Any Nullable(Tuple(...)) fails the same way. Tracked as an I6 residual.
+        // Nullable over an alias for a tuple: the null map sits outside, and the inner tuple is still resolved
+        // from the alias name. The bare Nullable(Tuple(...)) case is in the nullable section above; this one adds
+        // the alias.
+        yield return Same(
+            "Nullable(Point)",
+            "Nullable(Point)",
+            name => new ArrayColumn<(double, double)?>(name, "Nullable(Point)", new (double, double)?[]
+            {
+                (1.5d, -2.5d),
+                null,
+                (0d, 0d),
+            }),
+            NullableTupleSettings);
 
         // Geometry is a Variant over the six aliases, and the column header carries only "Geometry", so the client
         // expands it and picks the discriminator order itself. A row against each of the six discriminators, plus a
@@ -2058,6 +2081,12 @@ public sealed class InsertRoundTripCase
 
         return values;
     }
+
+    /// <summary>Enables Nullable over a Tuple, which the server refuses by default.</summary>
+    private static readonly IReadOnlyDictionary<string, string> NullableTupleSettings = new Dictionary<string, string>(StringComparer.Ordinal)
+    {
+        ["enable_nullable_tuple_type"] = "1",
+    };
 
     /// <summary>Enables the experimental BFloat16 type for the round-trip.</summary>
     private static readonly IReadOnlyDictionary<string, string> BFloat16Settings = new Dictionary<string, string>(StringComparer.Ordinal)

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
@@ -96,9 +96,11 @@ public sealed class InsertRoundTripCase
         yield return NullableEnumLabels("Enum8('a' = -1, 'b' = 127)", new sbyte?[] { -1, null, 127 }, "a", null, "b");
         yield return ArrayEnumLabels("Enum8('a' = -1, 'b' = 127)", new[] { new sbyte[] { -1, 127 }, Array.Empty<sbyte>() }, new[] { "a", "b" }, Array.Empty<string>());
 
-        // Floats and Bool are direct blittable maps, so the primitive factory covers them.
-        yield return Primitive("Float32", new[] { 0f, 1.5f, -1.5f, float.MinValue, float.MaxValue });
-        yield return Primitive("Float64", new[] { 0d, 1.5, -1.5e100, double.MinValue, double.MaxValue });
+        // Floats and Bool are direct blittable maps, so the primitive factory covers them. NaN and the infinities
+        // are the patterns a conversion through a decimal text form would lose; signed zero rides along, and
+        // FloatSpecialValueIntegrationTests is where its sign is actually observable.
+        yield return Primitive("Float32", new[] { 0f, -0f, 1.5f, -1.5f, float.MinValue, float.MaxValue, float.NaN, float.PositiveInfinity, float.NegativeInfinity });
+        yield return Primitive("Float64", new[] { 0d, -0d, 1.5, -1.5e100, double.MinValue, double.MaxValue, double.NaN, double.PositiveInfinity, double.NegativeInfinity });
         yield return Primitive("Bool", new[] { false, true, true, false });
 
         yield return Strings("String", string.Empty, "hello", "héllo✓", "a\0b", new string('x', 500));
@@ -178,7 +180,7 @@ public sealed class InsertRoundTripCase
         yield return Primitive("IntervalDay", new[] { 0L, 7L, -30L });
 
         // Newer/experimental server types: enable their flag on the round-trip
-        yield return BFloat16s("BFloat16", BFloat16Settings, 0f, 1f, -2f, 0.5f, 100f);
+        yield return BFloat16s("BFloat16", BFloat16Settings, 0f, -0f, 1f, -2f, 0.5f, 100f, float.NaN, float.PositiveInfinity, float.NegativeInfinity);
         // Time surfaces as the raw Int32 seconds; Time64 as the raw Int64 count at the column's scale. The
         // inserted values are the exact wire values, returned verbatim.
         yield return TimeSeconds("Time", TimeSettings, 0, (12 * 3600) + (34 * 60) + 56, -((1 * 3600) + (2 * 60) + 3));
@@ -222,8 +224,10 @@ public sealed class InsertRoundTripCase
         yield return NullableValues<Int128>("Int128", Int128.MinValue, null, Int128.MaxValue);
         yield return NullableValues<UInt256>("UInt256", UInt256.Zero, null, UInt256.FromBigInteger(System.Numerics.BigInteger.Pow(2, 200)));
         yield return NullableValues<Int256>("Int256", Int256.FromBigInteger(-System.Numerics.BigInteger.Pow(2, 200)), null, Int256.Zero);
-        yield return NullableValues<float>("Float32", 0f, null, -1.5f, float.MaxValue);
-        yield return NullableValues<double>("Float64", 1.5, null, -1.5e100, null);
+        // A special next to a null, because the null map and the value run are written separately: the placeholder
+        // a null row contributes must not be mistaken for the NaN beside it, or the other way round.
+        yield return NullableValues<float>("Float32", 0f, null, -1.5f, float.MaxValue, float.NaN, null, float.PositiveInfinity, -0f);
+        yield return NullableValues<double>("Float64", 1.5, null, -1.5e100, null, double.NaN, double.NegativeInfinity, -0d);
         yield return NullableValues<bool>("Bool", true, null, false);
         yield return NullableValues<sbyte>("Enum8('a' = -1, 'b' = 127)", -1, null, 127);
         yield return NullableValues<short>("Enum16('x' = -32768, 'y' = 32767)", -32768, null, 32767);
@@ -273,7 +277,7 @@ public sealed class InsertRoundTripCase
             settings: null);
 
         // Experimental server types: enable their flag on the round-trip (same as their non-nullable cases).
-        yield return NullableValues<float>("BFloat16", BFloat16Settings, 0f, null, 1f, -2f);
+        yield return NullableValues<float>("BFloat16", BFloat16Settings, 0f, null, 1f, -2f, float.NaN, null, float.PositiveInfinity);
         yield return NullableValues<int>("Time", TimeSettings, 0, null, (12 * 3600) + (34 * 60) + 56);
         yield return NullableValues<long>("Time64(3)", TimeSettings, 0L, null, (((1 * 3600) + (2 * 60) + 3) * 1000L) + 456);
 
@@ -311,8 +315,8 @@ public sealed class InsertRoundTripCase
         yield return Arrays("Int256", new[] { Int256.FromBigInteger(-System.Numerics.BigInteger.Pow(2, 200)), Int256.Zero });
         yield return Arrays("Enum8('a' = -1, 'b' = 127)", new sbyte[] { -1, 127 }, Array.Empty<sbyte>());
         yield return Arrays("Enum16('x' = -32768, 'y' = 32767)", new short[] { -32768, 32767 });
-        yield return Arrays("Float32", new[] { 0f, 1.5f, -1.5f, float.MaxValue }, Array.Empty<float>());
-        yield return Arrays("Float64", new[] { 0d, -1.5e100, double.MaxValue });
+        yield return Arrays("Float32", new[] { 0f, 1.5f, -1.5f, float.MaxValue }, Array.Empty<float>(), new[] { float.NaN, float.PositiveInfinity, float.NegativeInfinity, -0f });
+        yield return Arrays("Float64", new[] { 0d, -1.5e100, double.MaxValue }, new[] { double.NaN, double.PositiveInfinity, double.NegativeInfinity, -0d });
         yield return Arrays("Bool", new[] { true, false, true }, Array.Empty<bool>());
         yield return Arrays("String", new[] { "a", "bb" }, Array.Empty<string>(), new[] { string.Empty, "héllo✓" });
         yield return Arrays<byte[]>("FixedString(4)", new[] { new byte[] { 1, 2, 3, 4 }, new byte[] { 0xFF, 0, 0xFF, 0 } }, Array.Empty<byte[]>());
@@ -342,7 +346,7 @@ public sealed class InsertRoundTripCase
         yield return Arrays("IntervalDay", new[] { 7L, -30L });
 
         // Experimental server types: enable their flag on the round-trip (same as their bare cases).
-        yield return Arrays("BFloat16", BFloat16Settings, new[] { 0f, 1f, -2f, 0.5f }, Array.Empty<float>());
+        yield return Arrays("BFloat16", BFloat16Settings, new[] { 0f, 1f, -2f, 0.5f }, Array.Empty<float>(), new[] { float.NaN, float.PositiveInfinity, float.NegativeInfinity, -0f });
         yield return Arrays("Time", TimeSettings, new[] { 0, (12 * 3600) + (34 * 60) + 56 }, Array.Empty<int>());
         yield return Arrays("Time64(3)", TimeSettings, new[] { 0L, (((1 * 3600) + (2 * 60) + 3) * 1000L) + 456 });
 
@@ -1806,6 +1810,8 @@ public sealed class InsertRoundTripCase
     }
 
     // BFloat16 widens to float; values are chosen to be exactly representable so the narrow-on-write is lossless.
+    // NaN and the infinities qualify: truncating the low 16 bits keeps an all-ones exponent, and the quiet bit is
+    // the mantissa's top bit, which stays.
     private static InsertRoundTripCase BFloat16s(string clickHouseType, IReadOnlyDictionary<string, string> settings, params float[] values)
         => Same($"{clickHouseType} [{values.Length} rows]", clickHouseType, name => new ArrayColumn<float>(name, clickHouseType, values), settings);
 

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
@@ -76,8 +76,25 @@ public sealed class InsertRoundTripCase
         yield return Primitive("Int64", new[] { long.MinValue, -1, 0, long.MaxValue });
         yield return Primitive("UInt128", new[] { UInt128.Zero, UInt128.One, UInt128.MaxValue });
         yield return Primitive("Int128", new[] { Int128.MinValue, -Int128.One, Int128.Zero, Int128.MaxValue });
-        yield return Primitive("UInt256", new[] { UInt256.Zero, UInt256.FromBigInteger(1), UInt256.FromBigInteger(System.Numerics.BigInteger.Pow(2, 200)) });
-        yield return Primitive("Int256", new[] { Int256.FromBigInteger(-System.Numerics.BigInteger.Pow(2, 200)), Int256.FromBigInteger(-1), Int256.Zero, Int256.FromBigInteger(System.Numerics.BigInteger.Pow(2, 200)) });
+        // 2^200 pins the limb order; the values after it pin the top limb and the sign bit, which everything
+        // below 2^255 leaves clear.
+        yield return Primitive("UInt256", new[]
+        {
+            UInt256.Zero,
+            UInt256.FromBigInteger(1),
+            UInt256.FromBigInteger(System.Numerics.BigInteger.Pow(2, 200)),
+            UInt256.FromBigInteger(System.Numerics.BigInteger.Pow(2, 255)),
+            UInt256.FromBigInteger(System.Numerics.BigInteger.Pow(2, 256) - 1),
+        });
+        yield return Primitive("Int256", new[]
+        {
+            Int256.FromBigInteger(-System.Numerics.BigInteger.Pow(2, 200)),
+            Int256.FromBigInteger(-1),
+            Int256.Zero,
+            Int256.FromBigInteger(System.Numerics.BigInteger.Pow(2, 200)),
+            Int256.FromBigInteger(-System.Numerics.BigInteger.Pow(2, 255)),
+            Int256.FromBigInteger(System.Numerics.BigInteger.Pow(2, 255) - 1),
+        });
 
         // Enum columns are inserted and read as their raw underlying ordinals; the ordinals must be declared members.
         yield return Primitive("Enum8('a' = -1, 'b' = 127)", new sbyte[] { -1, 127 });
@@ -184,13 +201,30 @@ public sealed class InsertRoundTripCase
         yield return Uuids("UUID", Guid.Empty, new Guid("00112233-4455-6677-8899-aabbccddeeff"), new Guid("ffffffff-ffff-ffff-ffff-ffffffffffff"));
 
         yield return IpAddresses("IPv4", "0.0.0.0", "127.0.0.1", "192.168.1.1", "255.255.255.255");
-        yield return IpAddresses("IPv6", "::", "::1", "2001:db8::1", "fe80::1");
+        yield return IpAddresses("IPv6", "::", "::1", "2001:db8::1", "fe80::1", "2001:db8:85a3:8d3:1319:8a2e:370:7348");
+
+        // An IPv4 address written to an IPv6 column comes back in its IPv4-mapped form, so the insert value and
+        // the expected value differ. Nothing else in the corpus reads that mapping back off a server.
+        var mappedIpv4 = new[] { IPAddress.Parse("192.168.1.1"), IPAddress.Parse("0.0.0.0") };
+        yield return new InsertRoundTripCase(
+            "IPv6 <- IPv4",
+            "IPv6",
+            name => new ArrayColumn<IPAddress>(name, "IPv6", mappedIpv4),
+            name => new ArrayColumn<IPAddress>(name, "IPv6", new[] { IPAddress.Parse("::ffff:192.168.1.1"), IPAddress.Parse("::ffff:0.0.0.0") }),
+            settings: null);
 
         // Decimal32/64 surface as System.Decimal; Decimal128/256 as ClickHouseTcpDecimal.
         yield return Decimals("Decimal(9, 2)", 0m, 1.23m, -1.23m, 9999999.99m);
         yield return Decimals("Decimal(18, 4)", 0m, 12345.6789m, -12345.6789m, 99999999999999.9999m);
         yield return WideDecimals("Decimal(38, 10)", "0", "12345.6789", "-98765.4321");
         yield return WideDecimals("Decimal(76, 20)", "0", "1.00000000000000000001", "-1.00000000000000000001");
+
+        // Scale 0 takes neither of FixedPointScaling.ShiftDecimalPlaces's branches, and scale == precision leaves
+        // no integer part at all. The last case holds the largest magnitude a Decimal(76, 0) can, which pins the
+        // top limb of the 256-bit mantissa.
+        yield return WideDecimals("Decimal(38, 0)", "0", "-1", "99999999999999999999999999999999999999");
+        yield return WideDecimals("Decimal(38, 38)", "0.00000000000000000000000000000000000001", "-0.99999999999999999999999999999999999999");
+        yield return WideDecimals("Decimal(76, 0)", "0", "9999999999999999999999999999999999999999999999999999999999999999999999999999", "-9999999999999999999999999999999999999999999999999999999999999999999999999999");
 
         // The DecimalN(S) alias spellings resolve to the same codecs as Decimal(P, S); one case proves the server
         // round-trips the alias type name as declared.
@@ -913,9 +947,55 @@ public sealed class InsertRoundTripCase
             name => new ArrayColumn<uint>(name, "LowCardinality(DateTime)", new uint[] { 1_700_000_000, 1_700_000_000, 599_916_153, 0, 1_700_000_000, 599_916_153 }),
             LowCardinalitySettings);
 
+        // The dictionary is a bare column of the inner type, so its element width is the inner's and not the key
+        // stream's. The cases above are all four bytes wide; these are one, eight and sixteen.
+        yield return Same(
+            "LowCardinality(UInt8)",
+            "LowCardinality(UInt8)",
+            name => PrimitiveColumn<byte>.FromValues(name, "LowCardinality(UInt8)", new byte[] { 3, 3, 0, 255, 3 }),
+            LowCardinalitySettings);
+
+        yield return Same(
+            "LowCardinality(Int64)",
+            "LowCardinality(Int64)",
+            name => PrimitiveColumn<long>.FromValues(name, "LowCardinality(Int64)", new[] { long.MinValue, 0L, long.MaxValue, 0L }),
+            LowCardinalitySettings);
+
+        yield return Same(
+            "LowCardinality(UUID)",
+            "LowCardinality(UUID)",
+            name => new ArrayColumn<Guid>(name, "LowCardinality(UUID)", new[]
+            {
+                Guid.Empty,
+                new Guid("00112233-4455-6677-8899-aabbccddeeff"),
+                Guid.Empty,
+            }),
+            LowCardinalitySettings);
+
         // Array(LowCardinality(String)) flattens its jagged rows into one values stream handed to the
         // low-cardinality codec; empty rows and repeated values ride along.
         yield return Arrays("LowCardinality(String)", new[] { "a", "b" }, Array.Empty<string>(), new[] { "a", "a", "c" });
+
+        // Two levels of offsets over a dictionary-bearing leaf, where the flattening view is built over a view.
+        // The deep-nesting ladder uses prefix-free leaves only.
+        yield return Same(
+            "Array(Array(LowCardinality(String)))",
+            "Array(Array(LowCardinality(String)))",
+            name => new ArrayColumn<string[][]>(name, "Array(Array(LowCardinality(String)))", new[]
+            {
+                new[] { new[] { "a", "b" }, Array.Empty<string>(), new[] { "a" } },
+                Array.Empty<string[]>(),
+                new[] { new[] { "c", "a", "c" } },
+            }));
+
+        yield return Same(
+            "Array(Array(LowCardinality(Nullable(String))))",
+            "Array(Array(LowCardinality(Nullable(String))))",
+            name => new ArrayColumn<string[][]>(name, "Array(Array(LowCardinality(Nullable(String))))", new[]
+            {
+                new[] { new[] { "a", null }, Array.Empty<string>() },
+                new[] { new string[] { null, null }, new[] { "a", "b" } },
+            }));
 
         // A dictionary past 255 entries forces the client to widen the key stream from UInt8 to UInt16
         // (SelectKeyWidthCode switches on dictSize < byte.MaxValue). Unit tests assert the client picks that
@@ -1225,6 +1305,22 @@ public sealed class InsertRoundTripCase
             }),
             DynamicSettings);
 
+        // The key column has its own state, built separately from the value's: MapShape.WriteStatePrefix writes
+        // the key's prefix first. Every other map case has a prefix-free key, so nothing reached that order.
+        yield return Maps<string, byte>(
+            "LowCardinality(String)",
+            "UInt8",
+            Pairs<string, byte>(("a", 1), ("b", 2)),
+            Array.Empty<KeyValuePair<string, byte>>(),
+            Pairs<string, byte>(("a", 3)));
+
+        // A composite key, where the key column is itself two child columns.
+        yield return Maps<(int, int), int>(
+            "Tuple(Int32, Int32)",
+            "Int32",
+            Pairs<(int, int), int>(((1, 2), 3), ((-1, 0), 4)),
+            Array.Empty<KeyValuePair<(int, int), int>>());
+
         // Map(String, Dynamic): a Dynamic value column inside a map, flattened like Array(Tuple(String, Dynamic)).
         yield return Maps<string, object>("String", "Dynamic", DynamicSettings,
             Pairs<string, object>(("a", 1UL), ("b", "x")),
@@ -1526,6 +1622,18 @@ public sealed class InsertRoundTripCase
                     Ramp(17, i => i % 2 == 0 ? float.MaxValue : float.MinValue),
                 }));
 
+            // An embedding-shaped width: 768 is the dimension of a common sentence embedding, and the widest the
+            // suite reaches otherwise is 17. Every row spans 96 bytes per plane, so QBitLayout's stride arithmetic
+            // and the dense plane copy are exercised at a size where an off-by-one row stride cannot look right.
+            yield return Same(
+                "QBit(Float32, 768)",
+                "QBit(Float32, 768)",
+                name => new ArrayColumn<float[]>(name, "QBit(Float32, 768)", new[]
+                {
+                    Ramp(768, i => (i * 0.25f) - 96f),
+                    Ramp(768, i => i % 3 == 0 ? float.MaxValue : (i % 3 == 1 ? -0f : float.NaN)),
+                }));
+
             yield return Same(
                 "QBit(Float64, 17)",
                 "QBit(Float64, 17)",
@@ -1627,6 +1735,18 @@ public sealed class InsertRoundTripCase
                 new ulong[] { 1, 2, 3 },
                 Array.Empty<ulong>(),
             }));
+
+        // A prefix-carrying inner: the alias has to echo the type name into the insert header exactly as declared
+        // and still write JSON's version word, which the four cases above (prefix-free inners) cannot show.
+        yield return Same(
+            "SimpleAggregateFunction(anyLast, JSON)",
+            "SimpleAggregateFunction(anyLast, JSON)",
+            name => new ArrayColumn<string>(name, "SimpleAggregateFunction(anyLast, JSON)", new[]
+            {
+                "{\"a\":1}",
+                "{}",
+            }),
+            JsonSettings);
 
         // A parameterized function keeps its parameters in the type name, on the wire as well as in the DDL. It
         // parses as one node carrying its own arguments, so the type still has exactly two arguments and the

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
@@ -1179,6 +1179,15 @@ public sealed class InsertRoundTripCase
             Array.Empty<object>(),
             new object[] { "b", 2UL, null });
 
+        // Array(Dynamic) with every row empty: the inner Dynamic has no rows while the block has, so the array
+        // still writes and reads the Dynamic prefix, and the zero-row body path runs with the prefix consumed
+        // rather than skipped. The only all-empty case otherwise is Array(UInt32), a leaf that carries no prefix.
+        yield return Same(
+            "Array(Dynamic) [every row empty]",
+            "Array(Dynamic)",
+            name => new ArrayColumn<object[]>(name, "Array(Dynamic)", new[] { Array.Empty<object>(), Array.Empty<object>() }),
+            DynamicSettings);
+
         // Tuple(Dynamic, String): a Dynamic element inside a tuple. Each element position is its own child column,
         // so the Dynamic child's type list (state prefix) is written from its own projected values.
         yield return Same(
@@ -1310,6 +1319,14 @@ public sealed class InsertRoundTripCase
         // Array(JSON): JSON carries a state prefix, so the array has to emit the version once ahead of its offsets
         // rather than treat JSON as a flat leaf. Empty rows and an all-empty column ride along.
         yield return Arrays("JSON", JsonSettings, new[] { "{\"a\":1}", "{}" }, Array.Empty<string>(), new[] { "{\"b\":\"hi\"}" });
+
+        // Array(JSON) with every row empty: the same shape as the all-empty Array(Dynamic) case, for the codec
+        // whose prefix is a version word rather than a type list.
+        yield return Same(
+            "Array(JSON) [every row empty]",
+            "Array(JSON)",
+            name => new ArrayColumn<string[]>(name, "Array(JSON)", new[] { Array.Empty<string>(), Array.Empty<string>() }),
+            JsonSettings);
 
         // Tuple(JSON, String): each element is its own child column, so the JSON version is written from the
         // element the tuple projects.

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/InsertRoundTripCase.cs
@@ -509,6 +509,14 @@ public sealed class InsertRoundTripCase
             "Tuple(a Int32, b String)",
             name => new TupleColumn<int, string>(name, "Tuple(a Int32, b String)", new (int, string)[] { (1, "a"), (-5, string.Empty), (int.MaxValue, "héllo✓") }));
 
+        // A field name the server has to quote. The comma inside the backticks would split the argument list, and
+        // the type name the client rebuilds is what the insert header carries, so only a real server proves both
+        // spellings agree. The server also normalizes a double-quoted name into a backticked one.
+        yield return Same(
+            "Tuple(`a,b` Int64, c String) [quoted field name]",
+            "Tuple(`a,b` Int64, c String)",
+            name => new TupleColumn<long, string>(name, "Tuple(`a,b` Int64, c String)", new (long, string)[] { (1L, "x"), (long.MinValue, string.Empty) }));
+
         // A named tuple whose elements are themselves parametric — the name/type split must survive nesting.
         yield return Same(
             "Tuple(a Array(Int32), b Nullable(String)) [named parametric]",
@@ -666,6 +674,22 @@ public sealed class InsertRoundTripCase
                     new ArrayColumn<byte>(name, "UInt8", new byte[] { 1, 2, 3 }),
                     new ArrayColumn<string>(name, "String", new[] { "a", "b", "c" }),
                 },
+                new[] { 0, 2, 2, 3 },
+                rowCount: 3,
+                pooledOffsets: false,
+                ownsFields: false),
+            NestedSettings);
+
+        // A field name the server has to quote: it arrives backticked in the header, and the insert header has to
+        // carry the same spelling back or the server rejects the block.
+        yield return Same(
+            "Nested(`a b` UInt8) [quoted field name]",
+            "Nested(`a b` UInt8)",
+            name => new NestedColumn(
+                name,
+                "Nested(`a b` UInt8)",
+                new[] { "a b" },
+                new IColumn[] { new ArrayColumn<byte>(name, "UInt8", new byte[] { 1, 2, 3 }) },
                 new[] { 0, 2, 2, 3 },
                 rowCount: 3,
                 pooledOffsets: false,
@@ -1235,6 +1259,15 @@ public sealed class InsertRoundTripCase
                 "{\"a\":1,\"b\":\"\",\"x\":\"p\"}",
                 "{\"a\":2,\"b\":\"q\"}",
             }),
+            JsonSettings);
+
+        // A typed path the server has to quote. The paren inside the backticks would end the argument list early,
+        // and the read fails on the header before a row decodes, so this case only ever fails at the header.
+        yield return new InsertRoundTripCase(
+            "JSON(`a(b` Int64) [quoted typed path]",
+            "JSON(`a(b` Int64)",
+            name => new ArrayColumn<string>(name, "JSON(`a(b` Int64)", new[] { "{\"a(b\":5}", "{}" }),
+            name => new ArrayColumn<string>(name, "JSON(`a(b` Int64)", new[] { "{\"a(b\":5}", "{\"a(b\":0}" }),
             JsonSettings);
 
         // The server parses a JSON value rather than storing the text, so what comes back is its own rendering:

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/NestedArrayShape.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/NestedArrayShape.cs
@@ -47,12 +47,14 @@ public sealed class NestedArrayShape
     /// <summary>The shapes, for use as an NUnit <c>TestCaseSource</c>.</summary>
     public static IEnumerable<NestedArrayShape> Shapes()
     {
-        // The UInt8 ladder, depth 2 to 5: a fixed-width leaf, so the innermost write is the bulk blit reached through
-        // the whole ConcatColumn stack.
+        // The UInt8 ladder, depth 2 to 7: a fixed-width leaf, so the innermost write is the bulk blit reached through
+        // the whole ConcatColumn stack. Depth 7 stacks six of those views, and the type-parsing corpus goes to 10.
         yield return Shape<byte[]>(2, "Array(UInt8)", Depth2Rows);
         yield return Shape<byte[][]>(3, "Array(Array(UInt8))", Depth3Rows);
         yield return Shape<byte[][][]>(4, "Array(Array(Array(UInt8)))", Depth4Rows);
         yield return Shape<byte[][][][]>(5, "Array(Array(Array(Array(UInt8))))", Depth5Rows);
+        yield return Shape<byte[][][][][]>(6, "Array(Array(Array(Array(Array(UInt8)))))", Depth6Rows);
+        yield return Shape<byte[][][][][][]>(7, "Array(Array(Array(Array(Array(Array(UInt8))))))", Depth7Rows);
 
         // Two other leaf kinds under the same skeleton, at depth 3 — enough to put more than one Array level above
         // the leaf, which is all that distinguishes them. Deeper adds another ConcatColumn but no new branch, so the
@@ -105,6 +107,24 @@ public sealed class NestedArrayShape
         new[] { Array.Empty<byte[][][]>() },
         new[] { Depth4Rows[3], Depth4Rows[4] },
         new[] { new[] { new[] { new[] { Array.Empty<byte>() } } } },
+    };
+
+    private static readonly byte[][][][][][][] Depth6Rows =
+    {
+        new[] { Depth5Rows[0] },
+        Array.Empty<byte[][][][][]>(),
+        new[] { Array.Empty<byte[][][][]>() },
+        new[] { Depth5Rows[3], Depth5Rows[4] },
+        new[] { new[] { new[] { new[] { new[] { Array.Empty<byte>() } } } } },
+    };
+
+    private static readonly byte[][][][][][][][] Depth7Rows =
+    {
+        new[] { Depth6Rows[0] },
+        Array.Empty<byte[][][][][][]>(),
+        new[] { Array.Empty<byte[][][][][]>() },
+        new[] { Depth6Rows[3], Depth6Rows[4] },
+        new[] { new[] { new[] { new[] { new[] { new[] { Array.Empty<byte>() } } } } } },
     };
 
     // The depth-2 skeleton over a variable-width leaf. The empty string is a distinct value from an empty row, so

--- a/ClickHouse.Driver.Tcp.Tests/Utilities/TlsTerminatingProxy.cs
+++ b/ClickHouse.Driver.Tcp.Tests/Utilities/TlsTerminatingProxy.cs
@@ -1,0 +1,110 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ClickHouse.Driver.Tcp.Tests.Utilities;
+
+/// <summary>
+/// A loopback TLS endpoint in front of a plaintext ClickHouse server: it terminates the tunnel and copies the
+/// bytes on to the real server, in both directions, one connection at a time as the client opens them.
+/// </summary>
+/// <remarks>
+/// This is how the default integration suite can do a native handshake over TLS. Enabling TLS on the server
+/// itself needs a certificate and a configuration file inside the container, which the suite cannot do when
+/// <c>CLICKHOUSE_TCP_HOST</c> points it at a server somebody else set up. The client side is what the driver
+/// owns, and it is complete here: the real <c>SslStream</c> handshake, then every protocol packet, block and
+/// insert inside the tunnel, answered by a real server.
+/// </remarks>
+internal sealed class TlsTerminatingProxy : IAsyncDisposable
+{
+    private readonly TcpListener listener;
+    private readonly X509Certificate2 certificate;
+    private readonly string targetHost;
+    private readonly int targetPort;
+    private readonly CancellationTokenSource shutdown = new();
+    private readonly Task accepting;
+
+    /// <summary>Starts listening, and connects to the target only when a client arrives.</summary>
+    /// <param name="targetHost">The plaintext server's host.</param>
+    /// <param name="targetPort">The plaintext server's native port.</param>
+    /// <param name="certificate">The certificate to present, with its private key.</param>
+    internal TlsTerminatingProxy(string targetHost, int targetPort, X509Certificate2 certificate)
+    {
+        this.targetHost = targetHost;
+        this.targetPort = targetPort;
+        this.certificate = certificate;
+
+        listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        Port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        accepting = AcceptAsync();
+    }
+
+    /// <summary>The loopback port a TLS client connects to.</summary>
+    internal int Port { get; }
+
+    /// <inheritdoc/>
+    public async ValueTask DisposeAsync()
+    {
+        shutdown.Cancel();
+        listener.Stop();
+        await accepting.ConfigureAwait(false);
+        shutdown.Dispose();
+    }
+
+    private async Task AcceptAsync()
+    {
+        try
+        {
+            while (!shutdown.IsCancellationRequested)
+            {
+                TcpClient accepted = await listener.AcceptTcpClientAsync(shutdown.Token).ConfigureAwait(false);
+
+                // Not awaited: the pool opens several connections, and each lives as long as its client keeps it.
+                _ = ServeAsync(accepted);
+            }
+        }
+        catch (Exception e) when (IsExpectedTeardown(e))
+        {
+        }
+    }
+
+    private async Task ServeAsync(TcpClient downstream)
+    {
+        try
+        {
+            using (downstream)
+            using (var tunnel = new SslStream(downstream.GetStream(), leaveInnerStreamOpen: false))
+            using (var upstream = new TcpClient())
+            {
+                downstream.NoDelay = true;
+                await tunnel.AuthenticateAsServerAsync(
+                    new SslServerAuthenticationOptions { ServerCertificate = certificate },
+                    shutdown.Token).ConfigureAwait(false);
+
+                await upstream.ConnectAsync(targetHost, targetPort, shutdown.Token).ConfigureAwait(false);
+                upstream.NoDelay = true;
+                NetworkStream plaintext = upstream.GetStream();
+
+                // Whichever side stops first ends the connection, and disposal below unblocks the other copy.
+                Task toServer = tunnel.CopyToAsync(plaintext, shutdown.Token);
+                Task toClient = plaintext.CopyToAsync(tunnel, shutdown.Token);
+                await Task.WhenAny(toServer, toClient).ConfigureAwait(false);
+            }
+        }
+        catch (Exception e) when (IsExpectedTeardown(e))
+        {
+        }
+    }
+
+    // A client that drops its connection, and this proxy's own disposal, are the normal ways a pump ends.
+    private static bool IsExpectedTeardown(Exception e)
+        => e is OperationCanceledException or IOException or SocketException or ObjectDisposedException
+            or AuthenticationException or InvalidOperationException;
+}

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClient.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClient.cs
@@ -639,7 +639,7 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient, IDisposable
     public void Dispose() => DisposeAsync().AsTask().GetAwaiter().GetResult();
 
     private IReadOnlyDictionary<string, string> BuildSettings(ClickHouseTcpQueryOptions options)
-        => MergeSettings(Options.CustomSettings, options?.Settings);
+        => MergeSettings(Options.CustomSettings, options?.Settings, Options.SendJsonAndDynamicSerializationSettings);
 
     /// <summary>
     /// The settings for one insert: the query settings, plus
@@ -715,10 +715,15 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient, IDisposable
     /// </summary>
     /// <param name="clientSettings">The client-level custom settings, or null for none.</param>
     /// <param name="perQuerySettings">The per-query settings that override the client-level ones, or null for none.</param>
+    /// <param name="sendSerializationSettings">
+    /// Whether to inject the two serialization settings, from
+    /// <see cref="ClickHouseTcpClientOptions.SendJsonAndDynamicSerializationSettings"/>.
+    /// </param>
     /// <returns>The merged settings to send with the operation.</returns>
     internal static IReadOnlyDictionary<string, string> MergeSettings(
         IReadOnlyDictionary<string, string> clientSettings,
-        IReadOnlyDictionary<string, string> perQuerySettings)
+        IReadOnlyDictionary<string, string> perQuerySettings,
+        bool sendSerializationSettings = true)
     {
         var merged = new Dictionary<string, string>(StringComparer.Ordinal);
         if (clientSettings is not null)
@@ -750,14 +755,20 @@ public sealed class ClickHouseTcpClient : IClickHouseTcpClient, IDisposable
             }
         }
 
-        if (!merged.ContainsKey(FlattenedSerializationSetting))
+        // Both server defaults are 0, so sending either is a setting modification, which a readonly profile
+        // refuses outright (Code 164). A caller who cannot modify settings turns this off and gives up only
+        // JSON and Dynamic reads.
+        if (sendSerializationSettings)
         {
-            merged[FlattenedSerializationSetting] = "1";
-        }
+            if (!merged.ContainsKey(FlattenedSerializationSetting))
+            {
+                merged[FlattenedSerializationSetting] = "1";
+            }
 
-        if (!merged.ContainsKey(JsonAsStringSetting))
-        {
-            merged[JsonAsStringSetting] = "1";
+            if (!merged.ContainsKey(JsonAsStringSetting))
+            {
+                merged[JsonAsStringSetting] = "1";
+            }
         }
 
         return merged;

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClientOptions.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpClientOptions.cs
@@ -162,6 +162,26 @@ public sealed record ClickHouseTcpClientOptions
     public IReadOnlyDictionary<string, string> CustomSettings { get; init; }
 
     /// <summary>
+    /// Whether every operation asks the server for the <c>JSON</c> and <c>Dynamic</c> wire form this client
+    /// reads, by sending <c>output_format_native_use_flattened_dynamic_and_json_serialization</c> and
+    /// <c>output_format_native_write_json_as_string</c>. Defaults to true.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Both server defaults are <c>0</c>, so sending them is a setting *modification* — and a user under a
+    /// readonly profile cannot modify a setting: every operation fails with
+    /// <c>Code: 164 … Cannot modify … in readonly mode</c>. Set this to false for such a user, or put either
+    /// setting in <see cref="CustomSettings"/> yourself, which also suppresses the injection for that one.
+    /// </para>
+    /// <para>
+    /// The cost of false is that a <c>JSON</c> or <c>Dynamic</c> column may arrive in a serialization this
+    /// client does not read, and that read then fails. Every other type is unaffected, so a session that
+    /// selects neither loses nothing.
+    /// </para>
+    /// </remarks>
+    public bool SendJsonAndDynamicSerializationSettings { get; init; } = true;
+
+    /// <summary>
     /// The soft cap, in bytes, on the client's send buffer during an insert: while a wire block is written, the
     /// buffered bytes are flushed to the socket once they pass this, bounding peak memory for a large insert.
     /// Independent of the block-split target, so blocks stay their natural size and simply stream out within this

--- a/ClickHouse.Driver.Tcp/Client/ClickHouseTcpConnectionStringBuilder.cs
+++ b/ClickHouse.Driver.Tcp/Client/ClickHouseTcpConnectionStringBuilder.cs
@@ -123,6 +123,18 @@ public sealed class ClickHouseTcpConnectionStringBuilder : DbConnectionStringBui
         set => this["UseTls"] = value;
     }
 
+    /// <summary>
+    /// Whether every operation asks for the <c>JSON</c>/<c>Dynamic</c> wire form this client reads. Defaults to
+    /// true; set false for a user under a readonly profile. See
+    /// <see cref="ClickHouseTcpClientOptions.SendJsonAndDynamicSerializationSettings"/>.
+    /// </summary>
+    /// <exception cref="ArgumentException">The stored value is not a boolean.</exception>
+    public bool SendJsonAndDynamicSerializationSettings
+    {
+        get => GetBoolOrDefault("SendJsonAndDynamicSerializationSettings", true);
+        set => this["SendJsonAndDynamicSerializationSettings"] = value;
+    }
+
     /// <summary>The host name to match the server certificate against. Absent, the default, uses <see cref="Host"/>.</summary>
     public string TlsServerName
     {
@@ -294,6 +306,7 @@ public sealed class ClickHouseTcpConnectionStringBuilder : DbConnectionStringBui
             Password = Password,
             Database = Database,
             QuotaKey = QuotaKey,
+            SendJsonAndDynamicSerializationSettings = SendJsonAndDynamicSerializationSettings,
             UseTls = UseTls,
             TlsServerName = TlsServerName,
             TlsAllowInvalidCertificates = TlsAllowInvalidCertificates,

--- a/ClickHouse.Driver.Tcp/Compression/FramedPackets.cs
+++ b/ClickHouse.Driver.Tcp/Compression/FramedPackets.cs
@@ -15,6 +15,10 @@ namespace ClickHouse.Driver.Tcp.Compression;
 /// The list matches the server's own notion of a compressible message, and the Go client's
 /// <c>ServerCode.Compressible</c>, which admits the same three.
 /// </para>
+/// <para>
+/// It governs block-bearing packets only: the one caller is the block reader. An <c>Exception</c> body is read
+/// from the raw stream by the code that decodes it, never through here, so this is not where that decision lives.
+/// </para>
 /// </summary>
 internal static class FramedPackets
 {

--- a/ClickHouse.Driver.Tcp/Format/BlockReader.cs
+++ b/ClickHouse.Driver.Tcp/Format/BlockReader.cs
@@ -98,8 +98,9 @@ internal static class BlockReader
                 // still owe its version marker. It does not, because ClickHouse writes that prefix from inside
                 // NativeWriter's writeData — which it calls only `if (rows)` — and NativeReader skips readData for a
                 // zero-row block symmetrically. BlockWriter gates both phases the same way, so the two halves agree.
-                // BlockWriterTests pins the byte layout and ClickHouseTcpConnectionQueryIntegrationTests pins the
-                // server's half; reading a prefix here that was never written desyncs every column after it.
+                // BlockWriterTests pins the byte layout, ClickHouseTcpConnectionQueryIntegrationTests pins the
+                // server's half, and MultiBlockStateIntegrationTests pins one prefix per non-empty block across a
+                // multi-block read; reading a prefix here that was never written desyncs every column after it.
                 if (rowCount != 0)
                 {
                     await codec.ReadStatePrefixAsync(reader, cancellationToken).ConfigureAwait(false);

--- a/ClickHouse.Driver.Tcp/Parameters/ParameterTypeInference.cs
+++ b/ClickHouse.Driver.Tcp/Parameters/ParameterTypeInference.cs
@@ -46,7 +46,9 @@ internal static class ParameterTypeInference
             case string or char or byte[] or ReadOnlyMemory<byte>: return "String";
             case Guid: return "UUID";
             case DateOnly: return "Date";
-            case TimeSpan: return "Time64(9)";
+
+            // Scale 9 holds every tick either one can carry, so neither loses a digit.
+            case TimeSpan or TimeOnly: return "Time64(9)";
 
             // Sub-second precision is kept, and the instant is anchored to UTC rather than to a session zone.
             case DateTime or DateTimeOffset: return "DateTime64(7, 'UTC')";

--- a/ClickHouse.Driver.Tcp/Parameters/ParameterTypeInference.cs
+++ b/ClickHouse.Driver.Tcp/Parameters/ParameterTypeInference.cs
@@ -62,6 +62,13 @@ internal static class ParameterTypeInference
             case IDictionary dictionary:
                 return InferMap(dictionary, parameterName);
 
+            // The shape this client reads a Map column back as, which Accepts already knows. It is also an
+            // IEnumerable, so it has to be decided before the Array arm below, whose element inference has no
+            // reading for a KeyValuePair. Without this arm a row read from a Map column could not be sent back
+            // as a Dynamic or an untyped parameter.
+            case not string and IEnumerable pairs when MapPairs.IsPairSequence(value):
+                return InferPairSequence(pairs, parameterName);
+
             case IEnumerable enumerable:
                 return $"Array({InferElement(enumerable, parameterName)})";
 
@@ -79,28 +86,35 @@ internal static class ParameterTypeInference
     /// <returns>True when the alternative accepts the value.</returns>
     public static bool Accepts(TypeNode node, object value)
     {
+        // The names below are canonical, so an alias or a case variant is mapped to one first, as the formatter
+        // does before its own dispatch. Without this Variant(BIGINT, String) accepted no Int64 at all, while the
+        // server resolves that declaration to Variant(Int64, String).
+        string name = ColumnCodecRegistry.Default.TryCanonicalName(node.Name, out string registered)
+            ? registered
+            : node.Name;
+
         if (value is null or DBNull)
         {
             // A null belongs to Nothing and to any Nullable, which is what carries it inside a composite.
-            return node.Name is "Nothing" or "Nullable"
-                || (node.Name is "LowCardinality" && node.Arguments.Count == 1 && Accepts(node.Arguments[0], value));
+            return name is "Nothing" or "Nullable"
+                || (name is "LowCardinality" && node.Arguments.Count == 1 && Accepts(node.Arguments[0], value));
         }
 
         // An alternative may itself be a wrapper; match against what it ultimately holds.
-        if (node.Name is "Nullable" or "LowCardinality" && node.Arguments.Count == 1)
+        if (name is "Nullable" or "LowCardinality" && node.Arguments.Count == 1)
         {
             return Accepts(node.Arguments[0], value);
         }
 
         // A geo name stands for a Tuple/Array shape, which is what the formatter writes it as. Matching the
         // name alone would reject every value, because no CLR type infers to "Point".
-        if (TcpParameterFormatter.TryGeoShapeOf(node.Name, out TypeNode geoShape))
+        if (TcpParameterFormatter.TryGeoShapeOf(name, out TypeNode geoShape))
         {
             return Accepts(geoShape, value);
         }
 
         // A QBit is a fixed-width vector of its element type, so it takes what an Array of that type takes.
-        if (node.Name is "QBit" && node.Arguments.Count == 2)
+        if (name is "QBit" && node.Arguments.Count == 2)
         {
             return value is not string and IEnumerable components && AcceptsElements(node.Arguments[0], components);
         }
@@ -108,20 +122,20 @@ internal static class ParameterTypeInference
         // Match composite alternatives recursively; their outer names are insufficient.
         switch (value)
         {
-            case IDictionary dictionary when node.Name is "Map":
+            case IDictionary dictionary when name is "Map":
                 return node.Arguments.Count == 2 && AcceptsPairs(node, dictionary);
 
             // Handle the Map read shape before the general Array case.
             case not string and IEnumerable pairs when MapPairs.IsPairSequence(value):
-                return node.Name is "Map"
+                return name is "Map"
                     && node.Arguments.Count == 2
                     && AcceptsPairSequence(node, pairs);
 
-            case ITuple tuple when node.Name is "Tuple":
+            case ITuple tuple when name is "Tuple":
                 return AcceptsTupleElements(node, tuple);
 
             // A byte[] is checked element by element here too, so it takes Array(UInt8) but not Array(String).
-            case not string and IEnumerable elements when node.Name is "Array":
+            case not string and IEnumerable elements when name is "Array":
                 return node.Arguments.Count == 1 && AcceptsElements(node.Arguments[0], elements);
 
             case IDictionary or ITuple:
@@ -132,21 +146,21 @@ internal static class ParameterTypeInference
         {
             // The Array case above already took a byte[] an element type accepts, so only the text arms remain.
             // A ReadOnlyMemory is not IEnumerable, so it never reaches that case and only the text arms format it.
-            byte[] or ReadOnlyMemory<byte> => node.Name is "String" or "FixedString" ? node.Name : "String",
+            byte[] or ReadOnlyMemory<byte> => name is "String" or "FixedString" ? name : "String",
 
             // These share one CLR type with several ClickHouse types, so the base name alone decides.
-            string or char => node.Name is "String" or "FixedString" or "Enum" or "Enum8" or "Enum16" ? node.Name : "String",
+            string or char => name is "String" or "FixedString" or "Enum" or "Enum8" or "Enum16" ? name : "String",
 
             // A float is the only value BFloat16 accepts, so it matches that alternative as well as Float32.
-            float => node.Name is "Float32" or "BFloat16" ? node.Name : "Float32",
-            DateTime or DateTimeOffset => node.Name is "DateTime" or "DateTime64" or "Date" or "Date32" ? node.Name : "DateTime64",
-            TimeSpan or TimeOnly => node.Name is "Time" or "Time64" ? node.Name : "Time64",
-            decimal or ClickHouseTcpDecimal => node.Name.StartsWith("Decimal", StringComparison.Ordinal) ? node.Name : "Decimal128",
+            float => name is "Float32" or "BFloat16" ? name : "Float32",
+            DateTime or DateTimeOffset => name is "DateTime" or "DateTime64" or "Date" or "Date32" ? name : "DateTime64",
+            TimeSpan or TimeOnly => name is "Time" or "Time64" ? name : "Time64",
+            decimal or ClickHouseTcpDecimal => name.StartsWith("Decimal", StringComparison.Ordinal) ? name : "Decimal128",
             not string and IEnumerable => "Array",
             _ => InferOrNothing(value),
         };
 
-        return string.Equals(inferred, node.Name, StringComparison.Ordinal);
+        return string.Equals(inferred, name, StringComparison.Ordinal);
     }
 
     /// <summary>Reports whether every element fits; an empty sequence fits any element type.</summary>
@@ -249,6 +263,18 @@ internal static class ParameterTypeInference
             return $"Map({Infer(entry.Key, parameterName)}, {Infer(entry.Value, parameterName)})";
         }
 
+        return "Map(String, String)";
+    }
+
+    private static string InferPairSequence(IEnumerable pairs, string parameterName)
+    {
+        foreach (object pair in pairs)
+        {
+            (object key, object value) = MapPairs.Read(pair);
+            return $"Map({Infer(key, parameterName)}, {Infer(value, parameterName)})";
+        }
+
+        // Empty, so no sample pair: the same fallback an empty dictionary takes.
         return "Map(String, String)";
     }
 

--- a/ClickHouse.Driver.Tcp/Parameters/ParameterTypeInference.cs
+++ b/ClickHouse.Driver.Tcp/Parameters/ParameterTypeInference.cs
@@ -140,6 +140,7 @@ internal static class ParameterTypeInference
             // A float is the only value BFloat16 accepts, so it matches that alternative as well as Float32.
             float => node.Name is "Float32" or "BFloat16" ? node.Name : "Float32",
             DateTime or DateTimeOffset => node.Name is "DateTime" or "DateTime64" or "Date" or "Date32" ? node.Name : "DateTime64",
+            TimeSpan or TimeOnly => node.Name is "Time" or "Time64" ? node.Name : "Time64",
             decimal or ClickHouseTcpDecimal => node.Name.StartsWith("Decimal", StringComparison.Ordinal) ? node.Name : "Decimal128",
             not string and IEnumerable => "Array",
             _ => InferOrNothing(value),

--- a/ClickHouse.Driver.Tcp/Parameters/ParameterTypeInference.cs
+++ b/ClickHouse.Driver.Tcp/Parameters/ParameterTypeInference.cs
@@ -135,7 +135,7 @@ internal static class ParameterTypeInference
             byte[] or ReadOnlyMemory<byte> => node.Name is "String" or "FixedString" ? node.Name : "String",
 
             // These share one CLR type with several ClickHouse types, so the base name alone decides.
-            string or char => node.Name is "String" or "FixedString" or "Enum8" or "Enum16" ? node.Name : "String",
+            string or char => node.Name is "String" or "FixedString" or "Enum" or "Enum8" or "Enum16" ? node.Name : "String",
 
             // A float is the only value BFloat16 accepts, so it matches that alternative as well as Float32.
             float => node.Name is "Float32" or "BFloat16" ? node.Name : "Float32",

--- a/ClickHouse.Driver.Tcp/Parameters/TcpParameterFormatter.cs
+++ b/ClickHouse.Driver.Tcp/Parameters/TcpParameterFormatter.cs
@@ -93,7 +93,9 @@ internal static class TcpParameterFormatter
     /// <returns>The formatted value.</returns>
     internal static string Format(TypeNode type, object value, bool quote)
     {
-        string name = type.Name;
+        // The arms below are the canonical names, so an alias or a case variant is mapped to one first. Every
+        // recursion into a child type comes back through here, which is what makes {p:Array(BIGINT)} format.
+        string name = TypeAliases.Canonical(type.Name);
 
         if (Array.IndexOf(IntegerTypeNames, name) >= 0
             || Array.IndexOf(FloatTypeNames, name) >= 0
@@ -182,8 +184,7 @@ internal static class TcpParameterFormatter
             case "Variant":
                 return FormatVariant(type, value, quote);
 
-            // The server takes either spelling and reports the type as JSON, so both must format.
-            case "JSON" or "Json":
+            case "JSON":
                 return (value is string json ? json : JsonSerializer.Serialize(value)).Escape();
 
             // A QBit is a fixed-width vector of its element type, written as an array.

--- a/ClickHouse.Driver.Tcp/Parameters/TcpParameterFormatter.cs
+++ b/ClickHouse.Driver.Tcp/Parameters/TcpParameterFormatter.cs
@@ -130,7 +130,7 @@ internal static class TcpParameterFormatter
             case "String" or "FixedString" when value is ReadOnlyMemory<byte> bytesMemory:
                 return QuoteIfNeeded(BytesToSqlText(bytesMemory.Span), quote);
 
-            case "String" or "FixedString" or "Enum8" or "Enum16" or "IPv4" or "IPv6" or "UUID":
+            case "String" or "FixedString" or "Enum" or "Enum8" or "Enum16" or "IPv4" or "IPv6" or "UUID":
                 return QuoteIfNeeded(value.ToString().Escape(), quote);
 
             case "Identifier":

--- a/ClickHouse.Driver.Tcp/Parameters/TcpParameterFormatter.cs
+++ b/ClickHouse.Driver.Tcp/Parameters/TcpParameterFormatter.cs
@@ -194,10 +194,44 @@ internal static class TcpParameterFormatter
             case "Point" or "Ring" or "LineString" or "Polygon" or "MultiLineString" or "MultiPolygon":
                 return Format(GeoShapeOf(name), value, quote);
 
-            default:
+            case "AggregateFunction":
                 throw new ArgumentException(
-                    $"Cannot convert value of type '{value.GetType().FullName}' ({value}) to ClickHouse type {type}");
+                    $"ClickHouse type '{type}' holds serialized aggregate states, so no parameter value spells it; " +
+                    "the server rejects one too. Pass the arguments the state is built from instead.");
+
+            // The server does take a text value for each of these (checked on 26.6), so the refusal is this
+            // client's own: a Dynamic needs the value's type to name itself, and a Geometry value is ambiguous —
+            // an array of points is both a Ring and a LineString.
+            case "Dynamic" or "Geometry" or "SimpleAggregateFunction":
+                throw new ArgumentException(
+                    $"This client cannot format a parameter value as ClickHouse type '{type}'. Name the concrete " +
+                    "type of the value instead.");
+
+            default:
+                throw NotFormattable(type, name, value);
         }
+    }
+
+    /// <summary>Explains why a value reached no formatting arm.</summary>
+    /// <param name="type">The parsed type.</param>
+    /// <param name="name">The type's base name.</param>
+    /// <param name="value">The value, which is never null here.</param>
+    /// <returns>The exception to throw.</returns>
+    private static ArgumentException NotFormattable(TypeNode type, string name, object value)
+    {
+        // Two unrelated failures arrive here and used to read the same: a type name this client does not know,
+        // and a known type an arm declined this value's shape for. Blaming the value for the first sends a
+        // caller looking at the value they wrote, which is fine, for a type name that never existed.
+        if (!ColumnCodecRegistry.Default.KnowsTypeName(name))
+        {
+            return new ArgumentException(
+                $"'{name}' is not a ClickHouse type name this client knows, so no value formats as '{type}'. " +
+                "Write the name the server reports for the column — SELECT toTypeName(expr) — as ClickHouse spells it, " +
+                "which is case-sensitive for most types.");
+        }
+
+        return new ArgumentException(
+            $"Cannot convert value of type '{value.GetType().FullName}' ({value}) to ClickHouse type {type}");
     }
 
     /// <summary>Expands a geo type name into the Tuple/Array shape it stands for.</summary>

--- a/ClickHouse.Driver.Tcp/Parameters/TcpParameterFormatter.cs
+++ b/ClickHouse.Driver.Tcp/Parameters/TcpParameterFormatter.cs
@@ -146,10 +146,17 @@ internal static class TcpParameterFormatter
             case "DateTime64":
                 return QuoteIfNeeded(FormatDateTime64(type, value), quote);
 
+            // A TimeOnly is a time of day and a TimeSpan an elapsed time, but both print as one clock reading.
+            case "Time" when value is TimeOnly timeOfDay:
+                return FormatTime(timeOfDay.ToTimeSpan());
+
             case "Time":
                 return value is TimeSpan timeSpan
                     ? FormatTime(timeSpan)
                     : FormatTime(Convert.ToInt32(value, CultureInfo.InvariantCulture));
+
+            case "Time64" when value is TimeOnly time64OfDay:
+                return FormatTime64(time64OfDay.ToTimeSpan(), ScaleOf(type, defaultScale: 3));
 
             case "Time64" when value is TimeSpan time64:
                 return FormatTime64(time64, ScaleOf(type, defaultScale: 3));

--- a/ClickHouse.Driver.Tcp/Parameters/TcpParameterFormatter.cs
+++ b/ClickHouse.Driver.Tcp/Parameters/TcpParameterFormatter.cs
@@ -207,13 +207,16 @@ internal static class TcpParameterFormatter
                     $"ClickHouse type '{type}' holds serialized aggregate states, so no parameter value spells it; " +
                     "the server rejects one too. Pass the arguments the state is built from instead.");
 
-            // The server does take a text value for each of these (checked on 26.6), so the refusal is this
-            // client's own: a Dynamic needs the value's type to name itself, and a Geometry value is ambiguous —
-            // an array of points is both a Ring and a LineString.
-            case "Dynamic" or "Geometry" or "SimpleAggregateFunction":
-                throw new ArgumentException(
-                    $"This client cannot format a parameter value as ClickHouse type '{type}'. Name the concrete " +
-                    "type of the value instead.");
+            // The alias is transparent: the value is written as T, which is also what the codec resolves the
+            // column to. The function only tells the server how to merge rows.
+            case "SimpleAggregateFunction" when type.Arguments.Count == 2:
+                return Format(type.Arguments[1], value, quote);
+
+            // Neither of these names a layout for the value on its own, so the value's own type does. A Geometry
+            // is ambiguous by construction — an array of points is both a Ring and a LineString — but the text is
+            // the same either way, and the server's parse is what picks the shape.
+            case "Dynamic" or "Geometry":
+                return Format(TypeParser.Parse(ParameterTypeInference.Infer(value, name)), value, quote);
 
             default:
                 throw NotFormattable(type, name, value);

--- a/ClickHouse.Driver.Tcp/Parameters/TcpParameterFormatter.cs
+++ b/ClickHouse.Driver.Tcp/Parameters/TcpParameterFormatter.cs
@@ -401,7 +401,9 @@ internal static class TcpParameterFormatter
     /// <returns>The wall-clock time in that timezone.</returns>
     private static DateTime InTargetTimezone(DateTimeOffset value, string declaredTimezone)
     {
-        TimeZoneInfo timeZone = DateTimeZones.Resolve(declaredTimezone, serverTimezone: null);
+        // Formatting a wall clock is exactly the calendar use the zone is needed for, so an unrepresentable one
+        // is reported here.
+        TimeZoneInfo timeZone = DateTimeZones.Resolve(declaredTimezone, serverTimezone: null).Value;
         return TimeZoneInfo.ConvertTime(value, timeZone).DateTime;
     }
 

--- a/ClickHouse.Driver.Tcp/Parameters/TcpParameterFormatter.cs
+++ b/ClickHouse.Driver.Tcp/Parameters/TcpParameterFormatter.cs
@@ -95,7 +95,7 @@ internal static class TcpParameterFormatter
     {
         // The arms below are the canonical names, so an alias or a case variant is mapped to one first. Every
         // recursion into a child type comes back through here, which is what makes {p:Array(BIGINT)} format.
-        string name = TypeAliases.Canonical(type.Name);
+        string name = ColumnCodecRegistry.Default.TryCanonicalName(type.Name, out string registered) ? registered : type.Name;
 
         if (Array.IndexOf(IntegerTypeNames, name) >= 0
             || Array.IndexOf(FloatTypeNames, name) >= 0
@@ -234,8 +234,7 @@ internal static class TcpParameterFormatter
         {
             return new ArgumentException(
                 $"'{name}' is not a ClickHouse type name this client knows, so no value formats as '{type}'. " +
-                "Write the name the server reports for the column — SELECT toTypeName(expr) — as ClickHouse spells it, " +
-                "which is case-sensitive for most types.");
+                "Write the name the server reports for the column — SELECT toTypeName(expr).");
         }
 
         return new ArgumentException(

--- a/ClickHouse.Driver.Tcp/PublicAPI/PublicAPI.Unshipped.txt
+++ b/ClickHouse.Driver.Tcp/PublicAPI/PublicAPI.Unshipped.txt
@@ -119,6 +119,8 @@ ClickHouse.Driver.Tcp.ClickHouseTcpClientOptions.QuotaKey.get -> string
 ClickHouse.Driver.Tcp.ClickHouseTcpClientOptions.QuotaKey.init -> void
 ClickHouse.Driver.Tcp.ClickHouseTcpClientOptions.ReadTimeout.get -> System.TimeSpan
 ClickHouse.Driver.Tcp.ClickHouseTcpClientOptions.ReadTimeout.init -> void
+ClickHouse.Driver.Tcp.ClickHouseTcpClientOptions.SendJsonAndDynamicSerializationSettings.get -> bool
+ClickHouse.Driver.Tcp.ClickHouseTcpClientOptions.SendJsonAndDynamicSerializationSettings.init -> void
 ClickHouse.Driver.Tcp.ClickHouseTcpClientOptions.StatementMaxLength.get -> int
 ClickHouse.Driver.Tcp.ClickHouseTcpClientOptions.StatementMaxLength.init -> void
 ClickHouse.Driver.Tcp.ClickHouseTcpClientOptions.ResolvedPort.get -> int
@@ -172,6 +174,8 @@ ClickHouse.Driver.Tcp.ClickHouseTcpConnectionStringBuilder.QuotaKey.get -> strin
 ClickHouse.Driver.Tcp.ClickHouseTcpConnectionStringBuilder.QuotaKey.set -> void
 ClickHouse.Driver.Tcp.ClickHouseTcpConnectionStringBuilder.ReadTimeout.get -> System.TimeSpan
 ClickHouse.Driver.Tcp.ClickHouseTcpConnectionStringBuilder.ReadTimeout.set -> void
+ClickHouse.Driver.Tcp.ClickHouseTcpConnectionStringBuilder.SendJsonAndDynamicSerializationSettings.get -> bool
+ClickHouse.Driver.Tcp.ClickHouseTcpConnectionStringBuilder.SendJsonAndDynamicSerializationSettings.set -> void
 ClickHouse.Driver.Tcp.ClickHouseTcpConnectionStringBuilder.SweepInterval.get -> System.TimeSpan?
 ClickHouse.Driver.Tcp.ClickHouseTcpConnectionStringBuilder.SweepInterval.set -> void
 ClickHouse.Driver.Tcp.ClickHouseTcpConnectionStringBuilder.TlsAllowInvalidCertificates.get -> bool

--- a/ClickHouse.Driver.Tcp/Types/Codecs/AggregateFunctionColumnCodecs.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/AggregateFunctionColumnCodecs.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 
 namespace ClickHouse.Driver.Tcp.Types.Codecs;
 
@@ -54,12 +55,30 @@ internal static class AggregateFunctionColumnCodecs
         // A parameterized function ("quantiles(0.5, 0.9)") parses as a node of its own: the Merge combinator
         // attaches to the bare name, and the parameters move to their own list ahead of the column —
         // quantilesMerge(0.5, 0.9)(column). Suggesting the bare form there hands back a query the server rejects.
-        TypeNode function = node.Arguments[0];
+        TypeNode function = FunctionOf(node);
         string parameters = function.Arguments.Count > 0 ? $"({string.Join(", ", function.Arguments)})" : string.Empty;
 
         throw new NotSupportedException(
             $"Column type '{node}' holds the intermediate states of the '{function.Name}' aggregate function, whose encoding is the " +
             $"function's own; this client cannot decode it. Merge the state in the query instead — " +
             $"'SELECT {function.Name}Merge{parameters}(column) ...' — which returns an ordinary column.");
+    }
+
+    /// <summary>Picks out the argument that names the aggregate function.</summary>
+    /// <param name="node">The parsed <c>AggregateFunction</c> node, with at least one argument.</param>
+    /// <returns>The argument naming the function.</returns>
+    private static TypeNode FunctionOf(TypeNode node)
+    {
+        // Some states carry a leading serialization version, which is not a function name: 26.6 reports
+        // sumMapState(...) as AggregateFunction(1, sumMap, Array(UInt64), Array(UInt64)), and the same for
+        // minMap, maxMap and sumMapFiltered([1, 2]). Naming that argument suggests '1Merge(column)'.
+        if (node.Arguments.Count > 1
+            && node.Arguments[0].Arguments.Count == 0
+            && uint.TryParse(node.Arguments[0].Name, NumberStyles.None, CultureInfo.InvariantCulture, out _))
+        {
+            return node.Arguments[1];
+        }
+
+        return node.Arguments[0];
     }
 }

--- a/ClickHouse.Driver.Tcp/Types/Codecs/DateTime64ColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/DateTime64ColumnCodec.cs
@@ -120,17 +120,17 @@ internal sealed class DateTime64ColumnCodec : IColumnCodec
             return true;
         }
 
-        // A calendar target is where the zone is needed, so an unrepresentable one is reported here rather than
-        // when the column was resolved, where it would fail a read that only wanted the counts.
+        // The resolved zone is embedded, not the zone, for the reason the DateTime codec gives: this method also
+        // answers CanRead and the POCO tier's mapping discovery, where no row and so no calendar value exists.
         if (targetType == typeof(DateTimeOffset))
         {
-            projected = ColumnValueProjections.Call(nameof(ColumnValueProjections.DateTime64ToOffset), value, scale, timeZone.Value);
+            projected = ColumnValueProjections.Call(nameof(ColumnValueProjections.DateTime64ToOffset), value, scale, timeZone);
             return true;
         }
 
         if (targetType == typeof(DateTime))
         {
-            projected = ColumnValueProjections.Call(nameof(ColumnValueProjections.DateTime64ToDateTime), value, scale, timeZone.Value);
+            projected = ColumnValueProjections.Call(nameof(ColumnValueProjections.DateTime64ToDateTime), value, scale, timeZone);
             return true;
         }
 

--- a/ClickHouse.Driver.Tcp/Types/Codecs/DateTime64ColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/DateTime64ColumnCodec.cs
@@ -20,9 +20,9 @@ internal sealed class DateTime64ColumnCodec : IColumnCodec
     private static readonly long UnixEpochTicks = DateTime.UnixEpoch.Ticks;
 
     private readonly int scale;
-    private readonly TimeZoneInfo timeZone;
+    private readonly ResolvedTimeZone timeZone;
 
-    private DateTime64ColumnCodec(string typeName, int scale, TimeZoneInfo timeZone)
+    private DateTime64ColumnCodec(string typeName, int scale, ResolvedTimeZone timeZone)
     {
         TypeName = typeName;
         this.scale = scale;
@@ -101,7 +101,7 @@ internal sealed class DateTime64ColumnCodec : IColumnCodec
         }
 
         string explicitTz = node.Arguments.Count > 1 ? DateTimeZones.UnquoteTimezone(node.Arguments[1]) : null;
-        TimeZoneInfo tz = DateTimeZones.Resolve(explicitTz, serverTimezone);
+        ResolvedTimeZone tz = DateTimeZones.Resolve(explicitTz, serverTimezone);
         return new DateTime64ColumnCodec(node.ToString(), scale, tz);
     }
 
@@ -120,15 +120,17 @@ internal sealed class DateTime64ColumnCodec : IColumnCodec
             return true;
         }
 
+        // A calendar target is where the zone is needed, so an unrepresentable one is reported here rather than
+        // when the column was resolved, where it would fail a read that only wanted the counts.
         if (targetType == typeof(DateTimeOffset))
         {
-            projected = ColumnValueProjections.Call(nameof(ColumnValueProjections.DateTime64ToOffset), value, scale, timeZone);
+            projected = ColumnValueProjections.Call(nameof(ColumnValueProjections.DateTime64ToOffset), value, scale, timeZone.Value);
             return true;
         }
 
         if (targetType == typeof(DateTime))
         {
-            projected = ColumnValueProjections.Call(nameof(ColumnValueProjections.DateTime64ToDateTime), value, scale, timeZone);
+            projected = ColumnValueProjections.Call(nameof(ColumnValueProjections.DateTime64ToDateTime), value, scale, timeZone.Value);
             return true;
         }
 
@@ -194,5 +196,5 @@ internal sealed class DateTime64ColumnCodec : IColumnCodec
     }
 
     private long CountFromDateTime(DateTime value)
-        => CountFromDateTimeOffset(new DateTimeOffset(DateTimeColumnCodec.ToUtc(value, timeZone)));
+        => CountFromDateTimeOffset(new DateTimeOffset(DateTimeColumnCodec.ToUtc(value, timeZone.Value)));
 }

--- a/ClickHouse.Driver.Tcp/Types/Codecs/DateTime64ColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/DateTime64ColumnCodec.cs
@@ -183,7 +183,19 @@ internal sealed class DateTime64ColumnCodec : IColumnCodec
         int places = scale - DotNetTickScale;
         if (places >= 0)
         {
-            return FixedPointScaling.ShiftDecimalPlaces(dotNetTicksSinceEpoch, places);
+            // The count is an Int64 of sub-second units, so a fine scale reaches a nearer instant than .NET does:
+            // scale 9 stops at 2262-04-11. Range-checked rather than left to the multiply, whose OverflowException
+            // would name neither the value nor the column.
+            long scaleUp = FixedPointScaling.Pow10(places);
+            if (dotNetTicksSinceEpoch > long.MaxValue / scaleUp || dotNetTicksSinceEpoch < long.MinValue / scaleUp)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(value),
+                    value,
+                    $"{value:o} cannot be written to {TypeName} (scale {scale}): the count of sub-second units since 1970-01-01 does not fit in an Int64.");
+            }
+
+            return dotNetTicksSinceEpoch * scaleUp;
         }
 
         long factor = FixedPointScaling.Pow10(-places);

--- a/ClickHouse.Driver.Tcp/Types/Codecs/DateTime64ColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/DateTime64ColumnCodec.cs
@@ -208,5 +208,5 @@ internal sealed class DateTime64ColumnCodec : IColumnCodec
     }
 
     private long CountFromDateTime(DateTime value)
-        => CountFromDateTimeOffset(new DateTimeOffset(DateTimeColumnCodec.ToUtc(value, timeZone.Value)));
+        => CountFromDateTimeOffset(new DateTimeOffset(DateTimeColumnCodec.ToUtc(value, timeZone)));
 }

--- a/ClickHouse.Driver.Tcp/Types/Codecs/DateTimeColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/DateTimeColumnCodec.cs
@@ -103,17 +103,18 @@ internal sealed class DateTimeColumnCodec : IColumnCodec
             return true;
         }
 
-        // A calendar target is where the zone is needed, so an unrepresentable one is reported here rather than
-        // when the column was resolved, where it would fail a read that only wanted the seconds.
+        // The resolved zone is embedded, not the zone: a calendar target is where the zone is needed, and that is
+        // the projected row rather than this method, which also answers CanRead and the POCO tier's mapping
+        // discovery. Asking for it here would refuse the reading instead of the value.
         if (targetType == typeof(DateTimeOffset))
         {
-            projected = ColumnValueProjections.Call(nameof(ColumnValueProjections.DateTimeToOffset), value, timeZone.Value);
+            projected = ColumnValueProjections.Call(nameof(ColumnValueProjections.DateTimeToOffset), value, timeZone);
             return true;
         }
 
         if (targetType == typeof(DateTime))
         {
-            projected = ColumnValueProjections.Call(nameof(ColumnValueProjections.DateTimeToDateTime), value, timeZone.Value);
+            projected = ColumnValueProjections.Call(nameof(ColumnValueProjections.DateTimeToDateTime), value, timeZone);
             return true;
         }
 

--- a/ClickHouse.Driver.Tcp/Types/Codecs/DateTimeColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/DateTimeColumnCodec.cs
@@ -160,12 +160,17 @@ internal sealed class DateTimeColumnCodec : IColumnCodec
     // Reduces a DateTime to the UTC instant to encode. Utc and Local already denote an instant; a Local value
     // resolves against the host machine's timezone, under the BCL's daylight-saving rules and not the ones below.
     // An Unspecified value has no offset, so its wall-clock is read in the column's timezone.
-    internal static DateTime ToUtc(DateTime value, TimeZoneInfo timeZone)
+    //
+    // Takes the resolved zone rather than the zone, so the two Kinds that name an instant never ask for it: a
+    // column may declare an offset .NET cannot represent, which must not stop a value that does not need it.
+    internal static DateTime ToUtc(DateTime value, ResolvedTimeZone resolved)
     {
         if (value.Kind != DateTimeKind.Unspecified)
         {
             return value.ToUniversalTime();
         }
+
+        TimeZoneInfo timeZone = resolved.Value;
 
         // A skipped wall-clock names no instant, so it is rejected instead of guessed. Deriving the pre-gap offset
         // from TimeZoneInfo is not reliable: GetUtcOffset answers with the zone's base offset, which differs from
@@ -216,7 +221,7 @@ internal sealed class DateTimeColumnCodec : IColumnCodec
         return (uint)seconds;
     }
 
-    private uint ToWireValue(DateTime value) => ToUnixSeconds(ToUtc(value, timeZone.Value));
+    private uint ToWireValue(DateTime value) => ToUnixSeconds(ToUtc(value, timeZone));
 
     private static uint ToWireValue(DateTimeOffset value) => ToUnixSeconds(value.UtcDateTime);
 }

--- a/ClickHouse.Driver.Tcp/Types/Codecs/DateTimeColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/DateTimeColumnCodec.cs
@@ -10,12 +10,14 @@ namespace ClickHouse.Driver.Tcp.Types.Codecs;
 /// <summary>
 /// Encodes ClickHouse <c>DateTime</c> as Unix seconds. The explicit or session timezone controls
 /// <see cref="DateTimeOffset"/> projections and how unspecified <see cref="DateTime"/> values are interpreted.
+/// The raw seconds need no timezone, so a zone this platform cannot represent surfaces only where a calendar
+/// value is asked for.
 /// </summary>
 internal sealed class DateTimeColumnCodec : IColumnCodec
 {
-    private readonly TimeZoneInfo timeZone;
+    private readonly ResolvedTimeZone timeZone;
 
-    private DateTimeColumnCodec(string typeName, TimeZoneInfo timeZone)
+    private DateTimeColumnCodec(string typeName, ResolvedTimeZone timeZone)
     {
         TypeName = typeName;
         this.timeZone = timeZone;
@@ -82,7 +84,7 @@ internal sealed class DateTimeColumnCodec : IColumnCodec
     public static DateTimeColumnCodec Create(TypeNode node, string serverTimezone)
     {
         string explicitTz = node.Arguments.Count > 0 ? DateTimeZones.UnquoteTimezone(node.Arguments[0]) : null;
-        TimeZoneInfo tz = DateTimeZones.Resolve(explicitTz, serverTimezone);
+        ResolvedTimeZone tz = DateTimeZones.Resolve(explicitTz, serverTimezone);
         return new DateTimeColumnCodec(node.ToString(), tz);
     }
 
@@ -101,15 +103,17 @@ internal sealed class DateTimeColumnCodec : IColumnCodec
             return true;
         }
 
+        // A calendar target is where the zone is needed, so an unrepresentable one is reported here rather than
+        // when the column was resolved, where it would fail a read that only wanted the seconds.
         if (targetType == typeof(DateTimeOffset))
         {
-            projected = ColumnValueProjections.Call(nameof(ColumnValueProjections.DateTimeToOffset), value, timeZone);
+            projected = ColumnValueProjections.Call(nameof(ColumnValueProjections.DateTimeToOffset), value, timeZone.Value);
             return true;
         }
 
         if (targetType == typeof(DateTime))
         {
-            projected = ColumnValueProjections.Call(nameof(ColumnValueProjections.DateTimeToDateTime), value, timeZone);
+            projected = ColumnValueProjections.Call(nameof(ColumnValueProjections.DateTimeToDateTime), value, timeZone.Value);
             return true;
         }
 
@@ -212,7 +216,7 @@ internal sealed class DateTimeColumnCodec : IColumnCodec
         return (uint)seconds;
     }
 
-    private uint ToWireValue(DateTime value) => ToUnixSeconds(ToUtc(value, timeZone));
+    private uint ToWireValue(DateTime value) => ToUnixSeconds(ToUtc(value, timeZone.Value));
 
     private static uint ToWireValue(DateTimeOffset value) => ToUnixSeconds(value.UtcDateTime);
 }

--- a/ClickHouse.Driver.Tcp/Types/Codecs/DateTimeZones.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/DateTimeZones.cs
@@ -5,6 +5,44 @@ using System.Text.RegularExpressions;
 namespace ClickHouse.Driver.Tcp.Types.Codecs;
 
 /// <summary>
+/// A column's timezone, or the reason this platform cannot represent the one the header named. A
+/// <c>DateTime</c> column carries a plain count that needs no zone, so an unrepresentable name is reported to a
+/// caller asking for a calendar value and not to the block read, which would lose every column and every row.
+/// </summary>
+internal sealed class ResolvedTimeZone
+{
+    /// <summary>UTC: the zone when neither the type string nor the session names one.</summary>
+    public static readonly ResolvedTimeZone Utc = new(TimeZoneInfo.Utc);
+
+    private readonly TimeZoneInfo zone;
+    private readonly string failure;
+    private readonly Exception cause;
+
+    /// <summary>Initializes a resolved zone.</summary>
+    /// <param name="zone">The zone.</param>
+    public ResolvedTimeZone(TimeZoneInfo zone) => this.zone = zone ?? throw new ArgumentNullException(nameof(zone));
+
+    private ResolvedTimeZone(string failure, Exception cause)
+    {
+        this.failure = failure;
+        this.cause = cause;
+    }
+
+    /// <summary>Whether a zone resolved, i.e. whether <see cref="Value"/> returns rather than throws.</summary>
+    public bool IsResolved => zone is not null;
+
+    /// <summary>The zone the column's counts are presented in.</summary>
+    /// <exception cref="FormatException">The header named a timezone this platform cannot represent.</exception>
+    public TimeZoneInfo Value => zone ?? throw new FormatException(failure, cause);
+
+    /// <summary>Records a timezone name no zone could be built from.</summary>
+    /// <param name="failure">The message <see cref="Value"/> throws with.</param>
+    /// <param name="cause">The underlying exception, when there was one.</param>
+    /// <returns>The unresolved timezone.</returns>
+    public static ResolvedTimeZone Unrepresentable(string failure, Exception cause = null) => new(failure, cause);
+}
+
+/// <summary>
 /// Resolves explicit and session timezones for the DateTime codecs. They control calendar projections and the
 /// interpretation of unspecified <see cref="DateTime"/> values; wire values remain UTC instants.
 /// </summary>
@@ -12,10 +50,11 @@ internal static class DateTimeZones
 {
     // ClickHouse emits synthetic fixed-offset timezone names like "Fixed/UTC+05:30:00" for a column declared
     // with a numeric UTC offset. These are not IANA ids, so FindSystemTimeZoneById cannot resolve them; they
-    // are parsed here into a custom fixed-offset zone instead. Minutes and seconds are restricted to 00-59 so
-    // a malformed name falls through rather than being misread as a different valid offset.
+    // are parsed here into a custom fixed-offset zone instead. The three components are summed as written,
+    // which is what the server does: 26.6 applies Fixed/UTC+05:00:60 as +05:01:00 and Fixed/UTC+05:70:00 as
+    // +06:10:00, keeping the name it was given.
     private static readonly Regex FixedUtcOffsetRegex = new(
-        @"^Fixed/UTC([+-])(\d{2}):([0-5]\d):([0-5]\d)$",
+        @"^Fixed/UTC([+-])(\d{2}):(\d{2}):(\d{2})$",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     /// <summary>
@@ -24,9 +63,12 @@ internal static class DateTimeZones
     /// </summary>
     /// <param name="explicitTimezone">The timezone from the type string (e.g. <c>Europe/London</c>), or null/empty.</param>
     /// <param name="serverTimezone">The session's timezone, or null/empty when unknown.</param>
-    /// <returns>The resolved timezone info.</returns>
-    /// <exception cref="FormatException">The named timezone is not known to the platform.</exception>
-    public static TimeZoneInfo Resolve(string explicitTimezone, string serverTimezone)
+    /// <returns>
+    /// The zone, or the reason it cannot be represented. Nothing here throws: a caller that needs the zone gets
+    /// the failure from <see cref="ResolvedTimeZone.Value"/>, so a name this platform cannot express does not
+    /// take a whole block's read with it.
+    /// </returns>
+    public static ResolvedTimeZone Resolve(string explicitTimezone, string serverTimezone)
     {
         string id = !string.IsNullOrEmpty(explicitTimezone) ? explicitTimezone
             : !string.IsNullOrEmpty(serverTimezone) ? serverTimezone
@@ -34,30 +76,30 @@ internal static class DateTimeZones
 
         if (id is null)
         {
-            return TimeZoneInfo.Utc;
+            return ResolvedTimeZone.Utc;
         }
 
         Match fixedOffset = FixedUtcOffsetRegex.Match(id);
         if (fixedOffset.Success)
         {
-            return CreateFixedOffsetZone(id, fixedOffset);
+            return FixedOffsetZone(id, fixedOffset);
         }
 
         try
         {
-            return TimeZoneInfo.FindSystemTimeZoneById(id);
+            return new ResolvedTimeZone(TimeZoneInfo.FindSystemTimeZoneById(id));
         }
         catch (TimeZoneNotFoundException ex)
         {
-            throw new FormatException($"Timezone '{id}' is not known to this platform.", ex);
+            return ResolvedTimeZone.Unrepresentable($"Timezone '{id}' is not known to this platform.", ex);
         }
         catch (InvalidTimeZoneException ex)
         {
-            throw new FormatException($"Timezone '{id}' is invalid.", ex);
+            return ResolvedTimeZone.Unrepresentable($"Timezone '{id}' is invalid.", ex);
         }
     }
 
-    private static TimeZoneInfo CreateFixedOffsetZone(string id, Match match)
+    private static ResolvedTimeZone FixedOffsetZone(string id, Match match)
     {
         int sign = match.Groups[1].Value == "+" ? 1 : -1;
         int hours = int.Parse(match.Groups[2].Value, CultureInfo.InvariantCulture);
@@ -65,16 +107,30 @@ internal static class DateTimeZones
         int seconds = int.Parse(match.Groups[4].Value, CultureInfo.InvariantCulture);
         int totalSeconds = sign * ((hours * 3600) + (minutes * 60) + seconds);
 
-        // A custom TimeZoneInfo base offset must be within ±14 hours and a whole number of minutes; ClickHouse
-        // fixed offsets in practice satisfy both, but reject anything that does not rather than let the BCL
-        // throw an opaque ArgumentException.
+        // A custom TimeZoneInfo base offset must be within ±14 hours and a whole number of minutes. The server
+        // goes further — 26.6 accepts and applies Fixed/UTC+19:00:00 and Fixed/UTC+05:30:15 — so an offset it
+        // uses and .NET cannot express is reported to whoever asks for a calendar value.
         if (Math.Abs(totalSeconds) > 14 * 3600 || totalSeconds % 60 != 0)
         {
-            throw new FormatException(
-                $"Timezone '{id}' has an offset outside the representable range (±14 hours, whole minutes).");
+            return ResolvedTimeZone.Unrepresentable(
+                $"Timezone '{id}' has an offset of {OffsetText(totalSeconds)}, which .NET's TimeZoneInfo cannot represent " +
+                "(it allows ±14 hours, in whole minutes). A DateTime or DateTime64 column with this timezone still reads " +
+                "as its raw counts; only a calendar value needs the zone.");
         }
 
-        return TimeZoneInfo.CreateCustomTimeZone(id, TimeSpan.FromSeconds(totalSeconds), id, id);
+        return new ResolvedTimeZone(TimeZoneInfo.CreateCustomTimeZone(id, TimeSpan.FromSeconds(totalSeconds), id, id));
+    }
+
+    private static string OffsetText(int totalSeconds)
+    {
+        int magnitude = Math.Abs(totalSeconds);
+        return string.Format(
+            CultureInfo.InvariantCulture,
+            "{0}{1:00}:{2:00}:{3:00}",
+            totalSeconds < 0 ? '-' : '+',
+            magnitude / 3600,
+            magnitude / 60 % 60,
+            magnitude % 60);
     }
 
     /// <summary>Extracts the single-quoted timezone argument from a type node's arguments, or null when absent.</summary>

--- a/ClickHouse.Driver.Tcp/Types/Codecs/DynamicColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/DynamicColumnCodec.cs
@@ -149,8 +149,9 @@ internal sealed class DynamicColumnCodec : IColumnCodec
     {
         if (rowCount == 0)
         {
-            // A zero-row block carries neither the version/type-list prefix (the block layer skips the prefix for
-            // zero rows) nor any body; surface an empty column with no runtime types.
+            // A zero-row Dynamic puts no discriminators and no runtime-type runs on the wire, so there is nothing
+            // to read here. Its prefix was either skipped with the rest of a zero-row block, or already read by
+            // an enclosing container whose every row is empty. Surface an empty column with no runtime types.
             return new DynamicColumn(columnName, columnType, Array.Empty<string>(), Array.Empty<int>(), Array.Empty<IColumn>(), 0, pooledDiscriminators: false, ownsColumns: true);
         }
 

--- a/ClickHouse.Driver.Tcp/Types/Codecs/EnumColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/EnumColumnCodec.cs
@@ -211,43 +211,21 @@ internal sealed class EnumColumnCodec<T> : IColumnCodec
     /// <summary>Parses a single <c>'label' = ordinal</c> member token into its label and ordinal.</summary>
     private static (string Label, long Ordinal) ParseMember(string token, TypeNode node)
     {
-        // A member is a single-quoted label, then '=', then a signed integer, e.g. 'a' = -1. The label may
-        // contain escaped quotes (\') and backslashes (\\), and may itself contain '=' inside the quotes, so
-        // scan the quoted run rather than splitting naively on '='.
+        // A member is a single-quoted label, then '=', then a signed integer, e.g. 'a' = -1. The label carries the
+        // server's own escaping (a label with a newline arrives as 'a\nb'), and may contain '=' or a comma inside
+        // the quotes, so scan and decode the quoted run rather than splitting naively on '='.
         int open = token.IndexOf('\'');
         if (open < 0)
         {
             throw new FormatException($"Malformed enum member '{token}' in type '{node}': expected a quoted label.");
         }
 
-        var label = new System.Text.StringBuilder();
-        int i = open + 1;
-        bool closed = false;
-        for (; i < token.Length; i++)
-        {
-            char c = token[i];
-            if (c == '\\' && i + 1 < token.Length)
-            {
-                label.Append(token[++i]);
-                continue;
-            }
-
-            if (c == '\'')
-            {
-                closed = true;
-                i++;
-                break;
-            }
-
-            label.Append(c);
-        }
-
-        if (!closed)
+        if (!QuotedText.TryRead(token, open, out string label, out int afterLabel))
         {
             throw new FormatException($"Malformed enum member '{token}' in type '{node}': unterminated label.");
         }
 
-        string rest = token.Substring(i).Trim();
+        string rest = token.Substring(afterLabel).Trim();
         if (rest.Length == 0 || rest[0] != '=')
         {
             throw new FormatException($"Malformed enum member '{token}' in type '{node}': expected '= ordinal' after the label.");
@@ -259,7 +237,7 @@ internal sealed class EnumColumnCodec<T> : IColumnCodec
             throw new FormatException($"Malformed enum member '{token}' in type '{node}': '{ordinalText}' is not a valid ordinal.");
         }
 
-        return (label.ToString(), ordinal);
+        return (label, ordinal);
     }
 }
 

--- a/ClickHouse.Driver.Tcp/Types/Codecs/EnumColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/EnumColumnCodec.cs
@@ -108,7 +108,7 @@ internal sealed class EnumColumnCodec<T> : IColumnCodec
 
         foreach (TypeNode argument in node.Arguments)
         {
-            (string label, long ordinal) = ParseMember(argument.Name, node);
+            (string label, long ordinal) = EnumColumnCodec.ParseMember(argument.Name, node);
             T value = parseOrdinal(ordinal, node.Name);
             if (!labelToOrdinal.TryAdd(label, value))
             {
@@ -207,9 +207,37 @@ internal sealed class EnumColumnCodec<T> : IColumnCodec
         => label is not null && LabelToOrdinal.TryGetValue(label, out T ordinal)
             ? ordinal
             : throw members.NoSuchLabel(label, nameof(label));
+}
+
+/// <summary>
+/// Factory for the bare <c>Enum</c> name, and the member parsing the three factories share.
+/// </summary>
+internal static class EnumColumnCodec
+{
+    /// <summary>Builds the codec for a bare <c>Enum</c>, whose width comes from the declared ordinals.</summary>
+    /// <param name="node">The parsed <c>Enum</c> type node.</param>
+    /// <returns>An <c>Enum8</c> or <c>Enum16</c> codec, named for the width chosen.</returns>
+    /// <exception cref="FormatException">A member is malformed, or no member is declared.</exception>
+    public static IColumnCodec Create(TypeNode node)
+    {
+        // Verified on 26.6: the server takes Enum8 while every ordinal is in the Int8 range and Enum16
+        // otherwise, and reports the column under the width it chose.
+        bool fitsInt8 = true;
+        foreach (TypeNode argument in node.Arguments)
+        {
+            (_, long ordinal) = ParseMember(argument.Name, node);
+            if (ordinal is < sbyte.MinValue or > sbyte.MaxValue)
+            {
+                fitsInt8 = false;
+            }
+        }
+
+        var sized = new TypeNode(fitsInt8 ? "Enum8" : "Enum16", node.Arguments, node.HasArgumentList);
+        return fitsInt8 ? Enum8ColumnCodec.Create(sized) : Enum16ColumnCodec.Create(sized);
+    }
 
     /// <summary>Parses a single <c>'label' = ordinal</c> member token into its label and ordinal.</summary>
-    private static (string Label, long Ordinal) ParseMember(string token, TypeNode node)
+    internal static (string Label, long Ordinal) ParseMember(string token, TypeNode node)
     {
         // A member is a single-quoted label, then '=', then a signed integer, e.g. 'a' = -1. The label carries the
         // server's own escaping (a label with a newline arrives as 'a\nb'), and may contain '=' or a comma inside

--- a/ClickHouse.Driver.Tcp/Types/Codecs/QBitColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/QBitColumnCodec.cs
@@ -70,6 +70,9 @@ internal abstract class QBitColumnCodec : IColumnCodec
                 $"QBit type '{node}' has an invalid vector length '{token}'; expected a positive integer.");
         }
 
+        // The four element types this codec encodes, each stored the same way — bits(T) planes over the element's
+        // raw bit pattern, most significant first. A fifth would need its own plane width here, so this is what
+        // the client implements rather than a copy of what the server permits.
         return element switch
         {
             "Int8" => new QBitSByteColumnCodec(typeName, dimension),
@@ -77,7 +80,7 @@ internal abstract class QBitColumnCodec : IColumnCodec
             "Float32" => new QBitFloatColumnCodec(typeName, dimension, bitWidth: 32),
             "Float64" => new QBitDoubleColumnCodec(typeName, dimension),
             _ => throw new NotSupportedException(
-                $"QBit type '{node}' has element type '{element}'; only Int8, BFloat16, Float32 and Float64 are supported."),
+                $"QBit type '{node}' has element type '{element}'; this client encodes Int8, BFloat16, Float32 and Float64."),
         };
     }
 

--- a/ClickHouse.Driver.Tcp/Types/Codecs/Time64ColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/Time64ColumnCodec.cs
@@ -12,7 +12,12 @@ namespace ClickHouse.Driver.Tcp.Types.Codecs;
 /// A codec for the ClickHouse <c>Time64(scale)</c> column: a little-endian <c>Int64</c> tick count at
 /// 10^-<c>scale</c> seconds (a signed time-of-day/duration), surfaced as the raw <see cref="long"/> count that
 /// retains the exact wire value at any scale (including scales 8 and 9, which are finer than a .NET tick). A
-/// <see cref="TimeSpan"/> can also be written for convenience, truncated toward zero to the column scale.
+/// <see cref="TimeSpan"/> or a <see cref="TimeOnly"/> can also be written for convenience, truncated toward zero
+/// to the column scale.
+/// <para>
+/// Reading as a <see cref="TimeOnly"/> is a narrowing: a column value may be negative or past 24 hours, which no
+/// time of day is, and such a row is refused rather than reduced modulo a day.
+/// </para>
 /// </summary>
 internal sealed class Time64ColumnCodec : IColumnCodec
 {
@@ -37,10 +42,10 @@ internal sealed class Time64ColumnCodec : IColumnCodec
     public Type ElementType => typeof(long);
 
     /// <inheritdoc/>
-    public IReadOnlyList<Type> WritableElementTypes { get; } = new[] { typeof(long), typeof(TimeSpan) };
+    public IReadOnlyList<Type> WritableElementTypes { get; } = new[] { typeof(long), typeof(TimeSpan), typeof(TimeOnly) };
 
     /// <inheritdoc/>
-    public IReadOnlyList<Type> ReadableElementTypes { get; } = new[] { typeof(long), typeof(TimeSpan) };
+    public IReadOnlyList<Type> ReadableElementTypes { get; } = new[] { typeof(long), typeof(TimeSpan), typeof(TimeOnly) };
 
     /// <inheritdoc/>
     public object NullPlaceholder => 0L;
@@ -58,12 +63,17 @@ internal sealed class Time64ColumnCodec : IColumnCodec
             return TimeSpan.Zero;
         }
 
+        if (writeType == typeof(TimeOnly))
+        {
+            return TimeOnly.MinValue;
+        }
+
         throw new NotSupportedException($"The '{TypeName}' codec has no null placeholder for {writeType}.");
     }
 
     /// <inheritdoc/>
-    // A TimeSpan is encoded as a count at this column's scale, so two values inside one tick of it encode
-    // identically.
+    // Both clock surfaces are encoded as a count at this column's scale, so two values inside one tick of it
+    // encode identically.
     public object WireEqualityComparer(Type writeType)
     {
         if (writeType == typeof(long))
@@ -71,7 +81,12 @@ internal sealed class Time64ColumnCodec : IColumnCodec
             return WireEquality.Default<long>();
         }
 
-        return writeType == typeof(TimeSpan) ? WireEquality.Projected<TimeSpan, long>(ToCount) : null;
+        if (writeType == typeof(TimeSpan))
+        {
+            return WireEquality.Projected<TimeSpan, long>(ToCount);
+        }
+
+        return writeType == typeof(TimeOnly) ? WireEquality.Projected<TimeOnly, long>(ToCount) : null;
     }
 
     /// <summary>Builds a <c>Time64</c> codec from its scale argument.</summary>
@@ -114,12 +129,18 @@ internal sealed class Time64ColumnCodec : IColumnCodec
             return true;
         }
 
+        if (targetType == typeof(TimeOnly))
+        {
+            projected = ColumnValueProjections.Call(nameof(ColumnValueProjections.Time64ToTimeOnly), value, scale);
+            return true;
+        }
+
         projected = null;
         return false;
     }
 
     /// <inheritdoc/>
-    public bool CanWrite(IColumn column) => column is IColumn<long> or IColumn<TimeSpan>;
+    public bool CanWrite(IColumn column) => column is IColumn<long> or IColumn<TimeSpan> or IColumn<TimeOnly>;
 
     /// <inheritdoc/>
     public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
@@ -140,10 +161,22 @@ internal sealed class Time64ColumnCodec : IColumnCodec
                 }
 
                 break;
+            case IColumn<TimeOnly> times:
+                for (int i = 0; i < length; i++)
+                {
+                    writer.WriteInt64(ToCount(times[start + i]));
+                }
+
+                break;
             default:
-                throw new ArgumentException($"A Time64 column must hold long or TimeSpan values, not {column.GetType()}.", nameof(column));
+                throw new ArgumentException($"A Time64 column must hold long, TimeSpan or TimeOnly values, not {column.GetType()}.", nameof(column));
         }
     }
+
+    // A time of day is always inside the column's range, so this needs no bound of its own; only the scale
+    // shift, which truncates toward zero exactly as the TimeSpan path does.
+    private long ToCount(TimeOnly value)
+        => FixedPointScaling.ShiftDecimalPlaces(value.Ticks, scale - DotNetTickScale);
 
     private long ToCount(TimeSpan value)
     {

--- a/ClickHouse.Driver.Tcp/Types/Codecs/TimeColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/TimeColumnCodec.cs
@@ -10,7 +10,12 @@ namespace ClickHouse.Driver.Tcp.Types.Codecs;
 /// <summary>
 /// A codec for the ClickHouse <c>Time</c> column: a little-endian <c>Int32</c> second count (a signed
 /// time-of-day/duration, not tied to a date), surfaced as the raw <see cref="int"/> second count. The
-/// representable range is [-999:59:59, 999:59:59]. A <see cref="TimeSpan"/> can also be written for convenience.
+/// representable range is [-999:59:59, 999:59:59]. A <see cref="TimeSpan"/> or a <see cref="TimeOnly"/> can also
+/// be written for convenience.
+/// <para>
+/// Reading as a <see cref="TimeOnly"/> is a narrowing: a column value may be negative or past 24 hours, which no
+/// time of day is, and such a row is refused rather than reduced modulo a day.
+/// </para>
 /// </summary>
 internal sealed class TimeColumnCodec : IColumnCodec
 {
@@ -32,10 +37,10 @@ internal sealed class TimeColumnCodec : IColumnCodec
     public Type ElementType => typeof(int);
 
     /// <inheritdoc/>
-    public IReadOnlyList<Type> WritableElementTypes { get; } = new[] { typeof(int), typeof(TimeSpan) };
+    public IReadOnlyList<Type> WritableElementTypes { get; } = new[] { typeof(int), typeof(TimeSpan), typeof(TimeOnly) };
 
     /// <inheritdoc/>
-    public IReadOnlyList<Type> ReadableElementTypes { get; } = new[] { typeof(int), typeof(TimeSpan) };
+    public IReadOnlyList<Type> ReadableElementTypes { get; } = new[] { typeof(int), typeof(TimeSpan), typeof(TimeOnly) };
 
     /// <inheritdoc/>
     public object NullPlaceholder => 0;
@@ -53,11 +58,16 @@ internal sealed class TimeColumnCodec : IColumnCodec
             return TimeSpan.Zero;
         }
 
+        if (writeType == typeof(TimeOnly))
+        {
+            return TimeOnly.MinValue;
+        }
+
         throw new NotSupportedException($"The '{TypeName}' codec has no null placeholder for {writeType}.");
     }
 
     /// <inheritdoc/>
-    // A TimeSpan is encoded as whole seconds, so two values inside one second encode identically.
+    // Both clock surfaces are encoded as whole seconds, so two values inside one second encode identically.
     public object WireEqualityComparer(Type writeType)
     {
         if (writeType == typeof(int))
@@ -65,7 +75,12 @@ internal sealed class TimeColumnCodec : IColumnCodec
             return WireEquality.Default<int>();
         }
 
-        return writeType == typeof(TimeSpan) ? WireEquality.Projected<TimeSpan, int>(ToSeconds) : null;
+        if (writeType == typeof(TimeSpan))
+        {
+            return WireEquality.Projected<TimeSpan, int>(ToSeconds);
+        }
+
+        return writeType == typeof(TimeOnly) ? WireEquality.Projected<TimeOnly, int>(ToSeconds) : null;
     }
 
     /// <inheritdoc/>
@@ -89,12 +104,18 @@ internal sealed class TimeColumnCodec : IColumnCodec
             return true;
         }
 
+        if (targetType == typeof(TimeOnly))
+        {
+            projected = ColumnValueProjections.Call(nameof(ColumnValueProjections.TimeToTimeOnly), value);
+            return true;
+        }
+
         projected = null;
         return false;
     }
 
     /// <inheritdoc/>
-    public bool CanWrite(IColumn column) => column is IColumn<int> or IColumn<TimeSpan>;
+    public bool CanWrite(IColumn column) => column is IColumn<int> or IColumn<TimeSpan> or IColumn<TimeOnly>;
 
     /// <inheritdoc/>
     public void WriteColumn(ClickHouseBinaryWriter writer, IColumn column, int start, int length)
@@ -115,10 +136,20 @@ internal sealed class TimeColumnCodec : IColumnCodec
                 }
 
                 break;
+            case IColumn<TimeOnly> times:
+                for (int i = 0; i < length; i++)
+                {
+                    writer.WriteInt32(ToSeconds(times[start + i]));
+                }
+
+                break;
             default:
-                throw new ArgumentException($"A Time column must hold int or TimeSpan values, not {column.GetType()}.", nameof(column));
+                throw new ArgumentException($"A Time column must hold int, TimeSpan or TimeOnly values, not {column.GetType()}.", nameof(column));
         }
     }
+
+    // A time of day is always inside the column's range, so this needs no bound of its own.
+    private static int ToSeconds(TimeOnly value) => (int)(value.Ticks / TimeSpan.TicksPerSecond);
 
     private static int ToSeconds(TimeSpan value)
     {

--- a/ClickHouse.Driver.Tcp/Types/Codecs/VariantColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/VariantColumnCodec.cs
@@ -254,9 +254,9 @@ internal sealed class VariantColumnCodec : IColumnCodec
     }
 
     /// <inheritdoc/>
-    // A dense variant column is only writable when its alternatives match this codec's; a bare IColumn<object> is
-    // scattered by runtime CLR type. A variant column of a different arity is rejected here rather than silently
-    // re-scattered (which could reorder its discriminators).
+    // Any column of boxed values is writable in shape: a dense VariantColumn whose alternatives are this codec's
+    // own goes out as its own discriminator stream, and anything else is scattered by each value's runtime CLR
+    // type. Which of the two a column takes is BeginWrite's decision, not this one.
     //
     // The dense test is the concrete VariantColumn, not the public IVariantColumn: the dense writer trusts
     // invariants only that class's constructor establishes (every discriminator is either a valid alternative index
@@ -273,8 +273,7 @@ internal sealed class VariantColumnCodec : IColumnCodec
     public bool CanWriteElementType(Type elementType) => allChildrenWritable && elementType == ElementType;
 
     /// <inheritdoc/>
-    public bool CanWrite(IColumn column)
-        => allChildrenWritable && (column is VariantColumn dense ? dense.TypeCount == children.Length : column is IColumn<object>);
+    public bool CanWrite(IColumn column) => allChildrenWritable && column is IColumn<object>;
 
     /// <inheritdoc/>
     // Project the slice into one column per alternative once, and open each alternative's own write state over it,
@@ -282,9 +281,35 @@ internal sealed class VariantColumnCodec : IColumnCodec
     // Every alternative gets a column and a state even when no row selects it: the alternative set is fixed by the
     // type rather than by the data, so each one's prefix belongs on the wire regardless of which rows arrived.
     public IColumnWriteState BeginWrite(IColumn column, int start, int length)
-        => column is VariantColumn dense && dense.TypeCount == children.Length
+        => column is VariantColumn dense && HasTheSameAlternatives(dense)
             ? BuildDenseState(dense, start, length)
             : BuildScatteredState(column, start, length);
+
+    // The dense path pairs the column's alternative i with this codec's alternative i and reuses the column's own
+    // discriminators, so it is only correct when the two alternative lists are the same list. Matching on the count
+    // alone paired Int64 with Bool for a two-alternative column and failed inside the body, after the
+    // discriminators had gone out — a write that CanWrite had already said yes to. A column that does not match
+    // goes down the scattered path instead of being refused: scattering reads each value's own runtime type, so a
+    // read-back of one Variant lands in the right alternative of another, and a value that fits no alternative is
+    // refused before anything is written.
+    private bool HasTheSameAlternatives(VariantColumn dense)
+    {
+        if (dense.TypeCount != children.Length)
+        {
+            return false;
+        }
+
+        IReadOnlyList<string> names = dense.TypeNames;
+        for (int i = 0; i < children.Length; i++)
+        {
+            if (!string.Equals(names[i], children[i].TypeName, StringComparison.Ordinal))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
 
     /// <inheritdoc/>
     public void WriteStatePrefix(ClickHouseBinaryWriter writer, IColumn column, int start, int length)

--- a/ClickHouse.Driver.Tcp/Types/Codecs/VariantColumnCodec.cs
+++ b/ClickHouse.Driver.Tcp/Types/Codecs/VariantColumnCodec.cs
@@ -187,13 +187,14 @@ internal sealed class VariantColumnCodec : IColumnCodec
                     $"Variant alternative '{argument}' must not be Nullable; a Variant carries NULL through its discriminator, not a nullable alternative.");
             }
 
-            // The server rejects Dynamic inside Variant (Dynamic is a superset of Variant). Reject it client-side
-            // too: a Variant does not thread the per-operation write state a data-dependent alternative needs, so a
-            // Dynamic alternative would desynchronize its type-list prefix from its body.
+            // A Variant does not thread the per-operation write state a data-dependent alternative needs, so a
+            // Dynamic alternative would desynchronize its type-list prefix from its body. That is this client's
+            // own limit; the server rejecting the type as well is not the reason to refuse it here.
             if (string.Equals(argument.Name, "Dynamic", StringComparison.Ordinal))
             {
                 throw new FormatException(
-                    $"Variant alternative '{argument}' must not be Dynamic; the server does not allow a Dynamic type inside a Variant.");
+                    $"Variant alternative '{argument}' must not be Dynamic; this client cannot write a Dynamic alternative, "
+                    + "whose type list would desynchronize from its body.");
             }
 
             childCodecs[i] = registry.ResolveNode(argument, in context);

--- a/ClickHouse.Driver.Tcp/Types/ColumnCodecRegistry.cs
+++ b/ClickHouse.Driver.Tcp/Types/ColumnCodecRegistry.cs
@@ -46,11 +46,21 @@ internal sealed class ColumnCodecRegistry
     /// resolving an INSERT target, or <see cref="ResolveContext.ForWrite"/> when no server context exists.</param>
     /// <returns>The codec for that type.</returns>
     /// <exception cref="FormatException"><paramref name="typeString"/> is malformed.</exception>
-    /// <exception cref="NotSupportedException">The type is well-formed but not yet supported by this client.</exception>
+    /// <exception cref="NotSupportedException">The type is well-formed but this client has no codec for it.</exception>
     public IColumnCodec Resolve(string typeString, in ResolveContext context)
     {
         TypeNode node = TypeParser.Parse(typeString);
-        return ResolveNode(node, in context);
+        try
+        {
+            return ResolveNode(node, in context);
+        }
+        catch (NotSupportedException refusal) when (!refusal.Message.Contains($"'{node}'", StringComparison.Ordinal))
+        {
+            // A refusal from a child names only the child, and 'Boolean' on its own sends a caller searching
+            // their code for a name they never wrote. Keep that message and add the type they did write. The
+            // exception type stays NotSupportedException, which is what the contract promises and callers catch.
+            throw new NotSupportedException($"{refusal.Message} It is inside the column type '{node}'.", refusal);
+        }
     }
 
     /// <summary>
@@ -60,7 +70,7 @@ internal sealed class ColumnCodecRegistry
     /// <param name="node">The parsed type node.</param>
     /// <param name="context">The resolution context (server timezone, etc.).</param>
     /// <returns>The codec for that type.</returns>
-    /// <exception cref="NotSupportedException">The type is well-formed but not yet supported by this client.</exception>
+    /// <exception cref="NotSupportedException">The type is well-formed but this client has no codec for it.</exception>
     public IColumnCodec ResolveNode(TypeNode node, in ResolveContext context)
     {
         if (byName.TryGetValue(node.Name, out CodecFactory factory))
@@ -68,7 +78,9 @@ internal sealed class ColumnCodecRegistry
             return factory(node, in context, this);
         }
 
-        throw new NotSupportedException($"ClickHouse type '{node}' is not supported by this client yet.");
+        // No "yet": some of what lands here is not a type any supported server has — Object('json') was removed
+        // from ClickHouse, and MultiPoint never existed — so promising it later would be wrong.
+        throw new NotSupportedException($"ClickHouse type '{node}' is not supported by this client.");
     }
 
     private static ColumnCodecRegistry CreateDefault()

--- a/ClickHouse.Driver.Tcp/Types/ColumnCodecRegistry.cs
+++ b/ClickHouse.Driver.Tcp/Types/ColumnCodecRegistry.cs
@@ -28,9 +28,18 @@ internal sealed class ColumnCodecRegistry
 
     private readonly Dictionary<string, CodecFactory> byName;
 
+    /// <summary>Every registered name keyed without regard to case, so any case a caller writes resolves.</summary>
+    private readonly Dictionary<string, string> canonicalByAnyCase;
+
     private ColumnCodecRegistry(Dictionary<string, CodecFactory> byName)
     {
         this.byName = byName;
+        canonicalByAnyCase = new Dictionary<string, string>(byName.Count, StringComparer.OrdinalIgnoreCase);
+        foreach (string name in byName.Keys)
+        {
+            canonicalByAnyCase[name] = name;
+        }
+
         Projections = new ColumnReadProjections(this);
     }
 
@@ -41,9 +50,33 @@ internal sealed class ColumnCodecRegistry
     public ColumnReadProjections Projections { get; }
 
     /// <summary>Whether a codec is registered for a base type name, i.e. whether this client knows the type.</summary>
-    /// <param name="name">The base type name, as ClickHouse spells it.</param>
+    /// <param name="name">The base type name, in any case and under any of its aliases.</param>
     /// <returns>True when the name is one this client resolves.</returns>
-    public bool KnowsTypeName(string name) => byName.ContainsKey(name);
+    public bool KnowsTypeName(string name) => TryCanonicalName(name, out _);
+
+    /// <summary>
+    /// The spelling this client registers a type under, for a name a caller wrote: an alias, or any case of a
+    /// registered name. Case is not checked against the server's own per-family rules — a name the server
+    /// happens to reject is the server's to reject, and it says so far better than a guess here would.
+    /// </summary>
+    /// <param name="name">The base type name as the caller wrote it.</param>
+    /// <param name="canonical">The registered spelling, or null when no codec matches the name.</param>
+    /// <returns>True when a codec is registered under some spelling of the name.</returns>
+    public bool TryCanonicalName(string name, out string canonical)
+    {
+        if (name is not null && byName.ContainsKey(name))
+        {
+            canonical = name;
+            return true;
+        }
+
+        if (TypeAliases.TryCanonical(name, out canonical) && byName.ContainsKey(canonical))
+        {
+            return true;
+        }
+
+        return canonicalByAnyCase.TryGetValue(name ?? string.Empty, out canonical);
+    }
 
     /// <summary>Resolves the codec for a ClickHouse type string.</summary>
     /// <param name="typeString">The type string from a column header (e.g. <c>UInt64</c>, <c>DateTime('UTC')</c>).</param>
@@ -84,12 +117,12 @@ internal sealed class ColumnCodecRegistry
         }
 
         // A header always names the canonical type, so this second lookup is for the names a caller writes: a
-        // {p:VARCHAR} hint, ClickHouseType, CanRead/CanWrite. Resolving under the canonical name also stamps the
+        // {p:VARCHAR} hint, ClickHouseType, CanRead/CanWrite. Resolving under the registered name also stamps the
         // codec with it, so DEC(4, 2) reports itself as Decimal(4, 2). Child nodes come back through here, which
         // is what makes an alias resolve inside a composite.
-        if (TypeAliases.TryCanonical(node.Name, out string canonical) && byName.TryGetValue(canonical, out factory))
+        if (TryCanonicalName(node.Name, out string canonical))
         {
-            return factory(new TypeNode(canonical, node.Arguments, node.HasArgumentList), in context, this);
+            return byName[canonical](new TypeNode(canonical, node.Arguments, node.HasArgumentList), in context, this);
         }
 
         // No "yet": some of what lands here is not a type any supported server has — Object('json') was removed

--- a/ClickHouse.Driver.Tcp/Types/ColumnCodecRegistry.cs
+++ b/ClickHouse.Driver.Tcp/Types/ColumnCodecRegistry.cs
@@ -40,6 +40,11 @@ internal sealed class ColumnCodecRegistry
     /// </summary>
     public ColumnReadProjections Projections { get; }
 
+    /// <summary>Whether a codec is registered for a base type name, i.e. whether this client knows the type.</summary>
+    /// <param name="name">The base type name, as ClickHouse spells it.</param>
+    /// <returns>True when the name is one this client resolves.</returns>
+    public bool KnowsTypeName(string name) => byName.ContainsKey(name);
+
     /// <summary>Resolves the codec for a ClickHouse type string.</summary>
     /// <param name="typeString">The type string from a column header (e.g. <c>UInt64</c>, <c>DateTime('UTC')</c>).</param>
     /// <param name="context">The resolution context (server timezone, etc.); use the sample block's context when

--- a/ClickHouse.Driver.Tcp/Types/ColumnCodecRegistry.cs
+++ b/ClickHouse.Driver.Tcp/Types/ColumnCodecRegistry.cs
@@ -158,6 +158,10 @@ internal sealed class ColumnCodecRegistry
         AddFactory("Enum8", static (TypeNode node, in ResolveContext _, ColumnCodecRegistry _) => Enum8ColumnCodec.Create(node));
         AddFactory("Enum16", static (TypeNode node, in ResolveContext _, ColumnCodecRegistry _) => Enum16ColumnCodec.Create(node));
 
+        // A header always names a width, so the bare name only ever arrives from a caller: a {p:Enum(...)} hint
+        // or a CanRead/CanWrite question. The shipped HTTP driver resolves it, so a moved query keeps working.
+        AddFactory("Enum", static (TypeNode node, in ResolveContext _, ColumnCodecRegistry _) => EnumColumnCodec.Create(node));
+
         // Decimal(P, S) and the fixed-width aliases share the width-by-precision codec factory.
         foreach (string name in new[] { "Decimal", "Decimal32", "Decimal64", "Decimal128", "Decimal256" })
         {

--- a/ClickHouse.Driver.Tcp/Types/ColumnCodecRegistry.cs
+++ b/ClickHouse.Driver.Tcp/Types/ColumnCodecRegistry.cs
@@ -83,6 +83,15 @@ internal sealed class ColumnCodecRegistry
             return factory(node, in context, this);
         }
 
+        // A header always names the canonical type, so this second lookup is for the names a caller writes: a
+        // {p:VARCHAR} hint, ClickHouseType, CanRead/CanWrite. Resolving under the canonical name also stamps the
+        // codec with it, so DEC(4, 2) reports itself as Decimal(4, 2). Child nodes come back through here, which
+        // is what makes an alias resolve inside a composite.
+        if (TypeAliases.TryCanonical(node.Name, out string canonical) && byName.TryGetValue(canonical, out factory))
+        {
+            return factory(new TypeNode(canonical, node.Arguments, node.HasArgumentList), in context, this);
+        }
+
         // No "yet": some of what lands here is not a type any supported server has — Object('json') was removed
         // from ClickHouse, and MultiPoint never existed — so promising it later would be wrong.
         throw new NotSupportedException($"ClickHouse type '{node}' is not supported by this client.");

--- a/ClickHouse.Driver.Tcp/Types/ColumnValueProjections.cs
+++ b/ClickHouse.Driver.Tcp/Types/ColumnValueProjections.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Linq.Expressions;
 using System.Reflection;
 using ClickHouse.Driver.Tcp.Types.Codecs;
@@ -20,6 +21,8 @@ internal static class ColumnValueProjections
 
     /// <summary>The exclusive upper bound of a time of day.</summary>
     private static readonly TimeSpan OneDay = TimeSpan.FromDays(1);
+
+    private const long SecondsPerDay = 24 * 60 * 60;
 
     /// <summary>
     /// Presents an instant as a <see cref="DateTime"/>: a zero offset yields <see cref="DateTimeKind.Utc"/>, any
@@ -116,7 +119,19 @@ internal static class ColumnValueProjections
     /// <param name="scale">The column's fractional-second scale (0–9).</param>
     /// <returns>The time of day, with sub-100 ns digits truncated toward zero.</returns>
     /// <exception cref="InvalidOperationException">The value is not a time of day.</exception>
-    public static TimeOnly Time64ToTimeOnly(long count, int scale) => AsTimeOfDay(Time64ToTimeSpan(count, scale), "Time64");
+    public static TimeOnly Time64ToTimeOnly(long count, int scale)
+    {
+        // Checked on the raw count rather than on the TimeSpan: at scale 8 or 9 the shift to 100 ns ticks
+        // truncates toward zero, so a negative count finer than one tick reaches zero and passes a check made
+        // after it. -1 at scale 9 would read as midnight.
+        if (count < 0 || count >= SecondsPerDay * FixedPointScaling.Pow10(scale))
+        {
+            decimal seconds = (decimal)count / FixedPointScaling.Pow10(scale);
+            throw NotATimeOfDay("Time64", $"{seconds.ToString(CultureInfo.InvariantCulture)} s");
+        }
+
+        return TimeOnly.FromTimeSpan(Time64ToTimeSpan(count, scale));
+    }
 
     /// <summary>
     /// Confirms a codec was handed an expression of its canonical <see cref="IColumnCodec.ElementType"/>. Catches the
@@ -144,12 +159,14 @@ internal static class ColumnValueProjections
     {
         if (value < TimeSpan.Zero || value >= OneDay)
         {
-            throw new InvalidOperationException(
-                $"A {typeName} column value of {value} is not a time of day, so it has no TimeOnly. Read the column as a TimeSpan.");
+            throw NotATimeOfDay(typeName, value.ToString());
         }
 
         return TimeOnly.FromTimeSpan(value);
     }
+
+    private static InvalidOperationException NotATimeOfDay(string typeName, string value)
+        => new($"A {typeName} column value of {value} is not a time of day, so it has no TimeOnly. Read the column as a TimeSpan.");
 
     /// <summary>
     /// Lifts an inner codec's projection over a source that can be absent: an absent row yields

--- a/ClickHouse.Driver.Tcp/Types/ColumnValueProjections.cs
+++ b/ClickHouse.Driver.Tcp/Types/ColumnValueProjections.cs
@@ -18,6 +18,9 @@ internal static class ColumnValueProjections
 
     private static readonly long UnixEpochTicks = DateTime.UnixEpoch.Ticks;
 
+    /// <summary>The exclusive upper bound of a time of day.</summary>
+    private static readonly TimeSpan OneDay = TimeSpan.FromDays(1);
+
     /// <summary>
     /// Presents an instant as a <see cref="DateTime"/>: a zero offset yields <see cref="DateTimeKind.Utc"/>, any
     /// other offset the wall clock in the column's timezone as <see cref="DateTimeKind.Unspecified"/>.
@@ -102,6 +105,19 @@ internal static class ColumnValueProjections
     public static TimeSpan Time64ToTimeSpan(long count, int scale)
         => TimeSpan.FromTicks(FixedPointScaling.ShiftDecimalPlaces(count, DotNetTickScale - scale));
 
+    /// <summary>Projects a <c>Time</c> column's raw second count to a <see cref="TimeOnly"/>.</summary>
+    /// <param name="seconds">The raw signed second count.</param>
+    /// <returns>The time of day.</returns>
+    /// <exception cref="InvalidOperationException">The value is not a time of day.</exception>
+    public static TimeOnly TimeToTimeOnly(int seconds) => AsTimeOfDay(TimeToTimeSpan(seconds), "Time");
+
+    /// <summary>Projects a <c>Time64</c> count at <paramref name="scale"/> to a <see cref="TimeOnly"/>.</summary>
+    /// <param name="count">The raw signed count at <c>10^-<paramref name="scale"/></c> seconds.</param>
+    /// <param name="scale">The column's fractional-second scale (0–9).</param>
+    /// <returns>The time of day, with sub-100 ns digits truncated toward zero.</returns>
+    /// <exception cref="InvalidOperationException">The value is not a time of day.</exception>
+    public static TimeOnly Time64ToTimeOnly(long count, int scale) => AsTimeOfDay(Time64ToTimeSpan(count, scale), "Time64");
+
     /// <summary>
     /// Confirms a codec was handed an expression of its canonical <see cref="IColumnCodec.ElementType"/>. Catches the
     /// caller's mistake here, instead of as an opaque expression-tree failure much later.
@@ -119,6 +135,20 @@ internal static class ColumnValueProjections
                 $"The '{typeName}' codec projects from its element type {elementType}, but was given an expression of type {value.Type}.",
                 nameof(value));
         }
+    }
+
+    // The narrowing a TimeOnly read is: a Time column holds a signed duration of up to 999 hours, and only the
+    // part of that range which is a time of day has a TimeOnly. Refused rather than wrapped, a duration reduced
+    // modulo a day being a different value.
+    private static TimeOnly AsTimeOfDay(TimeSpan value, string typeName)
+    {
+        if (value < TimeSpan.Zero || value >= OneDay)
+        {
+            throw new InvalidOperationException(
+                $"A {typeName} column value of {value} is not a time of day, so it has no TimeOnly. Read the column as a TimeSpan.");
+        }
+
+        return TimeOnly.FromTimeSpan(value);
     }
 
     /// <summary>

--- a/ClickHouse.Driver.Tcp/Types/ColumnValueProjections.cs
+++ b/ClickHouse.Driver.Tcp/Types/ColumnValueProjections.cs
@@ -47,14 +47,21 @@ internal static class ColumnValueProjections
     /// <param name="seconds">The raw epoch-second count.</param>
     /// <param name="timeZone">The column's timezone.</param>
     /// <returns>The instant, presented in <paramref name="timeZone"/>.</returns>
-    public static DateTimeOffset DateTimeToOffset(uint seconds, TimeZoneInfo timeZone)
-        => TimeZoneInfo.ConvertTime(DateTimeOffset.FromUnixTimeSeconds(seconds), timeZone);
+    /// <exception cref="FormatException">The column's timezone is one this platform cannot represent.</exception>
+    /// <remarks>
+    /// Takes the resolved zone, not the zone: a codec embeds this call in an expression tree before any row
+    /// exists, and asking for the zone there would refuse the reading rather than the value. The dereference
+    /// costs a null check against a timezone conversion.
+    /// </remarks>
+    public static DateTimeOffset DateTimeToOffset(uint seconds, ResolvedTimeZone timeZone)
+        => TimeZoneInfo.ConvertTime(DateTimeOffset.FromUnixTimeSeconds(seconds), timeZone.Value);
 
     /// <summary><see cref="DateTimeToOffset"/> as a <see cref="DateTime"/>; see <see cref="PresentAsDateTime"/>.</summary>
     /// <param name="seconds">The raw epoch-second count.</param>
     /// <param name="timeZone">The column's timezone.</param>
     /// <returns>The instant as a <see cref="DateTime"/>.</returns>
-    public static DateTime DateTimeToDateTime(uint seconds, TimeZoneInfo timeZone)
+    /// <exception cref="FormatException">The column's timezone is one this platform cannot represent.</exception>
+    public static DateTime DateTimeToDateTime(uint seconds, ResolvedTimeZone timeZone)
         => PresentAsDateTime(DateTimeToOffset(seconds, timeZone));
 
     /// <summary>
@@ -66,20 +73,23 @@ internal static class ColumnValueProjections
     /// <param name="timeZone">The column's timezone.</param>
     /// <returns>The instant, presented in <paramref name="timeZone"/>.</returns>
     /// <exception cref="OverflowException">The count is decodable but outside <see cref="DateTimeOffset"/>'s range.</exception>
-    public static DateTimeOffset DateTime64ToOffset(long count, int scale, TimeZoneInfo timeZone)
+    public static DateTimeOffset DateTime64ToOffset(long count, int scale, ResolvedTimeZone timeZone)
     {
+        // Resolved once, outside the try, since the conversion below needs it either way.
+        TimeZoneInfo zone = timeZone.Value;
+
         // A count can be decodable yet outside DateTimeOffset's range. Point at the raw values rather than let a bare
         // arithmetic exception surface.
         try
         {
             long dotNetTicks = FixedPointScaling.ShiftDecimalPlaces(count, DotNetTickScale - scale);
             var utc = new DateTimeOffset(UnixEpochTicks + dotNetTicks, TimeSpan.Zero);
-            return TimeZoneInfo.ConvertTime(utc, timeZone);
+            return TimeZoneInfo.ConvertTime(utc, zone);
         }
         catch (Exception ex) when (ex is OverflowException or ArgumentOutOfRangeException)
         {
             throw new OverflowException(
-                $"A DateTime64 count of {count} at scale {scale} is outside the range presentable as a DateTimeOffset in timezone '{timeZone.Id}'; read the raw count via Values instead.",
+                $"A DateTime64 count of {count} at scale {scale} is outside the range presentable as a DateTimeOffset in timezone '{zone.Id}'; read the raw count via Values instead.",
                 ex);
         }
     }
@@ -90,7 +100,7 @@ internal static class ColumnValueProjections
     /// <param name="timeZone">The column's timezone.</param>
     /// <returns>The instant as a <see cref="DateTime"/>.</returns>
     /// <exception cref="OverflowException">The count is decodable but outside <see cref="DateTimeOffset"/>'s range.</exception>
-    public static DateTime DateTime64ToDateTime(long count, int scale, TimeZoneInfo timeZone)
+    public static DateTime DateTime64ToDateTime(long count, int scale, ResolvedTimeZone timeZone)
         => PresentAsDateTime(DateTime64ToOffset(count, scale, timeZone));
 
     /// <summary>Projects a <c>Time</c> column's raw second count to a <see cref="TimeSpan"/>. Exact — whole seconds.</summary>

--- a/ClickHouse.Driver.Tcp/Types/DateTime64Column.cs
+++ b/ClickHouse.Driver.Tcp/Types/DateTime64Column.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using ClickHouse.Driver.Tcp.Protocol;
+using ClickHouse.Driver.Tcp.Types.Codecs;
 
 namespace ClickHouse.Driver.Tcp.Types;
 
@@ -23,7 +24,7 @@ namespace ClickHouse.Driver.Tcp.Types;
 internal sealed class DateTime64Column : IColumn<long>, IDateTimeColumn, IStoredValuesColumn
 {
     private readonly int scale;
-    private readonly TimeZoneInfo timeZone;
+    private readonly ResolvedTimeZone timeZone;
     private readonly int length;
     private readonly bool pooled;
     private byte[] buffer;
@@ -36,7 +37,7 @@ internal sealed class DateTime64Column : IColumn<long>, IDateTimeColumn, IStored
     /// <param name="buffer">The little-endian column bytes (may be longer than <paramref name="length"/>).</param>
     /// <param name="length">The logical byte length; must be a whole multiple of <c>sizeof(long)</c>.</param>
     /// <param name="pooled">Whether <paramref name="buffer"/> was rented and should be returned on dispose.</param>
-    public DateTime64Column(string name, string typeName, int scale, TimeZoneInfo timeZone, byte[] buffer, int length, bool pooled)
+    public DateTime64Column(string name, string typeName, int scale, ResolvedTimeZone timeZone, byte[] buffer, int length, bool pooled)
     {
         Name = name;
         TypeName = typeName;
@@ -61,7 +62,9 @@ internal sealed class DateTime64Column : IColumn<long>, IDateTimeColumn, IStored
 
     /// <summary>The timezone the counts are presented in, shared by every value in the column. Combine with
     /// <see cref="Scale"/> to interpret the raw <see cref="Values"/> counts.</summary>
-    public TimeZoneInfo TimeZone => timeZone;
+    /// <exception cref="FormatException">The header named a timezone this platform cannot represent. The
+    /// <see cref="Values"/> counts are unaffected.</exception>
+    public TimeZoneInfo TimeZone => timeZone.Value;
 
     /// <summary>
     /// The raw signed tick counts (at <c>10^-Scale</c> seconds since the epoch), as a zero-copy view. This is the
@@ -128,7 +131,7 @@ internal sealed class DateTime64Column : IColumn<long>, IDateTimeColumn, IStored
         string name,
         string typeName,
         int scale,
-        TimeZoneInfo timeZone,
+        ResolvedTimeZone timeZone,
         int rowCount,
         CancellationToken cancellationToken)
     {
@@ -155,5 +158,5 @@ internal sealed class DateTime64Column : IColumn<long>, IDateTimeColumn, IStored
     // Projects a raw count onto the .NET calendar and presents it in the column's timezone. Sub-100 ns digits at
     // scale 8/9 are truncated toward zero here; the exact value stays in Values. The offset is resolved from the
     // instant so both daylight-saving transitions and historical base-offset changes are honored.
-    private DateTimeOffset ToDateTimeOffset(long count) => ColumnValueProjections.DateTime64ToOffset(count, scale, timeZone);
+    private DateTimeOffset ToDateTimeOffset(long count) => ColumnValueProjections.DateTime64ToOffset(count, scale, timeZone.Value);
 }

--- a/ClickHouse.Driver.Tcp/Types/DateTime64Column.cs
+++ b/ClickHouse.Driver.Tcp/Types/DateTime64Column.cs
@@ -158,5 +158,5 @@ internal sealed class DateTime64Column : IColumn<long>, IDateTimeColumn, IStored
     // Projects a raw count onto the .NET calendar and presents it in the column's timezone. Sub-100 ns digits at
     // scale 8/9 are truncated toward zero here; the exact value stays in Values. The offset is resolved from the
     // instant so both daylight-saving transitions and historical base-offset changes are honored.
-    private DateTimeOffset ToDateTimeOffset(long count) => ColumnValueProjections.DateTime64ToOffset(count, scale, timeZone.Value);
+    private DateTimeOffset ToDateTimeOffset(long count) => ColumnValueProjections.DateTime64ToOffset(count, scale, timeZone);
 }

--- a/ClickHouse.Driver.Tcp/Types/DateTimeColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/DateTimeColumn.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using ClickHouse.Driver.Tcp.Protocol;
+using ClickHouse.Driver.Tcp.Types.Codecs;
 
 namespace ClickHouse.Driver.Tcp.Types;
 
@@ -27,7 +28,7 @@ namespace ClickHouse.Driver.Tcp.Types;
 /// </summary>
 internal sealed class DateTimeColumn : IColumn<uint>, IDateTimeColumn, IStoredValuesColumn
 {
-    private readonly TimeZoneInfo timeZone;
+    private readonly ResolvedTimeZone timeZone;
     private readonly int length;
     private readonly bool pooled;
     private byte[] buffer;
@@ -39,7 +40,7 @@ internal sealed class DateTimeColumn : IColumn<uint>, IDateTimeColumn, IStoredVa
     /// <param name="buffer">The little-endian column bytes (may be longer than <paramref name="length"/>).</param>
     /// <param name="length">The logical byte length; must be a whole multiple of <c>sizeof(uint)</c>.</param>
     /// <param name="pooled">Whether <paramref name="buffer"/> was rented and should be returned on dispose.</param>
-    public DateTimeColumn(string name, string typeName, TimeZoneInfo timeZone, byte[] buffer, int length, bool pooled)
+    public DateTimeColumn(string name, string typeName, ResolvedTimeZone timeZone, byte[] buffer, int length, bool pooled)
     {
         Name = name;
         TypeName = typeName;
@@ -60,7 +61,9 @@ internal sealed class DateTimeColumn : IColumn<uint>, IDateTimeColumn, IStoredVa
 
     /// <summary>The timezone the seconds are presented in, shared by every value in the column. Use it to
     /// interpret the raw <see cref="Values"/> seconds.</summary>
-    public TimeZoneInfo TimeZone => timeZone;
+    /// <exception cref="FormatException">The header named a timezone this platform cannot represent. The
+    /// <see cref="Values"/> seconds are unaffected.</exception>
+    public TimeZoneInfo TimeZone => timeZone.Value;
 
     /// <summary>Zero: <c>DateTime</c> counts whole seconds. <c>DateTime64(scale)</c> is where this varies.</summary>
     public int Scale => 0;
@@ -123,7 +126,7 @@ internal sealed class DateTimeColumn : IColumn<uint>, IDateTimeColumn, IStoredVa
         ClickHouseBinaryReader reader,
         string name,
         string typeName,
-        TimeZoneInfo timeZone,
+        ResolvedTimeZone timeZone,
         int rowCount,
         CancellationToken cancellationToken)
     {
@@ -147,5 +150,5 @@ internal sealed class DateTimeColumn : IColumn<uint>, IDateTimeColumn, IStoredVa
         return new DateTimeColumn(name, typeName, timeZone, rented, byteCount, pooled: true);
     }
 
-    private DateTimeOffset ToDateTimeOffset(uint seconds) => ColumnValueProjections.DateTimeToOffset(seconds, timeZone);
+    private DateTimeOffset ToDateTimeOffset(uint seconds) => ColumnValueProjections.DateTimeToOffset(seconds, timeZone.Value);
 }

--- a/ClickHouse.Driver.Tcp/Types/DateTimeColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/DateTimeColumn.cs
@@ -150,5 +150,5 @@ internal sealed class DateTimeColumn : IColumn<uint>, IDateTimeColumn, IStoredVa
         return new DateTimeColumn(name, typeName, timeZone, rented, byteCount, pooled: true);
     }
 
-    private DateTimeOffset ToDateTimeOffset(uint seconds) => ColumnValueProjections.DateTimeToOffset(seconds, timeZone.Value);
+    private DateTimeOffset ToDateTimeOffset(uint seconds) => ColumnValueProjections.DateTimeToOffset(seconds, timeZone);
 }

--- a/ClickHouse.Driver.Tcp/Types/IDateTimeColumn.cs
+++ b/ClickHouse.Driver.Tcp/Types/IDateTimeColumn.cs
@@ -33,6 +33,13 @@ public interface IDateTimeColumn : IColumn
     /// query's <c>session_timezone</c> setting if it has one, and to the timezone the handshake reported
     /// otherwise.
     /// </summary>
+    /// <remarks>
+    /// ClickHouse accepts fixed offsets .NET cannot represent — <c>Fixed/UTC+19:00:00</c> is past
+    /// <see cref="TimeZoneInfo"/>'s ±14 hours, and <c>Fixed/UTC+05:30:15</c> is not a whole number of minutes.
+    /// The counts such a column carries still read through the <see cref="IColumn{T}"/> view; only this property
+    /// and the instants below need the zone, so only they report it.
+    /// </remarks>
+    /// <exception cref="FormatException">The column's timezone cannot be represented on this platform.</exception>
     TimeZoneInfo TimeZone { get; }
 
     /// <summary>

--- a/ClickHouse.Driver.Tcp/Types/NamedElementParser.cs
+++ b/ClickHouse.Driver.Tcp/Types/NamedElementParser.cs
@@ -22,28 +22,53 @@ internal static class NamedElementParser
         var elements = new (string, TypeNode)[composite.Arguments.Count];
         for (int i = 0; i < composite.Arguments.Count; i++)
         {
-            TypeNode argument = composite.Arguments[i];
-            int space = IndexOfWhitespace(argument.Name);
-            if (space < 0)
-            {
-                elements[i] = (null, argument);
-            }
-            else
-            {
-                // Take the field name up to the first whitespace, then skip the whole whitespace run before the type
-                // so a hand-written type with extra spaces or a tab (e.g. "a  Int32") doesn't leave the base name
-                // with a leading space that would then fail codec resolution.
-                string fieldName = argument.Name.Substring(0, space);
-                string baseName = argument.Name.Substring(space).TrimStart();
-
-                // Carry the argument list forward rather than re-deriving it from the argument count, or a named
-                // element of the zero-element type (e.g. "y Tuple()") would come out as a bare, malformed Tuple.
-                elements[i] = (fieldName, new TypeNode(baseName, argument.Arguments, argument.HasArgumentList));
-            }
+            elements[i] = SplitElement(composite.Arguments[i]);
         }
 
         return elements;
     }
+
+    /// <summary>Separates one element's name from its type.</summary>
+    /// <param name="argument">The element's argument node.</param>
+    /// <returns>The pair; the name is null when the element is unnamed.</returns>
+    private static (string Name, TypeNode Type) SplitElement(TypeNode argument)
+    {
+        // A backtick-quoted name is opaque, so `a b` Int64 splits after the closing backtick and not inside the
+        // name. The name is decoded, because the server writes an identifier's escapes into the header it sends.
+        if (argument.Name.Length > 0 && argument.Name[0] == '`')
+        {
+            if (QuotedText.TryRead(argument.Name, 0, out string quoted, out int afterQuote)
+                && afterQuote < argument.Name.Length
+                && char.IsWhiteSpace(argument.Name[afterQuote]))
+            {
+                return (quoted, WithBaseName(argument, argument.Name.Substring(afterQuote).TrimStart()));
+            }
+
+            // A quoted run with no type after it names nothing this parser can use; leaving it whole lets the
+            // caller's own resolution report the element text it was given.
+            return (null, argument);
+        }
+
+        int space = IndexOfWhitespace(argument.Name);
+        if (space < 0)
+        {
+            return (null, argument);
+        }
+
+        // Take the field name up to the first whitespace, then skip the whole whitespace run before the type
+        // so a hand-written type with extra spaces or a tab (e.g. "a  Int32") doesn't leave the base name
+        // with a leading space that would then fail codec resolution.
+        return (argument.Name.Substring(0, space), WithBaseName(argument, argument.Name.Substring(space).TrimStart()));
+    }
+
+    /// <summary>Rebuilds an element's own type node from its base name, keeping the argument list.</summary>
+    /// <param name="argument">The element's argument node.</param>
+    /// <param name="baseName">The element's type name, with the element name removed.</param>
+    /// <returns>The element's type node.</returns>
+    // Carry the argument list forward rather than re-deriving it from the argument count, or a named element of
+    // the zero-element type (e.g. "y Tuple()") would come out as a bare, malformed Tuple.
+    private static TypeNode WithBaseName(TypeNode argument, string baseName)
+        => new(baseName, argument.Arguments, argument.HasArgumentList);
 
     private static int IndexOfWhitespace(string value)
     {

--- a/ClickHouse.Driver.Tcp/Types/QuotedText.cs
+++ b/ClickHouse.Driver.Tcp/Types/QuotedText.cs
@@ -1,0 +1,131 @@
+using System.Text;
+
+namespace ClickHouse.Driver.Tcp.Types;
+
+/// <summary>
+/// Scans the quoted spans a ClickHouse type string carries: single-quoted enum labels and backtick-quoted
+/// identifiers (a tuple or nested field name, a JSON typed path). Both spellings use one escaping, checked
+/// against a 26.6 server: <c>\a \b \e \f \n \r \t \v \0</c> and <c>\xHH</c> decode to that character, a
+/// backslash before a quote, a backslash, a double quote or a slash yields that character, and any other
+/// backslash pair keeps both characters. A doubled quote (<c>''</c> or <c>``</c>) is one literal quote, which
+/// the server accepts on input although it always prints the backslash form.
+/// </summary>
+internal static class QuotedText
+{
+    /// <summary>Finds the end of the quoted span opening at <paramref name="openIndex"/>, without decoding it.</summary>
+    /// <param name="input">The text to scan.</param>
+    /// <param name="openIndex">The index of the opening quote character, which also selects the closing one.</param>
+    /// <returns>The index of the closing quote, or -1 when the span is never closed.</returns>
+    public static int EndOfSpan(string input, int openIndex) => Scan(input, openIndex, decoded: null);
+
+    /// <summary>Reads the quoted span opening at <paramref name="openIndex"/> and decodes its escapes.</summary>
+    /// <param name="input">The text to scan.</param>
+    /// <param name="openIndex">The index of the opening quote character, which also selects the closing one.</param>
+    /// <param name="text">The decoded text without its quotes, or null when the span is never closed.</param>
+    /// <param name="end">The index just past the closing quote, or the input length when the span is never closed.</param>
+    /// <returns>True when the span is closed.</returns>
+    public static bool TryRead(string input, int openIndex, out string text, out int end)
+    {
+        var decoded = new StringBuilder();
+        int close = Scan(input, openIndex, decoded);
+        if (close < 0)
+        {
+            text = null;
+            end = input.Length;
+            return false;
+        }
+
+        text = decoded.ToString();
+        end = close + 1;
+        return true;
+    }
+
+    /// <summary>Scans one span, decoding into <paramref name="decoded"/> when a builder is supplied.</summary>
+    /// <param name="input">The text to scan.</param>
+    /// <param name="openIndex">The index of the opening quote character.</param>
+    /// <param name="decoded">Receives the decoded text, or null to only find the end.</param>
+    /// <returns>The index of the closing quote, or -1 when the span is never closed.</returns>
+    private static int Scan(string input, int openIndex, StringBuilder decoded)
+    {
+        char quote = input[openIndex];
+        for (int i = openIndex + 1; i < input.Length; i++)
+        {
+            char c = input[i];
+            if (c == quote)
+            {
+                if (i + 1 < input.Length && input[i + 1] == quote)
+                {
+                    decoded?.Append(quote);
+                    i++;
+                    continue;
+                }
+
+                return i;
+            }
+
+            if (c == '\\' && i + 1 < input.Length)
+            {
+                i = AppendEscape(input, i, decoded);
+                continue;
+            }
+
+            decoded?.Append(c);
+        }
+
+        return -1;
+    }
+
+    /// <summary>Decodes the escape sequence opening at <paramref name="backslash"/>.</summary>
+    /// <param name="input">The text to scan.</param>
+    /// <param name="backslash">The index of the backslash.</param>
+    /// <param name="decoded">Receives the decoded character(s), or null to only measure the sequence.</param>
+    /// <returns>The index of the sequence's last character.</returns>
+    private static int AppendEscape(string input, int backslash, StringBuilder decoded)
+    {
+        char c = input[backslash + 1];
+        if (c == 'x'
+            && backslash + 3 < input.Length
+            && TryHexDigit(input[backslash + 2], out int high)
+            && TryHexDigit(input[backslash + 3], out int low))
+        {
+            decoded?.Append((char)((high << 4) | low));
+            return backslash + 3;
+        }
+
+        switch (c)
+        {
+            case 'a': decoded?.Append('\a'); break;
+            case 'b': decoded?.Append('\b'); break;
+            case 'e': decoded?.Append('\u001B'); break;
+            case 'f': decoded?.Append('\f'); break;
+            case 'n': decoded?.Append('\n'); break;
+            case 'r': decoded?.Append('\r'); break;
+            case 't': decoded?.Append('\t'); break;
+            case 'v': decoded?.Append('\v'); break;
+            case '0': decoded?.Append('\0'); break;
+            case '\\' or '\'' or '"' or '`' or '/': decoded?.Append(c); break;
+
+            // An escape the server does not define keeps both characters, as the server's own lexer does.
+            default: decoded?.Append('\\').Append(c); break;
+        }
+
+        return backslash + 1;
+    }
+
+    /// <summary>Reads one hexadecimal digit.</summary>
+    /// <param name="c">The character.</param>
+    /// <param name="value">The digit's value.</param>
+    /// <returns>True when <paramref name="c"/> is a hexadecimal digit.</returns>
+    private static bool TryHexDigit(char c, out int value)
+    {
+        value = c switch
+        {
+            >= '0' and <= '9' => c - '0',
+            >= 'a' and <= 'f' => c - 'a' + 10,
+            >= 'A' and <= 'F' => c - 'A' + 10,
+            _ => -1,
+        };
+
+        return value >= 0;
+    }
+}

--- a/ClickHouse.Driver.Tcp/Types/TypeAliases.cs
+++ b/ClickHouse.Driver.Tcp/Types/TypeAliases.cs
@@ -1,0 +1,163 @@
+using System;
+using System.Collections.Generic;
+
+namespace ClickHouse.Driver.Tcp.Types;
+
+/// <summary>
+/// The alternative spellings ClickHouse accepts for a type name, and the canonical name each one means. The
+/// table is <c>system.data_type_families</c> on 26.6: every row with a non-empty <c>alias_to</c>, plus the
+/// families the server itself matches without regard to case.
+///
+/// <para>
+/// A column header never carries one of these — the server always reports the canonical name — so this exists
+/// for the names a caller writes: a <c>{p:Type}</c> hint, <see cref="ClickHouseTcpParameter.ClickHouseType"/>,
+/// and <c>ClickHouseTcpTypes.CanRead</c>/<c>CanWrite</c>. The shipped HTTP driver accepts all of them, so a
+/// caller moving a query from it should not have to respell their types.
+/// </para>
+///
+/// <para>
+/// Case is per family, not global: the server marks <c>case_insensitive = 1</c> for the families listed here and
+/// <c>0</c> for the rest, so <c>datetime64(3)</c> resolves while <c>string</c>, <c>int64</c>, <c>array(uint8)</c>
+/// and <c>geometry</c> are unknown families to it. Matching every name without regard to case would accept what
+/// the server rejects.
+/// </para>
+/// </summary>
+internal static class TypeAliases
+{
+    /// <summary>
+    /// The spellings the server matches without regard to case: the <c>case_insensitive = 1</c> families, whether
+    /// they are an alias of another family or the canonical name of their own.
+    /// </summary>
+    private static readonly Dictionary<string, string> AnyCase = new(StringComparer.OrdinalIgnoreCase)
+    {
+        // The families that are their own canonical name. Each is here so that any case of it resolves, and so
+        // that the canonical spelling is what a codec is stamped with.
+        ["Bool"] = "Bool",
+        ["Date"] = "Date",
+        ["Date32"] = "Date32",
+        ["DateTime"] = "DateTime",
+        ["DateTime64"] = "DateTime64",
+        ["Decimal"] = "Decimal",
+        ["Decimal32"] = "Decimal32",
+        ["Decimal64"] = "Decimal64",
+        ["Decimal128"] = "Decimal128",
+        ["Decimal256"] = "Decimal256",
+        ["Enum"] = "Enum",
+        ["JSON"] = "JSON",
+        ["Time"] = "Time",
+        ["Time64"] = "Time64",
+
+        // A family of its own on the server, which resolves to DateTime rather than aliasing it.
+        ["DateTime32"] = "DateTime",
+
+        ["boolean"] = "Bool",
+        ["TIMESTAMP"] = "DateTime",
+        ["DEC"] = "Decimal",
+        ["FIXED"] = "Decimal",
+        ["NUMERIC"] = "Decimal",
+        ["BINARY"] = "FixedString",
+        ["FLOAT"] = "Float32",
+        ["REAL"] = "Float32",
+        ["SINGLE"] = "Float32",
+        ["DOUBLE"] = "Float64",
+        ["DOUBLE PRECISION"] = "Float64",
+        ["INET4"] = "IPv4",
+        ["INET6"] = "IPv6",
+
+        ["BYTE"] = "Int8",
+        ["INT1"] = "Int8",
+        ["INT1 SIGNED"] = "Int8",
+        ["TINYINT"] = "Int8",
+        ["TINYINT SIGNED"] = "Int8",
+        ["SMALLINT"] = "Int16",
+        ["SMALLINT SIGNED"] = "Int16",
+        ["INT"] = "Int32",
+        ["INT SIGNED"] = "Int32",
+        ["INTEGER"] = "Int32",
+        ["INTEGER SIGNED"] = "Int32",
+        ["MEDIUMINT"] = "Int32",
+        ["MEDIUMINT SIGNED"] = "Int32",
+        ["BIGINT"] = "Int64",
+        ["BIGINT SIGNED"] = "Int64",
+        ["SIGNED"] = "Int64",
+
+        ["INT1 UNSIGNED"] = "UInt8",
+        ["TINYINT UNSIGNED"] = "UInt8",
+        ["SMALLINT UNSIGNED"] = "UInt16",
+        ["YEAR"] = "UInt16",
+        ["INT UNSIGNED"] = "UInt32",
+        ["INTEGER UNSIGNED"] = "UInt32",
+        ["MEDIUMINT UNSIGNED"] = "UInt32",
+        ["BIGINT UNSIGNED"] = "UInt64",
+        ["BIT"] = "UInt64",
+        ["SET"] = "UInt64",
+        ["UNSIGNED"] = "UInt64",
+
+        ["BINARY LARGE OBJECT"] = "String",
+        ["BINARY VARYING"] = "String",
+        ["BLOB"] = "String",
+        ["BYTEA"] = "String",
+        ["CHAR"] = "String",
+        ["CHAR LARGE OBJECT"] = "String",
+        ["CHAR VARYING"] = "String",
+        ["CHARACTER"] = "String",
+        ["CHARACTER LARGE OBJECT"] = "String",
+        ["CHARACTER VARYING"] = "String",
+        ["CLOB"] = "String",
+        ["LONGBLOB"] = "String",
+        ["LONGTEXT"] = "String",
+        ["MEDIUMBLOB"] = "String",
+        ["MEDIUMTEXT"] = "String",
+        ["NATIONAL CHAR"] = "String",
+        ["NATIONAL CHAR VARYING"] = "String",
+        ["NATIONAL CHARACTER"] = "String",
+        ["NATIONAL CHARACTER LARGE OBJECT"] = "String",
+        ["NATIONAL CHARACTER VARYING"] = "String",
+        ["NCHAR"] = "String",
+        ["NCHAR LARGE OBJECT"] = "String",
+        ["NCHAR VARYING"] = "String",
+        ["NVARCHAR"] = "String",
+        ["TEXT"] = "String",
+        ["TINYBLOB"] = "String",
+        ["TINYTEXT"] = "String",
+        ["VARBINARY"] = "String",
+        ["VARCHAR"] = "String",
+        ["VARCHAR2"] = "String",
+    };
+
+    /// <summary>
+    /// The one alias the server marks <c>case_insensitive = 0</c>: it takes <c>GEOMETRY</c> and the canonical
+    /// <c>Geometry</c>, and answers "Unknown data type family" for <c>geometry</c>.
+    /// </summary>
+    private static readonly Dictionary<string, string> ExactCase = new(StringComparer.Ordinal)
+    {
+        ["GEOMETRY"] = "Geometry",
+    };
+
+    /// <summary>Finds the canonical name an alternative spelling means.</summary>
+    /// <param name="name">The base type name as the caller wrote it.</param>
+    /// <param name="canonical">The canonical name, or null when the spelling is not one the server accepts.</param>
+    /// <returns>True when <paramref name="name"/> is an alias or a case variant of a canonical name.</returns>
+    public static bool TryCanonical(string name, out string canonical)
+        => ExactCase.TryGetValue(name, out canonical) || AnyCase.TryGetValue(name, out canonical);
+
+    /// <summary>The canonical name an alternative spelling means, or <paramref name="name"/> unchanged.</summary>
+    /// <param name="name">The base type name as the caller wrote it.</param>
+    /// <returns>The canonical name when there is one, otherwise the name given.</returns>
+    public static string Canonical(string name) => TryCanonical(name, out string canonical) ? canonical : name;
+
+    /// <summary>Every alternative spelling and the canonical name it means, for the tests that check the table.</summary>
+    /// <returns>One pair per spelling, the case-sensitive <c>GEOMETRY</c> included.</returns>
+    public static IEnumerable<KeyValuePair<string, string>> All()
+    {
+        foreach (KeyValuePair<string, string> alias in ExactCase)
+        {
+            yield return alias;
+        }
+
+        foreach (KeyValuePair<string, string> alias in AnyCase)
+        {
+            yield return alias;
+        }
+    }
+}

--- a/ClickHouse.Driver.Tcp/Types/TypeAliases.cs
+++ b/ClickHouse.Driver.Tcp/Types/TypeAliases.cs
@@ -5,8 +5,7 @@ namespace ClickHouse.Driver.Tcp.Types;
 
 /// <summary>
 /// The alternative spellings ClickHouse accepts for a type name, and the canonical name each one means. The
-/// table is <c>system.data_type_families</c> on 26.6: every row with a non-empty <c>alias_to</c>, plus the
-/// families the server itself matches without regard to case.
+/// table is every row of <c>system.data_type_families</c> on 26.6 with a non-empty <c>alias_to</c>.
 ///
 /// <para>
 /// A column header never carries one of these — the server always reports the canonical name — so this exists
@@ -16,40 +15,21 @@ namespace ClickHouse.Driver.Tcp.Types;
 /// </para>
 ///
 /// <para>
-/// Case is per family, not global: the server marks <c>case_insensitive = 1</c> for the families listed here and
-/// <c>0</c> for the rest, so <c>datetime64(3)</c> resolves while <c>string</c>, <c>int64</c>, <c>array(uint8)</c>
-/// and <c>geometry</c> are unknown families to it. Matching every name without regard to case would accept what
-/// the server rejects.
+/// Every name here matches without regard to case, and so does every name the codec registry knows. The server
+/// marks only some families <c>case_insensitive</c>, but which ones is the server's business: a spelling it
+/// rejects it rejects with a better message than a copy of that rule here would give, and the rule moves between
+/// versions and settings. A name this client cannot resolve at all is a different matter, and is still refused.
 /// </para>
 /// </summary>
 internal static class TypeAliases
 {
-    /// <summary>
-    /// The spellings the server matches without regard to case: the <c>case_insensitive = 1</c> families, whether
-    /// they are an alias of another family or the canonical name of their own.
-    /// </summary>
-    private static readonly Dictionary<string, string> AnyCase = new(StringComparer.OrdinalIgnoreCase)
+    /// <summary>Every alias, keyed without regard to case.</summary>
+    private static readonly Dictionary<string, string> Aliases = new(StringComparer.OrdinalIgnoreCase)
     {
-        // The families that are their own canonical name. Each is here so that any case of it resolves, and so
-        // that the canonical spelling is what a codec is stamped with.
-        ["Bool"] = "Bool",
-        ["Date"] = "Date",
-        ["Date32"] = "Date32",
-        ["DateTime"] = "DateTime",
-        ["DateTime64"] = "DateTime64",
-        ["Decimal"] = "Decimal",
-        ["Decimal32"] = "Decimal32",
-        ["Decimal64"] = "Decimal64",
-        ["Decimal128"] = "Decimal128",
-        ["Decimal256"] = "Decimal256",
-        ["Enum"] = "Enum",
-        ["JSON"] = "JSON",
-        ["Time"] = "Time",
-        ["Time64"] = "Time64",
-
         // A family of its own on the server, which resolves to DateTime rather than aliasing it.
         ["DateTime32"] = "DateTime",
 
+        ["GEOMETRY"] = "Geometry",
         ["boolean"] = "Bool",
         ["TIMESTAMP"] = "DateTime",
         ["DEC"] = "Decimal",
@@ -125,21 +105,15 @@ internal static class TypeAliases
         ["VARCHAR2"] = "String",
     };
 
-    /// <summary>
-    /// The one alias the server marks <c>case_insensitive = 0</c>: it takes <c>GEOMETRY</c> and the canonical
-    /// <c>Geometry</c>, and answers "Unknown data type family" for <c>geometry</c>.
-    /// </summary>
-    private static readonly Dictionary<string, string> ExactCase = new(StringComparer.Ordinal)
-    {
-        ["GEOMETRY"] = "Geometry",
-    };
-
     /// <summary>Finds the canonical name an alternative spelling means.</summary>
     /// <param name="name">The base type name as the caller wrote it.</param>
-    /// <param name="canonical">The canonical name, or null when the spelling is not one the server accepts.</param>
-    /// <returns>True when <paramref name="name"/> is an alias or a case variant of a canonical name.</returns>
+    /// <param name="canonical">The canonical name, or null when the name is not an alias.</param>
+    /// <returns>True when <paramref name="name"/> is an alias of a canonical name.</returns>
     public static bool TryCanonical(string name, out string canonical)
-        => ExactCase.TryGetValue(name, out canonical) || AnyCase.TryGetValue(name, out canonical);
+    {
+        canonical = null;
+        return name is not null && Aliases.TryGetValue(name, out canonical);
+    }
 
     /// <summary>The canonical name an alternative spelling means, or <paramref name="name"/> unchanged.</summary>
     /// <param name="name">The base type name as the caller wrote it.</param>
@@ -147,17 +121,6 @@ internal static class TypeAliases
     public static string Canonical(string name) => TryCanonical(name, out string canonical) ? canonical : name;
 
     /// <summary>Every alternative spelling and the canonical name it means, for the tests that check the table.</summary>
-    /// <returns>One pair per spelling, the case-sensitive <c>GEOMETRY</c> included.</returns>
-    public static IEnumerable<KeyValuePair<string, string>> All()
-    {
-        foreach (KeyValuePair<string, string> alias in ExactCase)
-        {
-            yield return alias;
-        }
-
-        foreach (KeyValuePair<string, string> alias in AnyCase)
-        {
-            yield return alias;
-        }
-    }
+    /// <returns>One pair per spelling.</returns>
+    public static IEnumerable<KeyValuePair<string, string>> All() => Aliases;
 }

--- a/ClickHouse.Driver.Tcp/Types/TypeTokenizer.cs
+++ b/ClickHouse.Driver.Tcp/Types/TypeTokenizer.cs
@@ -6,8 +6,10 @@ namespace ClickHouse.Driver.Tcp.Types;
 /// <summary>
 /// Splits a ClickHouse type string into tokens for <see cref="TypeParser"/>: the structural characters
 /// <c>(</c>, <c>)</c>, <c>,</c> each as their own token, and the (trimmed) runs between them as identifier
-/// tokens. Single-quoted spans (enum labels) are treated opaquely — commas and parentheses inside them, and
-/// backslash escapes, do not split — so <c>Enum8('a,b' = 1)</c> tokenizes as one argument, not two.
+/// tokens. Quoted spans are opaque — single-quoted enum labels and backtick-quoted identifiers alike, so
+/// <c>Enum8('a,b' = 1)</c> and <c>Tuple(`a,b` Int64)</c> each tokenize as one argument, not two. A run that is
+/// only whitespace yields no token, so a pretty-printed <c>Array( Array(Int32) )</c> tokenizes like its compact
+/// spelling.
 /// </summary>
 internal static class TypeTokenizer
 {
@@ -16,44 +18,33 @@ internal static class TypeTokenizer
     /// <summary>Tokenizes a type string.</summary>
     /// <param name="input">The type string.</param>
     /// <returns>The token sequence, in source order.</returns>
+    /// <exception cref="FormatException">A quoted span is never closed.</exception>
     public static IEnumerable<string> Tokenize(string input)
     {
         int start = 0;
-        bool inQuotes = false;
-        bool escaped = false;
 
         for (int i = 0; i < input.Length; i++)
         {
             char c = input[i];
-            if (inQuotes)
+            if (c is '\'' or '`')
             {
-                if (escaped)
+                int close = QuotedText.EndOfSpan(input, i);
+                if (close < 0)
                 {
-                    escaped = false;
-                }
-                else if (c == '\\')
-                {
-                    escaped = true;
-                }
-                else if (c == '\'')
-                {
-                    inQuotes = false;
+                    throw new FormatException(
+                        $"Malformed type string '{input}': unterminated quoted span (a {c} was never closed).");
                 }
 
-                continue;
-            }
-
-            if (c == '\'')
-            {
-                inQuotes = true;
+                i = close;
                 continue;
             }
 
             if (Array.IndexOf(Breaks, c) >= 0)
             {
-                if (i > start)
+                string token = input.Substring(start, i - start).Trim();
+                if (token.Length > 0)
                 {
-                    yield return input.Substring(start, i - start).Trim();
+                    yield return token;
                 }
 
                 yield return input.Substring(i, 1);
@@ -61,15 +52,13 @@ internal static class TypeTokenizer
             }
         }
 
-        if (inQuotes)
-        {
-            throw new FormatException(
-                $"Malformed type string '{input}': unterminated quoted span (a single quote was never closed).");
-        }
-
         if (start < input.Length)
         {
-            yield return input.Substring(start).Trim();
+            string tail = input.Substring(start).Trim();
+            if (tail.Length > 0)
+            {
+                yield return tail;
+            }
         }
     }
 }

--- a/examples/Tcp/Types/Tcp_002_DateTimeAndTimezones.cs
+++ b/examples/Tcp/Types/Tcp_002_DateTimeAndTimezones.cs
@@ -29,7 +29,8 @@ public static class TcpDateTimeAndTimezones
                     captured_at DateTime('Europe/Amsterdam'),
                     precise_at DateTime64(3, 'UTC'),
                     elapsed Time,
-                    precise_elapsed Time64(3)
+                    precise_elapsed Time64(3),
+                    opens_at Time
                 )
                 ENGINE = MergeTree
                 ORDER BY day
@@ -39,7 +40,7 @@ public static class TcpDateTimeAndTimezones
             var instant = new DateTime(2026, 6, 1, 12, 0, 0, DateTimeKind.Utc);
             await client.InsertAsync(
                 $"INSERT INTO {TableName} " +
-                "(day, old_day, captured_at, precise_at, elapsed, precise_elapsed) VALUES",
+                "(day, old_day, captured_at, precise_at, elapsed, precise_elapsed, opens_at) VALUES",
                 new IColumn[]
                 {
                     ClickHouseTcpColumn.Create("day", new[] { new DateOnly(2026, 6, 1) }),
@@ -49,11 +50,15 @@ public static class TcpDateTimeAndTimezones
                         "precise_at",
                         new[] { instant.AddMilliseconds(123) }),
 
-                    // Time and Time64 surface as TimeSpan, including values longer than one day.
+                    // Time and Time64 hold a signed duration of up to 999 hours, so TimeSpan is the reading that
+                    // covers the whole range.
                     ClickHouseTcpColumn.Create("elapsed", new[] { TimeSpan.FromHours(27) }),
                     ClickHouseTcpColumn.Create(
                         "precise_elapsed",
                         new[] { TimeSpan.FromMilliseconds(1234) }),
+
+                    // A TimeOnly is accepted too, for a column that holds a time of day rather than a duration.
+                    ClickHouseTcpColumn.Create("opens_at", new[] { new TimeOnly(9, 30) }),
                 });
 
             await foreach (Block block in client.StreamAsync($"SELECT * FROM {TableName}"))
@@ -66,6 +71,11 @@ public static class TcpDateTimeAndTimezones
                 PrintTimestamp((IDateTimeColumn)block["precise_at"]);
                 PrintTime((ITimeColumn)block["elapsed"]);
                 PrintTime((ITimeColumn)block["precise_elapsed"]);
+
+                // Reading back as a TimeOnly is a narrowing: a value outside 00:00:00-23:59:59.9999999 is not a
+                // time of day, and such a row is refused rather than reduced modulo a day. Read it as a TimeSpan
+                // when the column can hold a duration.
+                Console.WriteLine($"opens_at as TimeOnly: {block.ReadAs<TimeOnly>("opens_at")[0]:HH:mm}");
 
                 // ReadAs converts a whole column to a reading its type offers, applying the same zone and scale.
                 IColumn<DateTimeOffset> captured = block.ReadAs<DateTimeOffset>("captured_at");

--- a/examples/Tcp/Types/Tcp_004_VariantDynamicJson.cs
+++ b/examples/Tcp/Types/Tcp_004_VariantDynamicJson.cs
@@ -18,6 +18,13 @@ public static class TcpVariantDynamicJson
         builder["set_allow_experimental_dynamic_type"] = 1;
         builder["set_allow_experimental_json_type"] = 1;
 
+        // The client asks the server for the JSON and Dynamic serializations it reads, by sending two
+        // output_format_native_* settings with every operation. Both server defaults are 0, so that makes every
+        // operation a setting modification, which a user under a readonly profile is not allowed to make. Clear
+        // SendJsonAndDynamicSerializationSettings for such a user: every other column type is unaffected, and
+        // only JSON and Dynamic may then arrive in a serialization this client does not read.
+        builder.SendJsonAndDynamicSerializationSettings = true;
+
         await using var client = new ClickHouseTcpClient(builder.ToOptions());
         string[] tables = { VariantTable, DynamicTable, JsonTable };
 


### PR DESCRIPTION
## What this is

A test audit of the native client, and the defects it found.

The suite up to this point grew alongside the epics: each epic proved its own feature. This PR
attacks it from the other side, asking of each area what a test would have to do to fail, and
writing that test. 57 backlog items, one commit each where the item needed one, plus six commits
closing a review pass over the result.

Roughly half the commits change client behavior. Those came first as a failing test against a
real server, so every one of them is a defect an existing test did not catch.

## Correctness fixes

**A dense `Variant` could be written as a different `Variant` of the same arity.**
`ClickHouse.Driver.Tcp/Types/Codecs/VariantColumnCodec.cs`. The dense write gate compared the
*number* of alternatives, then reused the source column's own discriminator bytes. Reading
`Variant(Int64, String)` and inserting it into `Variant(Bool, Int64)` passed `CanWrite`, sent
discriminators that named the wrong alternative, and then hit an `InvalidCastException` inside the
body, after the discriminators were already on the wire. The gate now compares the alternative names
in order; a column that does not match is scattered by each value's own type, so a read-back of one
`Variant` lands in the right alternative of another.

**A backticked identifier in a type string broke the header parse.**
`Types/QuotedText.cs` (new), `Types/TypeTokenizer.cs`, `Types/NamedElementParser.cs`. The server
quotes an identifier it cannot spell bare — a JSON typed path, a `Tuple` or `Nested` field name — so
a real header carries `` `a(b` `` or `` `a,b` ``. Breaking on the comma or the paren inside it split
the argument list and the read failed on the header, before a row decoded. `QuotedText` scans a
quoted span once, for its boundaries and its text, so the tokenizer and both parsers agree on where
a span ends.

**Enum labels decoded wrong.** `Types/Codecs/EnumColumnCodec.cs`. A label holding a newline arrives
spelled `'a\nb'`; dropping the backslash and keeping the next character decoded that to `anb`, so
the label a caller read was wrong and writing the real label threw. Only `\\` and `\'` came out
right. Labels now go through the same `QuotedText` scanner as identifiers.

**A timezone .NET cannot represent killed the whole column.**
`Types/Codecs/DateTimeZones.cs`, `DateTimeColumn.cs`, `DateTime64Column.cs`. ClickHouse accepts
fixed offsets `TimeZoneInfo` cannot hold and 26.6 applies them: `Fixed/UTC+19:00:00` is past .NET's
±14 hours and `Fixed/UTC+05:30:15` is not a whole number of minutes. Resolving the zone while
*building* the codec made each of those a dead read — no column and no row arrived, including for a
caller who only wanted the epoch counts, which the zone does not affect. `ResolvedTimeZone` now
carries either the zone or the reason there is none, and only the calendar uses (`TimeZone`,
`GetDateTimeOffset`, a `DateTime`/`DateTimeOffset` projection, writing an `Unspecified` `DateTime`)
report it.

**`DateTime64` reported a bare `OverflowException`.** `Types/Codecs/DateTime64ColumnCodec.cs`. A
`DateTimeOffset` past the scale's range fell out of the multiply with no context. Range-checked
before scaling, naming the value and the column, as the `DateTime` path already did.

**A `Utc` or `Local` `DateTime` could not be written to a column whose zone .NET cannot represent.**
Same file plus `DateTimeColumnCodec.cs`. `ToUtc` consults the zone only for `Unspecified`, but both
callers evaluated `ResolvedTimeZone.Value` before it could look at `Kind`, so the check above did not
finish the job: writing a UTC instant to `DateTime('Fixed/UTC+19:00:00')` still threw, and so did a
null row, whose placeholder is `DateTime.UnixEpoch`. `ToUtc` now takes the resolved zone and asks for
it after the `Kind` test.

**A negative `Time64` finer than a tick read back as midnight.**
`Types/ColumnValueProjections.cs`. `Time64ToTimeOnly` shifted the raw count to 100 ns ticks and *then*
checked it was a time of day. The shift truncates toward zero, so every count from −1 to −99 at scale
9 reached zero and passed the check — a negative value presented as `00:00`, which is the exact
outcome the refusal exists to prevent. Checked on the raw count against `[0, 86400 · 10^scale)`.

## Diagnostics

- **`Array(Boolean)` said "ClickHouse type 'Boolean' is not supported".** Resolution recurses and a
  child node knows nothing about where it sits, so the message named a type the caller never wrote
  (the server spells it `Bool`). `Types/ColumnCodecRegistry.cs` now keeps the child's refusal and
  adds the type it was handed. Also drops "yet": `Object('json')` was removed from ClickHouse and
  `MultiPoint` never existed, so promising them later is wrong.
- **An `AggregateFunction` refusal named the serialization version as the function.** 26.6 reports
  `sumMapState(...)` as `AggregateFunction(1, sumMap, ...)`, so the message said "the '1' aggregate
  function" and suggested `SELECT 1Merge(column)`, which is not a function. Now
  `sumMapMerge(column)`, and `sumMapFilteredMerge([1, 2])(column)` with parameters — both run.
- **One parameter message covered two unrelated failures.** `Parameters/TcpParameterFormatter.cs`
  answered "Cannot convert value of type 'System.String' (abc) to ClickHouse type VARCHAR" both for
  a type name this client does not know and for a known type whose arm declined the value. For the
  first the value was never the problem. Split, with the registry answering whether a name is known
  so the two stay in step as codecs are added.
- **Two client limits read as copies of a server rule.** The `QBit` element switch and the `Variant`
  refusal of a `Dynamic` alternative. Neither is a server rule. Wording only.

## HTTP-client parity

A query written against the shipped HTTP driver should move to this client without respelling its
types. Five things stopped that:

- **Type-name aliases.** `{p:VARCHAR}`, `{p:BIGINT}`, `{p:DEC(4,2)}`, `{p:Boolean}`, `{p:json}` all
  threw client-side, before the query was sent. `Types/TypeAliases.cs` (new) is
  `system.data_type_families` on 26.6: every row with a non-empty `alias_to`. The registry consults
  it when an exact lookup misses and resolves under the canonical name, so `DEC(4, 2)` reports
  itself as `Decimal(4, 2)`. Child nodes come back through the same lookup, which is what makes
  `Array(Map(String, Tuple(Int32, BIGINT)))` resolve. An integration test compares the table against
  the live server in both directions, which is what caught the entries this would otherwise have
  mistyped.
- **Case.** The registry now matches any case of a name it knows. It deliberately does *not* carry a
  copy of which families the server matches case-insensitively: that rule moves between versions,
  and resolution serves reads, so a stale copy would refuse a header the server legitimately sent.
- **The same, inside a `Variant`.** Picking the alternative is a separate match from formatting the
  value, and it read the name as the caller wrote it, so `{p:Variant(BIGINT, String)}` accepted no
  `Int64` at all while the server resolves that declaration to `Variant(Int64, String)`.
  `ParameterTypeInference.Accepts` now canonicalizes first, as the formatter's dispatch already did.
- **A bare `Enum('A' = 1, 'B' = 2)`**, which the server accepts and the HTTP driver resolves. The
  client now picks the width the server would: `Enum8` while every ordinal fits `Int8`, `Enum16`
  otherwise. A header always names a width, so this only comes from a caller's hint.
- **`TimeOnly` as a parameter.** It reached neither time arm: `Time` called `Convert.ToInt32` on it,
  which a `TimeOnly` does not support, and `Time64` matched `TimeSpan` only.
- **`Dynamic`, `Geometry` and `SimpleAggregateFunction` parameters**, all three refused client-side
  while the server takes a text value for each (checked on 26.6). `SimpleAggregateFunction` writes
  as its inner type; the other two write the value's own text and leave the parse to the server. For
  `Dynamic` the server's answer turns out to be `String` whatever the text is — it reports
  `dynamicType` String for a bare `42` too — so what this buys is that the value arrives, not a
  particular runtime type.
- **A value read from a `Map` column, sent back as a parameter.** A `Map` row surfaces as
  `KeyValuePair<K, V>[]` so duplicate keys and pair order survive, and the explicit `Map(K, V)`
  formatter already took that shape — but `ParameterTypeInference.Infer` had no arm for it, so it
  fell to the `Array` arm, whose element inference has no reading for a `KeyValuePair`. A `Dynamic`
  parameter asks `Infer` what the value is, so a Map read-back could not be sent as one.

## Ergonomics

- **`Time` and `Time64` now take a `TimeOnly`.** `Date` takes a `DateOnly`, so a caller reasonably
  expects the symmetry; `ClickHouseTcpColumn.Create` over `TimeOnly` values had no codec at all.
  Reading *back* as a `TimeOnly` is the one narrowing in the read surface — a `Time` value may be
  negative or past 24 hours and is then not a time of day — so such a row is refused with a message
  pointing at `TimeSpan`, rather than reduced modulo a day, which would present a different value as
  the stored one.
- **`Variant(Time, String)` accepted no time value at all.**
  `Parameters/ParameterTypeInference.cs` had an arm for the instant types and none for the time ones,
  so a `TimeSpan` matched a `Time64` alternative and never a `Time` one, and a `Variant` that matches
  nothing is refused whole.

## New option: `SendJsonAndDynamicSerializationSettings`

`ClickHouseTcpClientOptions` and the connection string. Public API surface updated.

Every query, insert and execute from the high-level client carried
`output_format_native_use_flattened_dynamic_and_json_serialization` and
`output_format_native_write_json_as_string`. Both server defaults are 0, so **each operation was a
setting modification**, and a user under a `readonly` profile got Code 164 for all of them — the
high-level client was unusable for such a user while `ClickHouseTcpConnection` worked. The option is
on by default and turns the injection off when cleared. Sending the settings as `"0"` is not an
alternative: the server counts that as a modification too. The cost of clearing it is that a `JSON`
or `Dynamic` column may arrive in a serialization this client does not read; no other type is
affected.

## Coverage added

Most of the diff. New integration fixtures, all against a real server:

| Fixture | What it reaches that nothing did |
|---|---|
| `MidStreamFailureIntegrationTests` | an `Exception` packet *after* data blocks — its body is unframed while the blocks around it are framed, so uncompressed, LZ4 and ZSTD |
| `InsertInterruptionIntegrationTests` | a data phase that does not finish: cancelled from `OnBlockWritten`, and a constraint rejecting every block after the first |
| `ComputedColumnInsertIntegrationTests` | the insert schema block naming fewer columns than the table has |
| `MultiBlockStateIntegrationTests` | a `LowCardinality` dictionary, a `Dynamic` type list and a version word across more than one block — the only multi-block reads were of `UInt64` |
| `ConnectionPoolIntegrationTests` (+250) | the server hanging up on an idle connection (`idle_connection_timeout`, polled for with a bounded budget rather than slept past); a retired connection closed *on the server*, by `system.query_log` client ports and the `TCPConnection` metric; permit accounting at a pool of one |
| `TlsTransportIntegrationTests` + `TlsTerminatingProxy` | a query, a block and an insert through a real `SslStream`. The existing TLS tests answer with a canned `Hello`, and the Cloud fixture is skipped unless a service is configured |
| `TimezoneColumnIntegrationTests` | a non-UTC column asserted against the server's own rendering, including the ambiguous DST hour |
| `FloatSpecialValueIntegrationTests` | signed zero, which the corpus comparison cannot see because `(-0.0).Equals(0.0)` |
| `ReadonlyUserIntegrationTests` | a user who is not the fixture superuser |
| `ClickHouseTcpCancellationIntegrationTests` | the read deadline actually firing |

Plus ~330 lines of `InsertRoundTripCase` values: `UInt256`/`Int256` at 2^255 and both ends;
`Decimal` at scale 0, at scale == precision, and `Decimal(76, 0)`; a fully populated IPv6 and the
IPv4-mapped form; `LowCardinality` over 1-, 8- and 16-byte dictionaries; a dictionary leaf under two
levels of offsets; `Map` with a `LowCardinality` key and with a `Tuple` key; `QBit(Float32, 768)`;
`DateTime` past 2038; both `Int64` ends of `DateTime64(9)`; `NaN`/±∞/−0 on all three float widths in
bare, `Nullable` and `Array` form; `Nullable(Tuple(...))` and `Nullable(Point)`, which the corpus
note had said could not be written.

## Two things worth flagging to a reviewer

**Some coverage was written to make a test able to fail, not to add a case.** Three examples: the
read-deadline test could not fire because the server's `Progress` packet every `interactive_delay`
counts as speaking, so `SELECT sleep(3)` finished under a one-second deadline — raising
`interactive_delay` past the sleep buys the silence. The timezone assertions previously compared the
read-back against a value the same conversion produced, so they held even with the direction
inverted. The signed-zero test asserts stored *bits* through `reinterpretAsUInt32`, because
`[assembly: DefaultFloatingPointTolerance(1e-15)]` and `Equals` both hide the sign.

**Three backlog claims did not survive checking, and are closed on evidence rather than a fix.** The
`BFloat16` 1-ULP disagreement (client and server truncate identically, bit for bit), the
`Array(Dynamic)` zero-row desync (no desync; the codec's stated *reason* was wrong and is corrected,
the behavior was right), and >255 `Dynamic` runtime types (the server caps `max_types` at 254, so
the wide discriminator is unreachable end to end).

## What a review pass then found

The branch was reviewed by Codex with the repository's own review criteria, a live 26.6 to run
against, and licence to mutate the code to test a claim. It found nine things; four were real defects
in the branch, three were tests that could not support their names, and two are recorded rather than
fixed. The four defects and the three test repairs are in the commits above and below.

The most useful finding is one my own mutation discipline missed: **the mismatched-`Variant` insert
test passed with the fix reverted.** It used `Variant(Date, Int64)` → `Variant(Date32, Int64)`, where
the alternative keeps its index and both surface as `IColumn<DateOnly>`, so the old arity-only
shortcut reached the same answer. It is now `Variant(Int64, String)` → `Variant(Bool, Int64)`, which
moves the alternative from index 0 to index 1; reverting the gate now fails it with the
`InvalidCastException` the fix's commit message describes.

Two findings are declined, with the reasoning on record:

- **`Time`/`Time64` parameters round where the binary write truncates**, so `TimeOnly.MaxValue`
  formats as `24:00:00` and stores 86400 seconds, which no longer reads back as a `TimeOnly`. Real,
  but the rounding is deliberate parity with the shipped HTTP driver, which formats `TimeOnly`
  through the identical `Math.Round(TotalSeconds)` path, and the divergence applies to `TimeSpan`
  equally, so it predates this branch. Changing one client and not the other would reopen the parity
  gap five commits here exist to close. Filed as its own TODO item; the test that pinned it now says
  *why* it is pinned, and the case named "truncated to the scale" — which used a value that could not
  tell rounding from truncation — is replaced by midpoint cases that can.
- **No `docs/` update.** `docs/` has two files and no native-client page at all; documentation lands
  for the client as a whole. The examples half of that finding *was* valid and is done: the
  `Time`/`Time64` example now writes a `TimeOnly` and states the read-back narrowing, and the
  Variant/Dynamic/JSON example documents the new option and the readonly trade-off.

## Verification

Full suite, both ends of the supported range:

| Server | Result |
|---|---|
| 26.6.1.1193 | 4065 passed, 6 skipped, 0 failed |
| 25.8.32.4 (the CI floor) | 4001 passed, 12 skipped, 0 failed |

The 25.8 run is the reason for the version gates in the last commit. It found a pre-existing red
test, two ungated cases, and one server behavior change: 25.8's MergeTree part writer normalizes a
negative zero away, where a `Memory` table keeps it, so the signed-zero test uses `Memory`.

Every behavior change was verified by mutation — revert the fix, watch the new test fail. Three
mutations were inert on the first attempt and the tests were redesigned until they bit; the third of
those is the `Variant` case the review caught rather than I did.

## Not in this PR

- **Docs.** `docs/` has no native-client page yet; documentation lands for the client as a whole. The
  two user-visible additions are documented in the examples instead, which is where the client's
  usage documentation currently lives.
- **No changelog fragment**, per the standing rule for the `tcp/**` epic stack.
- **Roles and grants.** Deferred to a post-0.1 item. There is no protocol feature to add — the
  native protocol carries no role field, `SET ROLE` is SQL — so the work is coverage plus a
  documented pattern: over a pooled client, `SET ROLE` has to run inside `OpenSessionAsync` or the
  next statement lands on another connection with the role unset.
- Five backlog items are triaged as will-not-fix, four of them under the standing rule that the
  client does not gate on server type rules.
