### PR TITLE
Read a Fixed/UTC offset the way the server does

### DIFF
--- a/ClickHouse.Driver.Tests/Types/TimezoneHandlingTests.cs
+++ b/ClickHouse.Driver.Tests/Types/TimezoneHandlingTests.cs
@@ -1204,6 +1204,24 @@ public class ReadDateTimeFixedUtcOffsetTests : AbstractConnectionTestFixture
             wallClock, DateTimeKind.Utc, TimeSpan.Zero)
             .SetName("ReadDateTime_ZeroFixedUtcOffset_IsUtc");
 
+        // +/-14 h is the largest offset the server accepts, so it is the widest name a column
+        // can carry. Verified against 26.9, which rejects anything further from UTC.
+        yield return new TestCaseData(
+            "SELECT toDateTime('2024-01-15 10:30:00', 'Fixed/UTC+14:00:00')",
+            wallClock, DateTimeKind.Unspecified, new TimeSpan(14, 0, 0))
+            .SetName("ReadDateTime_MaxFixedUtcOffset");
+        yield return new TestCaseData(
+            "SELECT toDateTime('2024-01-15 10:30:00', 'Fixed/UTC-14:00:00')",
+            wallClock, DateTimeKind.Unspecified, new TimeSpan(-14, 0, 0))
+            .SetName("ReadDateTime_MinFixedUtcOffset");
+
+        // A minute field above 59 carries into the hour, so the server resolves this name to
+        // +06:00 and the driver has to agree with it. Accepted by 26.3 and by 26.9.
+        yield return new TestCaseData(
+            "SELECT toDateTime('2024-01-15 10:30:00', 'Fixed/UTC+05:60:00')",
+            wallClock, DateTimeKind.Unspecified, new TimeSpan(6, 0, 0))
+            .SetName("ReadDateTime_FixedUtcOffsetWithMinuteCarry");
+
         // DateTime64 uses the same offset handling and preserves sub-second precision.
         yield return new TestCaseData(
             "SELECT toDateTime64('2024-01-15 10:30:00.123', 3, 'Fixed/UTC+05:30:00')",
@@ -1237,33 +1255,6 @@ public class ReadDateTimeFixedUtcOffsetTests : AbstractConnectionTestFixture
             Assert.That(dateTime.Kind, Is.EqualTo(expectedKind), "DateTime.Kind");
             Assert.That(dateTimeOffset.Offset, Is.EqualTo(expectedOffset), "GetDateTimeOffset offset");
             Assert.That(dateTimeOffset.DateTime, Is.EqualTo(expectedWallClock), "GetDateTimeOffset wall-clock");
-        });
-    }
-
-    /// <summary>
-    /// Out-of-range Fixed/UTC offset (>18 h) cannot be represented by NodaTime's Offset, so
-    /// ResolveTimezone returns null and the driver falls back to the UTC wall-clock with
-    /// Kind=Unspecified and a zero offset. Pins that fallback and covers the return-null branch.
-    /// </summary>
-    [Test]
-    public async Task ReadDateTime_WithOutOfRangeFixedUtcOffset_FallsBackToUtcWallClock()
-    {
-        // Fixed/UTC+19:00:00 exceeds NodaTime's ±18 h cap → ResolveTimezone returns null.
-        // The stored instant for wall-clock 2024-01-15 10:30:00 in UTC+19 is
-        // 2024-01-14 15:30:00 UTC; the null-timezone fallback returns that UTC time.
-        using var reader = (ClickHouseDataReader)await connection.ExecuteReaderAsync(
-            "SELECT toDateTime('2024-01-15 10:30:00', 'Fixed/UTC+19:00:00')");
-        Assert.That(reader.Read(), Is.True);
-
-        var dateTime = reader.GetDateTime(0);
-        var dateTimeOffset = reader.GetDateTimeOffset(0);
-
-        Assert.Multiple(() =>
-        {
-            Assert.That(dateTime, Is.EqualTo(new DateTime(2024, 1, 14, 15, 30, 0)), "UTC-projected wall-clock");
-            Assert.That(dateTime.Kind, Is.EqualTo(DateTimeKind.Unspecified), "null-timezone fallback Kind");
-            Assert.That(dateTimeOffset.Offset, Is.EqualTo(TimeSpan.Zero), "UTC fallback offset");
-            Assert.That(dateTimeOffset.DateTime, Is.EqualTo(new DateTime(2024, 1, 14, 15, 30, 0)), "GetDateTimeOffset wall-clock");
         });
     }
 
@@ -1305,10 +1296,14 @@ public class ResolveTimezoneParseTests
         // Not IANA and not a Fixed/UTC offset → regex no-match → null TimeZone.
         yield return new TestCaseData("DateTime('Unknown/TZ')").SetName("ParseDateTime_UnrecognizedName");
         yield return new TestCaseData("DateTime64(3, 'Unknown/TZ')").SetName("ParseDateTime64_UnrecognizedName");
-        // Malformed Fixed/UTC: minutes/seconds outside 00-59 must be rejected by the tightened
-        // regex rather than misread as a different valid offset (e.g. 60 minutes as an extra hour).
-        yield return new TestCaseData("DateTime('Fixed/UTC+05:60:00')").SetName("ParseDateTime_FixedUtcMinutesOutOfRange");
-        yield return new TestCaseData("DateTime('Fixed/UTC+05:00:60')").SetName("ParseDateTime_FixedUtcSecondsOutOfRange");
+        // Each field has to be exactly two digits, the only spelling the server resolves.
+        yield return new TestCaseData("DateTime('Fixed/UTC+5:00:00')").SetName("ParseDateTime_FixedUtcSingleDigitHour");
+        // Past NodaTime's +/-18 h Offset range → range guard rejects → null TimeZone. Only a
+        // server older than 26.9 can send such a name; 26.9 caps a fixed offset at 14 hours.
+        yield return new TestCaseData("DateTime('Fixed/UTC+19:00:00')").SetName("ParseDateTime_FixedUtcHoursOutOfRange");
+        yield return new TestCaseData("DateTime64(3, 'Fixed/UTC-23:00:00')").SetName("ParseDateTime64_FixedUtcHoursOutOfRange");
+        // Carrying every field to its limit is ~100 h, so the range guard still rejects it.
+        yield return new TestCaseData("DateTime('Fixed/UTC+99:99:99')").SetName("ParseDateTime_FixedUtcAllFieldsOutOfRange");
     }
 
     /// <summary>
@@ -1333,12 +1328,20 @@ public class ResolveTimezoneParseTests
             .SetName("ParseDateTime_FixedUtcMaxInRangeHours");
         yield return new TestCaseData("DateTime('Fixed/UTC-18:00:00')", -18 * 3600)
             .SetName("ParseDateTime_FixedUtcMinInRangeHours");
+
+        // A field above its natural limit carries into the next one, which is how the server
+        // reads it: 26.3 and 26.9 both resolve Fixed/UTC+05:60:00 to +06:00, and 26.3 resolves
+        // Fixed/UTC+05:00:60 to +05:01:00 (26.9 rejects the name for being finer than 15 min).
+        yield return new TestCaseData("DateTime('Fixed/UTC+05:60:00')", 6 * 3600)
+            .SetName("ParseDateTime_FixedUtcMinutesCarryIntoHour");
+        yield return new TestCaseData("DateTime('Fixed/UTC+05:00:60')", (5 * 3600) + 60)
+            .SetName("ParseDateTime_FixedUtcSecondsCarryIntoMinute");
     }
 
     /// <summary>
     /// A well-formed Fixed/UTC name within NodaTime's ±18 h range resolves to a fixed-offset
     /// zone with exactly that offset. The boundary cases (59:59 minutes/seconds and the ±18 h
-    /// cap) prove the tightened MM/SS regex and the range guard accept all valid values.
+    /// cap) prove the range guard accepts all valid values.
     /// </summary>
     [TestCaseSource(nameof(ValidFixedUtcOffsetCases))]
     public void Parse_WithValidFixedUtcOffset_ResolvesToFixedOffsetZone(string typeString, int expectedOffsetSeconds)

--- a/ClickHouse.Driver/Types/AbstractDateTimeType.cs
+++ b/ClickHouse.Driver/Types/AbstractDateTimeType.cs
@@ -27,11 +27,10 @@ internal abstract class AbstractDateTimeType : ParameterizedType,
     // ClickHouse emits synthetic fixed-offset timezone names like "Fixed/UTC+05:30:00" for columns
     // declared with a fixed UTC offset. These names are not in the IANA TZDB so GetZoneOrNull
     // returns null for them. This regex parses them into a NodaTime fixed-offset zone.
-    // Minutes and seconds are restricted to 00-59 so a malformed name falls through to the null
-    // fallback instead of being misread as a different valid offset (e.g. 60 minutes as +1 h);
-    // out-of-range hours are rejected by the +/-18 h cap in ResolveTimezone.
+    // Each field is two digits and carries into the next, matching the server: it reads
+    // "Fixed/UTC+05:60:00" as +06:00. ResolveTimezone rejects the resulting out-of-range offsets.
     private static readonly Regex FixedUtcOffsetRegex = new(
-        @"^Fixed/UTC([+-])(\d{2}):([0-5]\d):([0-5]\d)$",
+        @"^Fixed/UTC([+-])(\d{2}):(\d{2}):(\d{2})$",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     /// <summary>

--- a/changelog.d/fixed-utc-offset-field-carry.fixes.md
+++ b/changelog.d/fixed-utc-offset-field-carry.fixes.md
@@ -1,0 +1,3 @@
+* Fixed a wall-clock shift when reading a `DateTime`/`DateTime64` column whose `Fixed/UTC±HH:MM:SS`
+  timezone name has a minute or second field above 59. The server carries such a field into the next
+  one, so `Fixed/UTC+05:60:00` means +06:00; the driver rejected the name and read the value as UTC.


### PR DESCRIPTION
## What changed

The nightly "Test against ClickHouse HEAD" job started failing on
`ReadDateTime_WithOutOfRangeFixedUtcOffset_FallsBackToUtcWallClock`:

```
Code: 36. DB::Exception: Time zone Fixed/UTC+19:00:00 is not supported: a fixed UTC offset is
spelled `Fixed/UTC±HH:MM:SS` and has to be a whole number of quarters of an hour, no further
from UTC than 14 hours. (BAD_ARGUMENTS) (version 26.9.1.876)
```

The cause is server-side, in ClickHouse
[#118286](https://github.com/ClickHouse/ClickHouse/pull/118286) (merged 2026-09-06, one nightly
before the failure). `cctz` synthesizes a zone for any `Fixed/UTC±HH:MM:SS` name up to 24 hours,
which is 172,801 distinct names, and each name that gets loaded costs ~4.6 MiB in a `DateLUT`
cache that never evicts. The new `DateLUTImpl::isSupportedTimeZoneName` bounds that by accepting
only the offsets a time zone can really have: **a whole number of quarters of an hour, no further
from UTC than 14 hours**.

So the test's `Fixed/UTC+19:00:00` is no longer a name any server will produce, and the branch it
covered is no longer reachable through the server.

## Where the driver applies these limits

One place on `main`: `AbstractDateTimeType.ResolveTimezone`. (`DateTimeZones.Resolve` in
`ClickHouse.Driver.Tcp` has the same job but is not on `main` yet — see the note at the end.)

I checked its two limits against a real 26.3 (support floor) and a real 26.9.1 server:

| Limit | Verdict |
| --- | --- |
| `±18 h` range guard | Correct, no change. It is NodaTime's `Offset` range, which is the widest the driver can represent, and it already covers everything any supported server can emit. |
| `[0-5]\d` on the minute and second fields | **Wrong.** Fixed here. |

The second one is a real bug. The comment claimed the restriction stops a malformed name from
"being misread as a different valid offset (e.g. 60 minutes as +1 h)" — but reading 60 minutes as
an extra hour is exactly what the server does, because `cctz` carries each field into the next:

```
                       26.3         26.9.1
Fixed/UTC+05:60:00     +06:00       +06:00
Fixed/UTC+05:00:60     +05:01:00    rejected (finer than 15 min)
Fixed/UTC+13:60:00     +14:00       +14:00
```

`Fixed/UTC+05:60:00` is accepted by every supported server, including 26.9. The driver's regex
rejected the name, `ResolveTimezone` returned null, and the read fell through to the UTC
projection — a silent 6-hour wall-clock shift, the same class of bug as #370.

The fix is to parse the family the way the server does: two digits per field, carrying into the
next. The existing `±18 h` guard still rejects whatever that produces out of range, so nothing
new is accepted — `Fixed/UTC+99:99:99` carries to ~100 h and is still null.

```diff
- @"^Fixed/UTC([+-])(\d{2}):([0-5]\d):([0-5]\d)$",
+ @"^Fixed/UTC([+-])(\d{2}):(\d{2}):(\d{2})$",
```

The `hours * 3600 + minutes * 60 + seconds` arithmetic already carried correctly, so the regex was
the only change needed.

## Tests

Removed `ReadDateTime_WithOutOfRangeFixedUtcOffset_FallsBackToUtcWallClock`. It needed the server
to emit a `Fixed/UTC+19:00:00` column, which 26.9 refuses to do. Its coverage of the
`ResolveTimezone` null branch moves to `ResolveTimezoneParseTests`, the class that already exists
for branches the server cannot reach.

Two expectations flipped, because they pinned behavior that a real server contradicts.
`ParseDateTime_FixedUtcMinutesOutOfRange` and `ParseDateTime_FixedUtcSecondsOutOfRange` asserted a
null zone for `+05:60:00` / `+05:00:60`; they are now
`ParseDateTime_FixedUtcMinutesCarryIntoHour` and `ParseDateTime_FixedUtcSecondsCarryIntoMinute`,
asserting the carried offsets shown in the table above.

Added:

- `ReadDateTime_FixedUtcOffsetWithMinuteCarry` — integration coverage of the fix. `+05:60:00` reads
  as +06:00 against a real server, and the name is accepted on 26.3 through 26.9.
- `ReadDateTime_MaxFixedUtcOffset` / `ReadDateTime_MinFixedUtcOffset` — `±14:00:00`, now the widest
  offset a column can carry.
- `ParseDateTime_FixedUtcHoursOutOfRange`, `ParseDateTime64_FixedUtcHoursOutOfRange`,
  `ParseDateTime_FixedUtcAllFieldsOutOfRange` — the range guard.
- `ParseDateTime_FixedUtcSingleDigitHour` — the two-digit shape, which the server also requires.

`ResolveTimezone` has three branches (IANA hit, fixed-offset parse, null fallback) and all three
are exercised, so no separate coverage run.

Verified locally on `net9.0` against two servers, both green:

- **26.9.1.879** (matches the failing nightly): full `ClickHouse.Driver.Tests` suite.
- **26.3.19.3** (support floor): the fixed-offset and parse fixtures.

## Follow-up, not in this PR

`ClickHouse.Driver.Tcp/Types/Codecs/DateTimeZones.cs` on the unmerged `tcp/**` stack has the same
parsing with the same `[0-5]\d` restriction, so it needs the same one-line change when that stack
is next restacked. Its `±14 h` and whole-minute limits are the BCL's
`TimeZoneInfo.CreateCustomTimeZone` constraints and should stay: they happen to match 26.9's rule
exactly, so nothing there is broken today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
